### PR TITLE
Add `stack up` failure prompts

### DIFF
--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -167,11 +167,7 @@ def up_stack() -> None:
         f"Bootstrapping resources for orchestrator: `{orchestrator_name}`. "
         f"This might take a few seconds..."
     )
-    try:
-        active_stack.orchestrator.up()
-    except Exception as e:
-        cli_utils.error(f"Failed to bootstrap resources: {e}")
-        return
+    active_stack.orchestrator.up()
     cli_utils.declare(f"Orchestrator: `{orchestrator_name}` is up.")
 
 

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -168,7 +168,6 @@ def up_stack() -> None:
         f"This might take a few seconds..."
     )
     active_stack.orchestrator.up()
-    cli_utils.declare(f"Orchestrator: `{orchestrator_name}` is up.")
 
 
 @stack.command("down")

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -167,7 +167,11 @@ def up_stack() -> None:
         f"Bootstrapping resources for orchestrator: `{orchestrator_name}`. "
         f"This might take a few seconds..."
     )
-    active_stack.orchestrator.up()
+    try:
+        active_stack.orchestrator.up()
+    except Exception as e:
+        cli_utils.error(f"Failed to bootstrap resources: {e}")
+        return
     cli_utils.declare(f"Orchestrator: `{orchestrator_name}` is up.")
 
 

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -221,12 +221,12 @@ class AirflowOrchestrator(BaseOrchestrator):
             self._log_webserver_credentials()
         except Exception as e:
             self.down()
+            logger.error(e)
             logger.error(
                 "An error occurred while starting the Airflow daemon."
                 "If you want to start it manually, use the commands described "
                 "in the official Airflow quickstart guide for running Airflow locally."
             )
-            raise e
 
     def down(self) -> None:
         """Stops the airflow daemon if necessary and tears down resources."""

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -220,13 +220,13 @@ class AirflowOrchestrator(BaseOrchestrator):
                 time.sleep(0.1)
             self._log_webserver_credentials()
         except Exception as e:
-            self.down()
             logger.error(e)
             logger.error(
-                "An error occurred while starting the Airflow daemon."
+                "An error occurred while starting the Airflow daemon. "
                 "If you want to start it manually, use the commands described "
                 "in the official Airflow quickstart guide for running Airflow locally."
             )
+            self.down()
 
     def down(self) -> None:
         """Stops the airflow daemon if necessary and tears down resources."""

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -220,6 +220,7 @@ class AirflowOrchestrator(BaseOrchestrator):
                 time.sleep(0.1)
             self._log_webserver_credentials()
         except Exception as e:
+            self.down()
             logger.error(
                 "An error occurred while starting the Airflow daemon."
                 "If you want to start it manually, use the commands described "

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -220,7 +220,11 @@ class AirflowOrchestrator(BaseOrchestrator):
                 time.sleep(0.1)
             self._log_webserver_credentials()
         except Exception as e:
-            logger.error("An error occurred while starting the Airflow daemon.")
+            logger.error(
+                "An error occurred while starting the Airflow daemon."
+                "If you want to start it manually, use the commands described "
+                "in the official Airflow quickstart guide for running Airflow locally."
+            )
             raise e
 
     def down(self) -> None:

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -205,21 +205,23 @@ class AirflowOrchestrator(BaseOrchestrator):
 
         from airflow.cli.commands.standalone_command import StandaloneCommand
 
-        command = StandaloneCommand()
-        # Run the daemon with a working directory inside the current
-        # zenml repo so the same repo will be used to run the DAGs
-        daemon.run_as_daemon(
-            command.run,
-            pid_file=self.pid_file,
-            log_file=self.log_file,
-            working_directory=zenml.io.utils.get_zenml_dir(),
-        )
-
-        while not self.is_running:
-            # Wait until the daemon started all the relevant airflow processes
-            time.sleep(0.1)
-
-        self._log_webserver_credentials()
+        try:
+            command = StandaloneCommand()
+            # Run the daemon with a working directory inside the current
+            # zenml repo so the same repo will be used to run the DAGs
+            daemon.run_as_daemon(
+                command.run,
+                pid_file=self.pid_file,
+                log_file=self.log_file,
+                working_directory=zenml.io.utils.get_zenml_dir(),
+            )
+            while not self.is_running:
+                # Wait until the daemon started all the relevant airflow processes
+                time.sleep(0.1)
+            self._log_webserver_credentials()
+        except Exception as e:
+            logger.error("An error occurred while starting the Airflow daemon.")
+            raise e
 
     def down(self) -> None:
         """Stops the airflow daemon if necessary and tears down resources."""

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -250,26 +250,20 @@ class KubeflowOrchestrator(BaseOrchestrator):
     ) -> None:
         """Logs manual steps needed to setup the Kubeflow local orchestrator."""
         global_config_dir_path = zenml.io.utils.get_global_config_directory()
+        kubeflow_commands = [
+            f"> k3d cluster create CLUSTER_NAME --registry-create {container_registry_name} --registry-config {container_registry_path} --volume {global_config_dir_path}:{global_config_dir_path}\n",
+            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}",
+            "> kubectl --context CLUSTER_NAME wait --timeout=60s --for condition=established crd/applications.app.k8s.io",
+            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}",
+            f"> kubectl --namespace kubeflow port-forward svc/ml-pipeline-ui {self.kubeflow_pipelines_ui_port}:80",
+        ]
+
         logger.error("Unable to spin up local Kubeflow Pipelines deployment.")
         logger.info(
             "If you wish to spin up this Kubeflow local orchestrator manually, "
             "please enter the following commands (substituting where appropriate):\n"
         )
-        logger.info(
-            f"k3d cluster create CLUSTER_NAME --registry-create {container_registry_name} --registry-config {container_registry_path} --volume {global_config_dir_path}:{global_config_dir_path}"
-        )
-        logger.info(
-            f"kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}"
-        )
-        logger.info(
-            "kubectl --context CLUSTER_NAME wait --timeout=60s --for condition=established crd/applications.app.k8s.io"
-        )
-        logger.info(
-            f"kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}"
-        )
-        logger.info(
-            f"kubectl --namespace kubeflow port-forward svc/ml-pipeline-ui {self.kubeflow_pipelines_ui_port}:80"
-        )
+        logger.info("\n".join(kubeflow_commands))
 
     def up(self) -> None:
         """Spins up a local Kubeflow Pipelines deployment."""
@@ -325,7 +319,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
             logger.info(
                 f"Finished local Kubeflow Pipelines deployment. The UI should now "
                 f"be accessible at "
-                f"http://localhost:{self.kubeflow_pipelines_ui_port}/."
+                f"http://localhost:{self.kubeflow_pipelines_ui_port}/. "
                 f"The orchestrator is now up."
             )
         except Exception as e:

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -30,6 +30,9 @@ from zenml.integrations.kubeflow.orchestrators.kubeflow_dag_runner import (
     KubeflowDagRunner,
     KubeflowDagRunnerConfig,
 )
+from zenml.integrations.kubeflow.orchestrators.local_deployment_utils import (
+    KFP_VERSION,
+)
 from zenml.integrations.utils import get_requirements_for_module
 from zenml.io import fileio
 from zenml.logger import get_logger
@@ -242,6 +245,30 @@ class KubeflowOrchestrator(BaseOrchestrator):
             cluster_name=self._k3d_cluster_name
         )
 
+    def list_manual_setup_steps(self) -> None:
+        """Logs manual steps needed to setup the Kubeflow local orchestrator."""
+        global_config_dir_path = zenml.io.utils.get_global_config_directory()
+        logger.error("Unable to spin up local Kubeflow Pipelines deployment.")
+        logger.info(
+            "If you wish to spin up this Kubeflow local orchestrator manually, "
+            "please enter the following commands (substituting where appropriate):\n"
+        )
+        logger.info(
+            f"k3d cluster create CLUSTER_NAME --registry-create REGISTRY_NAME --registry-config REGISTRY_CONFIG_PATH --volume {global_config_dir_path}:{global_config_dir_path}"
+        )
+        logger.info(
+            f"kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}"
+        )
+        logger.info(
+            "kubectl --context CLUSTER_NAME wait --timeout=60s --for condition=established crd/applications.app.k8s.io"
+        )
+        logger.info(
+            f"kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}"
+        )
+        logger.info(
+            f"kubectl --namespace kubeflow port-forward svc/ml-pipeline-ui {self.kubeflow_pipelines_ui_port}:80"
+        )
+
     def up(self) -> None:
         """Spins up a local Kubeflow Pipelines deployment."""
         if self.is_running:
@@ -268,35 +295,39 @@ class KubeflowOrchestrator(BaseOrchestrator):
             return
 
         logger.info("Spinning up local Kubeflow Pipelines deployment...")
-        fileio.make_dirs(self.root_directory)
-        container_registry_port = int(container_registry.uri.split(":")[-1])
-        container_registry_name = self._get_k3d_registry_name(
-            port=container_registry_port
-        )
-        local_deployment_utils.write_local_registry_yaml(
-            yaml_path=self._k3d_registry_config_path,
-            registry_name=container_registry_name,
-            registry_uri=container_registry.uri,
-        )
-        local_deployment_utils.create_k3d_cluster(
-            cluster_name=self._k3d_cluster_name,
-            registry_name=container_registry_name,
-            registry_config_path=self._k3d_registry_config_path,
-        )
-        kubernetes_context = f"k3d-{self._k3d_cluster_name}"
-        local_deployment_utils.deploy_kubeflow_pipelines(
-            kubernetes_context=kubernetes_context
-        )
-        local_deployment_utils.start_kfp_ui_daemon(
-            pid_file_path=self._pid_file_path,
-            port=self.kubeflow_pipelines_ui_port,
-        )
 
-        logger.info(
-            f"Finished local Kubeflow Pipelines deployment. The UI should now "
-            f"be accessible at "
-            f"http://localhost:{self.kubeflow_pipelines_ui_port}/."
-        )
+        try:
+            fileio.make_dirs(self.root_directory)
+            container_registry_port = int(container_registry.uri.split(":")[-1])
+            container_registry_name = self._get_k3d_registry_name(
+                port=container_registry_port
+            )
+            local_deployment_utils.write_local_registry_yaml(
+                yaml_path=self._k3d_registry_config_path,
+                registry_name=container_registry_name,
+                registry_uri=container_registry.uri,
+            )
+            local_deployment_utils.create_k3d_cluster(
+                cluster_name=self._k3d_cluster_name,
+                registry_name=container_registry_name,
+                registry_config_path=self._k3d_registry_config_path,
+            )
+            kubernetes_context = f"k3d-{self._k3d_cluster_name}"
+            local_deployment_utils.deploy_kubeflow_pipelines(
+                kubernetes_context=kubernetes_context
+            )
+            local_deployment_utils.start_kfp_ui_daemon(
+                pid_file_path=self._pid_file_path,
+                port=self.kubeflow_pipelines_ui_port,
+            )
+            logger.info(
+                f"Finished local Kubeflow Pipelines deployment. The UI should now "
+                f"be accessible at "
+                f"http://localhost:{self.kubeflow_pipelines_ui_port}/."
+                f"The orchestrator is now up."
+            )
+        except Exception:
+            self.list_manual_setup_steps()
 
     def down(self) -> None:
         """Tears down a local Kubeflow Pipelines deployment."""

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -297,18 +297,18 @@ class KubeflowOrchestrator(BaseOrchestrator):
             return
 
         logger.info("Spinning up local Kubeflow Pipelines deployment...")
+        fileio.make_dirs(self.root_directory)
+        container_registry_port = int(container_registry.uri.split(":")[-1])
+        container_registry_name = self._get_k3d_registry_name(
+            port=container_registry_port
+        )
+        local_deployment_utils.write_local_registry_yaml(
+            yaml_path=self._k3d_registry_config_path,
+            registry_name=container_registry_name,
+            registry_uri=container_registry.uri,
+        )
 
         try:
-            fileio.make_dirs(self.root_directory)
-            container_registry_port = int(container_registry.uri.split(":")[-1])
-            container_registry_name = self._get_k3d_registry_name(
-                port=container_registry_port
-            )
-            local_deployment_utils.write_local_registry_yaml(
-                yaml_path=self._k3d_registry_config_path,
-                registry_name=container_registry_name,
-                registry_uri=container_registry.uri,
-            )
             local_deployment_utils.create_k3d_cluster(
                 cluster_name=self._k3d_cluster_name,
                 registry_name=container_registry_name,
@@ -329,15 +329,6 @@ class KubeflowOrchestrator(BaseOrchestrator):
                 f"The orchestrator is now up."
             )
         except Exception as e:
-            container_registry_port = int(container_registry.uri.split(":")[-1])
-            container_registry_name = self._get_k3d_registry_name(
-                port=container_registry_port
-            )
-            local_deployment_utils.write_local_registry_yaml(
-                yaml_path=self._k3d_registry_config_path,
-                registry_name=container_registry_name,
-                registry_uri=container_registry.uri,
-            )
             logger.error(e)
             self.list_manual_setup_steps(
                 container_registry_name, self._k3d_registry_config_path

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -338,11 +338,11 @@ class KubeflowOrchestrator(BaseOrchestrator):
                 registry_name=container_registry_name,
                 registry_uri=container_registry.uri,
             )
+            logger.error(e)
             self.list_manual_setup_steps(
                 container_registry_name, self._k3d_registry_config_path
             )
             self.down()
-            raise e
 
     def down(self) -> None:
         """Tears down a local Kubeflow Pipelines deployment."""

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -326,8 +326,9 @@ class KubeflowOrchestrator(BaseOrchestrator):
                 f"http://localhost:{self.kubeflow_pipelines_ui_port}/."
                 f"The orchestrator is now up."
             )
-        except Exception:
+        except Exception as e:
             self.list_manual_setup_steps()
+            raise e
 
     def down(self) -> None:
         """Tears down a local Kubeflow Pipelines deployment."""


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
- add messages to airflow and kubeflow orchestrators to direct the user when `zenml stack up` or `zenml orchestrator up` fails for both those cases.
- the message prompts them to set up the respective orchestrators manually, following the steps we are attempting to implement for them.