### PR TITLE
remove misspelling of preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@
 
 ## What is ZenML?
 
-**ZenML** is an extensible, open-source MLOps framework to create production-ready machine learning pipelines. It has a simple, flexible syntax, 
+**ZenML** is an extensible, open-source MLOps framework to create production-ready machine learning pipelines. It has a simple, flexible syntax,
 is cloud and tool agnostic, and has interfaces/abstractions that are catered towards ML workflows.
 
-At its core, ZenML  pipelines execute ML-specific workflows from sourcing data to splitting, preprocessing, training, all the way to the evaluation of 
-results and even serving. There are many built-in batteries as things progress in ML development. ZenML is not here to replace the great tools that 
+At its core, ZenML pipelines execute ML-specific workflows from sourcing data to splitting, preprocessing, training, all the way to the evaluation of
+results and even serving. There are many built-in batteries as things progress in ML development. ZenML is not here to replace the great tools that
 solve these individual problems. Rather, it integrates natively with many popular ML tooling, and gives standard abstraction to write your workflows.
 
 ## Why do I need it?
@@ -47,50 +47,50 @@ solve these individual problems. Rather, it integrates natively with many popula
 _**Ichi Wa Zen, Zen Wa Ichi.**_
 
 We built ZenML because we could not find an easy framework that translates the patterns observed in the research phase with Jupyter notebooks into a production-ready ML environment.
-ZenML follows the paradigm of [`Pipelines As Experiments` (PaE)](https://docs.zenml.io/why/why-zenml), meaning ZenML pipelines are designed to be written early on the development lifecycle, where the users can explore their 
+ZenML follows the paradigm of [`Pipelines As Experiments` (PaE)](https://docs.zenml.io/why/why-zenml), meaning ZenML pipelines are designed to be written early on the development lifecycle, where the users can explore their
 pipelines as they develop towards production.
 
 By using ZenML at the early stages of development, you get the following features:
 
-* **Reproducibility** of training and inference workflows.
-* Managing ML **metadata**, including versioning data, code, and models.
-* Getting an **overview** of your ML development, with a reliable link between training and deployment.
-* Maintaining **comparability** between ML models.
-* **Scaling** ML training/inference to large datasets.
-* Retaining code **quality** alongside development velocity. 
-* **Reusing** code/data and reducing waste.
-* Keeping up with the **ML tooling landscape** with standard abstractions and interfaces.
-
+- **Reproducibility** of training and inference workflows.
+- Managing ML **metadata**, including versioning data, code, and models.
+- Getting an **overview** of your ML development, with a reliable link between training and deployment.
+- Maintaining **comparability** between ML models.
+- **Scaling** ML training/inference to large datasets.
+- Retaining code **quality** alongside development velocity.
+- **Reusing** code/data and reducing waste.
+- Keeping up with the **ML tooling landscape** with standard abstractions and interfaces.
 
 ## Who is it for?
-ZenML is built for ML practitioners who are ramping up their ML workflows towards production. 
+
+ZenML is built for ML practitioners who are ramping up their ML workflows towards production.
 It is created for data science / machine learning teams that are engaged in not only training models, but also putting them out in production. Production can mean many things, but examples would be:
 
-* If you are using a model to generate analysis periodically for any business process.
-* If you are using models as a software service to serve predictions and are consistently improving the model over time.
-* If you are trying to understand patterns using machine learning for any business process.
+- If you are using a model to generate analysis periodically for any business process.
+- If you are using models as a software service to serve predictions and are consistently improving the model over time.
+- If you are trying to understand patterns using machine learning for any business process.
 
-* In all of the above, there will be team that is engaged with creating, deploying, managing and improving the entire process. You always want the best results, the best models, and the most robust and reliable results. This is where ZenML can help.
-In terms of user persona, ZenML is created for producers of the models. This role is classically known as 'data scientist' in the industry and can range from research-minded individuals to more engineering-driven people. The goal of ZenML is to enable these practitioners to own their models until deployment and beyond.
-
+- In all of the above, there will be team that is engaged with creating, deploying, managing and improving the entire process. You always want the best results, the best models, and the most robust and reliable results. This is where ZenML can help.
+  In terms of user persona, ZenML is created for producers of the models. This role is classically known as 'data scientist' in the industry and can range from research-minded individuals to more engineering-driven people. The goal of ZenML is to enable these practitioners to own their models until deployment and beyond.
 
 ## Release 0.5.0 and what lies ahead
+
 The current release is bare bones (as it is a complete rewrite).
 We are missing some basic features which used to be part of ZenML 0.3.8 (the previous release):
 
-* Standard interfaces for `TrainingPipeline`.
-* Individual step interfaces like `PreprocesserStep`, `TrainerStep`, `DeployerStep` etc. need to be rewritten from within the new paradigm. They should
-be included in the non-RC version of this release.
-* A proper production setup with an orchestrator like Airflow.
-* A post-execution workflow to analyze and inspect pipeline runs.
-* The concept of `Backends` will evolve into a simple mechanism of transitioning individual steps into different runners.
-* Support for `KubernetesOrchestrator`, `KubeflowOrchestrator`, `GCPOrchestrator` and `AWSOrchestrator` are also planned.
-* Dependency management including Docker support is planned.
+- Standard interfaces for `TrainingPipeline`.
+- Individual step interfaces like `PreprocessorStep`, `TrainerStep`, `DeployerStep` etc. need to be rewritten from within the new paradigm. They should
+  be included in the non-RC version of this release.
+- A proper production setup with an orchestrator like Airflow.
+- A post-execution workflow to analyze and inspect pipeline runs.
+- The concept of `Backends` will evolve into a simple mechanism of transitioning individual steps into different runners.
+- Support for `KubernetesOrchestrator`, `KubeflowOrchestrator`, `GCPOrchestrator` and `AWSOrchestrator` are also planned.
+- Dependency management including Docker support is planned.
 
 However, bare with us: Adding those features back in should be relatively faster as we now have a solid foundation to build on. Look out for the next email!
 
-
 ## Roadmap and Community
+
 ZenML is being built in public. The [roadmap](https://zenml.io/roadmap) is a regularly updated source of truth for the ZenML community to understand where the product is going in the short, medium, and long term.
 
 ZenML is managed by a [core team](https://zenml.io/team) of developers that are responsible for making key decisions and incorporating feedback from the community. The team oversee's feedback via various channels, but you can directly influence the roadmap as follows:
@@ -115,7 +115,8 @@ ZenML is built on the shoulders of giants: we leverage, and would like to give c
 You can read more about why we actually started building ZenML at our [blog](https://blog.zenml.io/why-zenml/).
 
 ## Legacy [Updated Soon Q4 2021]
-From this point onwards, the README is intended to give a glimpse as to what lies ahead. We have redesigned our [public roadmap](https://zenml.io/roadmap) 
+
+From this point onwards, the README is intended to give a glimpse as to what lies ahead. We have redesigned our [public roadmap](https://zenml.io/roadmap)
 to showcase better the timeline in which these features will be complete.
 
 ## Quickstart
@@ -150,7 +151,7 @@ zenml init
 from zenml.pipelines import TrainingPipeline
 from zenml.steps.evaluator import TFMAEvaluator
 from zenml.steps.split import RandomSplit
-from zenml.steps.preprocesser import StandardPreprocesser
+from zenml.steps.preprocessor import StandardPreprocessor
 from zenml.steps.trainer import TFFeedForwardTrainer
 
 
@@ -162,16 +163,16 @@ def TFFeedForwardTrainer():
 def SplitPipeline(simple_step: Step[SimplestStepEver],
                   data_step: Step[DataIngestionStep],
                   split_step: Step[DistSplitStep],
-                  preprocesser_step: Step[InMemPreprocesserStep]):
+                  preprocessor_step: Step[InMemPreprocessorStep]):
     data_step(input_random_number=simple_step.outputs["return_output"])
     split_step(input_artifact=data_step.outputs["output_artifact"])
-    preprocesser_step(input_artifact=split_step.outputs["output_artifact"])
+    preprocessor_step(input_artifact=split_step.outputs["output_artifact"])
 
 
 pipeline = TrainingPipeline(
     data_step=ImportDataStep(uri='gs://zenml_quickstart/diabetes.csv'),
     split_step=RandomSplit(split_map={'train': 0.7, 'test': 0.3}),
-    preprocesser_step=StandardPreprocesser(),
+    preprocessor_step=StandardPreprocessor(),
     trainer_step=TFFeedForwardTrainer(),
     evaluator_step=TFMAEvaluator()
 )
@@ -182,7 +183,7 @@ pipeline.run()
 
 ## Leverage powerful integrations
 
-Once code is organized into a ZenML pipeline, you can supercharge your ML development with powerful integrations and 
+Once code is organized into a ZenML pipeline, you can supercharge your ML development with powerful integrations and
 on multiple [MLOps stacks].
 
 ### Work locally but switch seamlessly to the cloud
@@ -243,8 +244,8 @@ repo.compare_training_runs()
 Leverage distributed compute powered by [Apache Beam](https://beam.apache.org/):
 
 ```python
-training_pipeline.add_preprocesser(
-    StandardPreprocesser(...).with_backend(
+training_pipeline.add_preprocessor(
+    StandardPreprocessor(...).with_backend(
       ProcessingDataFlowBackend(
         project=GCP_PROJECT,
         num_workers=10,

--- a/docs/book/core-concepts.md
+++ b/docs/book/core-concepts.md
@@ -26,7 +26,7 @@ Pipelines are functions. They are created by using decorators appropriate to the
 
 **Step**
 
-A step is a single piece or stage of a ZenML pipeline. Think of each step as being one of the nodes of the DAG. Steps are responsible for one aspect of processing or interacting with the data / artifacts in the pipeline. ZenML currently implements a `SimpleStep` interface, but there will be other more customised interfaces \(layered in a hierarchy\) for specialized implementations. For example, broad steps like `SplitStep`, `PreprocesserStep,` `TrainerStep` and so on.
+A step is a single piece or stage of a ZenML pipeline. Think of each step as being one of the nodes of the DAG. Steps are responsible for one aspect of processing or interacting with the data / artifacts in the pipeline. ZenML currently implements a `SimpleStep` interface, but there will be other more customised interfaces \(layered in a hierarchy\) for specialized implementations. For example, broad steps like `SplitStep`, `PreprocessorStep,` `TrainerStep` and so on.
 
 In this way, steps can be thought of as hierarchical. In a later release, you can see how the `TrainerStep` might look like:
 
@@ -74,9 +74,9 @@ An orchestrator is a special kind of backend that manages the running of each st
 
 A stack is made up of the following three core components:
 
-* An Artifact Store
-* A Metadata Store
-* An Orchestrator \(backend\)
+- An Artifact Store
+- A Metadata Store
+- An Orchestrator \(backend\)
 
 A ZenML stack also happens to be a Pydantic `BaseSettings` class, which means that there are multiple ways to use it.
 
@@ -92,9 +92,9 @@ On a high level, when data is read from an **artifact** the results are persiste
 
 A few rules apply:
 
-* Every **orchestrator** \(local, Google Cloud VMs, etc\) can run all **pipeline steps**, including training.
-* **Orchestrators** have a selection of compatible **processing backends**.
-* **Pipelines** can be configured to utilize more powerful **processing** \(e.g. distributed\) and **training** \(e.g. Google AI Platform\) **executors**.
+- Every **orchestrator** \(local, Google Cloud VMs, etc\) can run all **pipeline steps**, including training.
+- **Orchestrators** have a selection of compatible **processing backends**.
+- **Pipelines** can be configured to utilize more powerful **processing** \(e.g. distributed\) and **training** \(e.g. Google AI Platform\) **executors**.
 
 A quick example for large datasets makes this clearer. By default, your experiments will run locally. Pipelines that load large datasets would be severely bottlenecked, so you can configure [Google Dataflow](https://cloud.google.com/dataflow) as a **processing executor** for distributed computation, and [Google AI Platform](https://cloud.google.com/ai-platform) as a **training executor**.
 
@@ -104,12 +104,11 @@ The design choices in **ZenML** follow the understanding that production-ready m
 
 In different words, **ZenML** runs your **ML** code while taking care of the "**Op**eration**s**" for you. It takes care of:
 
-* Interfacing between the individual processing **steps** \(splitting, transform, training\).
-* Tracking of intermediate results and metadata
-* Caching your processing artifacts.
-* Parallelization of computing tasks.
-* Ensuring the immutability of your pipelines from data sourcing to model artifacts.
-* No matter where - cloud, on-prem, or locally.
+- Interfacing between the individual processing **steps** \(splitting, transform, training\).
+- Tracking of intermediate results and metadata
+- Caching your processing artifacts.
+- Parallelization of computing tasks.
+- Ensuring the immutability of your pipelines from data sourcing to model artifacts.
+- No matter where - cloud, on-prem, or locally.
 
 Since production scenarios often look complex, **ZenML** is built with integrations in mind. **ZenML** will support a range of integrations for processing, training, and serving, and you can always add custom integrations via our extensible interfaces.
-

--- a/docs/book/core/pipelines.md
+++ b/docs/book/core/pipelines.md
@@ -14,12 +14,12 @@ def SplitPipeline(
     simple_step: Step[SimplestStepEver],
     data_step: Step[DataIngestionStep],
     split_step: Step[DistSplitStep],
-    preprocesser_step: Step[InMemPreprocesserStep]
+    preprocessor_step: Step[InMemPreprocessorStep]
 ):
 
     data_step(input_random_number=simple_step.outputs["return_output"])
     split_step(input_artifact=data_step.outputs["output_artifact"])
-    preprocesser_step(input_artifact=split_step.outputs["output_artifact"])
+    preprocessor_step(input_artifact=split_step.outputs["output_artifact"])
 
 
 # Pipeline
@@ -27,11 +27,10 @@ pipeline = SplitPipeline(
     simple_step=SimplestStepEver(basic_param_1=2, basic_param_2="3"),
     data_step=DataIngestionStep(uri=os.getenv("test_data")),
     split_step=DistSplitStep(),
-    preprocesser_step=InMemPreprocesserStep(),
+    preprocessor_step=InMemPreprocessorStep(),
 )
 
 pipeline_run = split_pipeline.run()
 ```
 
 Pipelines consist of many [steps](steps.md#how-to-create-steps)..
-


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Remove references to 'preprocesser' [sic], an incorrect spelling of 'preprocessor'.

I didn't touch anywhere it is found in legacy code, or in docs or release notes referring to that legacy code.