### PR TITLE
Remove TODO from Feature Store `init` docstring

### DIFF
--- a/src/zenml/feature_stores/__init__.py
+++ b/src/zenml/feature_stores/__init__.py
@@ -12,7 +12,6 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """
-# TODO [ENG-793]: Write docstring.
 ## Feature Store
 
 Feature stores allow data teams to serve data via an offline store and an online


### PR DESCRIPTION
## Describe changes
Removed a todo from a docstring that unfortunately gets pretty prominently displayed [on our API docs](https://apidocs.zenml.io/0.7.2/) at the moment.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

