### PR TITLE
Made rich traceback optional with ENV variable

### DIFF
--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -23,6 +23,8 @@ def handle_bool_env_var(var: str, default: bool = False) -> bool:
     value = os.getenv(var)
     if value in ["1", "y", "yes", "True", "true"]:
         return True
+    elif value in ["0", "n", "no", "False", "false"]:
+        return False
     return default
 
 
@@ -46,6 +48,7 @@ ENV_ZENML_LOGGING_VERBOSITY = "ZENML_LOGGING_VERBOSITY"
 ENV_ABSL_LOGGING_VERBOSITY = "ZENML_ABSL_LOGGING_VERBOSITY"
 ENV_ZENML_REPOSITORY_PATH = "ZENML_REPOSITORY_PATH"
 ENV_ZENML_PREVENT_PIPELINE_EXECUTION = "ZENML_PREVENT_PIPELINE_EXECUTION"
+ENV_ZENML_ENABLE_RICH_TRACEBACK = "ZENML_ENABLE_RICH_TRACEBACK"
 
 # Logging variables
 IS_DEBUG_ENV: bool = handle_bool_env_var(ENV_ZENML_DEBUG, default=False)
@@ -104,3 +107,8 @@ SHOULD_PREVENT_PIPELINE_EXECUTION = handle_bool_env_var(
 )
 
 USER_MAIN_MODULE: Optional[str] = None
+
+# Rich config
+ENABLE_RICH_TRACEBACK = handle_bool_env_var(
+    ENV_ZENML_ENABLE_RICH_TRACEBACK, "True"
+)

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -110,5 +110,5 @@ USER_MAIN_MODULE: Optional[str] = None
 
 # Rich config
 ENABLE_RICH_TRACEBACK = handle_bool_env_var(
-    ENV_ZENML_ENABLE_RICH_TRACEBACK, "True"
+    ENV_ZENML_ENABLE_RICH_TRACEBACK, True
 )

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -25,6 +25,7 @@ from rich.traceback import install as rich_tb_install
 from zenml.constants import (
     ABSL_LOGGING_VERBOSITY,
     APP_NAME,
+    ENABLE_RICH_TRACEBACK,
     ZENML_LOGGING_VERBOSITY,
 )
 from zenml.enums import LoggingLevels
@@ -104,7 +105,8 @@ def set_root_verbosity() -> None:
     """Set the root verbosity."""
     level = get_logging_level()
     if level != LoggingLevels.NOTSET:
-        rich_tb_install(show_locals=(level == LoggingLevels.DEBUG))
+        if ENABLE_RICH_TRACEBACK:
+            rich_tb_install(show_locals=(level == LoggingLevels.DEBUG))
 
         logging.basicConfig(level=level.value)
         get_logger(__name__).debug(


### PR DESCRIPTION
## Describe changes
I implemented a simple env variable called `ZENML_ENABLE_RICH_TRACEBACK` that flips a toggled called `ENABLE_RICH_TRACEBACK`, which I then use in the `logger.py` code to control whether rich traceback is used or not. i tested it locally and it works, please do take a look at whether it is enough to achieve the functionality we wanted with this.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

