### PR TITLE
Fixed Error message for Version Mismatch in Config

### DIFF
--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -224,7 +224,7 @@ class GlobalConfiguration(
                     "Please update ZenML to at least match the global "
                     "configuration version to avoid loss of "
                     "information.".format(config_version, curr_version)
-                    )
+                )
             if config_version == curr_version:
                 return
 

--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -219,13 +219,12 @@ class GlobalConfiguration(
             config_version = VersionInfo.parse(self.version)
             if self.version > curr_version:
                 raise RuntimeError(
-                    "The ZenML global configuration version (%s) is higher "
-                    "than the version of ZenML currently being used (%s). "
+                    "The ZenML global configuration version ({}) is higher "
+                    "than the version of ZenML currently being used ({}). "
                     "Please update ZenML to at least match the global "
-                    "configuration version to avoid loss of information.",
-                    config_version,
-                    curr_version,
-                )
+                    "configuration version to avoid loss of "
+                    "information.".format(config_version, curr_version)
+                    )
             if config_version == curr_version:
                 return
 


### PR DESCRIPTION
## Describe changes
I got the following error message while working locally:

```
RuntimeError: ('The ZenML global configuration version (%s) is higher than the version of ZenML currently being used (%s). Please update ZenML to at least match the global configuration version to avoid loss of information.', 
VersionInfo(major=0, minor=7, patch=3, prerelease=None, build=None), VersionInfo(major=0, minor=7, patch=2, prerelease=None, build=None))
```

I replaced the %s with .format formatting and tested in a separate python process:

```python
from semver import VersionInfo  # type: ignore[import]

config_version = VersionInfo.parse('0.9.0')
curr_version = VersionInfo.parse('0.9.1')
raise RuntimeError("The ZenML global configuration version {} is
higher "
                    "than the version of ZenML currently being used {}. "
                    "Please update ZenML to at least match the global "
                    "configuration version to avoid loss of "
                    "information.".format(config_version, curr_version))
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

