### PR TITLE
Add linting of examples to `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         name: lint
         entry: poetry run bash scripts/lint.sh
         language: system
-        files: ^src/zenml/|^tests/
+        files: ^src/zenml/|^tests/|^examples/
         types: [file, python]
         pass_filenames: false
 


### PR DESCRIPTION
## Describe changes
A previous PR (#482) had added the `examples` to the linting script, but I hadn't fully realised that the `pre-commit-config.yaml` overrode the arguments passed into the linting script, so this PR fixes that.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

