### PR TITLE
Prevent KFP install timeouts during `stack up`

### DIFF
--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -252,9 +252,9 @@ class KubeflowOrchestrator(BaseOrchestrator):
         global_config_dir_path = zenml.io.utils.get_global_config_directory()
         kubeflow_commands = [
             f"> k3d cluster create CLUSTER_NAME --registry-create {container_registry_name} --registry-config {container_registry_path} --volume {global_config_dir_path}:{global_config_dir_path}\n",
-            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref={KFP_VERSION}",
+            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref={KFP_VERSION}&timeout=1m",
             "> kubectl --context CLUSTER_NAME wait --timeout=60s --for condition=established crd/applications.app.k8s.io",
-            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}",
+            f"> kubectl --context CLUSTER_NAME apply -k github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}&timeout=1m",
             f"> kubectl --namespace kubeflow port-forward svc/ml-pipeline-ui {self.kubeflow_pipelines_ui_port}:80",
         ]
 

--- a/src/zenml/integrations/kubeflow/orchestrators/local_deployment_utils.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/local_deployment_utils.py
@@ -133,7 +133,7 @@ def deploy_kubeflow_pipelines(kubernetes_context: str) -> None:
             kubernetes_context,
             "apply",
             "-k",
-            f"github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref={KFP_VERSION}",
+            f"github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref={KFP_VERSION}&timeout=1m",
         ]
     )
     subprocess.check_call(
@@ -155,7 +155,7 @@ def deploy_kubeflow_pipelines(kubernetes_context: str) -> None:
             kubernetes_context,
             "apply",
             "-k",
-            f"github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}",
+            f"github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref={KFP_VERSION}&timeout=1m",
         ]
     )
 


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
The Kubeflow Kustomize repository is quite large, as it consists of
several components. As a consequence, `kubectl apply -f` can sometimes
fail with a timeout while it's git-cloning the files locally. To prevent
that, a custom timeout value of 1 minute is used instead of the
kustomize default value of 27 seconds.

[1] kustomize option to allow configurable git timeouts: https://github.com/kubernetes-sigs/kustomize/pull/3900