### PR TITLE
Add `stack delete` confirmation prompt

### DIFF
--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -564,12 +564,13 @@ def describe_stack(stack_name: Optional[str]) -> None:
 
 @stack.command("delete")
 @click.argument("stack_name", type=str)
-@click.option("--yes", "-y", type=click.BOOL, default=False)
+@click.option("--yes", "-y", is_flag=True, required=False)
 def delete_stack(stack_name: str, yes: bool = False) -> None:
     """Delete a stack."""
     cli_utils.print_active_profile()
-
-    if not yes:
+    if yes:
+        confirmation = True
+    else:
         confirmation = cli_utils.confirmation(
             f"This will delete stack '{stack_name}' from your repository. \n"
             "Are you sure you want to proceed?"

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -568,40 +568,36 @@ def describe_stack(stack_name: Optional[str]) -> None:
 def delete_stack(stack_name: str, yes: bool = False) -> None:
     """Delete a stack."""
     cli_utils.print_active_profile()
-    if yes:
-        confirmation = True
-    else:
-        confirmation = cli_utils.confirmation(
-            f"This will delete stack '{stack_name}' from your repository. \n"
-            "Are you sure you want to proceed?"
-        )
+    confirmation = yes or cli_utils.confirmation(
+        f"This will delete stack '{stack_name}' from your repository. \n"
+        "Are you sure you want to proceed?"
+    )
 
-    if confirmation:
-        with console.status(f"Deleting stack '{stack_name}'...\n"):
-            cfg = GlobalConfiguration()
-            repo = Repository()
-
-            if cfg.active_stack_name == stack_name:
-                cli_utils.error(
-                    f"Stack {stack_name} cannot be deleted while it is globally "
-                    f"active. Please choose a different active global stack first "
-                    f"by running 'zenml stack set --global STACK'."
-                )
-                return
-
-            if repo.active_stack_name == stack_name:
-                cli_utils.error(
-                    f"Stack {stack_name} cannot be deleted while it is "
-                    f"active. Please choose a different active stack first by "
-                    f"running 'zenml stack set STACK'."
-                )
-                return
-
-        Repository().deregister_stack(stack_name)
-        cli_utils.declare(f"Deleted stack '{stack_name}'.")
-
-    else:
+    if not confirmation:
         cli_utils.declare("Stack deletion cancelled.")
+
+    with console.status(f"Deleting stack '{stack_name}'...\n"):
+        cfg = GlobalConfiguration()
+        repo = Repository()
+
+        if cfg.active_stack_name == stack_name:
+            cli_utils.error(
+                f"Stack {stack_name} cannot be deleted while it is globally "
+                f"active. Please choose a different active global stack first "
+                f"by running 'zenml stack set --global STACK'."
+            )
+            return
+
+        if repo.active_stack_name == stack_name:
+            cli_utils.error(
+                f"Stack {stack_name} cannot be deleted while it is "
+                f"active. Please choose a different active stack first by "
+                f"running 'zenml stack set STACK'."
+            )
+            return
+
+    Repository().deregister_stack(stack_name)
+    cli_utils.declare(f"Deleted stack '{stack_name}'.")
 
 
 @stack.command("set")

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -564,32 +564,43 @@ def describe_stack(stack_name: Optional[str]) -> None:
 
 @stack.command("delete")
 @click.argument("stack_name", type=str)
-def delete_stack(stack_name: str) -> None:
+@click.option("--yes", "-y", type=click.BOOL, default=False)
+def delete_stack(stack_name: str, yes: bool = False) -> None:
     """Delete a stack."""
     cli_utils.print_active_profile()
 
-    with console.status(f"Deleting stack '{stack_name}'...\n"):
-        cfg = GlobalConfiguration()
-        repo = Repository()
+    if not yes:
+        confirmation = cli_utils.confirmation(
+            f"This will delete stack '{stack_name}' from your repository. \n"
+            "Are you sure you want to proceed?"
+        )
 
-        if cfg.active_stack_name == stack_name:
-            cli_utils.error(
-                f"Stack {stack_name} cannot be deleted while it is globally "
-                f"active. Please choose a different active global stack first "
-                f"by running 'zenml stack set --global STACK'."
-            )
-            return
+    if confirmation:
+        with console.status(f"Deleting stack '{stack_name}'...\n"):
+            cfg = GlobalConfiguration()
+            repo = Repository()
 
-        if repo.active_stack_name == stack_name:
-            cli_utils.error(
-                f"Stack {stack_name} cannot be deleted while it is "
-                f"active. Please choose a different active stack first by "
-                f"running 'zenml stack set STACK'."
-            )
-            return
+            if cfg.active_stack_name == stack_name:
+                cli_utils.error(
+                    f"Stack {stack_name} cannot be deleted while it is globally "
+                    f"active. Please choose a different active global stack first "
+                    f"by running 'zenml stack set --global STACK'."
+                )
+                return
+
+            if repo.active_stack_name == stack_name:
+                cli_utils.error(
+                    f"Stack {stack_name} cannot be deleted while it is "
+                    f"active. Please choose a different active stack first by "
+                    f"running 'zenml stack set STACK'."
+                )
+                return
 
         Repository().deregister_stack(stack_name)
         cli_utils.declare(f"Deleted stack '{stack_name}'.")
+
+    else:
+        cli_utils.declare("Stack deletion cancelled.")
 
 
 @stack.command("set")

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -18,6 +18,7 @@ from click.testing import CliRunner
 from zenml.artifact_stores import LocalArtifactStore
 from zenml.cli.stack import (
     describe_stack,
+    delete_stack,
     remove_stack_component,
     rename_stack,
     update_stack,
@@ -82,7 +83,8 @@ def test_updating_non_active_stack_succeeds(clean_repo) -> None:
     )
     assert result.exit_code == 0
     assert (
-        clean_repo.get_stack("arias_new_stack").orchestrator == new_orchestrator
+        clean_repo.get_stack("arias_new_stack").orchestrator
+        == new_orchestrator
     )
 
 
@@ -100,7 +102,8 @@ def test_adding_to_stack_succeeds(clean_repo) -> None:
     assert result.exit_code == 0
     assert clean_repo.get_stack("default").secrets_manager is not None
     assert (
-        clean_repo.get_stack("default").secrets_manager == local_secrets_manager
+        clean_repo.get_stack("default").secrets_manager
+        == local_secrets_manager
     )
 
 
@@ -158,7 +161,9 @@ def test_renaming_non_active_stack_succeeds(clean_repo) -> None:
     clean_repo.register_stack(new_stack)
 
     runner = CliRunner()
-    result = runner.invoke(rename_stack, ["arias_stack", "arias_renamed_stack"])
+    result = runner.invoke(
+        rename_stack, ["arias_stack", "arias_renamed_stack"]
+    )
     assert result.exit_code == 0
     assert clean_repo.get_stack("arias_renamed_stack") is not None
     assert (
@@ -203,3 +208,19 @@ def test_remove_non_core_component_from_stack_succeeds(clean_repo) -> None:
     )
     assert result.exit_code == 0
     assert clean_repo.active_stack.secrets_manager is None
+
+
+def test_deleting_stack_with_flag_succeeds(clean_repo) -> None:
+    """Test stack delete with flag succeeds."""
+    new_stack = Stack(
+        name="arias_new_stack",
+        orchestrator=clean_repo.active_stack.orchestrator,
+        metadata_store=clean_repo.active_stack.metadata_store,
+        artifact_store=clean_repo.active_stack.artifact_store,
+    )
+    clean_repo.register_stack(new_stack)
+    runner = CliRunner()
+    result = runner.invoke(delete_stack, ["arias_new_stack", "-y"])
+    assert result.exit_code == 0
+    with pytest.raises(KeyError):
+        clean_repo.get_stack("arias_new_stack")

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -17,8 +17,8 @@ from click.testing import CliRunner
 
 from zenml.artifact_stores import LocalArtifactStore
 from zenml.cli.stack import (
-    describe_stack,
     delete_stack,
+    describe_stack,
     remove_stack_component,
     rename_stack,
     update_stack,
@@ -83,8 +83,7 @@ def test_updating_non_active_stack_succeeds(clean_repo) -> None:
     )
     assert result.exit_code == 0
     assert (
-        clean_repo.get_stack("arias_new_stack").orchestrator
-        == new_orchestrator
+        clean_repo.get_stack("arias_new_stack").orchestrator == new_orchestrator
     )
 
 
@@ -102,8 +101,7 @@ def test_adding_to_stack_succeeds(clean_repo) -> None:
     assert result.exit_code == 0
     assert clean_repo.get_stack("default").secrets_manager is not None
     assert (
-        clean_repo.get_stack("default").secrets_manager
-        == local_secrets_manager
+        clean_repo.get_stack("default").secrets_manager == local_secrets_manager
     )
 
 
@@ -161,9 +159,7 @@ def test_renaming_non_active_stack_succeeds(clean_repo) -> None:
     clean_repo.register_stack(new_stack)
 
     runner = CliRunner()
-    result = runner.invoke(
-        rename_stack, ["arias_stack", "arias_renamed_stack"]
-    )
+    result = runner.invoke(rename_stack, ["arias_stack", "arias_renamed_stack"])
     assert result.exit_code == 0
     assert clean_repo.get_stack("arias_renamed_stack") is not None
     assert (


### PR DESCRIPTION
## Describe changes
I added a confirmation check prior to stack deletion. You can do a 'force' delete (i.e. without confirmation) by passing in a `-y` flag.

The ticket, which admittedly I wrote, says that the logged output shouldn't refer to 'deregistering' stacks (but should just use the word 'delete') but on further consideration I think that's maybe not a smart idea and will be confusing (primarily for us). As long as we retain the concepts of 'registering' and 'deregistering' inside the repo and stack stores, we probably should retain that language.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

