### PR TITLE
Updated README to successively install requirements

### DIFF
--- a/examples/airflow_local/README.md
+++ b/examples/airflow_local/README.md
@@ -13,7 +13,7 @@ In order to run this example, you need to install and initialize ZenML and Airfl
 ### Installation
 ```bash
 # install CLI
-pip install zenml apache-airflow tensorflow
+pip install zenml && pip install apache-airflow && pip install tensorflow && pip install sklearn
 
 # pull example
 zenml example pull airflow_local


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Previously installing all 3 requirements in a single pip install command lead to the wrong pyparsing version to be installed. This lead to an error during the execution of ```zenml init```. By separately installing the packages after one another this is no longer the case. 
Additionally, the sklearn dependency of the airflow_local example was not apparent within the README. 