### PR TITLE
Unified use of cli_utils.print_table for all table format cli printouts

### DIFF
--- a/src/zenml/cli/artifact.py
+++ b/src/zenml/cli/artifact.py
@@ -69,7 +69,9 @@ def list_artifact_stores() -> None:
     """List all available artifact stores from service."""
     service = Repository().get_service()
     cli_utils.title("Artifact Stores:")
-    cli_utils.echo_component_list(service.artifact_stores)
+    cli_utils.print_table(
+        cli_utils.format_component_list(service.artifact_stores)
+    )
 
 
 @artifact.command("delete")

--- a/src/zenml/cli/container_registry.py
+++ b/src/zenml/cli/container_registry.py
@@ -64,7 +64,9 @@ def list_container_registries() -> None:
     """List all available container registries from service."""
     service = Repository().get_service()
     cli_utils.title("Container registries:")
-    cli_utils.echo_component_list(service.container_registries)
+    cli_utils.print_table(
+        cli_utils.format_component_list(service.container_registries)
+    )
 
 
 @container_registry.command("delete")

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -15,7 +15,6 @@
 from typing import List, Optional
 
 import click
-from tabulate import tabulate
 
 from zenml.cli.cli import cli
 from zenml.cli.utils import (
@@ -23,6 +22,7 @@ from zenml.cli.utils import (
     declare,
     error,
     install_package,
+    print_table,
     title,
     uninstall_package,
     warning,
@@ -109,7 +109,7 @@ def list() -> None:
                 "Installed": is_installed,
             }
         )
-    declare(tabulate(table_rows, headers="keys"))
+    print_table(table_rows)
 
     warning("\nTo install the dependencies of a specific integration, type: ")
     warning("zenml integration install EXAMPLE_NAME")

--- a/src/zenml/cli/metadata.py
+++ b/src/zenml/cli/metadata.py
@@ -74,7 +74,9 @@ def list_metadata_stores() -> None:
     """List all available metadata stores from service."""
     service = Repository().get_service()
     cli_utils.title("Metadata Stores:")
-    cli_utils.echo_component_list(service.metadata_stores)
+    cli_utils.print_table(
+        cli_utils.format_component_list(service.metadata_stores)
+    )
 
 
 @metadata.command("delete")

--- a/src/zenml/cli/orchestrator.py
+++ b/src/zenml/cli/orchestrator.py
@@ -101,7 +101,9 @@ def list_orchestrators() -> None:
     """List all available orchestrators from service."""
     service = Repository().get_service()
     cli_utils.title("Orchestrators:")
-    cli_utils.echo_component_list(service.orchestrators)
+    cli_utils.print_table(
+        cli_utils.format_component_list(service.orchestrators)
+    )
 
 
 @orchestrator.command("delete")

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -62,7 +62,9 @@ def list_stacks() -> None:
     cli_utils.title("Stacks:")
     # TODO [ENG-144]: once there is a common superclass for Stack/ArtifactStore etc.,
     #  remove the mypy ignore
-    cli_utils.echo_component_list(service.stacks)  # type: ignore[arg-type]
+    cli_utils.print_table(
+        cli_utils.format_component_list(service.stacks)  # type: ignore[arg-type]
+    )
 
 
 @stack.command("delete")

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -141,9 +141,15 @@ def format_component_list(
     """
     list_of_dicts = []
     for key, c in component_list.items():
-        # TODO [ENG-143]: This will break if component has element called `key`
-        data = {"key": key}
-        data.update(c.dict(exclude={"_superfluous_options"}))
+        # Make sure that the `name` key is not taken in the component dict
+        # In case `name` exists, it is replaced inplace with `component_name`
+        component_dict = {
+            "component_name" if k == "name" else k: v
+            for k, v in c.dict(exclude={"_superfluous_options"}).items()
+        }
+
+        data = {"name": key}
+        data.update(component_dict)
         list_of_dicts.append(data)
     return list_of_dicts
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -115,15 +115,37 @@ def pretty_print(obj: Any) -> None:
     click.echo(str(obj))
 
 
-def echo_component_list(component_list: Mapping[str, "BaseComponent"]) -> None:
-    """Echoes a list of components in a pretty style."""
+def print_table(obj: List[Dict[str, str]]) -> None:
+    """Echoes the list of dicts in a table format. The input object should be a
+    List of Dicts. Each item in that list represent a line in the Table. Each
+    dict should have the same keys. The keys of the dict will be used as
+    headers of the resulting table.
+
+    Args:
+      obj: An List containing dictionaries.
+    """
+    click.echo(tabulate(obj, headers="keys"))
+
+
+def format_component_list(
+    component_list: Mapping[str, "BaseComponent"]
+) -> List[Dict[str, str]]:
+    """Formats a list of components into a List of Dicts. This list of dicts
+    can then be printed in a table style using cli_utils.print_table.
+
+    Args:
+      component_list: The component_list is a mapping of component key to
+                      component class with its relevant attributes
+    Returns:
+        list_of_dicts: A list of all components with each component as a dict
+    """
     list_of_dicts = []
     for key, c in component_list.items():
         # TODO [ENG-143]: This will break if component has element called `key`
         data = {"key": key}
         data.update(c.dict(exclude={"_superfluous_options"}))
         list_of_dicts.append(data)
-    click.echo(tabulate(list_of_dicts, headers="keys"))
+    return list_of_dicts
 
 
 def format_date(


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Fixing inconsistent formatting in CLI command for integration list. Split up echo_component list into format_component_list and print_table. This will make it easier to reuse print_tables for non component lists and/or to replace the backend for our cli outputs.