### PR TITLE
Added --use-virtualenvs option to allow choosing envs to run

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -26,15 +26,6 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Load cached poetry.lock
-      id: cached-poetry-lock
-      if: ${{ matrix.python-version == '3.6' && matrix.os == 'windows-latest' }}
-      uses: actions/cache@v2.1.6
-      with:
-        path: poetry.lock
-        # Cache the poetry lock for a given os, python version, pyproject.toml
-        key: lock-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-
     - name: Load cached venv
       id: cached-poetry-dependencies
       if: steps.cached-poetry-lock.outputs.cache-hit != 'true'

--- a/.github/workflows/kubeflow.yml
+++ b/.github/workflows/kubeflow.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Run tests
         run: |
           source $VENV
-          pytest tests/integration/test_examples.py -s --on-kubeflow
+          pytest tests/integration/test_examples.py -s --on-kubeflow --use-virtualenv

--- a/scripts/test-coverage-xml.sh
+++ b/scripts/test-coverage-xml.sh
@@ -17,7 +17,7 @@ if [ -n "$1" ]; then
     coverage run -m pytest $TEST_SRC --color=yes
 else
     coverage run -m pytest tests/unit --color=yes
-    coverage run -m pytest tests/integration --color=yes
+    coverage run -m pytest tests/integration  --use-virtualenv --color=yes
 fi
 coverage combine
 coverage report --show-missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,7 @@ def generate_empty_steps():
         output = []
 
         for i in range(count):
+
             @step(name=f"step_{i}")
             def _step_function():
                 pass
@@ -234,8 +235,7 @@ def step_context_with_two_outputs():
 
 @pytest.fixture
 def virtualenv(
-    request: pytest.FixtureRequest,
-    tmp_path_factory: pytest.TempPathFactory
+    request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory
 ) -> str:
     """Based on the underlying virtual environment a copy of the environment is
     made and used for the test that uses this fixture.
@@ -262,7 +262,8 @@ def virtualenv(
         #  If this happens outside of a virtual environment the complete
         #  /usr space is cloned
         clone_virtualenv(
-            src_dir=str(orig_sys_executable.parent.parent), dst_dir=str(tmp_path)
+            src_dir=str(orig_sys_executable.parent.parent),
+            dst_dir=str(tmp_path),
         )
 
         env_bin_dir = "bin"
@@ -280,7 +281,9 @@ def virtualenv(
                 "tests"
             )
 
-        execfile(str(activate_this_file), dict(__file__=str(activate_this_file)))
+        execfile(
+            str(activate_this_file), dict(__file__=str(activate_this_file))
+        )
 
         # Set new system executable
         sys.executable = tmp_path / env_bin_dir / "python"
@@ -302,7 +305,7 @@ def virtualenv(
         execfile(str(activate_this_f), dict(__file__=str(activate_this_f)))
 
     else:
-        yield ''
+        yield ""
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,10 +73,10 @@ def base_repo(tmp_path_factory, session_mocker):
 
 @pytest.fixture
 def clean_repo(
-        request: pytest.FixtureRequest,
-        tmp_path_factory: pytest.TempPathFactory,
-        mocker: pytest_mock.MockerFixture,
-        base_repo: Repository,
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+    mocker: pytest_mock.MockerFixture,
+    base_repo: Repository,
 ) -> Repository:
     """Fixture to get a clean repository for an individual test.
 
@@ -234,8 +234,8 @@ def step_context_with_two_outputs():
 
 @pytest.fixture
 def virtualenv(
-        request: pytest.FixtureRequest,
-        tmp_path_factory: pytest.TempPathFactory
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory
 ) -> str:
     """Based on the underlying virtual environment a copy of the environment is
     made and used for the test that uses this fixture.
@@ -249,9 +249,7 @@ def virtualenv(
     Yields:
         Path to the virtual environment
     """
-    if request.config.getoption("no_virtualenv"):
-        yield ''
-    else:
+    if request.config.getoption("use_virtualenv"):
         # Remember the old executable
         orig_sys_executable = Path(sys.executable)
 
@@ -303,6 +301,9 @@ def virtualenv(
             )
         execfile(str(activate_this_f), dict(__file__=str(activate_this_f)))
 
+    else:
+        yield ''
+
 
 def pytest_addoption(parser):
     """Fixture that gets called by pytest ahead of tests. Adds cli option to
@@ -320,10 +321,10 @@ def pytest_addoption(parser):
         help="Only run Kubeflow",
     )
     parser.addoption(
-        "--no-virtualenv",
+        "--use-virtualenv",
         action="store_true",
         default=False,
-        help="Run Integration tests in base env",
+        help="Run Integration tests in cloned env",
     )
 
 

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -144,7 +144,7 @@ def test_run_example(
     example_configuration: ExampleIntegrationTestConfiguration,
     repo_fixture_name: str,
     request: pytest.FixtureRequest,
-    virtualenv,
+    virtualenv: str,
 ) -> None:
     """Runs the given examples and validates they ran correctly.
 
@@ -155,6 +155,8 @@ def test_run_example(
             active stack of the repository given by the fixture.
         request: Pytest fixture needed to run the fixture given in the
             `repo_fixture_name` argument
+        virtualenv: Either a separate cloned environment for each test, or an
+                    empty string.
     """
     # run the fixture given by repo_fixture_name
     repo = request.getfixturevalue(repo_fixture_name)


### PR DESCRIPTION
## Describe changes
With this you should be able to run integration tests locally without separate virtualenvs for each test. This is necessary in case you installed your virtualenvironment with venv or pyenv. 

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

