### PR TITLE
Fix typo in mysql password parameter

### DIFF
--- a/docs/book/features/cloud-pipelines/cloud-pipelines.md
+++ b/docs/book/features/cloud-pipelines/cloud-pipelines.md
@@ -69,7 +69,7 @@ zenml metadata-store register METADATA_STORE_NAME --type=mysql \
     --host=127.0.0.1 \ 
     --port=3306 \
     --username=USER \
-    --passwd=PASSWD \
+    --password=PASSWD \
     --database=DATABASE
 ```
 


### PR DESCRIPTION
## Describe changes
I fixed the naming of the password parameter in the docs.

## Pre-requisites
Please ensure you have done the following:
- [x ] I have read the **CONTRIBUTING.md** document.
- [x ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Other (add details above)

