### PR TITLE
Improve missing brackets error message

### DIFF
--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -48,6 +48,7 @@ from zenml.pipelines.schedule import Schedule
 from zenml.repository import Repository
 from zenml.runtime_configuration import RuntimeConfiguration
 from zenml.steps import BaseStep
+from zenml.steps.base_step import BaseStepMeta
 from zenml.utils import yaml_utils
 from zenml.utils.analytics_utils import AnalyticsEvent, track_event
 
@@ -189,6 +190,16 @@ class BasePipeline(metaclass=BasePipelineMeta):
                     f"Unexpected keyword argument '{key}' for pipeline "
                     f"'{self.name}'. A step for this key was "
                     f"already passed as a positional argument."
+                )
+
+            if isinstance(step, BaseStepMeta):
+                raise PipelineInterfaceError(
+                    f"Wrong argument type (`{step_class}`) for argument "
+                    f"'{key}' of pipeline '{self.name}'. "
+                    f"A `BaseStep` subclass was provided instead of an instance. "
+                    f"This might have been caused by missing brackets when "
+                    f"creating a pipeline with `@step` decorated functions, "
+                    f"for which the correct syntax is `pipeline(step=step())`."
                 )
 
             if not isinstance(step, BaseStep):

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -162,9 +162,11 @@ class BasePipeline(metaclass=BasePipelineMeta):
                 raise PipelineInterfaceError(
                     f"Wrong argument type (`{step_class}`) for argument "
                     f"'{key}' of pipeline '{self.name}'. "
-                    f"A `BaseStep` subclass was provided instead of an instance. "
-                    f"This might have been caused by missing brackets when "
-                    f"creating a pipeline with `@step` decorated functions, "
+                    f"A `BaseStep` subclass was provided instead of an "
+                    f"instance. "
+                    f"This might have been caused due to missing brackets of "
+                    f"your steps when creating a pipeline with `@step` "
+                    f"decorated functions, "
                     f"for which the correct syntax is `pipeline(step=step())`."
                 )
 

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -165,6 +165,24 @@ def test_initialize_pipeline_with_wrong_kwarg_type(
         unconnected_two_step_pipeline(step_1=1, step_2=empty_step())
 
 
+def test_initialize_pipeline_with_missing_arg_step_brackets(
+    unconnected_two_step_pipeline, generate_empty_steps
+):
+    """Test that pipeline initialization fails with missing arg brackets."""
+    with pytest.raises(PipelineInterfaceError):
+        empty_step_1, empty_step_2 = generate_empty_steps(2)
+        unconnected_two_step_pipeline(empty_step_1, empty_step_2)
+
+
+def test_initialize_pipeline_with_missing_kwarg_step_brackets(
+    unconnected_two_step_pipeline, generate_empty_steps
+):
+    """Test that pipeline initialization fails with missing kwarg brackets."""
+    with pytest.raises(PipelineInterfaceError):
+        empty_step_1, empty_step_2 = generate_empty_steps(2)
+        unconnected_two_step_pipeline(step_1=empty_step_1, step_2=empty_step_2)
+
+
 def test_setting_step_parameter_with_config_object():
     """Test whether step parameters can be set using a config object."""
     config_value = 0


### PR DESCRIPTION
## Describe changes
I added a more detailed error message for when the brackets of a @step decorated function are missing during pipeline creation. E.g., pipeline(step=step) will fail since the correct syntax is pipeline(step=step()).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

