### PR TITLE
Backport/replace localstack png

### DIFF
--- a/docs/book/guides/functional-api/deploy-to-production.md
+++ b/docs/book/guides/functional-api/deploy-to-production.md
@@ -56,7 +56,7 @@ key                   stack_type    metadata_store_name    artifact_store_name  
 local_stack           base          local_metadata_store   local_artifact_store   local_orchestrator
 ```
 
-![Your local stack when you start.](../../.gitbook/assets/localstack.png)
+![Your local stack when you start.](../../assets/localstack.png)
 
 Let's stick with the `local_metadata_store` and a `local_artifact_store` for now and create a stack with a Kubeflow orchestrator and a local container registry
 


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
Currently the docs are pointing at an old version of the localstack image within the .gitbook folder - this backport changes that link to point at the new localstack diagram within the assets folder