### PR TITLE
Fix datetime test / bug

### DIFF
--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -27,7 +27,7 @@ SAMPLE_CUSTOM_ARGUMENTS = [
 ]
 
 
-@given(sample_datetime=datetimes())
+@given(sample_datetime=datetimes(allow_imaginary=False))
 def test_format_date_formats_a_string_properly(
     sample_datetime: datetime,
 ) -> None:


### PR DESCRIPTION
## Describe changes
The `test_format_date_formats_a_string_properly` test was failing on my local machine. This added parameter should fix it.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

