### PR TITLE
Build docker base images quicker after release

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,26 +6,10 @@ steps:
     args: ['-c', 'docker login --username=$$USERNAME --password=$$PASSWORD']
     secretEnv: ['USERNAME', 'PASSWORD']
 
-  # build base development image
-  - name : 'gcr.io/cloud-builders/docker'
-    id: 'build-base-dev'
-    waitFor: ['docker-login']
-    entrypoint: 'bash'
-    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-dev -t $$USERNAME/zenml:latest-dev -f docker/base-dev.Dockerfile .']
-    secretEnv: ['USERNAME']
-
-  # build CUDA development image
-  - name : 'gcr.io/cloud-builders/docker'
-    id: 'build-cuda-dev'
-    waitFor: [ 'docker-login' ]
-    entrypoint: 'bash'
-    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-cuda-dev -t $$USERNAME/zenml:latest-cuda-dev -f docker/cuda-dev.Dockerfile .']
-    secretEnv: ['USERNAME']
-
   # build base image
   - name : 'gcr.io/cloud-builders/docker'
     id: 'build-base'
-    waitFor: ['build-base-dev']
+    waitFor: ['docker-login']
     entrypoint: 'bash'
     args: ['-c', 'docker build --build-arg ZENML_VERSION=$TAG_NAME -t $$USERNAME/zenml:$TAG_NAME -t $$USERNAME/zenml:latest -f docker/base.Dockerfile .']
     secretEnv: ['USERNAME']
@@ -33,14 +17,39 @@ steps:
   # build CUDA image
   - name : 'gcr.io/cloud-builders/docker'
     id: 'build-cuda'
-    waitFor: [ 'build-cuda-dev' ]
+    waitFor: [ 'docker-login' ]
     entrypoint: 'bash'
     args: ['-c', 'docker build --build-arg ZENML_VERSION=$TAG_NAME -t $$USERNAME/zenml:$TAG_NAME-cuda -t $$USERNAME/zenml:latest-cuda -f docker/cuda.Dockerfile .']
     secretEnv: ['USERNAME']
 
-  # push all images
+  # push the non-development images. this happens early to get the images
+  # published as soon as possible after the release to provide the base
+  # container image for kubeflow etc.
   - name: 'gcr.io/cloud-builders/docker'
     id: 'push'
+    entrypoint: 'bash'
+    args: [ '-c', 'docker push $$USERNAME/zenml' ]
+    secretEnv: [ 'USERNAME' ]
+
+  # build base development image
+  - name : 'gcr.io/cloud-builders/docker'
+    id: 'build-base-dev'
+    waitFor: ['push']
+    entrypoint: 'bash'
+    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-dev -t $$USERNAME/zenml:latest-dev -f docker/base-dev.Dockerfile .']
+    secretEnv: ['USERNAME']
+
+  # build CUDA development image
+  - name : 'gcr.io/cloud-builders/docker'
+    id: 'build-cuda-dev'
+    waitFor: [ 'push' ]
+    entrypoint: 'bash'
+    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-cuda-dev -t $$USERNAME/zenml:latest-cuda-dev -f docker/cuda-dev.Dockerfile .']
+    secretEnv: ['USERNAME']
+
+  # push the development images
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'push-dev'
     entrypoint: 'bash'
     args: [ '-c', 'docker push $$USERNAME/zenml' ]
     secretEnv: [ 'USERNAME' ]
@@ -52,4 +61,4 @@ availableSecrets:
       env: 'PASSWORD'
     - versionName: projects/$PROJECT_ID/secrets/docker-username/versions/1
       env: 'USERNAME'
-timeout: 3600s
+timeout: 7200s


### PR DESCRIPTION
## Describe changes
Before this PR, all docker images were built before pushing them to dockerhub. Especially the ones that install zenml using poetry take a long time, which is why I swapped the order to:
- build non-poetry images
- push them
- build poetry images
- push them

This should now build and push the base images required for kubeflow/step operators within minutes instead of hours. I also increased the timeout to two hours so there is enough time to build the poetry images even if the build is slow.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

