### PR TITLE
Run KFP container as local user/group if local

### DIFF
--- a/src/zenml/integrations/kubeflow/container_entrypoint.py
+++ b/src/zenml/integrations/kubeflow/container_entrypoint.py
@@ -156,7 +156,7 @@ def _render_artifact_as_mdstr(single_artifact: artifact.Artifact) -> str:
 def _dump_ui_metadata(
     node: pipeline_pb2.PipelineNode,  # type: ignore[valid-type]
     execution_info: data_types.ExecutionInfo,
-    ui_metadata_path: str = "/mlpipeline-ui-metadata.json",
+    ui_metadata_path: str = "/tmp/mlpipeline-ui-metadata.json",
 ) -> None:
     """Dump KFP UI metadata json file for visualization purpose.
 
@@ -427,7 +427,7 @@ def _parse_command_line_arguments() -> argparse.Namespace:
         "--metadata_ui_path",
         type=str,
         required=False,
-        default="/mlpipeline-ui-metadata.json",
+        default="/tmp/mlpipeline-ui-metadata.json",
     )
     parser.add_argument("--tfx_ir", type=str, required=True)
     parser.add_argument("--node_id", type=str, required=True)

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_component.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_component.py
@@ -22,6 +22,7 @@ Note: This requires Kubeflow Pipelines SDK to be installed.
 """
 import json
 import os.path
+import sys
 from typing import Dict, List, Set
 
 from google.protobuf import json_format
@@ -95,7 +96,7 @@ class KubeflowComponent:
         step_module: str,
         step_function_name: str,
         runtime_parameters: List[data_types.RuntimeParameter],
-        metadata_ui_path: str = "/mlpipeline-ui-metadata.json",
+        metadata_ui_path: str = "/tmp/mlpipeline-ui-metadata.json",
     ):
         """Creates a new Kubeflow-based component.
         This class essentially wraps a dsl.ContainerOp construct in Kubeflow
@@ -144,8 +145,10 @@ class KubeflowComponent:
         metadata_store = repo.get_active_stack().metadata_store
 
         volumes: Dict[str, k8s_client.V1Volume] = {}
+        has_local_repos = False
 
         if isinstance(artifact_store, LocalArtifactStore):
+            has_local_repos = True
             host_path = k8s_client.V1HostPathVolumeSource(
                 path=artifact_store.path, type="Directory"
             )
@@ -159,6 +162,7 @@ class KubeflowComponent:
             )
 
         if isinstance(metadata_store, SQLiteMetadataStore):
+            has_local_repos = True
             metadata_store_dir = os.path.dirname(metadata_store.uri)
             host_path = k8s_client.V1HostPathVolumeSource(
                 path=metadata_store_dir, type="Directory"
@@ -183,6 +187,19 @@ class KubeflowComponent:
             pvolumes=volumes,
         )
 
+        if has_local_repos and sys.platform != "win32":
+            # Run KFP containers in the context of the local UID/GID
+            # to ensure that the artifact and metadata stores can be shared
+            # with the local pipeline runs.
+            self.container_op.container.security_context = (
+                k8s_client.V1SecurityContext(
+                    run_as_user=os.getuid(), run_as_group=os.getgid()
+                )
+            )
+            logger.debug(
+                "Setting security context UID and GID to local user/group "
+                "in kubeflow pipelines container."
+            )
         for op in depends_on:
             self.container_op.after(op)
 

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_dag_runner.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_dag_runner.py
@@ -163,7 +163,7 @@ class KubeflowDagRunnerConfig(pipeline_config.PipelineConfig):
         supported_launcher_classes: Optional[
             List[Type[base_component_launcher.BaseComponentLauncher]]
         ] = None,
-        metadata_ui_path: str = "/mlpipeline-ui-metadata.json",
+        metadata_ui_path: str = "/tmp/mlpipeline-ui-metadata.json",
         **kwargs: Any
     ):
         """Creates a KubeflowDagRunnerConfig object.


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Some files and folders in the local repositories (e.g. database,
.system TFX directories) are shared between different runs of the
same pipeline or of different pipelines. If pipelines are run
in the context of different users, such as when switching between
KFP and the local orchestrators, this can create problems with
permissions.

Running the KFP containers with the same UID/GID as the local
user maintains permissions consistent across orchestrators.