### PR TITLE
Fix link to CI workflow from CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ At its core, **ZenML pipelines execute ML-specific workflows** from sourcing dat
 ![GitHub](https://img.shields.io/github/license/zenml-io/zenml)
 [![Codecov](https://codecov.io/gh/zenml-io/zenml/branch/main/graph/badge.svg)](https://codecov.io/gh/zenml-io/zenml)
 [![Interrogate](docs/interrogate.svg)](https://interrogate.readthedocs.io/en/latest/)
-![Main Workflow Tests](https://github.com/zenml-io/zenml/actions/workflows/ci.yml/badge.svg)
+[![Main Workflow Tests](https://github.com/zenml-io/zenml/actions/workflows/ci.yml/badge.svg)](https://github.com/zenml-io/zenml/actions/workflows/ci.yml)
 
 <div align="center">
 Join our <a href="https://zenml.io/slack-invite" target="_blank">


### PR DESCRIPTION
The default link for a workflow badge points to the image itself.
Update link to point to the Actions tab on GitHub with the list of runs.
[skip ci] since we are not modifying any code that would impact CI.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

