### PR TITLE
Stream model deployer logs through CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ exclude = [
     "docs",
     "*.tests",
     "*.tests",
-    "tests",
     "*.tests.*",
     "tests.*",
     "legacy",

--- a/src/zenml/cli/served_models.py
+++ b/src/zenml/cli/served_models.py
@@ -274,24 +274,47 @@ def delete_model_service(
 
 @served_models.command("logs")
 @click.argument("served_model_uuid", type=click.STRING)
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    help="Continue to output new log data as it becomes available.",
+)
+@click.option(
+    "--tail",
+    "-t",
+    type=click.INT,
+    default=None,
+    help="Only show the last NUM lines of log output.",
+)
+@click.option(
+    "--raw",
+    "-r",
+    is_flag=True,
+    help="Show raw log contents (don't pretty-print logs).",
+)
 @click.pass_obj
 def get_model_service_logs(
     model_deployer: "BaseModelDeployer",
     served_model_uuid: str,
+    follow: bool,
+    tail: int,
+    raw: bool,
 ) -> None:
     """Display the logs for a model server."""
 
     served_models = model_deployer.find_model_server(
         service_uuid=uuid.UUID(served_model_uuid)
     )
-    if served_models:
-        with console.pager():
-            console.print(
-                model_deployer.get_model_server_logs(
-                    served_models[0].uuid
-                )
-            )
+    if not served_models:
+        warning(f"No model with uuid: '{served_model_uuid}' could be found.")
         return
 
-    warning(f"No model with uuid: '{served_model_uuid}' could be found.")
-    return
+    for line in model_deployer.get_model_server_logs(
+        served_models[0].uuid, follow=follow, tail=tail
+    ):
+        # don't pretty-print log lines that are already pretty-printed
+        if raw or line.startswith("\x1b["):
+            print(line)
+        else:
+            console.print(line)

--- a/src/zenml/cli/served_models.py
+++ b/src/zenml/cli/served_models.py
@@ -298,7 +298,7 @@ def get_model_service_logs(
     model_deployer: "BaseModelDeployer",
     served_model_uuid: str,
     follow: bool,
-    tail: int,
+    tail: Optional[int],
     raw: bool,
 ) -> None:
     """Display the logs for a model server."""

--- a/src/zenml/cli/served_models.py
+++ b/src/zenml/cli/served_models.py
@@ -24,6 +24,7 @@ from zenml.cli.utils import (
     print_served_model_configuration,
     warning,
 )
+from zenml.console import console
 from zenml.enums import CliCategories, StackComponentType
 from zenml.model_deployers import BaseModelDeployer
 from zenml.repository import Repository
@@ -265,6 +266,31 @@ def delete_model_service(
             served_models[0].uuid, timeout=timeout, force=force
         )
         declare(f"Model server {served_models[0]} was deleted.")
+        return
+
+    warning(f"No model with uuid: '{served_model_uuid}' could be found.")
+    return
+
+
+@served_models.command("logs")
+@click.argument("served_model_uuid", type=click.STRING)
+@click.pass_obj
+def get_model_service_logs(
+    model_deployer: "BaseModelDeployer",
+    served_model_uuid: str,
+) -> None:
+    """Display the logs for a model server."""
+
+    served_models = model_deployer.find_model_server(
+        service_uuid=uuid.UUID(served_model_uuid)
+    )
+    if served_models:
+        with console.pager():
+            console.print(
+                model_deployer.get_model_server_logs(
+                    served_models[0].uuid
+                )
+            )
         return
 
     warning(f"No model with uuid: '{served_model_uuid}' could be found.")

--- a/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
+++ b/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
@@ -462,22 +462,3 @@ class SeldonModelDeployer(BaseModelDeployer):
         # secret used to store the authentication information for the Seldon
         # Core model server storage initializer
         self._delete_kubernetes_secret()
-
-    def get_model_server_logs(
-        self,
-        uuid: UUID,
-    ) -> str:
-        """Get the logs of a Seldon Core model deployment.
-
-        Args:
-            uuid: UUID of the model server to get the logs of.
-        """
-        services = self.find_model_server(service_uuid=uuid)
-        if len(services) == 0:
-            raise RuntimeError(
-                f"No Seldon Core model server found with UUID {uuid}"
-            )
-        service = cast(SeldonDeploymentService, services[0])
-        return self.seldon_client.get_deployment_logs(
-            service.seldon_deployment_name
-        )

--- a/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
+++ b/src/zenml/integrations/seldon/model_deployers/seldon_model_deployer.py
@@ -462,3 +462,22 @@ class SeldonModelDeployer(BaseModelDeployer):
         # secret used to store the authentication information for the Seldon
         # Core model server storage initializer
         self._delete_kubernetes_secret()
+
+    def get_model_server_logs(
+        self,
+        uuid: UUID,
+    ) -> str:
+        """Get the logs of a Seldon Core model deployment.
+
+        Args:
+            uuid: UUID of the model server to get the logs of.
+        """
+        services = self.find_model_server(service_uuid=uuid)
+        if len(services) == 0:
+            raise RuntimeError(
+                f"No Seldon Core model server found with UUID {uuid}"
+            )
+        service = cast(SeldonDeploymentService, services[0])
+        return self.seldon_client.get_deployment_logs(
+            service.seldon_deployment_name
+        )

--- a/src/zenml/integrations/seldon/services/seldon_deployment.py
+++ b/src/zenml/integrations/seldon/services/seldon_deployment.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 
 import os
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Tuple
 from uuid import UUID
 
 import numpy as np
@@ -310,6 +310,26 @@ class SeldonDeploymentService(BaseService):
             client.delete_deployment(name=name, force=force)
         except SeldonDeploymentNotFoundError:
             pass
+
+    def get_logs(
+        self,
+        follow: bool = False,
+        tail: Optional[int] = None,
+    ) -> Generator[str, bool, None]:
+        """Get the logs of a Seldon Core model deployment.
+
+        Args:
+            follow: if True, the logs will be streamed as they are written
+            tail: only retrieve the last NUM lines of log output.
+
+        Returns:
+            A generator that can be acccessed to get the service logs.
+        """
+        return self._get_client().get_deployment_logs(
+            self.seldon_deployment_name,
+            follow=follow,
+            tail=tail,
+        )
 
     @property
     def prediction_url(self) -> Optional[str]:

--- a/src/zenml/model_deployers/base_model_deployer.py
+++ b/src/zenml/model_deployers/base_model_deployer.py
@@ -198,3 +198,14 @@ class BaseModelDeployer(StackComponent, ABC):
                 deprovisioning the service, without waiting for it to stop.
             force: if True, force the service to stop.
         """
+
+    @abstractmethod
+    def get_model_server_logs(
+        self,
+        uuid: UUID,
+    ) -> str:
+        """Abstract method to get the logs of a model server.
+
+        Args:
+            uuid: UUID of the model server to get the logs of.
+        """

--- a/src/zenml/model_deployers/base_model_deployer.py
+++ b/src/zenml/model_deployers/base_model_deployer.py
@@ -12,7 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 from abc import ABC, abstractmethod
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, Dict, Generator, List, Optional
 from uuid import UUID
 
 from zenml.enums import StackComponentType
@@ -199,13 +199,20 @@ class BaseModelDeployer(StackComponent, ABC):
             force: if True, force the service to stop.
         """
 
-    @abstractmethod
     def get_model_server_logs(
         self,
         uuid: UUID,
-    ) -> str:
-        """Abstract method to get the logs of a model server.
+        follow: bool = False,
+        tail: Optional[int] = None,
+    ) -> Generator[str, bool, None]:
+        """Get the logs of a model server.
 
         Args:
             uuid: UUID of the model server to get the logs of.
+            follow: if True, the logs will be streamed as they are written
+            tail: only retrieve the last NUM lines of log output.
         """
+        services = self.find_model_server(service_uuid=uuid)
+        if len(services) == 0:
+            raise RuntimeError(f"No model server found with UUID {uuid}")
+        return services[0].get_logs(follow=follow, tail=tail)

--- a/src/zenml/services/local/local_service.py
+++ b/src/zenml/services/local/local_service.py
@@ -17,8 +17,9 @@ import pathlib
 import subprocess
 import sys
 import tempfile
+import time
 from abc import abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Generator, List, Optional, Tuple
 
 import psutil
 from pydantic import Field
@@ -365,6 +366,45 @@ class LocalDaemonService(BaseService):
 
     def deprovision(self, force: bool = False) -> None:
         self._stop_daemon(force)
+
+    def get_logs(
+        self, follow: bool = False, tail: Optional[int] = None
+    ) -> Generator[str, bool, None]:
+        """Retrieve the service logs.
+
+        Args:
+            follow: if True, the logs will be streamed as they are written
+            tail: only retrieve the last NUM lines of log output.
+
+        Returns:
+            A generator that can be acccessed to get the service logs.
+        """
+        if not self.status.log_file or not os.path.exists(self.status.log_file):
+            return
+
+        with open(self.status.log_file, "r") as f:
+            if tail:
+                # TODO[LOW]: implement a more efficient tailing mechanism that
+                #   doesn't read the entire file
+                lines = f.readlines()[-tail:]
+                for line in lines:
+                    yield line.rstrip("\n")
+                if not follow:
+                    return
+            line = ""
+            while True:
+                partial_line = f.readline()
+                if partial_line:
+                    line += partial_line
+                    if line.endswith("\n"):
+                        stop = yield line.rstrip("\n")
+                        if stop:
+                            break
+                        line = ""
+                elif follow:
+                    time.sleep(1)
+                else:
+                    break
 
     @abstractmethod
     def run(self) -> None:

--- a/src/zenml/services/service.py
+++ b/src/zenml/services/service.py
@@ -14,7 +14,7 @@
 
 import time
 from abc import abstractmethod
-from typing import Any, ClassVar, Dict, Optional, Tuple, Type, cast
+from typing import Any, ClassVar, Dict, Generator, Optional, Tuple, Type, cast
 from uuid import UUID, uuid4
 
 from pydantic import Field
@@ -172,6 +172,23 @@ class BaseService(BaseTypedModel, metaclass=BaseServiceMeta):
             providing additional information about that state (e.g. a
             description of the error if one is encountered while checking the
             service status).
+        """
+
+    @abstractmethod
+    def get_logs(
+        self, follow: bool = False, tail: Optional[int] = None
+    ) -> Generator[str, bool, None]:
+        """Retrieve the service logs.
+
+        This method should be overridden by subclasses that implement
+        concrete service tracking functionality.
+
+        Args:
+            follow: if True, the logs will be streamed as they are written
+            tail: only retrieve the last NUM lines of log output.
+
+        Returns:
+            A generator that can be acccessed to get the service logs.
         """
 
     def update_status(self) -> None:


### PR DESCRIPTION
## Describe changes

Implements a `zenml served-models logs` CLI command that streams the log contents of
model servers through the CLI, for easy access to the back-end logs. The command supports "following" the remote logs, "tailing" the last X lines of logs and also pretty-prints everything in the
logs by default, so the result is an improved version of the remote logs. Large files are also supported through the use of IO buffering, HTTP streaming and Python generators.

Example output:

![Screenshot from 2022-05-03 12-42-27](https://user-images.githubusercontent.com/3963946/166440162-4f108f79-a5fd-46f3-8692-063b02f0a877.png)


Log streaming now works not only with the Seldon and MLflow model servers, but also with
every local daemon service. The base Service class now specifies this abstract method:

```python
    @abstractmethod
    def get_logs(
        self, follow: bool = False, tail: Optional[int] = None
    ) -> Generator[str, bool, None]:
``` 

TODO:
- [x] support multiple "log sources" for services that are implemented using multiple components, such as Kubernetes deployments
- [x] add init containers to the list of logs sources that can be retrieved for Seldon Core deployments

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

