### PR TITLE
Implementing the `explain` subcommand

### DIFF
--- a/src/zenml/artifact_stores/__init__.py
+++ b/src/zenml/artifact_stores/__init__.py
@@ -12,17 +12,20 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """
-An artifact store is a place where artifacts are stored. These artifacts may
-have been produced by the pipeline steps, or they may be the data first ingested
-into a pipeline via an ingestion step.
+## Artifact Stores
 
-Definitions of the ``BaseArtifactStore`` class and the ``LocalArtifactStore``
-that builds on it are in this module.
+In `ZenML`, the inputs and outputs which go through any step is treated as an
+artifact and as its name suggests, an `ArtifactStore` is a place where these
+artifacts get stored.
 
-Other artifact stores corresponding to specific integrations are to be found in
-the ``integrations`` module. For example, the ``GCPArtifactStore``, used when
-running ZenML on Google Cloud Platform, is defined in
-``integrations.gcp.artifact_stores``.
+Out of the box, `ZenML` comes with the `BaseArtifactStore` and
+`LocalArtifactStore` implementations. While the `BaseArtifactStore` establishes
+an interface for people who want to extend it to their needs, the
+`LocalArtifactStore` is a simple implementation for a local setup.
+
+Moreover, additional artifact stores can be found in specific `integrations`
+modules, such as the `GCPArtifactStore` in the `gcp` integration and the
+`AzureArtifactStore` in the `azure` integration.
 """
 
 from zenml.artifact_stores.base_artifact_store import BaseArtifactStore

--- a/src/zenml/artifact_stores/__init__.py
+++ b/src/zenml/artifact_stores/__init__.py
@@ -14,11 +14,11 @@
 """
 ## Artifact Stores
 
-In `ZenML`, the inputs and outputs which go through any step is treated as an
+In ZenML, the inputs and outputs which go through any step is treated as an
 artifact and as its name suggests, an `ArtifactStore` is a place where these
 artifacts get stored.
 
-Out of the box, `ZenML` comes with the `BaseArtifactStore` and
+Out of the box, ZenML comes with the `BaseArtifactStore` and
 `LocalArtifactStore` implementations. While the `BaseArtifactStore` establishes
 an interface for people who want to extend it to their needs, the
 `LocalArtifactStore` is a simple implementation for a local setup.

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -31,7 +31,7 @@ order to find out which version of ZenML you are running, type:
 If you ever need more information on exactly what a certain command will
 do, use the ``--help`` flag attached to the end of your command string.
 
-For example, to get a sense of all of the commands available to you
+For example, to get a sense of all the commands available to you
 while using the ``zenml`` command, type:
 
 ```bash
@@ -188,7 +188,7 @@ Customizing your Metadata Store
 -------------------------------
 
 The configuration of each pipeline, step, backend, and produced
-artifacts are all tracked within the metadata store. By default ZenML
+artifacts are all tracked within the metadata store. By default, ZenML
 initializes your repository with a metadata store kept on your local
 machine. If you wish to register a new metadata store, do so with the
 ``register`` command:
@@ -283,7 +283,7 @@ zenml container-registry list
 ```
 
 For details about a particular container registry, use the `describe` command.
-By default (without a specific registry name passed in) it will describe the
+By default, (without a specific registry name passed in) it will describe the
 active or currently used container registry:
 
 ```bash

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -363,6 +363,13 @@ def generate_stack_component_explain_command(
         if component_module.__doc__ is not None:
             md = Markdown(component_module.__doc__)
             console.print(md)
+        else:
+            console.print(
+                "The explain subcommand is yet not available for "
+                "this stack component. For more information, you can "
+                "visit our docs page: https://docs.zenml.io/ and "
+                "stay tuned for future releases."
+            )
 
     return explain_stack_components_command
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -353,10 +353,10 @@ def generate_stack_component_logs_command(
 def generate_stack_component_explain_command(
     component_type: StackComponentType,
 ) -> Callable[[], None]:
-    """Generates an `explain` command for the specific stack component type"""
+    """Generates an `explain` command for the specific stack component type."""
 
     def explain_stack_components_command() -> None:
-        """Explains the concept of the stack component"""
+        """Explains the concept of the stack component."""
 
         component_module = import_module(f"zenml.{component_type.plural}")
 

--- a/src/zenml/container_registries/__init__.py
+++ b/src/zenml/container_registries/__init__.py
@@ -11,7 +11,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+"""
+## Container Registry
 
+A container registry is a store for (Docker) containers. A ZenML workflow
+involving a container registry would automatically containerize your code to
+be transported across stacks running remotely. As part of the deployment to
+the cluster, the ZenML base image would be downloaded (from a cloud container
+registry) and used as the basis for the deployed 'run'.
+
+For instance, when you are running a local container-based stack, you would
+therefore have a local container registry which stores the container images
+you create that bundle up your pipeline code. You could also use a remote
+container registry like the Elastic Container Registry at AWS in a more
+production setting.
+"""
 from zenml.container_registries.base_container_registry import (
     BaseContainerRegistry,
 )

--- a/src/zenml/metadata_stores/__init__.py
+++ b/src/zenml/metadata_stores/__init__.py
@@ -12,6 +12,8 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """
+## Metadata Store
+
 The configuration of each pipeline, step, backend, and produced artifacts are
 all tracked within the metadata store. The metadata store is an SQL database,
 and can be `sqlite` or `mysql`.

--- a/src/zenml/orchestrators/__init__.py
+++ b/src/zenml/orchestrators/__init__.py
@@ -12,6 +12,8 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """
+## Orchestrator
+
 An orchestrator is a special kind of backend that manages the running of each
 step of the pipeline. Orchestrators administer the actual pipeline runs. You can
 think of it as the 'root' of any pipeline job that you run during your


### PR DESCRIPTION
## Describe changes
Implemented an `explain` subcommand for any `StackComponent` type which parses out the `__init__` file of the corresponding module, creates a Markdown file, and print it through the console. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

