### PR TITLE
Change prediction_uri to prediction_url in MLflow deployer

### DIFF
--- a/examples/mlflow_deployment/run.py
+++ b/examples/mlflow_deployment/run.py
@@ -129,7 +129,7 @@ def main(
             print(
                 f"The MLflow prediction server is running locally as a daemon "
                 f"process service and accepts inference requests at:\n"
-                f"    {service.prediction_uri}\n"
+                f"    {service.prediction_url}\n"
                 f"To stop the service, run "
                 f"[italic green]`zenml served-models delete "
                 f"{str(service.uuid)}`[/italic green]."

--- a/src/zenml/integrations/mlflow/model_deployers/mlflow_model_deployer.py
+++ b/src/zenml/integrations/mlflow/model_deployers/mlflow_model_deployer.py
@@ -62,7 +62,7 @@ class MLFlowModelDeployer(BaseModelDeployer):
         """
 
         return {
-            "PREDICTION_URL": service_instance.endpoint.prediction_uri,
+            "PREDICTION_URL": service_instance.endpoint.prediction_url,
             "MODEL_URI": service_instance.config.model_uri,
             "MODEL_NAME": service_instance.config.model_name,
             "SERVICE_PATH": service_instance.status.runtime_path,

--- a/src/zenml/integrations/mlflow/services/mlflow_deployment.py
+++ b/src/zenml/integrations/mlflow/services/mlflow_deployment.py
@@ -32,10 +32,10 @@ class MLFlowDeploymentEndpointConfig(LocalDaemonServiceEndpointConfig):
     """MLflow daemon service endpoint configuration.
 
     Attributes:
-        prediction_uri_path: URI subpath for prediction requests
+        prediction_url_path: URI subpath for prediction requests
     """
 
-    prediction_uri_path: str
+    prediction_url_path: str
 
 
 class MLFlowDeploymentEndpoint(LocalDaemonServiceEndpoint):
@@ -50,11 +50,11 @@ class MLFlowDeploymentEndpoint(LocalDaemonServiceEndpoint):
     monitor: HTTPEndpointHealthMonitor
 
     @property
-    def prediction_uri(self) -> Optional[str]:
+    def prediction_url(self) -> Optional[str]:
         uri = self.status.uri
         if not uri:
             return None
-        return f"{uri}{self.config.prediction_uri_path}"
+        return f"{uri}{self.config.prediction_url_path}"
 
 
 class MLFlowDeploymentConfig(LocalDaemonServiceConfig):
@@ -109,18 +109,18 @@ class MLFlowDeploymentService(LocalDaemonService):
             and "endpoint" not in attrs
         ):
             if config.mlserver:
-                prediction_uri_path = MLSERVER_PREDICTION_URL_PATH
+                prediction_url_path = MLSERVER_PREDICTION_URL_PATH
                 healthcheck_uri_path = MLSERVER_HEALTHCHECK_URL_PATH
                 use_head_request = False
             else:
-                prediction_uri_path = MLFLOW_PREDICTION_URL_PATH
+                prediction_url_path = MLFLOW_PREDICTION_URL_PATH
                 healthcheck_uri_path = MLFLOW_HEALTHCHECK_URL_PATH
                 use_head_request = True
 
             endpoint = MLFlowDeploymentEndpoint(
                 config=MLFlowDeploymentEndpointConfig(
                     protocol=ServiceEndpointProtocol.HTTP,
-                    prediction_uri_path=prediction_uri_path,
+                    prediction_url_path=prediction_url_path,
                 ),
                 monitor=HTTPEndpointHealthMonitor(
                     config=HTTPEndpointHealthMonitorConfig(
@@ -159,7 +159,7 @@ class MLFlowDeploymentService(LocalDaemonService):
             )
 
     @property
-    def prediction_uri(self) -> Optional[str]:
+    def prediction_url(self) -> Optional[str]:
         """Get the URI where the prediction service is answering requests.
 
         Returns:
@@ -168,7 +168,7 @@ class MLFlowDeploymentService(LocalDaemonService):
         """
         if not self.is_running:
             return None
-        return self.endpoint.prediction_uri
+        return self.endpoint.prediction_url
 
     def predict(self, request: "NDArray[Any]") -> "NDArray[Any]":
         """Make a prediction using the service.
@@ -185,9 +185,9 @@ class MLFlowDeploymentService(LocalDaemonService):
                 "Please start the service before making predictions."
             )
 
-        if self.endpoint.prediction_uri is not None:
+        if self.endpoint.prediction_url is not None:
             response = requests.post(
-                self.endpoint.prediction_uri,
+                self.endpoint.prediction_url,
                 json={"instances": request.tolist()},
             )
         else:

--- a/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
@@ -161,7 +161,7 @@ def mlflow_model_deployer_step(
 
     logger.info(
         f"MLflow deployment service started and reachable at:\n"
-        f"    {new_service.prediction_uri}\n"
+        f"    {new_service.prediction_url}\n"
     )
 
     return new_service


### PR DESCRIPTION
## Describe changes
This aligns the MLflow deployer service to be the same as the Seldon Core one, until we implement a better Model Deployment Service abstraction.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

