### PR TITLE
CLI active component highlighting

### DIFF
--- a/src/zenml/cli/artifact.py
+++ b/src/zenml/cli/artifact.py
@@ -67,10 +67,14 @@ def register_artifact_store(
 @artifact.command("list")
 def list_artifact_stores() -> None:
     """List all available artifact stores from service."""
-    service = Repository().get_service()
+    repo = Repository()
+    service = repo.get_service()
+    active_artifact_store = repo.get_active_stack().artifact_store_name
     cli_utils.title("Artifact Stores:")
     cli_utils.print_table(
-        cli_utils.format_component_list(service.artifact_stores)
+        cli_utils.format_component_list(
+            service.artifact_stores, active_artifact_store
+        )
     )
 
 

--- a/src/zenml/cli/container_registry.py
+++ b/src/zenml/cli/container_registry.py
@@ -62,10 +62,14 @@ def register_container_registry(
 @container_registry.command("list")
 def list_container_registries() -> None:
     """List all available container registries from service."""
-    service = Repository().get_service()
+    repo = Repository()
+    active_container_registry = repo.get_active_stack().container_registry_name
+    service = repo.get_service()
     cli_utils.title("Container registries:")
     cli_utils.print_table(
-        cli_utils.format_component_list(service.container_registries)
+        cli_utils.format_component_list(
+            service.container_registries, active_container_registry
+        )
     )
 
 

--- a/src/zenml/cli/container_registry.py
+++ b/src/zenml/cli/container_registry.py
@@ -63,7 +63,9 @@ def register_container_registry(
 def list_container_registries() -> None:
     """List all available container registries from service."""
     repo = Repository()
-    active_container_registry = repo.get_active_stack().container_registry_name
+    active_container_registry = str(
+        repo.get_active_stack().container_registry_name
+    )
     service = repo.get_service()
     cli_utils.title("Container registries:")
     cli_utils.print_table(

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -106,7 +106,7 @@ def list() -> None:
             {
                 "Integration": name,
                 "Required Packages": integration_impl.REQUIREMENTS,
-                "Installed": is_installed,
+                "Installed": "*" if is_installed else "",
             }
         )
     print_table(table_rows)

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -102,11 +102,12 @@ def list() -> None:
     table_rows = []
     for name, integration_impl in integration_registry.integrations.items():
         is_installed = integration_impl.check_installation()
+        # TODO [MEDIUM]: Make the installed column right-aligned once we add rich or some other similar dependency
         table_rows.append(
             {
-                "Integration": name,
-                "Required Packages": integration_impl.REQUIREMENTS,
-                "Installed": "*" if is_installed else "",
+                "INSTALLED": "*" if is_installed else "",
+                "INTEGRATION": name,
+                "REQUIRED_PACKAGES": integration_impl.REQUIREMENTS,
             }
         )
     print_table(table_rows)

--- a/src/zenml/cli/metadata.py
+++ b/src/zenml/cli/metadata.py
@@ -72,10 +72,15 @@ def register_metadata_store(
 @metadata.command("list")
 def list_metadata_stores() -> None:
     """List all available metadata stores from service."""
-    service = Repository().get_service()
+    repo = Repository()
+    service = repo.get_service()
+    active_metadata_store = repo.get_active_stack().metadata_store_name
+
     cli_utils.title("Metadata Stores:")
     cli_utils.print_table(
-        cli_utils.format_component_list(service.metadata_stores)
+        cli_utils.format_component_list(
+            service.metadata_stores, active_metadata_store
+        )
     )
 
 

--- a/src/zenml/cli/orchestrator.py
+++ b/src/zenml/cli/orchestrator.py
@@ -99,8 +99,9 @@ def register_orchestrator(
 @orchestrator.command("list")
 def list_orchestrators() -> None:
     """List all available orchestrators from service."""
-    service = Repository().get_service()
-    active_orchestrator = Repository().get_active_stack().orchestrator_name
+    repo = Repository()
+    service = repo.get_service()
+    active_orchestrator = repo.get_active_stack().orchestrator_name
     cli_utils.title("Orchestrators:")
     cli_utils.print_table(
         cli_utils.format_component_list(

--- a/src/zenml/cli/orchestrator.py
+++ b/src/zenml/cli/orchestrator.py
@@ -100,9 +100,12 @@ def register_orchestrator(
 def list_orchestrators() -> None:
     """List all available orchestrators from service."""
     service = Repository().get_service()
+    active_orchestrator = Repository().get_active_stack().orchestrator_name
     cli_utils.title("Orchestrators:")
     cli_utils.print_table(
-        cli_utils.format_component_list(service.orchestrators)
+        cli_utils.format_component_list(
+            service.orchestrators, active_orchestrator
+        )
     )
 
 

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -62,8 +62,10 @@ def list_stacks() -> None:
     cli_utils.title("Stacks:")
     # TODO [ENG-144]: once there is a common superclass for Stack/ArtifactStore etc.,
     #  remove the mypy ignore
+    repo = Repository()
+    active_stack = repo.get_active_stack_key()
     cli_utils.print_table(
-        cli_utils.format_component_list(service.stacks)  # type: ignore[arg-type]
+        cli_utils.format_component_list(service.stacks, active_stack)  # type: ignore[arg-type]
     )
 
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -127,14 +127,14 @@ def print_table(obj: List[Dict[str, Any]]) -> None:
 
 
 def format_component_list(
-    component_list: Mapping[str, "BaseComponent"]
+    component_list: Mapping[str, "BaseComponent"], active_component: str
 ) -> List[Dict[str, str]]:
     """Formats a list of components into a List of Dicts. This list of dicts
     can then be printed in a table style using cli_utils.print_table.
 
     Args:
-      component_list: The component_list is a mapping of component key to
-                      component class with its relevant attributes
+        component_list: The component_list is a mapping of component key to component class with its relevant attributes
+        active_component: The component that is currently active
     Returns:
         list_of_dicts: A list of all components with each component as a dict
     """
@@ -146,6 +146,7 @@ def format_component_list(
             "component_name" if k == "name" else k: v
             for k, v in c.dict(exclude={"_superfluous_options"}).items()
         }
+        component_dict["active"] = "*" if key == active_component else ""
 
         data = {"name": key}
         data.update(component_dict)

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -143,12 +143,11 @@ def format_component_list(
         # Make sure that the `name` key is not taken in the component dict
         # In case `name` exists, it is replaced inplace with `component_name`
         component_dict = {
-            "component_name" if k == "name" else k: v
+            "COMPONENT_NAME" if k == "name" else k.upper(): v
             for k, v in c.dict(exclude={"_superfluous_options"}).items()
         }
-        component_dict["active"] = "*" if key == active_component else ""
 
-        data = {"name": key}
+        data = {"ACTIVE": "*" if key == active_component else "", "NAME": key}
         data.update(component_dict)
         list_of_dicts.append(data)
     return list_of_dicts


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Active component is always referenced for the following commands:

- `artifact list`
- `container-registry list`
- `metadata list`
- `orchestrator list`
- `stack list`

I updated how `integration list` displays whether a component is installed or not, too.

One caveat is that the order for `orchestrator list` comes out a bit weird and I'm not quite sure why. `active` is not the final column. It's followed by `custom_docker_base_image_name` and `kubernetes_context`.