### PR TITLE
Bug: fix long Kubernetes labels in Seldon deployments

### DIFF
--- a/src/zenml/integrations/seldon/seldon_client.py
+++ b/src/zenml/integrations/seldon/seldon_client.py
@@ -474,9 +474,17 @@ class SeldonClient:
 
     @staticmethod
     def sanitize_labels(labels: Dict[str, str]) -> None:
-        """Update the label values to be valid Kubernetes labels"""
+        """Update the label values to be valid Kubernetes labels.
+
+        See: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+        """
         for key, value in labels.items():
-            labels[key] = re.sub(r"[^0-9a-zA-Z-_\.]+", "_", value)
+            # Kubernetes labels must be alphanumeric, no longer than
+            # 63 characters, and must begin and end with an alphanumeric
+            # character ([a-z0-9A-Z])
+            labels[key] = re.sub(r"[^0-9a-zA-Z-_\.]+", "_", value)[:63].strip(
+                "-_."
+            )
 
     @property
     def namespace(self) -> str:


### PR DESCRIPTION
## Describe changes

Kubernetes imposes a length limit of max 63 characters on their labels.
Our Seldon Core deployments failed because the model URI that we save as a label
can sometimes exceed that.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

