### PR TITLE
Copy the entire stack configuration into containers

### DIFF
--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 import json
 import os
-import shutil
 import uuid
 from typing import Any, Dict, Optional, cast
 
@@ -298,22 +297,28 @@ class GlobalConfiguration(
         """
         return os.path.join(config_path or self._config_path, "config.yaml")
 
-    def copy_config_with_active_profile(
+    def copy_active_configuration(
         self,
         config_path: str,
         load_config_path: Optional[str] = None,
     ) -> "GlobalConfiguration":
-        """Create a copy of the global config and the active repository profile
-        using a different config path.
+        """Create a copy of the global config, the active repository profile
+        and the active stack using a different configuration path.
+
+        This method is used to extract the active slice of the current state
+        (consisting only of the global configuration, the active profile and the
+        active stack) and store it in a different configuration path, where it
+        can be loaded in the context of a new environment, such as a container
+        image.
 
         Args:
-            config_path: path where the global config copy should be saved
-            load_config_path: path that will be used to load the global config
+            config_path: path where the active configuration copy should be saved
+            load_config_path: path that will be used to load the configuration
                 copy. This can be set to a value different than `config_path`
-                if the global config copy will be loaded from a different
+                if the configuration copy will be loaded from a different
                 path, e.g. when the global config copy is copied to a
                 container image. This will be reflected in the paths and URLs
-                encoded in the copied profile.
+                encoded in the profile copy.
         """
         from zenml.repository import Repository
 
@@ -321,49 +326,28 @@ class GlobalConfiguration(
 
         config_copy = GlobalConfiguration(config_path=config_path)
         config_copy.profiles = {}
-        profile = Repository().active_profile
 
-        profile_copy = config_copy.add_or_update_profile(profile)
-        profile_copy.active_stack = Repository().active_stack_name
-        config_copy.activate_profile(profile.name)
-
-        if not profile.store_type or not profile.store_url:
-            # should not happen, but just in case
-            raise RuntimeError(
-                f"No store type or URL set for profile " f"`{profile.name}`."
-            )
-
-        # if the profile stores its state locally inside a local directory,
-        # we need to copy that as well
-        store_class = Repository.get_store_class(profile.store_type)
-        if not store_class:
-            raise RuntimeError(
-                f"No store implementation found for store type "
-                f"`{profile.store_type}`."
-            )
-
-        profile_path = store_class.get_path_from_url(profile.store_url)
-        dst_profile_url = store_class.get_local_url(
-            profile_copy.config_directory
+        repo = Repository()
+        profile = ProfileConfiguration(
+            name=repo.active_profile_name,
+            active_stack=repo.active_stack_name,
         )
-        dst_profile_path = store_class.get_path_from_url(dst_profile_url)
-        if profile_path and dst_profile_path:
-            if profile_path.is_dir():
-                shutil.copytree(
-                    profile_path,
-                    dst_profile_path,
-                )
-            else:
-                fileio.create_dir_recursive_if_not_exists(
-                    str(dst_profile_path.parent)
-                )
-                shutil.copyfile(profile_path, dst_profile_path)
+        profile._config = config_copy
+        # circumvent the profile initialization done in the
+        # ProfileConfiguration and the Repository classes to avoid triggering
+        # the analytics and interact directly with the store creation
+        config_copy.profiles[profile.name] = profile
+        store = Repository.create_store(profile, skip_default_stack=True)
+        # transfer the active stack to the new store
+        store.register_stack(repo.stack_store.get_stack(repo.active_stack_name))
 
-            if load_config_path:
-                dst_profile_url = dst_profile_url.replace(
-                    config_path, load_config_path
-                )
-            profile_copy.store_url = dst_profile_url
+        # if a custom load config path is specified, use it to replace the
+        # current store local path in the profile URL
+        if load_config_path:
+            profile.store_url = store.url.replace(
+                str(config_copy.config_directory), load_config_path
+            )
+
         config_copy._write_config()
         return config_copy
 
@@ -379,6 +363,9 @@ class GlobalConfiguration(
 
         Args:
             profile: profile configuration
+
+        Returns:
+            the profile configuration added to the global configuration
         """
         profile = profile.copy()
         profile._config = self

--- a/src/zenml/repository.py
+++ b/src/zenml/repository.py
@@ -509,7 +509,9 @@ class Repository(BaseConfiguration, metaclass=RepositoryMetaClass):
         }.get(type)
 
     @staticmethod
-    def create_store(profile: ProfileConfiguration) -> BaseStackStore:
+    def create_store(
+        profile: ProfileConfiguration, skip_default_stack: bool = False
+    ) -> BaseStackStore:
         """Create the repository persistance back-end store from a configuration
         profile.
 
@@ -519,6 +521,8 @@ class Repository(BaseConfiguration, metaclass=RepositoryMetaClass):
         Args:
             profile: The configuration profile to use for persisting the
                 repository information.
+            skip_default_stack: If True, the creation of the default stack in
+                the store will be skipped.
 
         Returns:
             The initialized repository store.
@@ -542,7 +546,9 @@ class Repository(BaseConfiguration, metaclass=RepositoryMetaClass):
 
         if store_class.is_valid_url(profile.store_url):
             store = store_class()
-            store.initialize(url=profile.store_url)
+            store.initialize(
+                url=profile.store_url, skip_default_stack=skip_default_stack
+            )
             return store
 
         raise ValueError(

--- a/src/zenml/stack_stores/base_stack_store.py
+++ b/src/zenml/stack_stores/base_stack_store.py
@@ -53,12 +53,18 @@ class BaseStackStore(ABC):
 
     @abstractmethod
     def initialize(
-        self, url: str, *args: Any, **kwargs: Any
+        self,
+        url: str,
+        skip_default_stack: bool = False,
+        *args: Any,
+        **kwargs: Any,
     ) -> "BaseStackStore":
         """Initialize the store.
 
         Args:
             url: The URL of the store.
+            skip_default_stack: If True, the creation of the default stack will
+                be skipped.
             *args: Additional arguments to pass to the concrete store
                 implementation.
             **kwargs: Additional keyword arguments to pass to the concrete
@@ -68,7 +74,7 @@ class BaseStackStore(ABC):
             The initialized concrete store instance.
         """
 
-        if self.is_empty():
+        if not skip_default_stack and self.is_empty():
 
             logger.info("Initializing store...")
             self.register_default_stack()

--- a/src/zenml/utils/docker_utils.py
+++ b/src/zenml/utils/docker_utils.py
@@ -207,9 +207,10 @@ def build_docker_image(
     try:
 
         # Save a copy of the current global configuration with the
-        # active profile contents into the build context, to have
-        # the configured stacks accessible from within the container.
-        GlobalConfiguration().copy_config_with_active_profile(
+        # active profile and the active stack configuration into the build
+        # context, to have the active profile and active stack accessible from
+        # within the container.
+        GlobalConfiguration().copy_active_configuration(
             config_path,
             load_config_path=f"/app/{CONTAINER_ZENML_CONFIG_DIR}",
         )


### PR DESCRIPTION
## Describe changes

Rather than copying the profile configuration and accessing the
active stack from the store back-end directly, make an entire copy
of the active status (global config, active profile and active
stack) using an entirely new local store back-end that is pointed
at the new path.
This way, the containers are completely decoupled from the store
back-end used by ZenML clients and don't need to access any external
services to retrieve information about the current stack.

This is a change left-over from the Profiles PR (see [here](https://github.com/zenml-io/zenml/pull/471#discussion_r835134628)).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

