### PR TITLE
Secret Manager improvements and Seldon Core secret passing

### DIFF
--- a/examples/mlflow_deployment/run.py
+++ b/examples/mlflow_deployment/run.py
@@ -100,6 +100,7 @@ def main(
                 MLFlowDeploymentLoaderStepConfig(
                     pipeline_name="continuous_deployment_pipeline",
                     pipeline_step_name="mlflow_model_deployer_step",
+                    running=False,
                 )
             ),
             predictor=predictor(),

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -196,6 +196,8 @@ This stack consists of the following components:
 * the local orchestrator
 * the local metadata store
 * a Seldon Core model deployer
+* a local secret manager used to store the credentials needed by Seldon Core to
+access the AWS S3 artifact store
 
 To have access to the AWS S3 artifact store from your local workstation, the
 AWS client credentials needs to be properly set up locally as documented in
@@ -225,35 +227,23 @@ Extract the URL where the Seldon Core model server exposes its prediction API, e
 export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 ```
 
-Give Seldon Core access to the S3 artifact store in the configured namespace:
-
-```bash
-kubectl -n zenml-workloads create secret generic seldon-init-container-secret \
-    --from-literal=RCLONE_CONFIG_S3_PROVIDER='aws' \
-    --from-literal=RCLONE_CONFIG_S3_TYPE='s3' \
-    --from-literal=RCLONE_CONFIG_S3_ENV_AUTH=true
-```
-
-The name of the created secret also needs to be passed to the `run.py` example
-launcher script via its `--secret` command line argument.
-
-NOTE: this is based on the assumption that Seldon Core is running in an EKS
-cluster that already has IAM access enabled and doesn't need any explicit AWS
-credentials. If that is not the case, you will need to set up credentials
-differently. Please look up the variables relevant to your use-case in the
-[official Seldon Core documentation](https://docs.seldon.io/projects/seldon-core/en/latest/servers/overview.html#handling-credentials).
-
 Configuring the stack can be done like this:
 
 ```
 zenml integration install s3 seldon
 zenml model-deployer register seldon_eks --type=seldon \
   --kubernetes_context=zenml-eks --kubernetes_namespace=zenml-workloads \
-  --base_url=http://abb84c444c7804aa98fc8c097896479d-377673393.us-east-1.elb.amazonaws.com
+  --base_url=http://$INGRESS_HOST \
+  --secret=s3-store
 zenml artifact-store register aws --type s3 --path s3://mybucket
-zenml stack register local_with_aws_storage -m default -a aws -o default -d seldon_eks
+zenml secrets-manager register local -t local
+zenml stack register local_with_aws_storage -m default -a aws -o default -d seldon_eks -x local
 zenml stack set local_with_aws_storage
 ```
+
+As the last step in setting up the stack, we need to configure a ZenML secret
+with the credentials needed by Seldon Core to access the Artifact Store. This is
+covered in the [Managing Seldon Core Credentials section](#managing-seldon-core-credentials).
 
 #### Full AWS stack
 
@@ -264,6 +254,10 @@ This stack has all components running in the AWS cloud:
 * a metadata store that uses the same database as the Kubeflow deployment as
 a backend
 * an AWS ECR container registry
+* an AWS secret manager used to store the credentials needed by Seldon Core to
+access the AWS S3 artifact store
+* a Seldon Core model deployer pointing to the AWS EKS cluster
+
 
 To have access to the AWS S3 artifact store from your local workstation, the
 AWS client credentials needs to be properly set up locally as documented in
@@ -295,51 +289,107 @@ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway \
   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 ```
 
-Give Seldon Core access to the S3 artifact store in the Kubeflow namespace:
-
-```bash
-kubectl -n kubeflow create secret generic seldon-init-container-secret \
-    --from-literal=RCLONE_CONFIG_S3_PROVIDER='aws' \
-    --from-literal=RCLONE_CONFIG_S3_TYPE='s3' \
-    --from-literal=RCLONE_CONFIG_S3_ENV_AUTH=true
-```
-
-The name of the created secret also needs to be passed to the `run.py` example
-launcher script via its `--secret` command line argument.
-
-NOTE: this is based on the assumption that Seldon Core is running in an EKS
-cluster that already has IAM access enabled and doesn't need any explicit AWS
-credentials. If that is not the case, you will need to set up credentials
-differently. Please look up the variables relevant to your use-case in the
-[official Seldon Core documentation](https://docs.seldon.io/projects/seldon-core/en/latest/servers/overview.html#handling-credentials).
-
 Configuring the stack can be done like this:
 
 ```
-zenml integration install s3 kubeflow seldon
+zenml integration install s3 aws kubeflow seldon
 
 zenml artifact-store register aws --type=s3 --path=s3://mybucket
 zenml model-deployer register seldon_aws --type=seldon \
   --kubernetes_context=zenml-eks --kubernetes_namespace=kubeflow \
-  --base_url=http://abb84c444c7804aa98fc8c097896479d-377673393.us-east-1.elb.amazonaws.com
+  --base_url=http://$INGRESS_HOST \
+  --secret=s3-store
 zenml container-registry register aws --type=default --uri=715803424590.dkr.ecr.us-east-1.amazonaws.com
 zenml metadata-store register aws --type=kubeflow
 zenml orchestrator register aws --type=kubeflow --kubernetes_context=zenml-eks --synchronous=True
-zenml stack register aws -m aws -a aws -o aws -c aws -d seldon_aws
+zenml secrets-manager register aws -t aws
+zenml stack register aws -m aws -a aws -o aws -c aws -d seldon_aws -x aws
 zenml stack set aws
 ```
+
+As the last step in setting up the stack, we need to configure a ZenML secret
+with the credentials needed by Seldon Core to access the Artifact Store. This is
+covered in the [Managing Seldon Core Credentials section](#managing-seldon-core-credentials).
+
+#### Managing Seldon Core Credentials
+
+The Seldon Core model servers need to access the Artifact Store in the ZenML
+stack to retrieve the model artifacts. This usually involve passing some
+credentials to the Seldon Core model servers required to authenticate with
+the Artifact Store. In ZenML, this is done by creating a ZenML secret with the
+proper credentials and configuring the Seldon Core Model Deployer stack component
+to use it, by passing the `--secret` argument to the CLI command used
+to register the model deployer. We've already done the latter, now all that is
+left to do is to configure the `s3-store` ZenML secret specified before as a
+Seldon Model Deployer configuration attribute with the credentials needed by
+Seldon Core to access the artifact store.
+
+There are built-in secret schemas that the Seldon Core integration provides which
+can be used to configure credentials for the 3 main types of Artifact Stores
+supported by ZenML: S3, GCS and Azure.
+
+For this AWS S3 example, we'll use the standard `seldon_s3` secret schema, but
+you can also use `seldon_gs` for GCS and `seldon_az` for Azure. To read more about
+secrets, secret schemas and how they are used in ZenML, please refer to the
+[ZenML documentation](https://docs.zenml.io/features/secrets).
+
+
+To give Seldon Core access to the S3 artifact store, we just need to create a
+`seldon_aws` type secret that sets the `rclone_config_s3_env_auth` attribute
+to `True` and leaves everything else as is. This is based on the assumption that
+the EKS cluster where Seldon Core is running already has
+[IAM access](https://docs.aws.amazon.com/eks/latest/userguide/security-iam.html)
+configured to grant the EKS pods access to the AWS S3 bucket and doesn't need
+any explicit AWS credentials. If that is not the case for you, you will
+probably need to set up credentials explicitly in the ZenML secret. Please look
+up the variables relevant to your use-case in the
+[official Seldon Core documentation](https://docs.seldon.io/projects/seldon-core/en/latest/servers/overview.html#handling-credentials) and set them accordingly in the `s3-store` secret.
+
+```bash
+$ zenml secret register -s seldon_s3 s3-store
+You have supplied a secret_set_schema with predefined keys. You can fill these
+out sequentially now. Just press ENTER to skip optional secrets that you do not
+want to set
+Secret value for rclone_config_s3_type:
+Secret value for rclone_config_s3_provider:
+Secret value for rclone_config_s3_env_auth: True
+Secret value for rclone_config_s3_access_key_id:
+Secret value for rclone_config_s3_secret_access_key:
+Secret value for rclone_config_s3_session_token:
+Secret value for rclone_config_s3_region:
+Secret value for rclone_config_s3_endpoint:
+The following secret will be registered.
+┏━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┓
+┃ SECRET_NAME │ SECRET_KEY                │ SECRET_VALUE ┃
+┠─────────────┼───────────────────────────┼──────────────┨
+┃ seldon_aws  │ rclone_config_s3_type     │ ***          ┃
+┃ seldon_aws  │ rclone_config_s3_provider │ ***          ┃
+┃ seldon_aws  │ rclone_config_s3_env_auth │ ***          ┃
+┗━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┛
+
+$ zenml secret get s3-store
+INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
+┏━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┓
+┃ SECRET_NAME │ SECRET_KEY                │ SECRET_VALUE ┃
+┠─────────────┼───────────────────────────┼──────────────┨
+┃ seldon_aws  │ rclone_config_s3_type     │ s3           ┃
+┃ seldon_aws  │ rclone_config_s3_provider │ aws          ┃
+┃ seldon_aws  │ rclone_config_s3_env_auth │ True         ┃
+┗━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┛
+```
+
 
 ### Run the project
 To run the continuous deployment pipeline:
 
 ```shell
-python run.py --secret seldon-init-container-secret --deploy
+python run.py --deploy
 ```
 
 Example output when run with the local orchestrator stack:
 
 ```
-zenml/seldon_deployment$ python run.py --secret seldon-init-container-secret --deploy --min-accuracy 0.80 --model-flavor sklearn
+zenml/seldon_deployment$ python run.py --deploy --min-accuracy 0.80 --model-flavor sklearn
 
 2022-04-06 15:40:28.903233: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory
 2022-04-06 15:40:28.903253: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
@@ -381,7 +431,7 @@ Re-running the example with different hyperparameter values will re-train
 the model and update the deployment server to serve the new model:
 
 ```shell
-python run.py --secret seldon-init-container-secret --deploy --epochs=10 --lr=0.1
+python run.py --deploy --epochs=10 --lr=0.1
 ```
 
 If the input hyperparameter argument values are not changed, the pipeline
@@ -394,7 +444,7 @@ The inference pipeline will use the currently running Seldon Core deployment
 server to perform an online prediction. To run the inference pipeline:
 
 ```shell
-python run.py --secret seldon-init-container-secret --predict
+python run.py --predict
 ```
 
 Example output when run with the local orchestrator stack:
@@ -434,7 +484,7 @@ training and the Seldon Core model server implementation, the `--model-flavor`
 command line argument can be used:
 
 ```
-python run.py --secret seldon-init-container-secret --deploy --predict --model-flavor sklearn --penalty=l2
+python run.py --deploy --predict --model-flavor sklearn --penalty=l2
 ```
 
 The `zenml served-models list` CLI command can be run to list the active model servers:

--- a/examples/seldon_deployment/run.py
+++ b/examples/seldon_deployment/run.py
@@ -107,14 +107,6 @@ from zenml.integrations.seldon.steps import (
     default=0.92,
     help="Minimum accuracy required to deploy the model (default: 0.92)",
 )
-@click.option(
-    "--secret",
-    "-x",
-    type=str,
-    required=True,
-    help="Specify the name of a Kubernetes secret to be passed to Seldon Core "
-    "deployments to authenticate to the Artifact Store",
-)
 def main(
     deploy: bool,
     predict: bool,
@@ -126,14 +118,13 @@ def main(
     penalty_strength: float,
     toleration: float,
     min_accuracy: float,
-    secret: str,
 ):
     """Run the Seldon example continuous deployment or inference pipeline
 
     Example usage:
 
         python run.py --deploy --predict --model-flavor tensorflow \
-             --min-accuracy 0.80 --secret seldon-init-container-secret
+             --min-accuracy 0.80
 
     """
     model_name = "mnist"
@@ -178,7 +169,6 @@ def main(
                         model_name=model_name,
                         replicas=1,
                         implementation=seldon_implementation,
-                        secret_name=secret,
                     ),
                     timeout=120,
                 )

--- a/src/zenml/artifact_stores/local_artifact_store.py
+++ b/src/zenml/artifact_stores/local_artifact_store.py
@@ -56,6 +56,11 @@ class LocalArtifactStore(BaseArtifactStore):
     FLAVOR: ClassVar[str] = "local"
     SUPPORTED_SCHEMES: ClassVar[Set[str]] = {""}
 
+    @property
+    def local_path(self) -> str:
+        """Path to the local directory where the artifacts are stored."""
+        return self.path
+
     @staticmethod
     def open(name: PathType, mode: str = "r") -> Any:
         """Open a file at the given path."""

--- a/src/zenml/cli/secret.py
+++ b/src/zenml/cli/secret.py
@@ -131,7 +131,8 @@ def register_secret(
         )
         for k in secret_keys:
             v = getpass.getpass(f"Secret value for {k}:")
-            secret_contents[k] = v
+            if v:
+                secret_contents[k] = v
 
     elif secret_key and secret_value:
         secret_contents[secret_key] = secret_value

--- a/src/zenml/cli/secret.py
+++ b/src/zenml/cli/secret.py
@@ -26,8 +26,9 @@ from zenml.cli.utils import (
     warning,
 )
 from zenml.console import console
-from zenml.enums import SecretSchemaType, StackComponentType
+from zenml.enums import StackComponentType
 from zenml.repository import Repository
+from zenml.secret import ARBITRARY_SECRET_SCHEMA_TYPE
 from zenml.secret.secret_schema_class_registry import SecretSchemaClassRegistry
 from zenml.secrets_managers.base_secrets_manager import BaseSecretsManager
 
@@ -65,9 +66,9 @@ def secret(ctx: click.Context) -> None:
     "--schema",
     "-s",
     "secret_schema_type",
-    default=SecretSchemaType.ARBITRARY.value,
+    default=ARBITRARY_SECRET_SCHEMA_TYPE,
     help="Register a secret with an optional schema.",
-    type=click.Choice(SecretSchemaType.values()),
+    type=str,
 )
 @click.option(
     "--key",

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -369,11 +369,19 @@ def pretty_print_secret(
         hide_secret: boolean that configures if the secret values are shown
             on the CLI
     """
+
+    def get_secret_value(value: Any) -> str:
+        if value is None:
+            return ""
+        if hide_secret:
+            return "***"
+        return str(value)
+
     stack_dicts = [
         {
             "SECRET_NAME": secret.name,
             "SECRET_KEY": key,
-            "SECRET_VALUE": "***" if hide_secret else value,
+            "SECRET_VALUE": get_secret_value(value),
         }
         for key, value in secret.content.items()
     ]

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -66,13 +66,6 @@ class MetadataContextTypes(Enum):
     PIPELINE_REQUIREMENTS = "pipeline_requirements"
 
 
-class SecretSchemaType(StrEnum):
-    """All supported secret schema types."""
-
-    AWS = "aws"
-    ARBITRARY = "arbitrary"
-
-
 class StoreType(StrEnum):
     """Repository Store Backend Types"""
 

--- a/src/zenml/integrations/aws/__init__.py
+++ b/src/zenml/integrations/aws/__init__.py
@@ -28,6 +28,7 @@ class AWSIntegration(Integration):
     @classmethod
     def activate(cls) -> None:
         """Activates the integration."""
+        from zenml.integrations.aws import secret_schemas  # noqa
         from zenml.integrations.aws import secrets_managers  # noqa
 
 

--- a/src/zenml/integrations/aws/secret_schemas/aws_secret_schema.py
+++ b/src/zenml/integrations/aws/secret_schemas/aws_secret_schema.py
@@ -11,14 +11,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import Optional
+from typing import ClassVar, Optional
 
-from zenml.enums import SecretSchemaType
+from zenml.secret import register_secret_schema_class
 from zenml.secret.base_secret import BaseSecretSchema
 
+AWS_SECRET_SCHEMA_TYPE = "aws"
 
+
+@register_secret_schema_class
 class AWSSecretSchema(BaseSecretSchema):
+
+    TYPE: ClassVar[str] = AWS_SECRET_SCHEMA_TYPE
+
     aws_access_key_id: str
     aws_secret_access_key: str
     aws_session_token: Optional[str]
-    schema_type: SecretSchemaType = SecretSchemaType.AWS

--- a/src/zenml/integrations/aws/secrets_managers/aws_secrets_manager.py
+++ b/src/zenml/integrations/aws/secrets_managers/aws_secrets_manager.py
@@ -43,7 +43,7 @@ def jsonify_secret_contents(secret: BaseSecretSchema) -> str:
         type
     """
     secret_contents = secret.content
-    secret_contents[ZENML_SCHEMA_NAME] = secret.schema_type
+    secret_contents[ZENML_SCHEMA_NAME] = secret.TYPE
     return json.dumps(secret_contents)
 
 

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_component.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_component.py
@@ -22,6 +22,7 @@ Note: This requires Kubeflow Pipelines SDK to be installed.
 """
 import json
 import os.path
+import re
 import sys
 from typing import Dict, List, Set
 
@@ -32,11 +33,9 @@ from tfx.dsl.components.base import base_component as tfx_base_component
 from tfx.orchestration import data_types
 from tfx.proto.orchestration import pipeline_pb2
 
-from zenml.artifact_stores import LocalArtifactStore
 from zenml.constants import ENV_ZENML_PREVENT_PIPELINE_EXECUTION
 from zenml.integrations.kubeflow.orchestrators import kubeflow_utils as utils
 from zenml.logger import get_logger
-from zenml.metadata_stores import SQLiteMetadataStore
 from zenml.repository import Repository
 from zenml.utils import source_utils
 
@@ -153,38 +152,33 @@ class KubeflowComponent:
             arguments.append(_encode_runtime_parameter(param))
 
         stack = Repository().active_stack
-        artifact_store = stack.artifact_store
-        metadata_store = stack.metadata_store
 
+        # go through all stack components and identify those that advertise
+        # a local path where they persist information that they need to be
+        # available when running pipelines. For those that do, mount them
+        # into the Kubeflow container.
         has_local_repos = False
-
-        if isinstance(artifact_store, LocalArtifactStore):
+        for stack_comp in stack.components.values():
+            local_path = stack_comp.local_path
+            if not local_path:
+                continue
             has_local_repos = True
             host_path = k8s_client.V1HostPathVolumeSource(
-                path=artifact_store.path, type="Directory"
+                path=local_path, type="Directory"
             )
-            volumes[artifact_store.path] = k8s_client.V1Volume(
-                name="local-artifact-store", host_path=host_path
-            )
-            logger.debug(
-                "Adding host path volume for local artifact store (path: %s) "
-                "in kubeflow pipelines container.",
-                artifact_store.path,
-            )
-
-        if isinstance(metadata_store, SQLiteMetadataStore):
-            has_local_repos = True
-            metadata_store_dir = os.path.dirname(metadata_store.uri)
-            host_path = k8s_client.V1HostPathVolumeSource(
-                path=metadata_store_dir, type="Directory"
-            )
-            volumes[metadata_store_dir] = k8s_client.V1Volume(
-                name="local-metadata-store", host_path=host_path
+            volume_name = f"{stack_comp.TYPE.value}-{stack_comp.name}"
+            volumes[local_path] = k8s_client.V1Volume(
+                name=re.sub(r"[^0-9a-zA-Z-]+", "-", volume_name)
+                .strip("-")
+                .lower(),
+                host_path=host_path,
             )
             logger.debug(
-                "Adding host path volume for local metadata store (uri: %s) "
+                "Adding host path volume for %s %s (path: %s) "
                 "in kubeflow pipelines container.",
-                metadata_store.uri,
+                stack_comp.TYPE.value,
+                stack_comp.name,
+                local_path,
             )
 
         self.container_op = dsl.ContainerOp(

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -132,6 +132,30 @@ class KubeflowOrchestrator(BaseOrchestrator):
             push_docker_image,
         )
 
+        # if the orchestrator is not running in a local k3d cluster,
+        # we cannot mount the local path into the container. This
+        # may result in problems when running the pipeline, because
+        # the local components will not be available inside the
+        # Kubeflow containers.
+        if self.kubernetes_context:
+            # go through all stack components and identify those that advertise
+            # a local path where they persist information that they need to be
+            # available when running pipelines.
+            for stack_comp in stack.components.values():
+                local_path = stack_comp.local_path
+                if not local_path:
+                    continue
+                logger.warning(
+                    "The Kubeflow orchestrator is not running in a local k3d "
+                    "cluster. The '%s' %s is a local stack component and will "
+                    "not be available in the Kubeflow pipeline step. Please "
+                    "ensure that you never combine non-local stack components "
+                    "with a remote orchestrator, otherwise you may run into "
+                    "pipeline execution problems.",
+                    stack_comp.name,
+                    stack_comp.TYPE.value,
+                )
+
         image_name = self.get_docker_image_name(pipeline.name)
 
         requirements = {*stack.requirements(), *pipeline.requirements}

--- a/src/zenml/integrations/seldon/__init__.py
+++ b/src/zenml/integrations/seldon/__init__.py
@@ -31,6 +31,7 @@ class SeldonIntegration(Integration):
     def activate() -> None:
         """Activate the Seldon Core integration."""
         from zenml.integrations.seldon import model_deployers  # noqa
+        from zenml.integrations.seldon import secret_schemas  # noqa
         from zenml.integrations.seldon import services  # noqa
 
 

--- a/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
+++ b/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
@@ -282,10 +282,12 @@ class SeldonModelDeployer(BaseModelDeployer):
         config = cast(SeldonDeploymentConfig, config)
         service = None
 
-        # update the service configuration with the name of the Kubernetes
-        # secret that is used to authenticate Seldon Core to the Artifact
-        # Store
-        config.secret_name = self._create_or_update_kubernetes_secret()
+        # if a custom Kubernetes secret is not explicitly specified in the
+        # SeldonDeploymentConfig, try to create one from the ZenML secret
+        # configured for the model deployer
+        config.secret_name = (
+            config.secret_name or self._create_or_update_kubernetes_secret()
+        )
 
         # if replace is True, find equivalent Seldon Core deployments
         if replace is True:

--- a/src/zenml/integrations/seldon/secret_schemas/__init__.py
+++ b/src/zenml/integrations/seldon/secret_schemas/__init__.py
@@ -1,0 +1,36 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""
+## Seldon Secret Schemas
+
+These are secret schemas that can be used to authenticate Seldon to the
+Artifact Store used to store served ML models.
+"""
+from zenml.integrations.seldon.secret_schemas.secret_schemas import (
+    SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE,
+    SELDON_GS_SECRET_SCHEMA_TYPE,
+    SELDON_S3_SECRET_SCHEMA_TYPE,
+    SeldonAzureSecretSchema,
+    SeldonGSSecretSchema,
+    SeldonS3SecretSchema,
+)
+
+__all__ = [
+    "SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE",
+    "SELDON_GS_SECRET_SCHEMA_TYPE",
+    "SELDON_S3_SECRET_SCHEMA_TYPE",
+    "SeldonAzureSecretSchema",
+    "SeldonGSSecretSchema",
+    "SeldonS3SecretSchema",
+]

--- a/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
+++ b/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
@@ -1,0 +1,118 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+from typing import ClassVar, Dict, Literal, Optional
+
+from zenml.secret import register_secret_schema_class
+from zenml.secret.base_secret import BaseSecretSchema
+
+SELDON_S3_SECRET_SCHEMA_TYPE = "seldon_s3"
+SELDON_GS_SECRET_SCHEMA_TYPE = "seldon_gs"
+SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE = "seldon_azureblob"
+
+
+@register_secret_schema_class
+class SeldonS3SecretSchema(BaseSecretSchema):
+    """Seldon S3 credentials.
+
+    Based on: https://rclone.org/s3/#amazon-s3
+
+    Attributes:
+        rclone_config_s3_type: the rclone config type. Must be set to "s3" for
+            this schema.
+        rclone_config_s3_provider: the S3 provider (e.g. aws, ceph, minio).
+        rclone_config_s3_env_auth: get AWS credentials from EC2/ECS meta data
+            (i.e. with IAM roles configuration). Only applies if access_key_id
+            and secret_access_key are blank.
+        rclone_config_s3_access_key_id: AWS Access Key ID.
+        rclone_config_s3_secret_access_key: AWS Secret Access Key.
+        rclone_config_s3_session_token: AWS Session Token.
+        rclone_config_s3_region: region to connect to.
+        rclone_config_s3_endpoint: S3 API endpoint.
+
+    """
+
+    TYPE: ClassVar[str] = SELDON_S3_SECRET_SCHEMA_TYPE
+
+    rclone_config_s3_type: Literal["s3"]
+    rclone_config_s3_provider: str = "aws"
+    rclone_config_s3_env_auth: bool = False
+    rclone_config_s3_access_key_id: Optional[str]
+    rclone_config_s3_secret_access_key: Optional[str]
+    rclone_config_s3_session_token: Optional[str]
+    rclone_config_s3_region: Optional[str]
+    rclone_config_s3_endpoint: Optional[str]
+
+
+@register_secret_schema_class
+class SeldonGSSecretSchema(BaseSecretSchema):
+    """Seldon GCS credentials.
+
+    Based on: https://rclone.org/googlecloudstorage/
+
+    Attributes:
+
+        rclone_config_gs_type: the rclone config type. Must be set to "google
+            cloud storage" for this schema.
+        rclone_config_gs_client_id: OAuth client id.
+        rclone_config_gs_client_secret: OAuth client secret.
+        rclone_config_gs_token: OAuth Access Token as a JSON blob.
+        rclone_config_gs_project_number: project number.
+        rclone_config_gs_service_account_credentials: service account
+            credentials JSON blob.
+        rclone_config_gs_anonymous: access public buckets and objects without
+            credentials. Set to True if you just want to download files and
+            don't configure credentials.
+        rclone_config_gs_auth_url: auth server URL.
+    """
+
+    TYPE: ClassVar[str] = SELDON_GS_SECRET_SCHEMA_TYPE
+
+    rclone_config_gs_type: Literal["google cloud storage"]
+    rclone_config_gs_client_id: Optional[str]
+    rclone_config_gs_client_secret: Optional[str]
+    rclone_config_gs_project_number: Optional[str]
+    rclone_config_gs_service_account_credentials: Optional[Dict[str, str]]
+    rclone_config_gs_anonymous: bool = False
+    rclone_config_gs_token: Optional[str]
+    rclone_config_gs_auth_url: Optional[str]
+    rclone_config_gs_token_url: Optional[str]
+
+
+@register_secret_schema_class
+class SeldonAzureSecretSchema(BaseSecretSchema):
+    """Seldon Azure Blob Storage credentials.
+
+    Based on: https://rclone.org/azureblob/
+
+    Attributes:
+
+        rclone_config_azureblob_type: the rclone config type. Must be set to
+            "azureblob" for this schema.
+        rclone_config_azureblob_account: storage Account Name. Leave blank to
+            use SAS URL or MSI.
+        rclone_config_azureblob_key: storage Account Key. Leave blank to
+            use SAS URL or MSI.
+        rclone_config_azureblob_sas_url: SAS URL for container level access
+            only. Leave blank if using account/key or MSI.
+        rclone_config_azureblob_use_msi: use a managed service identity to
+            authenticate (only works in Azure).
+    """
+
+    TYPE: ClassVar[str] = SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE
+
+    rclone_config_azureblob_type: Literal["azureblob"]
+    rclone_config_azureblob_account: Optional[str]
+    rclone_config_azureblob_key: Optional[str]
+    rclone_config_azureblob_sas_url: Optional[str]
+    rclone_config_azureblob_use_msi: bool = False

--- a/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
+++ b/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
@@ -11,14 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import ClassVar, Dict, Literal, Optional
+from typing import ClassVar, Literal, Optional
 
 from zenml.secret import register_secret_schema_class
 from zenml.secret.base_secret import BaseSecretSchema
 
 SELDON_S3_SECRET_SCHEMA_TYPE = "seldon_s3"
 SELDON_GS_SECRET_SCHEMA_TYPE = "seldon_gs"
-SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE = "seldon_azureblob"
+SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE = "seldon_az"
 
 
 @register_secret_schema_class
@@ -44,7 +44,7 @@ class SeldonS3SecretSchema(BaseSecretSchema):
 
     TYPE: ClassVar[str] = SELDON_S3_SECRET_SCHEMA_TYPE
 
-    rclone_config_s3_type: Literal["s3"]
+    rclone_config_s3_type: Literal["s3"] = "s3"
     rclone_config_s3_provider: str = "aws"
     rclone_config_s3_env_auth: bool = False
     rclone_config_s3_access_key_id: Optional[str]
@@ -78,11 +78,13 @@ class SeldonGSSecretSchema(BaseSecretSchema):
 
     TYPE: ClassVar[str] = SELDON_GS_SECRET_SCHEMA_TYPE
 
-    rclone_config_gs_type: Literal["google cloud storage"]
+    rclone_config_gs_type: Literal[
+        "google cloud storage"
+    ] = "google cloud storage"
     rclone_config_gs_client_id: Optional[str]
     rclone_config_gs_client_secret: Optional[str]
     rclone_config_gs_project_number: Optional[str]
-    rclone_config_gs_service_account_credentials: Optional[Dict[str, str]]
+    rclone_config_gs_service_account_credentials: Optional[str]
     rclone_config_gs_anonymous: bool = False
     rclone_config_gs_token: Optional[str]
     rclone_config_gs_auth_url: Optional[str]
@@ -111,7 +113,7 @@ class SeldonAzureSecretSchema(BaseSecretSchema):
 
     TYPE: ClassVar[str] = SELDON_AZUREBLOB_SECRET_SCHEMA_TYPE
 
-    rclone_config_azureblob_type: Literal["azureblob"]
+    rclone_config_azureblob_type: Literal["azureblob"] = "azureblob"
     rclone_config_azureblob_account: Optional[str]
     rclone_config_azureblob_key: Optional[str]
     rclone_config_azureblob_sas_url: Optional[str]

--- a/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
+++ b/src/zenml/integrations/seldon/secret_schemas/secret_schemas.py
@@ -11,7 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Optional
+
+from typing_extensions import Literal
 
 from zenml.secret import register_secret_schema_class
 from zenml.secret.base_secret import BaseSecretSchema

--- a/src/zenml/metadata_stores/sqlite_metadata_store.py
+++ b/src/zenml/metadata_stores/sqlite_metadata_store.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+from pathlib import Path
 from typing import ClassVar, Union
 
 from ml_metadata.proto import metadata_store_pb2
@@ -28,6 +29,11 @@ class SQLiteMetadataStore(BaseMetadataStore):
 
     # Class Configuration
     FLAVOR: ClassVar[str] = "sqlite"
+
+    @property
+    def local_path(self) -> str:
+        """Path to the local directory where the SQLite DB is stored."""
+        return str(Path(self.uri).parent)
 
     @property
     def upgrade_migration_enabled(self) -> bool:

--- a/src/zenml/secret/__init__.py
+++ b/src/zenml/secret/__init__.py
@@ -22,10 +22,20 @@ point of registration, ZenML will set the schema as `ArbitrarySecretSchema`, a
 kind of default schema where things that aren't attached to a grouping can be
 stored.
 """
+from zenml.secret.arbitrary_secret_schema import (
+    ARBITRARY_SECRET_SCHEMA_TYPE,
+    ArbitrarySecretSchema,
+)
 from zenml.secret.base_secret import BaseSecretSchema
-from zenml.secret.secret_schema_class_registry import SecretSchemaClassRegistry
+from zenml.secret.secret_schema_class_registry import (
+    SecretSchemaClassRegistry,
+    register_secret_schema_class,
+)
 
 __all__ = [
+    "ARBITRARY_SECRET_SCHEMA_TYPE",
+    "ArbitrarySecretSchema",
     "BaseSecretSchema",
     "SecretSchemaClassRegistry",
+    "register_secret_schema_class",
 ]

--- a/src/zenml/secret/arbitrary_secret_schema.py
+++ b/src/zenml/secret/arbitrary_secret_schema.py
@@ -15,7 +15,7 @@ from typing import Any, ClassVar, Dict
 
 from pydantic import root_validator
 
-from zenml.secret import BaseSecretSchema
+from zenml.secret.base_secret import BaseSecretSchema
 
 ARBITRARY_SECRET_SCHEMA_TYPE = "arbitrary"
 

--- a/src/zenml/secret/arbitrary_secret_schema.py
+++ b/src/zenml/secret/arbitrary_secret_schema.py
@@ -11,19 +11,20 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import Any, Dict
+from typing import Any, ClassVar, Dict
 
 from pydantic import root_validator
 
-from zenml.enums import SecretSchemaType
 from zenml.secret import BaseSecretSchema
+
+ARBITRARY_SECRET_SCHEMA_TYPE = "arbitrary"
 
 
 class ArbitrarySecretSchema(BaseSecretSchema):
     """Schema for arbitrary collections of key value pairs with no
     predefined schema."""
 
-    schema_type: SecretSchemaType = SecretSchemaType.ARBITRARY
+    TYPE: ClassVar[str] = ARBITRARY_SECRET_SCHEMA_TYPE
 
     arbitrary_kv_pairs: Dict[str, Any]
 

--- a/src/zenml/secret/base_secret.py
+++ b/src/zenml/secret/base_secret.py
@@ -30,7 +30,7 @@ class BaseSecretSchema(BaseModel, ABC):
         Returns:
             A dictionary containing the content of the SecretSchema.
         """
-        fields_dict = self.dict()
+        fields_dict = self.dict(exclude_none=True)
         fields_dict.pop("name")
         if "arbitrary_kv_pairs" in fields_dict:
             arbitrary_kv_pairs = fields_dict.pop("arbitrary_kv_pairs")

--- a/src/zenml/secret/base_secret.py
+++ b/src/zenml/secret/base_secret.py
@@ -12,16 +12,14 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 from abc import ABC
-from typing import Any, Dict, List
+from typing import Any, ClassVar, Dict, List
 
 from pydantic import BaseModel
-
-from zenml.enums import SecretSchemaType
 
 
 class BaseSecretSchema(BaseModel, ABC):
     name: str
-    schema_type: SecretSchemaType
+    TYPE: ClassVar[str]
 
     @property
     def content(self) -> Dict[str, Any]:
@@ -34,7 +32,6 @@ class BaseSecretSchema(BaseModel, ABC):
         """
         fields_dict = self.dict()
         fields_dict.pop("name")
-        fields_dict.pop("schema_type")
         if "arbitrary_kv_pairs" in fields_dict:
             arbitrary_kv_pairs = fields_dict.pop("arbitrary_kv_pairs")
             fields_dict.update(arbitrary_kv_pairs)
@@ -50,7 +47,7 @@ class BaseSecretSchema(BaseModel, ABC):
             A list of all attribute keys that are not part of the ignored set.
         """
 
-        ignored_keys = ["name", "arbitrary_kv_pairs", "schema_type"]
+        ignored_keys = ["name", "arbitrary_kv_pairs"]
         return [
             schema_key
             for schema_key in cls.__fields__.keys()

--- a/src/zenml/secret/secret_schema_class_registry.py
+++ b/src/zenml/secret/secret_schema_class_registry.py
@@ -11,10 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import Callable, ClassVar, Dict, Type, TypeVar, Union
+from typing import ClassVar, Dict, Type, TypeVar
 
-from zenml.enums import SecretSchemaType
-from zenml.integrations.aws.secret_schemas import AWSSecretSchema
 from zenml.logger import get_logger
 from zenml.secret import BaseSecretSchema
 from zenml.secret.arbitrary_secret_schema import ArbitrarySecretSchema
@@ -35,58 +33,50 @@ class SecretSchemaClassRegistry:
     @classmethod
     def register_class(
         cls,
-        secret_schema: SecretSchemaType,
         secret: Type[BaseSecretSchema],
     ) -> None:
         """Registers a SecretSchema class.
 
         Args:
-            secret_schema: The flavor of the SecretSchema class to register.
             secret: The SecretSchema class to register.
         """
-        secret_schema_value = secret_schema.value
         flavors = cls.secret_schema_classes
-        if secret_schema_value in flavors:
+        if secret.TYPE in flavors:
             logger.warning(
-                "Overwriting previously registered stack component class `%s` "
+                "Overwriting previously registered secret schema class `%s` "
                 "for type '%s' and flavor '%s'.",
-                flavors[secret_schema_value].__class__.__name__,
-                secret_schema_value,
+                flavors[secret.TYPE].__class__.__name__,
+                secret.TYPE,
             )
 
-        flavors[secret_schema_value] = secret
+        flavors[secret.TYPE] = secret
         logger.debug(
-            "Registered stack component class for type '%s' and flavor '%s'.",
+            "Registered secret schema class for type '%s' and flavor '%s'.",
             secret.__class__.__name__,
-            secret_schema_value,
+            secret.TYPE,
         )
 
     @classmethod
     def get_class(
         cls,
-        secret_schema: Union[SecretSchemaType, str],
+        secret_schema: str,
     ) -> Type[BaseSecretSchema]:
-        """Returns the SecretSchema class for the given type and flavor.
+        """Returns the SecretSchema class for the given flavor.
 
         Args:
             secret_schema: The flavor of the SecretSchema class to return.
 
         Returns:
-            The SecretSchema class for the given type and flavor.
+            The SecretSchema class for the given flavor.
 
         Raises:
-            KeyError: If no SecretSchema class is registered for the given type
-                and flavor.
+            KeyError: If no SecretSchema class is registered for the given
+                flavor.
         """
-        if isinstance(secret_schema, SecretSchemaType):
-            secret_schema = secret_schema.value
-
         available_schemas = cls.secret_schema_classes
         try:
             return available_schemas[secret_schema]
         except KeyError:
-            # TODO [ENG-722]: Probably remove this exception catch. Doesn't apply
-            # to SecretSchema
             # The SecretSchema might be part of an integration
             # -> Activate the integrations and try again
             from zenml.integrations.registry import integration_registry
@@ -97,50 +87,29 @@ class SecretSchemaClassRegistry:
                 return available_schemas[secret_schema]
             except KeyError:
                 raise KeyError(
-                    f"No SecretSchema class found for SecretSet  "
-                    f"of flavor {secret_schema}. Registered flavors are:"
-                    f" {set(available_schemas)}."
+                    f"No SecretSchema class found for schema flavor "
+                    f"{secret_schema}. Registered flavors are: "
+                    f"{set(available_schemas)}. If your secret schema "
+                    f"class is part of a ZenML integration, make "
+                    f"sure the corresponding integration is installed by "
+                    f"running `zenml integration install INTEGRATION_NAME`."
                 ) from None
 
 
 C = TypeVar("C", bound=BaseSecretSchema)
 
 
-def register_secret_schema_class(
-    secret_schema: SecretSchemaType,
-) -> Callable[[Type[C]], Type[C]]:
-    """Parametrized decorator function to register SecretSchema classes.
+def register_secret_schema_class(cls: Type[C]) -> Type[C]:
+    """Registers the SecretSchema class and returns it unmodified.
 
     Args:
-        secret_schema: The flavor of the SecretSchema class to register.
+        cls: The SecretSchema class to register.
 
     Returns:
-        A decorator function that registers and returns the decorated SecretSchema class.
+        The (unmodified) SecretSchema class to register.
     """
-
-    def decorator_function(cls: Type[C]) -> Type[C]:
-        """Registers the SecretSchema class and returns it unmodified.
-
-        Args:
-            cls: The SecretSchema class to register.
-
-        Returns:
-            The (unmodified) SecretSchema class to register.
-        """
-        SecretSchemaClassRegistry.register_class(
-            secret_schema=secret_schema,
-            secret=cls,
-        )
-        return cls
-
-    return decorator_function
+    SecretSchemaClassRegistry.register_class(secret=cls)
+    return cls
 
 
-SecretSchemaClassRegistry.register_class(
-    SecretSchemaType.AWS,
-    AWSSecretSchema,
-)
-SecretSchemaClassRegistry.register_class(
-    SecretSchemaType.ARBITRARY,
-    ArbitrarySecretSchema,
-)
+SecretSchemaClassRegistry.register_class(ArbitrarySecretSchema)

--- a/src/zenml/secrets_managers/local/local_secrets_manager.py
+++ b/src/zenml/secrets_managers/local/local_secrets_manager.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 import os
 import uuid
+from pathlib import Path
 from typing import Any, ClassVar, Dict, List
 
 from zenml.cli.utils import error
@@ -62,6 +63,11 @@ class LocalSecretsManager(BaseSecretsManager):
             kwargs["secrets_file"] = get_secret_store_path(temp_uuid)
             kwargs["uuid"] = temp_uuid
         super().__init__(*args, **kwargs)
+
+    @property
+    def local_path(self) -> str:
+        """Path to the local directory where the secrets are stored."""
+        return str(Path(self.secrets_file).parent)
 
     def _create_secrets_file__if_not_exists(self) -> None:
         """Makes sure the secrets yaml file exists"""

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -66,6 +66,17 @@ class StackComponent(BaseModel, ABC):
         """Set of PyPI requirements for the component."""
         return set(get_requirements_for_module(self.__module__))
 
+    @property
+    def local_path(self) -> Optional[str]:
+        """Path to a local directory used by the component to store persistent
+        information.
+
+        This property should only be implemented by components that need to
+        store persistent information in a directory on the local machine and
+        also need that information to be available during pipeline runs.
+        """
+        return None
+
     def prepare_pipeline_deployment(
         self,
         pipeline: "BasePipeline",

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -74,6 +74,28 @@ class StackComponent(BaseModel, ABC):
         This property should only be implemented by components that need to
         store persistent information in a directory on the local machine and
         also need that information to be available during pipeline runs.
+
+        IMPORTANT: the path returned by this property must always be a path
+        that is relative to the ZenML global config directory. The local
+        Kubeflow orchestrator relies on this convention to correctly mount the
+        local folders in the Kubeflow containers. This is an example of a valid
+        path:
+
+        ```python
+        from zenml.io.utils import get_global_config_directory
+        from zenml.constants import LOCAL_STORES_DIRECTORY_NAME
+
+        ...
+
+        @property
+        def local_path(self) -> Optional[str]:
+
+            return os.path.join(
+                get_global_config_directory(),
+                LOCAL_STORES_DIRECTORY_NAME,
+                str(uuid),
+            )
+        ```
         """
         return None
 

--- a/src/zenml/utils/secrets_manager_utils.py
+++ b/src/zenml/utils/secrets_manager_utils.py
@@ -41,7 +41,7 @@ def encode_secret(secret: BaseSecretSchema) -> Dict[str, str]:
         Encoded secret Dict containing key-value pairs
     """
     encoded_secret = {k: encode_string(v) for k, v in secret.content.items()}
-    encoded_secret[ZENML_SCHEMA_NAME] = secret.schema_type.value
+    encoded_secret[ZENML_SCHEMA_NAME] = secret.TYPE
     return encoded_secret
 
 

--- a/src/zenml/utils/secrets_manager_utils.py
+++ b/src/zenml/utils/secrets_manager_utils.py
@@ -40,7 +40,11 @@ def encode_secret(secret: BaseSecretSchema) -> Dict[str, str]:
     Returns:
         Encoded secret Dict containing key-value pairs
     """
-    encoded_secret = {k: encode_string(v) for k, v in secret.content.items()}
+    encoded_secret = {
+        k: encode_string(str(v))
+        for k, v in secret.content.items()
+        if v is not None
+    }
     encoded_secret[ZENML_SCHEMA_NAME] = secret.TYPE
     return encoded_secret
 


### PR DESCRIPTION
## Describe changes

This PR updates the Secret Manager implementation to make it more flexible:

* allows integrations and user code to more easily register their own secret schemas
* mounts the local secret manager inside the local Kubeflow, so it can be accessed by steps if needed (e.g. this is required to deploy models in Seldon Core with a local Kubeflow orchestrator and secret manager, but with a remote Seldon Core installation and an AWS S3 artifact store)
* other minor improvements to the secret manager CLI to take into account optional keys

As a result of unifying how the paths of local stack components are mounted inside local Kubeflow containers, the PR also updates the MLflow model deployer so that it can be used with a local Kubeflow orchestrator.

The final goal of this PR is to update the Seldon Core model deployer so that it configures Kubernetes secrets automatically from ZenML secrets. The model deployer component now accepts a new `--secret` configuration attribute that points to a ZenML secret that contains credentials needed to access the AWS S3, GCS or Azure Blob storage artifact store. Three secret schemas are also included to help with that.

### Implementation Details

#### Formalizing stack components with locally persisted state

The base`StackComponent` class gets a new property that all stack components with local folders, like the default Artifact Store, the default Metadata Store and the local Secrets Manager need to implement to provide the path of the local folder where information is persisted:

```python
    @property
    def local_path(self) -> Optional[str]:
        ...
```

This property is then used in the Kubeflow orchestrator to determine which local folders need to be mounted in the Kubeflow pipeline containers when the local Kubeflow orchestrator is used. The end result is that the local Secrets Manager folder is now automatically mounted in Kubeflow and can be accessed from pipeline steps. This is important for pipeline steps like the Seldon Core model deployment step that must access a ZenML secret with credentials needed to authenticate the Seldon Core model servers to the Artifact Store.

#### Allowing registration of secret schemas from integrations

Following the same approach used for stack component classes, the `BaseSecretSchema` type is now a `ClassVar` attribute of type string:

```python
class BaseSecretSchema(BaseModel, ABC):
    name: str
    TYPE: ClassVar[str]
```

This allows secret schemas to be more easily registered from any part of the code, ZenML integration or otherwise:

```python
AWS_SECRET_SCHEMA_TYPE = "aws"

@register_secret_schema_class
class AWSSecretSchema(BaseSecretSchema):

    TYPE: ClassVar[str] = AWS_SECRET_SCHEMA_TYPE

    aws_access_key_id: str
    aws_secret_access_key: str
    aws_session_token: Optional[str]
```

#### Seldon Core authentication through ZenML secrets

The Seldon Core Model Deployer gets a new `secret` configuration attribute that points to a ZenML secret. The Model Deployer then converts that ZenML secret into a Kubernetes secret. The Seldon Core integration also provides 3 different secret schemas for the 3 flavors of Artifact Store:  AWS, GCP and Azure.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

