### PR TITLE
Fix caching & `mypy` errors

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -4,6 +4,10 @@ description: "Install Poetry, loads cached venv if applicable, and performs misc
 runs:
   using: "composite"
   steps:
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'calendar-week-%W')"
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -33,8 +37,9 @@ runs:
         path: |
           .venv
           poetry.lock
-        # Cache the complete venv dir for a given os, python version, pyproject.toml
-        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+        # Cache the complete venv dir for a given os, python version,
+        # pyproject.toml, and the current calendar week
+        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ steps.date.outputs.date }}
 
     - name: Install Project
       shell: bash

--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -4,10 +4,6 @@ description: "Install Poetry, loads cached venv if applicable, and performs misc
 runs:
   using: "composite"
   steps:
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'calendar-week-%W')"
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -29,6 +25,11 @@ runs:
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
+
+    - name: Get current date
+      shell: bash
+      id: date
+      run: echo "::set-output name=date::$(date +'calendar-week-%W')"
 
     - name: Load cached venv
       id: cached-poetry-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,6 @@ follow_imports = "skip"
 module = [
     "tfx.proto.*",
     "google.*" ,
-    "transformers.*"  # https://github.com/huggingface/transformers/issues/13390
 ]
 follow_imports = "skip"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ follow_imports = "skip"
 module = [
     "tfx.proto.*",
     "google.*" ,
+    "transformers.*"  # https://github.com/huggingface/transformers/issues/13390
 ]
 follow_imports = "skip"
 

--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -16,8 +16,8 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, Type
 
-from datasets import Dataset, load_from_disk  # type: ignore [import]
-from datasets.dataset_dict import DatasetDict  # type: ignore [import]
+from datasets import Dataset, load_from_disk  # type: ignore[attr-defined]
+from datasets.dataset_dict import DatasetDict
 
 from zenml.artifacts import DataArtifact
 from zenml.io import utils as fileio_utils

--- a/src/zenml/integrations/huggingface/materializers/huggingface_pt_model_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_pt_model_materializer.py
@@ -17,7 +17,7 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, Type
 
-from transformers import AutoConfig, PreTrainedModel  # type: ignore [import]
+from transformers import AutoConfig, PreTrainedModel
 
 from zenml.artifacts import ModelArtifact
 from zenml.io import utils as fileio_utils
@@ -56,5 +56,6 @@ class HFPTModelMaterializer(BaseMaterializer):
         temp_dir = TemporaryDirectory()
         model.save_pretrained(temp_dir.name)
         fileio_utils.copy_dir(
-            temp_dir.name, os.path.join(self.artifact.uri, DEFAULT_PT_MODEL_DIR)
+            temp_dir.name,
+            os.path.join(self.artifact.uri, DEFAULT_PT_MODEL_DIR),
         )

--- a/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
@@ -17,7 +17,7 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, Type
 
-from transformers import AutoConfig, TFPreTrainedModel  # type: ignore [import]
+from transformers import AutoConfig, TFPreTrainedModel
 
 from zenml.artifacts import ModelArtifact
 from zenml.io import utils as fileio_utils
@@ -56,5 +56,6 @@ class HFTFModelMaterializer(BaseMaterializer):
         temp_dir = TemporaryDirectory()
         model.save_pretrained(temp_dir.name)
         fileio_utils.copy_dir(
-            temp_dir.name, os.path.join(self.artifact.uri, DEFAULT_TF_MODEL_DIR)
+            temp_dir.name,
+            os.path.join(self.artifact.uri, DEFAULT_TF_MODEL_DIR),
         )

--- a/src/zenml/integrations/huggingface/materializers/huggingface_tokenizer_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_tokenizer_materializer.py
@@ -16,10 +16,8 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, Type
 
-from transformers import AutoTokenizer  # type: ignore [import]
-from transformers.tokenization_utils_base import (  # type: ignore [import]
-    PreTrainedTokenizerBase,
-)
+from transformers import AutoTokenizer
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from zenml.artifacts import ModelArtifact
 from zenml.io import utils as fileio_utils

--- a/src/zenml/integrations/wandb/wandb_environment.py
+++ b/src/zenml/integrations/wandb/wandb_environment.py
@@ -136,7 +136,7 @@ class WandbStepEnvironment(BaseEnvironmentComponent):
         entity = (
             os.getenv("WANDB_ENTITY") if self._entity is None else self._entity
         )
-        runs = api.runs(f"{entity}/{self._project_name}")
+        runs = api.runs(f"{entity}/{self._project_name}")  # type: ignore[no-untyped-call]
         for run in runs:
             if run.name == self._run_name:
                 run_exists = True


### PR DESCRIPTION
## Describe changes
I added an extra fragment to the end of the cache key (the current calendar week), which means that the cache will be rendered invalid once a week at least. (It will also hopefully fix the issues around `huggingface` and `mypy` which are causing branches to fail on `develop`.)

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

