### PR TITLE
Improve detection of third party modules during class resolving

### DIFF
--- a/src/zenml/utils/source_utils.py
+++ b/src/zenml/utils/source_utils.py
@@ -27,6 +27,7 @@ import importlib
 import inspect
 import os
 import pathlib
+import site
 import sys
 import types
 from typing import Any, Optional, Type, Union
@@ -56,6 +57,17 @@ def is_inside_repository(file_path: str) -> bool:
     repo_path = pathlib.Path(Repository().path).resolve()
     absolute_file_path = pathlib.Path(file_path).resolve()
     return repo_path in absolute_file_path.parents
+
+
+def is_third_party_module(file_path: str) -> bool:
+    """Returns whether a file belongs to a third party package."""
+    absolute_file_path = pathlib.Path(file_path).resolve()
+
+    for path in site.getsitepackages() + [site.getusersitepackages()]:
+        if pathlib.Path(path).resolve() in absolute_file_path.parents:
+            return True
+
+    return False
 
 
 def create_zenml_pin() -> str:
@@ -210,15 +222,17 @@ def resolve_class(class_: Type[Any]) -> str:
         # builtin file
         return initial_source
 
-    # Get the full module path relative to the repository
-    if initial_source.startswith("__main__") or not is_inside_repository(
-        file_path
+    if (
+        initial_source.startswith("__main__")
+        or not is_inside_repository(file_path)
+        or is_third_party_module(file_path)
     ):
-        class_source = initial_source
-    else:
-        module_source = get_module_source_from_file_path(file_path)
-        class_source = module_source + "." + class_.__name__
-    return class_source
+        return initial_source
+
+    # Regular user file inside the repository -> get the full module
+    # path relative to the repository
+    module_source = get_module_source_from_file_path(file_path)
+    return module_source + "." + class_.__name__
 
 
 def import_class_by_path(class_path: str) -> Type[Any]:

--- a/tests/utils/test_source_utils.py
+++ b/tests/utils/test_source_utils.py
@@ -12,6 +12,17 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
+import inspect
 
-def test_me():
-    """A simple test to check a functionality"""
+import pytest
+
+from zenml.utils import source_utils
+
+
+def test_is_third_party_module():
+    """Tests that third party modules get detected correctly."""
+    third_party_file = inspect.getfile(pytest.Cache)
+    assert source_utils.is_third_party_module(third_party_file)
+
+    non_third_party_file = inspect.getfile(source_utils)
+    assert not source_utils.is_third_party_module(non_third_party_file)


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
- Detect whether a module belongs to a third party package when resolving a class