### PR TITLE
Make MLflow integration work with kubeflow and scheduled pipelines

### DIFF
--- a/examples/mlflow_tracking/README.md
+++ b/examples/mlflow_tracking/README.md
@@ -15,7 +15,7 @@ will train a classifier using [Tensorflow (Keras)](https://www.tensorflow.org/).
 We will run two experiments with different parameters (epochs and learning rate)
 and log these experiments into a local mlflow backend.
 
-This example is uses an mlflow setup that is based on the local filesystem for
+This example uses an mlflow setup that is based on the local filesystem for
 things like the artifact store. See the [mlflow
 documentation](https://www.mlflow.org/docs/latest/tracking.html#scenario-1-mlflow-on-localhost) 
 for details.

--- a/examples/mlflow_tracking/pipeline.py
+++ b/examples/mlflow_tracking/pipeline.py
@@ -20,7 +20,6 @@ import os
 import tensorflow as tf
 
 from zenml.integrations.mlflow.mlflow_step_decorator import enable_mlflow
-from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
 
 from zenml.pipelines import Schedule, pipeline
 from zenml.steps import BaseStepConfig, Output, step

--- a/examples/mlflow_tracking/pipeline.py
+++ b/examples/mlflow_tracking/pipeline.py
@@ -1,0 +1,122 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+from datetime import datetime
+from datetime import datetime, timedelta
+
+import mlflow
+import numpy as np
+import os
+import tensorflow as tf
+
+from zenml.integrations.mlflow.mlflow_step_decorator import enable_mlflow
+from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
+
+from zenml.pipelines import Schedule, pipeline
+from zenml.steps import BaseStepConfig, Output, step
+
+# Path to a pip requirements file that contains requirements necessary to run
+# the pipeline
+requirements_file = os.path.join(os.path.dirname(__file__), "requirements.txt")
+
+
+class TrainerConfig(BaseStepConfig):
+    """Trainer params"""
+
+    epochs: int = 1
+    lr: float = 0.001
+
+
+@step
+def importer_mnist() -> Output(
+    x_train=np.ndarray, y_train=np.ndarray, x_test=np.ndarray, y_test=np.ndarray
+):
+    """Download the MNIST data store it as an artifact"""
+    (x_train, y_train), (
+        x_test,
+        y_test,
+    ) = tf.keras.datasets.mnist.load_data()
+    return x_train, y_train, x_test, y_test
+
+
+@step
+def normalizer(
+    x_train: np.ndarray, x_test: np.ndarray
+) -> Output(x_train_normed=np.ndarray, x_test_normed=np.ndarray):
+    """Normalize the values for all the images so they are between 0 and 1"""
+    x_train_normed = x_train / 255.0
+    x_test_normed = x_test / 255.0
+    return x_train_normed, x_test_normed
+
+
+# Define the step and enable mlflow - order of decorators is important here
+@enable_mlflow
+@step
+def tf_trainer(
+    config: TrainerConfig,
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+) -> tf.keras.Model:
+    """Train a neural net from scratch to recognize MNIST digits return our
+    model or the learner"""
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            tf.keras.layers.Dense(10),
+        ]
+    )
+
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(config.lr),
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=["accuracy"],
+    )
+
+    mlflow.tensorflow.autolog()
+    model.fit(
+        x_train,
+        y_train,
+        epochs=config.epochs,
+    )
+
+    # write model
+    return model
+
+
+# Define the step and enable mlflow - order of decorators is important here
+@enable_mlflow
+@step
+def tf_evaluator(
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+    model: tf.keras.Model,
+) -> float:
+    """Calculate the loss for the model for each epoch in a graph"""
+
+    _, test_acc = model.evaluate(x_test, y_test, verbose=2)
+    mlflow.log_metric("val_accuracy", test_acc)
+    return test_acc
+
+
+@pipeline(enable_cache=False, requirements_file=requirements_file)
+def mlflow_example_pipeline(
+    importer,
+    normalizer,
+    trainer,
+    evaluator,
+):
+    # Link all the steps artifacts together
+    x_train, y_train, x_test, y_test = importer()
+    x_trained_normed, x_test_normed = normalizer(x_train=x_train, x_test=x_test)
+    model = trainer(x_train=x_trained_normed, y_train=y_train)
+    evaluator(x_test=x_test_normed, y_test=y_test, model=model)

--- a/examples/mlflow_tracking/requirements.txt
+++ b/examples/mlflow_tracking/requirements.txt
@@ -1,0 +1,2 @@
+mlflow>=1.2.0
+tensorflow

--- a/examples/mlflow_tracking/run.py
+++ b/examples/mlflow_tracking/run.py
@@ -14,7 +14,8 @@
 from datetime import datetime
 from datetime import datetime, timedelta
 
-from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
+from zenml.environment import Environment
+from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT
 
 from pipeline import (
     TrainerConfig,
@@ -46,9 +47,10 @@ if __name__ == "__main__":
     )
 
     run_2.run()
+    mlflow_env = Environment()[MLFLOW_ENVIRONMENT]
     print(
         "Now run \n "
-        f"    mlflow ui --backend-store-uri {local_mlflow_backend()}\n"
+        f"    mlflow ui --backend-store-uri {mlflow_env.tracking_uri}\n"
         "To inspect your experiment runs within the mlflow ui.\n"
         "You can find your runs tracked within the `mlflow_example_pipeline`"
         "experiment. Here you'll also be able to compare the two runs.)"

--- a/examples/mlflow_tracking/run_schedule.py
+++ b/examples/mlflow_tracking/run_schedule.py
@@ -14,7 +14,8 @@
 from datetime import datetime
 from datetime import datetime, timedelta
 
-from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
+from zenml.environment import Environment
+from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT
 
 from zenml.pipelines import Schedule
 
@@ -54,9 +55,10 @@ if __name__ == "__main__":
     )
 
     run_2.run(schedule=schedule)
+    mlflow_env = Environment()[MLFLOW_ENVIRONMENT]
     print(
         "Now run \n "
-        f"    mlflow ui --backend-store-uri {local_mlflow_backend()}\n"
+        f"    mlflow ui --backend-store-uri {mlflow_env.tracking_uri}\n"
         "To inspect your experiment runs within the mlflow ui.\n"
         "You can find your runs tracked within the `mlflow_example_pipeline`"
         "experiment. Here you'll also be able to compare the two runs.)"

--- a/examples/mlflow_tracking/run_schedule.py
+++ b/examples/mlflow_tracking/run_schedule.py
@@ -16,6 +16,8 @@ from datetime import datetime, timedelta
 
 from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
 
+from zenml.pipelines import Schedule
+
 from pipeline import (
     TrainerConfig,
     mlflow_example_pipeline,
@@ -27,6 +29,12 @@ from pipeline import (
 
 if __name__ == "__main__":
 
+    schedule=Schedule(
+        start_time=datetime.now(),
+        end_time=datetime.now() + timedelta(minutes=10),
+        interval_second=60,
+    )
+
     # Initialize a pipeline run
     run_1 = mlflow_example_pipeline(
         importer=importer_mnist(),
@@ -35,7 +43,7 @@ if __name__ == "__main__":
         evaluator=tf_evaluator(),
     )
 
-    run_1.run()
+    run_1.run(schedule=schedule)
 
     # Initialize a pipeline run again
     run_2 = mlflow_example_pipeline(
@@ -45,7 +53,7 @@ if __name__ == "__main__":
         evaluator=tf_evaluator(),
     )
 
-    run_2.run()
+    run_2.run(schedule=schedule)
     print(
         "Now run \n "
         f"    mlflow ui --backend-store-uri {local_mlflow_backend()}\n"

--- a/examples/mlflow_tracking/run_schedule.py
+++ b/examples/mlflow_tracking/run_schedule.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from datetime import datetime, timedelta
 
 from zenml.environment import Environment
-from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT
+from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT_NAME
 
 from zenml.pipelines import Schedule
 
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     )
 
     run_2.run(schedule=schedule)
-    mlflow_env = Environment()[MLFLOW_ENVIRONMENT]
+    mlflow_env = Environment()[MLFLOW_ENVIRONMENT_NAME]
     print(
         "Now run \n "
         f"    mlflow ui --backend-store-uri {mlflow_env.tracking_uri}\n"

--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -257,7 +257,7 @@ class EnvironmentComponentMeta(type):
 class BaseEnvironmentComponent(metaclass=EnvironmentComponentMeta):
     """Base Environment component class.
 
-    All Environment components must inherit this class and provide a unique
+    All Environment components must inherit from this class and provide a unique
     value for the `NAME` attribute.
 
 

--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -24,7 +24,12 @@ logger = get_logger(__name__)
 
 
 class Environment(metaclass=SingletonMetaClass):
-    """Provides environment information."""
+    """Provides environment information.
+
+    Individual environment components can be registered separately to extend
+    the global Environment object with additional information (see
+    `BaseEnvironmentComponent`).
+    """
 
     def __init__(self) -> None:
         """Initializes an Environment instance.
@@ -239,9 +244,9 @@ class BaseEnvironmentComponent(metaclass=EnvironmentComponentMeta):
     All Environment components must inherit this class and provide a unique
     value for the `NAME` attribute.
 
-    Different parts of the core code, integrations and maybe even the user code
-    can independently contribute with information to the global Environment by
-    extending and instantiating this class.
+
+    Different code components can independently contribute with information to
+    the global Environment by extending and instantiating this class:
 
     ```python
     MY_ENV_NAME = "my_env"

--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -13,12 +13,14 @@
 #  permissions and limitations under the License.
 import os
 import platform
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Optional, Tuple, Type, cast
 
 import distro
 
+from zenml.logger import get_logger
 from zenml.utils.singleton import SingletonMetaClass
+
+logger = get_logger(__name__)
 
 
 class Environment(metaclass=SingletonMetaClass):
@@ -31,12 +33,16 @@ class Environment(metaclass=SingletonMetaClass):
         only get called once. All following `Environment()` calls will return
         the previously initialized instance.
         """
-        self.__step_is_running = False
+        self._components: Dict[str, "BaseEnvironmentComponent"] = {}
 
     @property
     def step_is_running(self) -> bool:
         """Returns if a step is currently running."""
-        return self.__step_is_running
+        from zenml.steps import STEP_ENVIRONMENT
+
+        # A step is considered to be running if there is an active step
+        # environment
+        return self.has_component(STEP_ENVIRONMENT)
 
     @staticmethod
     def get_system_info() -> Dict[str, Any]:
@@ -109,44 +115,229 @@ class Environment(metaclass=SingletonMetaClass):
         """If the current python process is running in Paperspace Gradient."""
         return "PAPERSPACE_NOTEBOOK_REPO_ID" in os.environ
 
-    @classmethod
-    @contextmanager
-    def _layer(
-        cls, step_is_running: Optional[bool] = None
-    ) -> Iterator["Environment"]:
-        """Contextmanager to temporarily set attributes on the singleton
-        instance.
+    def register_component(
+        self, name: str, component: "BaseEnvironmentComponent"
+    ) -> "BaseEnvironmentComponent":
+        """Registers an environment component.
 
-        These attributes will only be persisted for the active duration of this
-        contextmanager:
-        ```python
-        env = Environment()
-        print(env.step_is_running)  # False
+        Args:
+            name: the environment component name.
+            component: a BaseEnvironmentComponent instance.
 
-        with Environment._layer(step_is_running=True):
-            print(env.step_is_running)  # True
-
-        print(env.step_is_running)  # False
-        ```
-
-        Calls to this contextmanager can also be nested:
-        ```python
-        with Environment._layer(...):
-            # only attributes from outer context manager are set
-            with Environment._layer(...):
-                # attributes from outer and inner context manager are set
-                # (inner context manager can overwrite values from outer one)
-
-            # only attributes from outer context manager are set
-        ```
+        Returns:
+            The newly registered environment component, or the environment
+            component that was already registered under the given name.
         """
-        instance = cls()
-        old_dict = instance.__dict__.copy()
+        if name not in self._components:
+            self._components[name] = component
+            logger.debug(f"Registered environment component {name}")
+            return component
+        else:
+            logger.warning(
+                f"Ignoring attempt to overwrite an existing Environment "
+                f"component registered under the name {name}."
+            )
+            return self._components[name]
 
-        if step_is_running is not None:
-            instance.__step_is_running = step_is_running
+    def deregister_component(self, name: str) -> None:
+        """Deregisters an environment component.
 
-        try:
-            yield instance
-        finally:
-            instance.__dict__ = old_dict
+        Args:
+            name: the environment component name.
+        """
+        if name in self._components:
+            del self._components[name]
+            logger.debug(f"Deregistered environment component {name}")
+
+        else:
+            logger.warning(
+                f"Ignoring attempt to deregister an inexistent Environment "
+                f"component with the name {name}."
+            )
+
+    def get_component(self, name: str) -> Optional["BaseEnvironmentComponent"]:
+        """Get the environment component with a known name.
+
+        Args:
+            name: the environment component name.
+
+        Returns:
+            The environment component that is registered under the given name,
+            or None if no such component is registered.
+        """
+        return self._components.get(name)
+
+    def get_components(
+        self,
+    ) -> Dict[str, "BaseEnvironmentComponent"]:
+        """Get all registered environment components."""
+        return self._components.copy()
+
+    def has_component(self, name: str) -> bool:
+        """Check if the environment component with a known name is currently
+        available.
+
+        Args:
+            name: the environment component name.
+
+        Returns:
+            `True` if an environment component with the given name is
+            currently registered for the given name, `False` otherwise.
+
+        """
+        return name in self._components
+
+    def __getitem__(self, name: str) -> "BaseEnvironmentComponent":
+        """Get the environment component with the given name.
+
+        Args:
+            name: the environment component name.
+
+        Returns:
+            `BaseEnvironmentComponent` instance that was registered for the
+            given name.
+
+        Raises:
+            KeyError: if no environment component is registered for the given
+            name.
+        """
+        if name in self._components:
+            return self._components[name]
+        else:
+            raise KeyError(
+                f"No environment component with name {name} is currently "
+                f"registered. Make sure you're calling this in the context of a "
+                f"step function that has all relevant integrations enabled."
+            )
+
+
+_BASE_ENVIRONMENT_COMPONENT_NAME = "base_environment_component"
+
+
+class EnvironmentComponentMeta(type):
+    """Metaclass responsible for registering different EnvironmentComponent
+    instances in the global Environment"""
+
+    def __new__(
+        mcs, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]
+    ) -> "EnvironmentComponentMeta":
+        """Hook into creation of an BaseEnvironmentComponent class."""
+        cls = cast(
+            Type["BaseEnvironmentComponent"],
+            super().__new__(mcs, name, bases, dct),
+        )
+        if name != "BaseEnvironmentComponent":
+            assert (
+                cls.NAME and cls.NAME != _BASE_ENVIRONMENT_COMPONENT_NAME
+            ), "You should specify a unique NAME when creating an EnvironmentComponent !"
+        return cls
+
+
+class BaseEnvironmentComponent(metaclass=EnvironmentComponentMeta):
+    """Base Environment component class.
+
+    All Environment components must inherit this class and provide a unique
+    value for the `NAME` attribute.
+
+    Different parts of the core code, integrations and maybe even the user code
+    can independently contribute with information to the global Environment by
+    extending and instantiating this class.
+
+    ```python
+    MY_ENV_NAME = "my_env"
+
+    class MyEnvironmentComponent(BaseEnvironmentComponent):
+
+        NAME = MY_ENV_NAME
+
+        def __init__(self, my_env_attr: str) -> None:
+            super().__init__()
+            self._my_env_attr = my_env_attr
+
+        @property
+        def my_env_attr(self) -> str:
+            return self._my_env_attr
+
+    my_env = MyEnvironmentComponent()
+    ```
+
+
+    There are two ways to register and deregister a `BaseEnvironmentComponent`
+    instance with the global Environment:
+
+    1. by explicitly calling its `activate` and `deactivate` methods:
+
+    ```python
+    my_env.activate()
+
+    # ... environment component is active
+    # and registered in the global Environment
+
+    my_env.deactivate()
+
+    # ... environment component is not active
+    ```
+
+    2. by using the instance as a context:
+
+    ```python
+    with my_env:
+        # ... environment component is active
+        # and registered in the global Environment
+
+    # ... environment component is not active
+    ```
+
+    While active, environment components can be discovered and accessed from
+    the global environment:
+
+    ```python
+    from foo.bar.my_env import MY_ENV_NAME
+    from zenml.environment import Environment
+
+    my_env = Environment.get_component(MY_ENV_NAME)
+
+    # this works too, but throws an error if the component is not active:
+
+    my_env = Environment[MY_ENV_NAME]
+    ```
+
+    Attributes:
+        NAME: a unique name for this component. This name will be used to
+            register this component in the global Environment and to
+            subsequently retrieve it by calling `Environment().get_component`.
+    """
+
+    NAME: str = _BASE_ENVIRONMENT_COMPONENT_NAME
+
+    def __init__(self) -> None:
+        """Initialize an environment component."""
+        self._active = False
+
+    def activate(self) -> None:
+        if self._active:
+            raise RuntimeError(
+                f"Environment component {self.NAME} is already active."
+            )
+        Environment().register_component(self.NAME, self)
+        self._active = True
+
+    def deactivate(self) -> None:
+        if not self._active:
+            raise RuntimeError(
+                f"Environment component {self.NAME} is not active."
+            )
+        Environment().deregister_component(self.NAME)
+
+    def __enter__(self) -> "BaseEnvironmentComponent":
+        """Environment component context entry point.
+
+        Returns:
+            The BaseEnvironmentComponent instance.
+        """
+        self.activate()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Environment component context exit point."""
+        self.deactivate()

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -25,5 +25,15 @@ class MlflowIntegration(Integration):
     NAME = MLFLOW
     REQUIREMENTS = ["mlflow>=1.2.0"]
 
+    @staticmethod
+    def activate() -> None:
+        """Activate the MLflow integration."""
+        from zenml.integrations.mlflow.mlflow_environment import (
+            MLFlowEnvironment,
+        )
+
+        # Create and activate the global MLflow environment
+        MLFlowEnvironment().activate()
+
 
 MlflowIntegration.check_installation()

--- a/src/zenml/integrations/mlflow/mlflow_environment.py
+++ b/src/zenml/integrations/mlflow/mlflow_environment.py
@@ -1,0 +1,100 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+import os
+from pathlib import Path
+from typing import Optional
+
+from mlflow import set_tracking_uri  # type: ignore
+
+from zenml.environment import BaseEnvironmentComponent
+from zenml.logger import get_logger
+from zenml.repository import Repository
+
+logger = get_logger(__name__)
+
+MLFLOW_ENVIRONMENT = "mlflow"
+
+
+class MLFlowEnvironment(BaseEnvironmentComponent):
+    """Manages the global MLflow environment in the form of an Environment
+    component. To access it inside your step function or in the post-execution
+    workflow:
+
+    ```python
+    from zenml.environment import Environment
+    from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT
+
+
+    @step
+    def my_step(...)
+        env = Environment[MLFLOW_ENVIRONMENT]
+        do_something_with(env.mlflow_tracking_uri)
+    ```
+
+    """
+
+    NAME = MLFLOW_ENVIRONMENT
+
+    def __init__(self, repo_root: Optional[Path] = None):
+        """Initialize a MLflow environment component.
+
+        Args:
+            root: Optional root directory of the ZenML repository. If no path
+                is given, the default repository location will be used.
+        """
+        super().__init__()
+        # TODO [ENG-316]: Implement a way to get the mlflow token and set
+        #  it as env variable at MLFLOW_TRACKING_TOKEN
+        self._mlflow_tracking_uri = self._local_mlflow_backend(repo_root)
+
+    @staticmethod
+    def _local_mlflow_backend(root: Optional[Path] = None) -> str:
+        """Returns the local mlflow backend inside the zenml artifact
+        repository directory
+
+        Args:
+            root: Optional root directory of the repository. If no path is
+                given, this function tries to find the repository using the
+                environment variable `ZENML_REPOSITORY_PATH` (if set) and
+                recursively searching in the parent directories of the current
+                working directory.
+
+        Returns:
+            The MLflow tracking URI for the local mlflow backend.
+        """
+        repo = Repository(root)
+        artifact_store = repo.active_stack.artifact_store
+        local_mlflow_backend_uri = os.path.join(artifact_store.path, "mlruns")
+        if not os.path.exists(local_mlflow_backend_uri):
+            os.makedirs(local_mlflow_backend_uri)
+            # TODO [medium]: safely access (possibly non-existent) artifact stores
+        return "file:" + local_mlflow_backend_uri
+
+    def activate(self) -> None:
+        """Activate the MLflow environment for the current stack."""
+        logger.debug(
+            "Setting the MLflow tracking uri to %s", self._mlflow_tracking_uri
+        )
+        set_tracking_uri(self._mlflow_tracking_uri)
+        return super().activate()
+
+    def deactivate(self) -> None:
+        logger.debug("Resetting the MLflow tracking uri to local")
+        set_tracking_uri("")
+        return super().deactivate()
+
+    @property
+    def tracking_uri(self) -> str:
+        """Returns the MLflow tracking URI for the current stack."""
+        return self._mlflow_tracking_uri

--- a/src/zenml/integrations/mlflow/mlflow_environment.py
+++ b/src/zenml/integrations/mlflow/mlflow_environment.py
@@ -78,7 +78,7 @@ class MLFlowEnvironment(BaseEnvironmentComponent):
         local_mlflow_backend_uri = os.path.join(artifact_store.path, "mlruns")
         if not os.path.exists(local_mlflow_backend_uri):
             os.makedirs(local_mlflow_backend_uri)
-            # TODO [medium]: safely access (possibly non-existent) artifact stores
+            # TODO [MEDIUM]: safely access (possibly non-existent) artifact stores
         return "file:" + local_mlflow_backend_uri
 
     def activate(self) -> None:

--- a/src/zenml/integrations/mlflow/mlflow_environment.py
+++ b/src/zenml/integrations/mlflow/mlflow_environment.py
@@ -23,7 +23,7 @@ from zenml.repository import Repository
 
 logger = get_logger(__name__)
 
-MLFLOW_ENVIRONMENT = "mlflow"
+MLFLOW_ENVIRONMENT_NAME = "mlflow"
 
 
 class MLFlowEnvironment(BaseEnvironmentComponent):
@@ -33,18 +33,18 @@ class MLFlowEnvironment(BaseEnvironmentComponent):
 
     ```python
     from zenml.environment import Environment
-    from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT
+    from zenml.integrations.mlflow.mlflow_environment import MLFLOW_ENVIRONMENT_NAME
 
 
     @step
     def my_step(...)
-        env = Environment[MLFLOW_ENVIRONMENT]
+        env = Environment[MLFLOW_ENVIRONMENT_NAME]
         do_something_with(env.mlflow_tracking_uri)
     ```
 
     """
 
-    NAME = MLFLOW_ENVIRONMENT
+    NAME = MLFLOW_ENVIRONMENT_NAME
 
     def __init__(self, repo_root: Optional[Path] = None):
         """Initialize a MLflow environment component.
@@ -78,7 +78,7 @@ class MLFlowEnvironment(BaseEnvironmentComponent):
         local_mlflow_backend_uri = os.path.join(artifact_store.path, "mlruns")
         if not os.path.exists(local_mlflow_backend_uri):
             os.makedirs(local_mlflow_backend_uri)
-            # TODO [MEDIUM]: safely access (possibly non-existent) artifact stores
+            # TODO [medium]: safely access (possibly non-existent) artifact stores
         return "file:" + local_mlflow_backend_uri
 
     def activate(self) -> None:

--- a/src/zenml/integrations/mlflow/mlflow_step_decorator.py
+++ b/src/zenml/integrations/mlflow/mlflow_step_decorator.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Optional, Type, TypeVar, Union, cast, overload
 from zenml.environment import Environment
 from zenml.integrations.mlflow.mlflow_utils import get_or_create_mlflow_run
 from zenml.logger import get_logger
-from zenml.steps import STEP_ENVIRONMENT, BaseStep, StepEnvironment
+from zenml.steps import BaseStep
 from zenml.steps.utils import STEP_INNER_FUNC_NAME
 
 logger = get_logger(__name__)
@@ -144,7 +144,7 @@ def mlflow_step_entrypoint(
                 "Setting up MLflow backend before running step entrypoint %s",
                 func.__name__,
             )
-            step_env = cast(StepEnvironment, Environment()[STEP_ENVIRONMENT])
+            step_env = Environment().step_environment
             experiment = experiment_name or step_env.pipeline_name
             with get_or_create_mlflow_run(
                 experiment_name=experiment, run_name=step_env.pipeline_run_id

--- a/src/zenml/integrations/mlflow/mlflow_step_decorator.py
+++ b/src/zenml/integrations/mlflow/mlflow_step_decorator.py
@@ -14,12 +14,10 @@
 import functools
 from typing import Any, Callable, Optional, Type, TypeVar, Union, cast, overload
 
-from zenml.integrations.mlflow.mlflow_utils import (
-    get_or_create_mlflow_run,
-    setup_mlflow,
-)
+from zenml.environment import Environment
+from zenml.integrations.mlflow.mlflow_utils import get_or_create_mlflow_run
 from zenml.logger import get_logger
-from zenml.steps import BaseStep, StepEnvironment
+from zenml.steps import STEP_ENVIRONMENT, BaseStep, StepEnvironment
 from zenml.steps.utils import STEP_INNER_FUNC_NAME
 
 logger = get_logger(__name__)
@@ -146,9 +144,8 @@ def mlflow_step_entrypoint(
                 "Setting up MLflow backend before running step entrypoint %s",
                 func.__name__,
             )
-            step_env = StepEnvironment()  # type: ignore[call-arg]
+            step_env = cast(StepEnvironment, Environment()[STEP_ENVIRONMENT])
             experiment = experiment_name or step_env.pipeline_name
-            setup_mlflow(experiment_name=experiment)
             with get_or_create_mlflow_run(
                 experiment_name=experiment, run_name=step_env.pipeline_run_id
             ):

--- a/src/zenml/integrations/mlflow/mlflow_step_decorator.py
+++ b/src/zenml/integrations/mlflow/mlflow_step_decorator.py
@@ -1,0 +1,159 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+import functools
+from typing import Any, Callable, Optional, Type, TypeVar, Union, cast, overload
+
+from zenml.integrations.mlflow.mlflow_utils import (
+    get_or_create_mlflow_run,
+    setup_mlflow,
+)
+from zenml.logger import get_logger
+from zenml.steps import BaseStep, StepEnvironment
+from zenml.steps.utils import STEP_INNER_FUNC_NAME
+
+logger = get_logger(__name__)
+
+
+# step entrypoint type
+F = TypeVar("F", bound=Callable[..., Any])
+
+# step class type
+S = TypeVar("S", bound=Type[BaseStep])
+
+
+@overload
+def enable_mlflow(
+    _step: S,
+) -> S:
+    """Type annotations for mlflow step decorator in case of no arguments."""
+    ...
+
+
+@overload
+def enable_mlflow(
+    *,
+    experiment_name: Optional[str] = None,
+) -> Callable[[S], S]:
+    """Type annotations for mlflow step decorator in case of arguments."""
+    ...
+
+
+def enable_mlflow(
+    _step: Optional[S] = None,
+    *,
+    experiment_name: Optional[str] = None,
+) -> Union[S, Callable[[S], S]]:
+    """Decorator to enable mlflow for a step function.
+
+    Apply this decorator to a ZenML pipeline step to enable MLflow experiment
+    tracking. The MLflow tracking configuration (tracking URI, experiment name,
+    run name) will be automatically configured before the step code is executed,
+    so the step can simply use the `mlflow` module to log metrics and artifacts,
+    like so:
+
+    ```python
+    @enable_mlflow
+    @step
+    def tf_evaluator(
+        x_test: np.ndarray,
+        y_test: np.ndarray,
+        model: tf.keras.Model,
+    ) -> float:
+        _, test_acc = model.evaluate(x_test, y_test, verbose=2)
+        mlflow.log_metric("val_accuracy", test_acc)
+        return test_acc
+    ```
+
+    All MLflow artifacts and metrics logged from all the steps in a pipeline
+    run are by default grouped under a single experiment named after the
+    pipeline. To log MLflow artifacts and metrics from a step in a separate
+    MLflow experiment, pass a custom `experiment_name` argument value to the
+    decorator.
+
+    Args:
+        _step: The decorated step class.
+        experiment_name: optional mlflow experiment name to use for the step.
+            If not provided, the name of the pipeline in the context of which
+            the step is executed will be used as experiment name.
+
+    Returns:
+        The inner decorator which enhaces the input step class with mlflow
+        tracking functionality
+    """
+
+    def inner_decorator(_step: S) -> S:
+
+        logger.debug(
+            "Applying 'enable_mlflow' decorator to step %s", _step.__name__
+        )
+
+        source_fn = getattr(_step, STEP_INNER_FUNC_NAME)
+        return cast(
+            S,
+            type(  # noqa
+                _step.__name__,
+                (_step,),
+                {
+                    STEP_INNER_FUNC_NAME: staticmethod(
+                        mlflow_step_entrypoint(experiment_name)(source_fn)
+                    ),
+                    "__module__": _step.__module__,
+                },
+            ),
+        )
+
+    if _step is None:
+        return inner_decorator
+    else:
+        return inner_decorator(_step)
+
+
+def mlflow_step_entrypoint(
+    experiment_name: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Decorator for a step entrypoint to enable mlflow.
+
+    Args:
+        experiment_name: optional mlflow experiment name to use for the step.
+            If not provided, the name of the pipeline in the context of which
+            the step is executed will be used as experiment name.
+
+    Returns:
+        the input function enhanced with mlflow profiling functionality
+    """
+
+    def inner_decorator(func: F) -> F:
+
+        logger.debug(
+            "Applying 'mlflow_step_entrypoint' decorator to step entrypoint %s",
+            func.__name__,
+        )
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa
+            logger.debug(
+                "Setting up MLflow backend before running step entrypoint %s",
+                func.__name__,
+            )
+            step_env = StepEnvironment()  # type: ignore[call-arg]
+            experiment = experiment_name or step_env.pipeline_name
+            setup_mlflow(experiment_name=experiment)
+            with get_or_create_mlflow_run(
+                experiment_name=experiment, run_name=step_env.pipeline_run_id
+            ):
+                return func(*args, **kwargs)
+
+        return cast(F, wrapper)
+
+    return inner_decorator

--- a/src/zenml/integrations/mlflow/mlflow_utils.py
+++ b/src/zenml/integrations/mlflow/mlflow_utils.py
@@ -11,72 +11,18 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-import os
-from pathlib import Path
-from typing import Optional
 
 from mlflow import (  # type: ignore
     ActiveRun,
     get_experiment_by_name,
     search_runs,
     set_experiment,
-    set_tracking_uri,
     start_run,
 )
 
-from zenml.integrations.registry import integration_registry
 from zenml.logger import get_logger
-from zenml.repository import Repository
 
 logger = get_logger(__name__)
-
-
-def local_mlflow_backend(root: Optional[Path] = None) -> str:
-    """Returns the local mlflow backend inside the global zenml directory
-
-    Args:
-        root: Optional root directory of the repository. If no path is
-            given, this function tries to find the repository using the
-            environment variable `ZENML_REPOSITORY_PATH` (if set) and
-            recursively searching in the parent directories of the current
-            working directory.
-
-    Returns:
-        The MLflow tracking URI for the local mlflow backend.
-    """
-    repo = Repository(root)
-    integration_registry.activate_integrations()
-    artifact_store = repo.active_stack.artifact_store
-    local_mlflow_backend_uri = os.path.join(artifact_store.path, "mlruns")
-    if not os.path.exists(local_mlflow_backend_uri):
-        os.makedirs(local_mlflow_backend_uri)
-        # TODO [medium]: safely access (possibly non-existent) artifact stores
-    return "file:" + local_mlflow_backend_uri
-
-
-def setup_mlflow(
-    backend_store_uri: Optional[str] = None, experiment_name: str = "default"
-) -> None:
-    """Setup all mlflow related configurations. This includes specifying which
-    mlflow tracking uri should be used and which experiment the tracking
-    will be associated with.
-
-    Args:
-        backend_store_uri: The mlflow backend to log to
-        experiment_name: The experiment name under which all runs will be
-            tracked. If no MLflow experiment with this name exists, onw will be
-            created.
-
-    """
-    # TODO [ENG-316]: Implement a way to get the mlflow token and set
-    #  it as env variable at MLFLOW_TRACKING_TOKEN
-    if not backend_store_uri:
-        backend_store_uri = local_mlflow_backend()
-    logger.debug("Setting the MLflow tracking uri to %s", backend_store_uri)
-    set_tracking_uri(backend_store_uri)
-    # Set which experiment is used within mlflow
-    logger.debug("Setting the MLflow experiment name to %s", experiment_name)
-    set_experiment(experiment_name)
 
 
 def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
@@ -89,9 +35,9 @@ def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
     and different IDs are created.
 
     Args:
-        experiment_name (str): the experiment name for the run. The experiment
-            must already be created in MLflow (e.g. by calling `setup_mlflow`
-            beforehand)
+        experiment_name (str): the experiment name under which this runs will
+            be tracked. If no MLflow experiment with this name exists, one will
+            be created.
         run_name (str): the name of the MLflow run. If a run with this name
             does not exist, one will be created, otherwise the existing run
             will be reused
@@ -99,10 +45,13 @@ def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
     Returns:
         ActiveRun: an active MLflow run object with the specified name
     """
+    # Set which experiment is used within mlflow
+    logger.debug("Setting the MLflow experiment name to %s", experiment_name)
+    set_experiment(experiment_name)
     mlflow_experiment = get_experiment_by_name(experiment_name)
 
-    # TODO [medium]: find a solution to avoid race-conditions while logging
-    #   to MLflow from parallel steps
+    # TODO [medium]: find a solution to avoid race-conditions while creating
+    #   the same MLflow run from parallel steps
     runs = search_runs(
         experiment_ids=[mlflow_experiment.experiment_id],
         filter_string=f'tags.mlflow.runName = "{run_name}"',

--- a/src/zenml/integrations/mlflow/mlflow_utils.py
+++ b/src/zenml/integrations/mlflow/mlflow_utils.py
@@ -12,22 +12,42 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import os
-from typing import Any, Callable, Optional, Type
+from pathlib import Path
+from typing import Optional
 
-import mlflow  # type: ignore
-from mlflow import set_experiment
-from mlflow.tracking import set_tracking_uri  # type: ignore
+from mlflow import (  # type: ignore
+    ActiveRun,
+    get_experiment_by_name,
+    search_runs,
+    set_experiment,
+    set_tracking_uri,
+    start_run,
+)
 
-from zenml.io.utils import get_global_config_directory
-from zenml.pipelines.base_pipeline import BasePipeline
-from zenml.steps import BaseStep
+from zenml.integrations.registry import integration_registry
+from zenml.logger import get_logger
+from zenml.repository import Repository
+
+logger = get_logger(__name__)
 
 
-def local_mlflow_backend() -> str:
-    """Returns the local mlflow backend inside the global zenml directory"""
-    local_mlflow_backend_uri = os.path.join(
-        get_global_config_directory(), "local_stores", "mlruns"
-    )
+def local_mlflow_backend(root: Optional[Path] = None) -> str:
+    """Returns the local mlflow backend inside the global zenml directory
+
+    Args:
+        root: Optional root directory of the repository. If no path is
+            given, this function tries to find the repository using the
+            environment variable `ZENML_REPOSITORY_PATH` (if set) and
+            recursively searching in the parent directories of the current
+            working directory.
+
+    Returns:
+        The MLflow tracking URI for the local mlflow backend.
+    """
+    repo = Repository(root)
+    integration_registry.activate_integrations()
+    artifact_store = repo.active_stack.artifact_store
+    local_mlflow_backend_uri = os.path.join(artifact_store.path, "mlruns")
     if not os.path.exists(local_mlflow_backend_uri):
         os.makedirs(local_mlflow_backend_uri)
         # TODO [medium]: safely access (possibly non-existent) artifact stores
@@ -38,127 +58,61 @@ def setup_mlflow(
     backend_store_uri: Optional[str] = None, experiment_name: str = "default"
 ) -> None:
     """Setup all mlflow related configurations. This includes specifying which
-    mlflow tracking uri should b e used and which experiment the tracking
+    mlflow tracking uri should be used and which experiment the tracking
     will be associated with.
 
     Args:
         backend_store_uri: The mlflow backend to log to
         experiment_name: The experiment name under which all runs will be
-                         tracked
+            tracked. If no MLflow experiment with this name exists, onw will be
+            created.
 
     """
     # TODO [ENG-316]: Implement a way to get the mlflow token and set
     #  it as env variable at MLFLOW_TRACKING_TOKEN
     if not backend_store_uri:
         backend_store_uri = local_mlflow_backend()
-
+    logger.debug("Setting the MLflow tracking uri to %s", backend_store_uri)
     set_tracking_uri(backend_store_uri)
     # Set which experiment is used within mlflow
+    logger.debug("Setting the MLflow experiment name to %s", experiment_name)
     set_experiment(experiment_name)
 
 
-def enable_mlflow_init(
-    original_init: Callable[[BasePipeline, BaseStep, Any], None],
-    experiment: Optional[str] = None,
-) -> Callable[..., None]:
-    """Outer decorator function for extending the __init__ method for pipelines
-    that should be run using mlflow
+def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
+    """Get or create an MLflow ActiveRun object for the given experiment and
+    run name.
+
+    IMPORTANT: this function is not race condition proof. If two or more
+    processes call it at the same time and with the same arguments, it could
+    lead to a situation where two or more MLflow runs with the same name
+    and different IDs are created.
 
     Args:
-        original_init: The __init__ method that should be extended
-        experiment: The users chosen experiment name to use for mlflow
+        experiment_name (str): the experiment name for the run. The experiment
+            must already be created in MLflow (e.g. by calling `setup_mlflow`
+            beforehand)
+        run_name (str): the name of the MLflow run. If a run with this name
+            does not exist, one will be created, otherwise the existing run
+            will be reused
 
     Returns:
-        the inner decorator which extends the __init__ method
+        ActiveRun: an active MLflow run object with the specified name
     """
+    mlflow_experiment = get_experiment_by_name(experiment_name)
 
-    def inner_decorator(
-        self: BasePipeline, *args: BaseStep, **kwargs: Any
-    ) -> None:
-        """Inner decorator overwriting the pipeline __init__
-        Makes sure mlflow is properly set up and all mlflow logging takes place
-        within one mlflow experiment that is associated with the pipeline
-        """
-        original_init(self, *args, **kwargs)
-        setup_mlflow(
-            backend_store_uri=local_mlflow_backend(),
-            experiment_name=experiment if experiment else self.name,
+    # TODO [medium]: find a solution to avoid race-conditions while logging
+    #   to MLflow from parallel steps
+    runs = search_runs(
+        experiment_ids=[mlflow_experiment.experiment_id],
+        filter_string=f'tags.mlflow.runName = "{run_name}"',
+        output_format="list",
+    )
+    if runs:
+        run_id = runs[0].info.run_id
+        return start_run(
+            run_id=run_id, experiment_id=mlflow_experiment.experiment_id
         )
-
-    return inner_decorator
-
-
-def enable_mlflow_run(run: Callable[..., Any]) -> Callable[..., Any]:
-    """Outer decorator function for extending the run method for pipelines
-    that should be run using mlflow
-
-    Args:
-        run: The run method that should be extended
-
-    Returns:
-        the inner decorator which extends the run method
-    """
-
-    def inner_decorator(
-        self: BasePipeline, *, run_name: Optional[str] = None, **kwargs: Any
-    ) -> Any:
-        """Inner decorator used to extend the run method of a pipeline.
-        This ensures each pipeline run is run within a different mlflow context.
-
-        Args:
-            self: self of the original pipeline class
-            run_name: Optional name for the run.
-            **kwargs: Additional kwargs passed to `pipeline.run()`
-        """
-        with mlflow.start_run(run_name=run_name):
-            return run(self, run_name=run_name, **kwargs)
-
-    return inner_decorator
-
-
-def enable_mlflow(
-    _pipeline: Type[BasePipeline], experiment_name: Optional[str] = None
-) -> Type[BasePipeline]:
-    """Outer decorator function for the creation of a ZenML pipeline with mlflow
-    tracking enabled.
-
-    In order for a pipeline to run within the context of mlflow, the mlflow
-    experiment should be associated with the pipeline directly. Each separate
-    pipeline run needs to be associated directly with a mlflow experiment. For
-    this, the __init__ and run methods need to be extended accordingly.
-
-    Args:
-        _pipeline: The decorated pipeline
-        experiment_name: Experiment name to use for mlflow
-
-    Returns:
-        the inner decorator which has a pipeline with the two methods extended
-    """
-
-    def inner_decorator(pipeline: Type[BasePipeline]) -> Type[BasePipeline]:
-        """Inner decorator function for the creation of a ZenML Pipeline with
-        mlflow
-
-        The __init__ and run method are both extended.
-
-        Args:
-          pipeline: BasePipeline which will be extended
-
-        Returns:
-            the class of a newly generated ZenML Pipeline with mlflow
-
-        """
-        # TODO [ENG-369]: Do we need to create a new class here or can we simply
-        #  extend the methods of the original pipeline class?
-        return type(  # noqa
-            pipeline.__name__,
-            (pipeline,),
-            {
-                "__init__": enable_mlflow_init(
-                    pipeline.__init__, experiment_name
-                ),
-                "run": enable_mlflow_run(pipeline.run),
-            },
-        )
-
-    return inner_decorator(_pipeline)
+    return start_run(
+        run_name=run_name, experiment_id=mlflow_experiment.experiment_id
+    )

--- a/src/zenml/integrations/mlflow/mlflow_utils.py
+++ b/src/zenml/integrations/mlflow/mlflow_utils.py
@@ -35,10 +35,10 @@ def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
     and different IDs are created.
 
     Args:
-        experiment_name (str): the experiment name under which this runs will
+        experiment_name: the experiment name under which this runs will
             be tracked. If no MLflow experiment with this name exists, one will
             be created.
-        run_name (str): the name of the MLflow run. If a run with this name
+        run_name: the name of the MLflow run. If a run with this name
             does not exist, one will be created, otherwise the existing run
             will be reused
 
@@ -50,7 +50,7 @@ def get_or_create_mlflow_run(experiment_name: str, run_name: str) -> ActiveRun:
     set_experiment(experiment_name)
     mlflow_experiment = get_experiment_by_name(experiment_name)
 
-    # TODO [medium]: find a solution to avoid race-conditions while creating
+    # TODO [MEDIUM]: find a solution to avoid race-conditions while creating
     #   the same MLflow run from parallel steps
     runs = search_runs(
         experiment_ids=[mlflow_experiment.experiment_id],

--- a/src/zenml/integrations/whylogs/whylogs_step_decorator.py
+++ b/src/zenml/integrations/whylogs/whylogs_step_decorator.py
@@ -69,19 +69,18 @@ def enable_whylogs(
     field that facilitates access to the whylogs dataset profiling API,
     like so:
 
-    .. highlight:: python
-    .. code-block:: python
-
-        @enable_whylogs
-        @step(enable_cache=True)
-        def data_loader(
-            context: StepContext,
-        ) -> Output(data=pd.DataFrame, profile=DatasetProfile,):
-            ...
-            data = pd.DataFrame(...)
-            profile = context.whylogs.profile_dataframe(data, dataset_name="input_data")
-            ...
-            return data, profile
+    ```python
+    @enable_whylogs
+    @step(enable_cache=True)
+    def data_loader(
+        context: StepContext,
+    ) -> Output(data=pd.DataFrame, profile=DatasetProfile,):
+        ...
+        data = pd.DataFrame(...)
+        profile = context.whylogs.profile_dataframe(data, dataset_name="input_data")
+        ...
+        return data, profile
+    ```
 
     Args:
         _step: The decorated step class.

--- a/src/zenml/steps/__init__.py
+++ b/src/zenml/steps/__init__.py
@@ -30,11 +30,11 @@ from zenml.steps.base_step import BaseStep
 from zenml.steps.base_step_config import BaseStepConfig
 from zenml.steps.step_context import StepContext
 from zenml.steps.step_decorator import step
-from zenml.steps.step_environment import STEP_ENVIRONMENT, StepEnvironment
+from zenml.steps.step_environment import STEP_ENVIRONMENT_NAME, StepEnvironment
 from zenml.steps.step_output import Output
 
 __all__ = [
-    "STEP_ENVIRONMENT",
+    "STEP_ENVIRONMENT_NAME",
     "BaseStep",
     "BaseStepConfig",
     "StepContext",

--- a/src/zenml/steps/__init__.py
+++ b/src/zenml/steps/__init__.py
@@ -30,6 +30,14 @@ from zenml.steps.base_step import BaseStep
 from zenml.steps.base_step_config import BaseStepConfig
 from zenml.steps.step_context import StepContext
 from zenml.steps.step_decorator import step
+from zenml.steps.step_environment import StepEnvironment
 from zenml.steps.step_output import Output
 
-__all__ = ["BaseStep", "BaseStepConfig", "StepContext", "step", "Output"]
+__all__ = [
+    "BaseStep",
+    "BaseStepConfig",
+    "StepContext",
+    "step",
+    "Output",
+    "StepEnvironment",
+]

--- a/src/zenml/steps/__init__.py
+++ b/src/zenml/steps/__init__.py
@@ -30,10 +30,11 @@ from zenml.steps.base_step import BaseStep
 from zenml.steps.base_step_config import BaseStepConfig
 from zenml.steps.step_context import StepContext
 from zenml.steps.step_decorator import step
-from zenml.steps.step_environment import StepEnvironment
+from zenml.steps.step_environment import STEP_ENVIRONMENT, StepEnvironment
 from zenml.steps.step_output import Output
 
 __all__ = [
+    "STEP_ENVIRONMENT",
     "BaseStep",
     "BaseStepConfig",
     "StepContext",

--- a/src/zenml/steps/step_environment.py
+++ b/src/zenml/steps/step_environment.py
@@ -12,28 +12,33 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-from typing import Any
+from zenml.environment import BaseEnvironmentComponent
 
-from zenml.utils.singleton import SingletonMetaClass
+STEP_ENVIRONMENT = "step_environment"
 
 
-class StepEnvironment(metaclass=SingletonMetaClass):
+class StepEnvironment(BaseEnvironmentComponent):
     """Provides additional information about a step runtime inside a step
-    function.
+    function in the form of an Environment component.
 
-    This singleton can be used from within a pipeline step implementation to
+    This class can be used from within a pipeline step implementation to
     access additional information about the runtime parameters of a pipeline
-    step inside a step function, such as the pipeline name, pipeine run ID
-    and other pipeline runtime information. To use it, instantiate it and
-    access it inside your step function, like this:
+    step, such as the pipeline name, pipeline run ID and other pipeline runtime
+    information. To use it, access it inside your step function like this:
 
     ```python
+    from zenml.environment import Environment
+    from zenml.steps.import STEP_ENVIRONMENT
+
     @step
     def my_step(...)
-        env = StepEnvironment()
+        env = Environment[STEP_ENVIRONMENT]
         do_something_with(env.pipeline_name, env.pipeline_run_id, env.step_name)
     ```
+
     """
+
+    NAME = STEP_ENVIRONMENT
 
     def __init__(
         self,
@@ -41,34 +46,18 @@ class StepEnvironment(metaclass=SingletonMetaClass):
         pipeline_run_id: str,
         step_name: str,
     ):
-        """Initialize or retrieve the environment of the currently running
+        """Initialize the environment of the currently running
         step.
-
-        NOTE: the StepEnvironment class is a singleton. A single
-        StepEnvironment instance exists at any given time and should only
-        be accessed from within a pipeline step function.
 
         Args:
             pipeline_name: the name of the currently running pipeline
             pipeline_run_id: the ID of the currently running pipeline
             step_name: the name of the currently running step
         """
+        super().__init__()
         self._pipeline_name = pipeline_name
         self._pipeline_run_id = pipeline_run_id
         self._step_name = step_name
-
-    def __enter__(self) -> "StepEnvironment":
-        """Environment context manager entry point.
-
-        Returns:
-            The StepEnvironment instance.
-        """
-        return self
-
-    def __exit__(self, *args: Any) -> None:
-        """Environment context manager exit point."""
-        # Delete the environment singleton instance on context exit
-        StepEnvironment._clear()
 
     @property
     def pipeline_name(self) -> str:

--- a/src/zenml/steps/step_environment.py
+++ b/src/zenml/steps/step_environment.py
@@ -14,7 +14,7 @@
 
 from zenml.environment import BaseEnvironmentComponent
 
-STEP_ENVIRONMENT = "step_environment"
+STEP_ENVIRONMENT_NAME = "step_environment"
 
 
 class StepEnvironment(BaseEnvironmentComponent):
@@ -37,7 +37,7 @@ class StepEnvironment(BaseEnvironmentComponent):
 
     """
 
-    NAME = STEP_ENVIRONMENT
+    NAME = STEP_ENVIRONMENT_NAME
 
     def __init__(
         self,

--- a/src/zenml/steps/step_environment.py
+++ b/src/zenml/steps/step_environment.py
@@ -28,11 +28,10 @@ class StepEnvironment(BaseEnvironmentComponent):
 
     ```python
     from zenml.environment import Environment
-    from zenml.steps.import STEP_ENVIRONMENT
 
     @step
     def my_step(...)
-        env = Environment[STEP_ENVIRONMENT]
+        env = Environment().step_environment
         do_something_with(env.pipeline_name, env.pipeline_run_id, env.step_name)
     ```
 

--- a/src/zenml/steps/step_environment.py
+++ b/src/zenml/steps/step_environment.py
@@ -1,0 +1,86 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from typing import Any
+
+from zenml.utils.singleton import SingletonMetaClass
+
+
+class StepEnvironment(metaclass=SingletonMetaClass):
+    """Provides additional information about a step runtime inside a step
+    function.
+
+    This singleton can be used from within a pipeline step implementation to
+    access additional information about the runtime parameters of a pipeline
+    step inside a step function, such as the pipeline name, pipeine run ID
+    and other pipeline runtime information. To use it, instantiate it and
+    access it inside your step function, like this:
+
+    ```python
+    @step
+    def my_step(...)
+        env = StepEnvironment()
+        do_something_with(env.pipeline_name, env.pipeline_run_id, env.step_name)
+    ```
+    """
+
+    def __init__(
+        self,
+        pipeline_name: str,
+        pipeline_run_id: str,
+        step_name: str,
+    ):
+        """Initialize or retrieve the environment of the currently running
+        step.
+
+        NOTE: the StepEnvironment class is a singleton. A single
+        StepEnvironment instance exists at any given time and should only
+        be accessed from within a pipeline step function.
+
+        Args:
+            pipeline_name: the name of the currently running pipeline
+            pipeline_run_id: the ID of the currently running pipeline
+            step_name: the name of the currently running step
+        """
+        self._pipeline_name = pipeline_name
+        self._pipeline_run_id = pipeline_run_id
+        self._step_name = step_name
+
+    def __enter__(self) -> "StepEnvironment":
+        """Environment context manager entry point.
+
+        Returns:
+            The StepEnvironment instance.
+        """
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Environment context manager exit point."""
+        # Delete the environment singleton instance on context exit
+        StepEnvironment._clear()
+
+    @property
+    def pipeline_name(self) -> str:
+        """The name of the currently running pipeline."""
+        return self._pipeline_name
+
+    @property
+    def pipeline_run_id(self) -> str:
+        """The ID of the current pipeline run."""
+        return self._pipeline_run_id
+
+    @property
+    def step_name(self) -> str:
+        """The name of the currently running step."""
+        return self._step_name

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -53,7 +53,6 @@ from tfx.types.channel import Channel
 from tfx.utils import json_utils
 
 from zenml.artifacts.base_artifact import BaseArtifact
-from zenml.environment import Environment
 from zenml.exceptions import MissingStepParameterError, StepInterfaceError
 from zenml.logger import get_logger
 from zenml.materializers.base_materializer import BaseMaterializer
@@ -410,17 +409,16 @@ class _FunctionExecutor(BaseExecutor):
                     input_dict[arg][0], arg_type
                 )
 
-        # Wrap the execution of the step function in an environment layer
-        # that the step function code can access to retrieve information about
-        # the pipeline runtime, such as the current step name and the current
-        # pipeline run ID
         if self._context is None:
             raise RuntimeError(
                 "No TFX context is set for the currently running pipeline. "
                 "Cannot retrieve pipeline runtime information."
             )
-        with Environment._layer(
-            step_is_running=True,
+        # Wrap the execution of the step function in a step environment
+        # that the step function code can access to retrieve information about
+        # the pipeline runtime, such as the current step name and the current
+        # pipeline run ID
+        with StepEnvironment(
             pipeline_name=self._context.pipeline_info.id,  # type: ignore[attr-defined]
             pipeline_run_id=self._context.pipeline_run_id,
             step_name=getattr(self, PARAM_STEP_NAME),

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -200,9 +200,10 @@ def test_run_mlflow(examples_dir: Path):
     import mlflow
     from mlflow.tracking import MlflowClient
 
-    from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
+    from zenml.integrations.mlflow.mlflow_environment import MLFlowEnvironment
 
-    mlflow.set_tracking_uri(local_mlflow_backend(local_example.path))
+    # Create and activate the global MLflow environment
+    MLFlowEnvironment(local_example.path).activate()
 
     # fetch the MLflow experiment created for the pipeline runs
     mlflow_experiment = mlflow.get_experiment_by_name(pipeline.name)

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -197,10 +197,49 @@ def test_run_mlflow(examples_dir: Path):
     for step in second_run.steps:
         assert step.status == ExecutionStatus.COMPLETED
 
-    # TODO [ENG-359]: Add some mlflow specific assertions.
-    #  Currently this is a bit difficult as the mlruns do not end up in the
-    #  expected location within the temporary fixtures. This needs to be
-    #  investigated
+    import mlflow
+    from mlflow.tracking import MlflowClient
+
+    from zenml.integrations.mlflow.mlflow_utils import local_mlflow_backend
+
+    mlflow.set_tracking_uri(local_mlflow_backend(local_example.path))
+
+    # fetch the MLflow experiment created for the pipeline runs
+    mlflow_experiment = mlflow.get_experiment_by_name(pipeline.name)
+    assert mlflow_experiment is not None
+
+    # fetch all MLflow runs created for the pipeline
+    mlflow_runs = mlflow.search_runs(
+        experiment_ids=[mlflow_experiment.experiment_id], output_format="list"
+    )
+    assert len(mlflow_runs) == 2
+
+    # fetch the MLflow run created for the first pipeline run
+    mlflow_runs = mlflow.search_runs(
+        experiment_ids=[mlflow_experiment.experiment_id],
+        filter_string=f'tags.mlflow.runName = "{first_run.name}"',
+        output_format="list",
+    )
+    assert len(mlflow_runs) == 1
+    first_mlflow_run = mlflow_runs[0]
+
+    # fetch the MLflow run created for the second pipeline run
+    mlflow_runs = mlflow.search_runs(
+        experiment_ids=[mlflow_experiment.experiment_id],
+        filter_string=f'tags.mlflow.runName = "{second_run.name}"',
+        output_format="list",
+    )
+    assert len(mlflow_runs) == 1
+    second_mlflow_run = mlflow_runs[0]
+
+    client = MlflowClient()
+    # fetch the MLflow artifacts logged during the first pipeline run
+    artifacts = client.list_artifacts(first_mlflow_run.info.run_id)
+    assert len(artifacts) == 3
+
+    # fetch the MLflow artifacts logged during the second pipeline run
+    artifacts = client.list_artifacts(second_mlflow_run.info.run_id)
+    assert len(artifacts) == 3
 
 
 def test_whylogs_profiling(examples_dir: Path):

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -65,11 +65,16 @@ def test_environment_component_activation():
     with pytest.raises(KeyError):
         Environment()["foo"]
 
-    with Foo() as f:
+    f = Foo()
+    assert f.active is False
+
+    with f:
+        assert f.active is True
         assert Environment().get_component("foo") is f
         assert Environment().has_component("foo")
         assert Environment()["foo"] is f
 
+    assert f.active is False
     assert Environment().get_component("foo") is None
     assert not Environment().has_component("foo")
     with pytest.raises(KeyError):


### PR DESCRIPTION
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Describe changes
This re-factoring of the MLflow integration is required to make it also function properly in the context of remotely executed pipelines (e.g. kubeflow).

* instead of a pipeline decorator, `enable_mlflow` is now a step decorator, while retaining all of its previous functionality. This is also the only breaking change introduced in this PR. This change was required because the modification made by pipeline decorators to user defined pipelines are not reflected in the compiled pipeline that is executed remotely.
* a StepEnvironment global singleton/context is used to store runtime environment information for the current step that can be consumed from within the step function implementation. The same singleton is used by the MLflow step decorator to determine the current pipeline run ID and pipeline name used in creating the MLflow experiment and run contexts.
* a scheduled pipeline run example is now available for the MLflow integration, in addition to the regular run