### PR TITLE
Update contributing and fix ci badge to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,13 +46,14 @@ For changes that address core functionality or would require breaking changes (e
 
 In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr)
 
-1. Fork the repository to your own Github account
-2. Clone the project to your machine
-3. Create a branch locally with a succinct but descriptive name
-4. Commit changes to the branch
-5. Following any formatting and testing guidelines specific to this repo
-6. Push changes to your fork
-7. Open a PR in our repository (to the `develop` branch, NOT `main`) and follow the PR template so that we can efficiently review the changes.
+1. Review and sign the [Contributor License Agreement](https://cla-assistant.io/zenml-io/zenml) (CLA).
+2. Fork the repository to your own Github account
+3. Clone the project to your machine
+4. Create a branch locally with a succinct but descriptive name
+5. Commit changes to the branch
+6. Following any formatting and testing guidelines specific to this repo
+7. Push changes to your fork
+8. Open a PR in our repository (to the `develop` branch, **NOT** `main`) and follow the PR template so that we can efficiently review the changes.
 
 ### Linting, formatting, and tests
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ At its core, **ZenML pipelines execute ML-specific workflows** from sourcing dat
 ![GitHub](https://img.shields.io/github/license/zenml-io/zenml)
 [![Codecov](https://codecov.io/gh/zenml-io/zenml/branch/main/graph/badge.svg)](https://codecov.io/gh/zenml-io/zenml)
 [![Interrogate](docs/interrogate.svg)](https://interrogate.readthedocs.io/en/latest/)
-![Main Workflow Tests](https://github.com/zenml-io/zenml/actions/workflows/ci.yml/badge.svg)
+[![Main Workflow Tests](https://github.com/zenml-io/zenml/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/zenml-io/zenml/actions/workflows/ci.yml)
 
 <div align="center">
 Join our <a href="https://zenml.io/slack-invite" target="_blank">


### PR DESCRIPTION
## Describe changes
I changed the link of the CI badge to point to main and added the CLA in the contributing.md, as rightly requested by @mbrukman.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

