### PR TITLE
Fix various usability bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 exclude = [
     "docs",
     "*.tests",
-    "*.tests",
     "tests",
     "*.tests.*",
     "tests.*",

--- a/src/zenml/cli/config.py
+++ b/src/zenml/cli/config.py
@@ -172,12 +172,15 @@ def list_profiles_command() -> None:
     profile_dicts = []
     for profile_name, profile in profiles.items():
         is_active = profile_name == repo.active_profile_name
+        active_stack = profile.active_stack
+        if is_active:
+            active_stack = repo.active_stack_name
         profile_config = {
             "ACTIVE": ":point_right:" if is_active else "",
             "PROFILE NAME": profile_name,
             "STORE TYPE": profile.store_type.value,
             "URL": profile.store_url,
-            "ACTIVE STACK": repo.active_stack_name,
+            "ACTIVE STACK": active_stack,
         }
         profile_dicts.append(profile_config)
 

--- a/src/zenml/cli/service.py
+++ b/src/zenml/cli/service.py
@@ -74,7 +74,7 @@ def up_server(port: int, profile: Optional[str]) -> None:
     try:
         with open(GLOBAL_ZENML_SERVICE_CONFIG_FILEPATH, "r") as f:
             zen_service = ServiceRegistry().load_service_from_json(f.read())
-    except (JSONDecodeError, FileNotFoundError, ModuleNotFoundError):
+    except (JSONDecodeError, FileNotFoundError, ModuleNotFoundError, TypeError):
         zen_service = ZenService(service_config)
 
     cli_utils.declare(

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -195,7 +195,7 @@ def register_stack(
 
 
 @stack.command("update", context_settings=dict(ignore_unknown_options=True))
-@click.argument("stack_name", type=str, required=True)
+@click.argument("stack_name", type=str, required=False)
 @click.option(
     "-m",
     "--metadata-store",
@@ -269,7 +269,7 @@ def register_stack(
     required=False,
 )
 def update_stack(
-    stack_name: str,
+    stack_name: Optional[str],
     metadata_store_name: Optional[str] = None,
     artifact_store_name: Optional[str] = None,
     orchestrator_name: Optional[str] = None,
@@ -281,6 +281,13 @@ def update_stack(
     experiment_tracker_name: Optional[str] = None,
 ) -> None:
     """Update a stack."""
+    cli_utils.print_active_profile()
+
+    repo = Repository()
+
+    active_stack_name = repo.active_stack_name
+    stack_name = stack_name or active_stack_name
+
     with console.status(f"Updating stack `{stack_name}`...\n"):
         repo = Repository()
         try:
@@ -370,7 +377,7 @@ def update_stack(
 @stack.command(
     "remove-component", context_settings=dict(ignore_unknown_options=True)
 )
-@click.argument("stack_name", type=str, required=True)
+@click.argument("stack_name", type=str, required=False)
 @click.option(
     "-c",
     "--container_registry",
@@ -420,7 +427,7 @@ def update_stack(
     required=False,
 )
 def remove_stack_component(
-    stack_name: str,
+    stack_name: Optional[str],
     container_registry_flag: Optional[bool] = False,
     step_operator_flag: Optional[bool] = False,
     secrets_manager_flag: Optional[bool] = False,
@@ -429,6 +436,14 @@ def remove_stack_component(
     experiment_tracker_flag: Optional[bool] = False,
 ) -> None:
     """Remove stack components from a stack."""
+
+    cli_utils.print_active_profile()
+
+    repo = Repository()
+
+    active_stack_name = repo.active_stack_name
+    stack_name = stack_name or active_stack_name
+
     with console.status(f"Updating stack `{stack_name}`...\n"):
         repo = Repository()
         try:

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 import time
 from importlib import import_module
-from typing import Callable, List, Optional, Type
+from typing import Callable, List, Optional, Sequence, Type
 
 import click
 from rich.markdown import Markdown
@@ -64,7 +64,7 @@ def _component_display_name(
 def _get_stack_component(
     component_type: StackComponentType,
     component_name: Optional[str] = None,
-) -> StackComponent:
+) -> Optional[StackComponent]:
     """Gets a stack component for a given type and name.
 
     Args:
@@ -73,21 +73,38 @@ def _get_stack_component(
             component of the active stack gets returned.
 
     Returns:
-        A stack component of the given type.
-
-    Raises:
-        KeyError: If no stack component is registered for the given name.
+        A stack component of the given type and name, or None, if no stack
+        component is registered for the given name and type.
     """
-    repo = Repository()
-    if component_name:
-        return repo.get_stack_component(component_type, name=component_name)
 
-    component = repo.active_stack.components[component_type]
-    cli_utils.declare(
-        f"No component name given, using `{component.name}` "
-        f"from active stack."
-    )
-    return component
+    singular_display_name = _component_display_name(component_type)
+    plural_display_name = _component_display_name(component_type, plural=True)
+
+    repo = Repository()
+
+    components = repo.zen_store.get_stack_components(component_type)
+    if len(components) == 0:
+        cli_utils.warning(f"No {plural_display_name} registered.")
+        return None
+
+    if component_name:
+        try:
+            return repo.get_stack_component(component_type, name=component_name)
+        except KeyError:
+            cli_utils.error(
+                f"No {singular_display_name} found for name '{component_name}'."
+            )
+    else:
+        try:
+            component = repo.active_stack.components[component_type]
+            cli_utils.declare(
+                f"No component name given, using `{component.name}` "
+                f"from active stack."
+            )
+            return component
+        except KeyError:
+            cli_utils.error(f"No {singular_display_name} in active stack.")
+    return None
 
 
 def generate_stack_component_get_command(
@@ -134,28 +151,9 @@ def generate_stack_component_describe_command(
         cli_utils.print_active_stack()
 
         singular_display_name = _component_display_name(component_type)
-        plural_display_name = _component_display_name(
-            component_type, plural=True
-        )
         repo = Repository()
-        components = repo.zen_store.get_stack_components(component_type)
-        if len(components) == 0:
-            cli_utils.warning(f"No {plural_display_name} registered.")
-            return
-
-        try:
-            component = _get_stack_component(
-                component_type, component_name=name
-            )
-        except KeyError:
-            if name:
-                cli_utils.warning(
-                    f"No {singular_display_name} found for name '{name}'."
-                )
-            else:
-                cli_utils.warning(
-                    f"No {singular_display_name} in active stack."
-                )
+        component = _get_stack_component(component_type, component_name=name)
+        if component is None:
             return
 
         try:
@@ -321,20 +319,33 @@ def generate_stack_component_update_command(
     @click.argument(
         "name",
         type=str,
-        required=True,
+        required=False,
     )
     @click.argument("args", nargs=-1, type=click.UNPROCESSED)
-    def update_stack_component_command(name: str, args: List[str]) -> None:
+    def update_stack_component_command(
+        name: Optional[str], args: Sequence[str]
+    ) -> None:
         """Updates a stack component."""
         cli_utils.print_active_profile()
+        cli_utils.print_active_stack()
+
+        kwargs = list(args)
+        if name and name.startswith("--"):
+            kwargs.append(name)
+            name = None
+
+        current_component = _get_stack_component(
+            component_type, component_name=name
+        )
+        if current_component is None:
+            return
+
+        name = current_component.name
         with console.status(f"Updating {display_name} '{name}'...\n"):
             repo = Repository()
-            current_component = repo.get_stack_component(component_type, name)
-            if current_component is None:
-                cli_utils.error(f"No {display_name} found for name '{name}'.")
 
             try:
-                parsed_args = cli_utils.parse_unknown_options(args)
+                parsed_args = cli_utils.parse_unknown_options(kwargs)
             except AssertionError as e:
                 cli_utils.error(str(e))
                 return
@@ -467,6 +478,9 @@ def generate_stack_component_up_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
+        if component is None:
+            return
+
         display_name = _component_display_name(component_type)
 
         if component.is_running:
@@ -519,6 +533,9 @@ def generate_stack_component_down_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
+        if component is None:
+            return
+
         display_name = _component_display_name(component_type)
 
         if not force:
@@ -577,6 +594,9 @@ def generate_stack_component_logs_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
+        if component is None:
+            return
+
         display_name = _component_display_name(component_type)
         log_file = component.log_file
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -119,7 +119,7 @@ def pretty_print(obj: Any) -> None:
     console.print(obj)
 
 
-def print_table(obj: List[Dict[str, Any]]) -> None:
+def print_table(obj: List[Dict[str, Any]], **columns: table.Column) -> None:
     """Prints the list of dicts in a table format. The input object should be a
     List of Dicts. Each item in that list represent a line in the Table. Each
     dict should have the same keys. The keys of the dict will be used as
@@ -127,9 +127,10 @@ def print_table(obj: List[Dict[str, Any]]) -> None:
 
     Args:
       obj: A List containing dictionaries.
+      columns: Optional column configurations to be used in the table.
     """
     column_keys = {key: None for dict_ in obj for key in dict_}
-    column_names = [key.upper() for key in column_keys]
+    column_names = [columns.get(key, key.upper()) for key in column_keys]
     rich_table = table.Table(*column_names, box=box.HEAVY_EDGE)
 
     for dict_ in obj:
@@ -530,7 +531,9 @@ def pretty_print_model_deployer(
             }
         )
 
-    print_table(model_service_dicts)
+    print_table(
+        model_service_dicts, UUID=table.Column(header="UUID", min_width=36)
+    )
 
 
 def print_served_model_configuration(

--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -219,14 +219,25 @@ class GlobalConfiguration(
         else:
             config_version = VersionInfo.parse(self.version)
             if self.version > curr_version:
-                raise RuntimeError(
+                logger.error(
                     "The ZenML global configuration version (%s) is higher "
                     "than the version of ZenML currently being used (%s). "
-                    "Please update ZenML to at least match the global "
-                    "configuration version to avoid loss of information.",
+                    "This may happen if you recently downgraded ZenML to an "
+                    "earlier version, or if you have already used a more recent "
+                    "ZenML version on the same machine."
+                    "It is highly recommended that you update ZenML to at least "
+                    "match the global configuration version, otherwise you may "
+                    "run into unexpected issues such as model schema "
+                    "validation failures or even loss of information. As an "
+                    "alternative, if you run into incompatibility issues but "
+                    "do not want to update ZenML, you can use the `zenml clean` "
+                    "command to wipe your global configuration, profiles and "
+                    "stacks and restore ZenML to a clean and valid state.",
                     config_version,
                     curr_version,
                 )
+                return
+
             if config_version == curr_version:
                 return
 

--- a/src/zenml/console.py
+++ b/src/zenml/console.py
@@ -19,7 +19,7 @@ from rich.theme import Theme
 zenml_custom_theme = Theme(
     {
         "info": "dim cyan",
-        "warning": "magenta",
+        "warning": "yellow",
         "danger": "bold red",
         "title": "bold cyan underline",
         "error": "red",

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -20,6 +20,7 @@ from uuid import UUID
 import kfp
 import urllib3
 from kfp_server_api.exceptions import ApiException
+from kubernetes import config as k8s_config
 from pydantic import root_validator
 
 import zenml.io.utils
@@ -71,12 +72,21 @@ class KubeflowOrchestrator(BaseOrchestrator):
             current-context`.
         synchronous: If `True`, running a pipeline using this orchestrator will
             block until all steps finished running on KFP.
+        skip_local_validations: If `True`, the local validations will be
+            skipped.
+        skip_cluster_provisioning: If `True`, the k3d cluster provisioning will
+            be skipped.
+        skip_ui_daemon_provisioning: If `True`, provisioning the KFP UI daemon
+            will be skipped.
     """
 
     custom_docker_base_image_name: Optional[str] = None
     kubeflow_pipelines_ui_port: int = DEFAULT_KFP_UI_PORT
     kubernetes_context: Optional[str] = None
-    synchronous = False
+    synchronous: bool = False
+    skip_local_validations: bool = False
+    skip_cluster_provisioning: bool = False
+    skip_ui_daemon_provisioning: bool = False
 
     # Class Configuration
     FLAVOR: ClassVar[str] = KUBEFLOW_ORCHESTRATOR_FLAVOR
@@ -110,15 +120,32 @@ class KubeflowOrchestrator(BaseOrchestrator):
         Returns:
             Values passed to the Pydantic constructor
         """
-        if values.get("kubernetes_context"):
-            return values
-        # not likely, due to Pydantic validation, but mypy complains
-        assert "uuid" in values
+        if not values.get("kubernetes_context"):
+            # not likely, due to Pydantic validation, but mypy complains
+            assert "uuid" in values
+            values["kubernetes_context"] = cls._get_k3d_kubernetes_context(
+                values["uuid"]
+            )
 
-        values["kubernetes_context"] = cls._get_k3d_kubernetes_context(
-            values["uuid"]
-        )
         return values
+
+    def get_kubernetes_contexts(self) -> Tuple[List[str], str]:
+        """Get the list of configured Kubernetes contexts and the active
+        context.
+
+        Raises:
+            RuntimeError: if the Kubernetes configuration cannot be loaded
+        """
+        try:
+            contexts = k8s_config.list_kube_config_contexts()
+        except k8s_config.config_exception.ConfigException as e:
+            raise RuntimeError(
+                "Could not load the Kubernetes configuration"
+            ) from e
+
+        context_names = [c["name"] for c in contexts[0]]
+        current_context = contexts[1]["name"]
+        return context_names, current_context
 
     @property
     def validator(self) -> Optional[StackValidator]:
@@ -133,7 +160,47 @@ class KubeflowOrchestrator(BaseOrchestrator):
             # this, but just in case
             assert container_registry is not None
 
-            if not self.is_local:
+            contexts, active_context = self.get_kubernetes_contexts()
+
+            if self.kubernetes_context not in contexts:
+                if not self.is_local:
+                    return False, (
+                        f"Could not find a Kubernetes context named "
+                        f"'{self.kubernetes_context}' in the local Kubernetes "
+                        f"configuration. Please make sure that the Kubernetes "
+                        f"cluster is running and that the kubeconfig file is "
+                        f"configured correctly. To list all configured "
+                        f"contexts, run:\n\n"
+                        f"  `kubectl config get-contexts`\n"
+                    )
+            elif self.kubernetes_context != active_context:
+                logger.warning(
+                    f"The Kubernetes context '{self.kubernetes_context}' "
+                    f"configured for the Kubeflow orchestrator is not the "
+                    f"same as the active context in the local Kubernetes "
+                    f"configuration. If this is not deliberate, you should "
+                    f"update the orchestrator's `kubernetes_context` field by "
+                    f"running:\n\n"
+                    f"  `zenml orchestrator update {self.name} "
+                    f"--kubernetes_context={active_context}`\n"
+                    f"To list all configured contexts, run:\n\n"
+                    f"  `kubectl config get-contexts`\n"
+                    f"To set the active context to be the same as the one "
+                    f"configured in the Kubeflow orchestrator and silence "
+                    f"this warning, run:\n\n"
+                    f"  `kubectl config use-context "
+                    f"{self.kubernetes_context}`\n"
+                )
+
+            silence_local_validations_msg = (
+                f"To silence this warning, set the "
+                f"`skip_local_validations` attribute to True in the "
+                f"orchestrator configuration by running:\n\n"
+                f"  'zenml orchestrator update {self.name} "
+                f"--skip_local_validations=True'\n"
+            )
+
+            if not self.skip_local_validations and not self.is_local:
 
                 # if the orchestrator is not running in a local k3d cluster,
                 # we cannot have any other local components in our stack,
@@ -150,38 +217,57 @@ class KubeflowOrchestrator(BaseOrchestrator):
                     if not local_path:
                         continue
                     return False, (
-                        f"The Kubeflow orchestrator is not running in a local "
-                        f"k3d cluster. The '{stack_comp.name}' "
+                        f"The Kubeflow orchestrator is configured to run "
+                        f"pipelines in a remote Kubernetes cluster designated "
+                        f"by the '{self.kubernetes_context}' configuration "
+                        f"context, but the '{stack_comp.name}' "
                         f"{stack_comp.TYPE.value} is a local stack component "
                         f"and will not be available in the Kubeflow pipeline "
-                        f"step. Please ensure that you always use non-local "
+                        f"step.\nPlease ensure that you always use non-local "
                         f"stack components with a remote Kubeflow orchestrator, "
                         f"otherwise you may run into pipeline execution "
-                        f"problems."
+                        f"problems. You should use a flavor of "
+                        f"{stack_comp.TYPE.value} other than "
+                        f"'{stack_comp.FLAVOR}'.\n"
+                        + silence_local_validations_msg
                     )
 
                 # if the orchestrator is remote, the container registry must
                 # also be remote.
                 if container_registry.is_local:
                     return False, (
-                        f"The Kubeflow orchestrator is not running in a local "
-                        f"k3d cluster but the {container_registry.name} "
+                        f"The Kubeflow orchestrator is configured to run "
+                        f"pipelines in a remote Kubernetes cluster designated "
+                        f"by the '{self.kubernetes_context}' configuration "
+                        f"context, but the '{container_registry.name}' "
                         f"container registry URI '{container_registry.uri}' "
                         f"points to a local container registry. Please ensure "
                         f"that you always use non-local stack components with "
                         f"a remote Kubeflow orchestrator, otherwise you will "
-                        f"run into problems."
+                        f"run into problems. You should use a flavor of "
+                        f"container registry other than "
+                        f"'{container_registry.FLAVOR}'.\n"
+                        + silence_local_validations_msg
                     )
-            else:
+
+            if not self.skip_local_validations and self.is_local:
+
                 # if the orchestrator is local, the container registry must
                 # also be local.
                 if not container_registry.is_local:
                     return False, (
-                        f"The container registry URI '{container_registry.uri}' "
-                        f"doesn't match the expected format 'localhost:$PORT'. "
+                        f"The Kubeflow orchestrator is configured to run "
+                        f"pipelines in a local k3d Kubernetes cluster "
+                        f"designated by the '{self.kubernetes_context}' "
+                        f"configuration context, but the container registry "
+                        f"URI '{container_registry.uri}' doesn't match the "
+                        f"expected format 'localhost:$PORT'. "
                         f"The local Kubeflow orchestrator only works with a "
                         f"local container registry because it cannot "
-                        f"authenticate to external container registries."
+                        f"currently authenticate to external container "
+                        f"registries. You should use a flavor of container "
+                        f"registry other than '{container_registry.FLAVOR}'.\n"
+                        + silence_local_validations_msg
                     )
 
             return True, ""
@@ -241,30 +327,6 @@ class KubeflowOrchestrator(BaseOrchestrator):
             build_docker_image,
             push_docker_image,
         )
-
-        # if the orchestrator is not running in a local k3d cluster,
-        # we cannot mount the local path into the container. This
-        # may result in problems when running the pipeline, because
-        # the local components will not be available inside the
-        # Kubeflow containers.
-        if self.kubernetes_context:
-            # go through all stack components and identify those that advertise
-            # a local path where they persist information that they need to be
-            # available when running pipelines.
-            for stack_comp in stack.components.values():
-                local_path = stack_comp.local_path
-                if not local_path:
-                    continue
-                logger.warning(
-                    "The Kubeflow orchestrator is not running in a local k3d "
-                    "cluster. The '%s' %s is a local stack component and will "
-                    "not be available in the Kubeflow pipeline step. Please "
-                    "ensure that you never combine non-local stack components "
-                    "with a remote orchestrator, otherwise you may run into "
-                    "pipeline execution problems.",
-                    stack_comp.name,
-                    stack_comp.TYPE.value,
-                )
 
         image_name = self.get_docker_image_name(pipeline.name)
 
@@ -409,9 +471,10 @@ class KubeflowOrchestrator(BaseOrchestrator):
                     )
         except urllib3.exceptions.HTTPError as error:
             logger.warning(
-                "Failed to upload Kubeflow pipeline: %s. "
-                "Please make sure your kube config is configured and the "
-                "current context is set correctly.",
+                f"Failed to upload Kubeflow pipeline: %s. "
+                f"Please make sure your kube config is configured and the "
+                f"{self.kubernetes_context} kubernetes context is set "
+                f"correctly.",
                 error,
             )
 
@@ -473,7 +536,11 @@ class KubeflowOrchestrator(BaseOrchestrator):
     @property
     def is_provisioned(self) -> bool:
         """Returns if a local k3d cluster for this orchestrator exists."""
-        if not local_deployment_utils.check_prerequisites():
+        if not local_deployment_utils.check_prerequisites(
+            skip_k3d=self.skip_cluster_provisioning or not self.is_local,
+            skip_kubectl=self.skip_cluster_provisioning
+            and self.skip_ui_daemon_provisioning,
+        ):
             # if any prerequisites are missing there is certainly no
             # local deployment running
             return False
@@ -496,8 +563,8 @@ class KubeflowOrchestrator(BaseOrchestrator):
         orchestrator are both stopped."""
         return (
             self.is_provisioned
-            and not self.is_cluster_running
-            and not self.is_daemon_running
+            and (self.skip_cluster_provisioning or not self.is_cluster_running)
+            and (self.skip_ui_daemon_provisioning or not self.is_daemon_running)
         )
 
     @property
@@ -507,7 +574,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
         For remote (i.e. not managed by ZenML) Kubeflow Pipelines installations,
         this always returns True.
         """
-        if not self.is_local:
+        if self.skip_cluster_provisioning or not self.is_local:
             return True
         return local_deployment_utils.k3d_cluster_exists(
             cluster_name=self._k3d_cluster_name
@@ -520,7 +587,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
         For remote (i.e. not managed by ZenML) Kubeflow Pipelines installations,
         this always returns True.
         """
-        if not self.is_local:
+        if self.skip_cluster_provisioning or not self.is_local:
             return True
         return local_deployment_utils.k3d_cluster_running(
             cluster_name=self._k3d_cluster_name
@@ -530,6 +597,9 @@ class KubeflowOrchestrator(BaseOrchestrator):
     def is_daemon_running(self) -> bool:
         """Returns if the local Kubeflow UI daemon for this orchestrator is
         running."""
+        if self.skip_ui_daemon_provisioning:
+            return True
+
         if sys.platform != "win32":
             from zenml.utils.daemon import check_if_daemon_is_running
 
@@ -539,6 +609,9 @@ class KubeflowOrchestrator(BaseOrchestrator):
 
     def provision(self) -> None:
         """Provisions a local Kubeflow Pipelines deployment."""
+        if self.skip_cluster_provisioning:
+            return
+
         if self.is_running:
             logger.info(
                 "Found already existing local Kubeflow Pipelines deployment. "
@@ -607,6 +680,9 @@ class KubeflowOrchestrator(BaseOrchestrator):
 
     def deprovision(self) -> None:
         """Deprovisions a local Kubeflow Pipelines deployment."""
+        if self.skip_cluster_provisioning:
+            return
+
         if self.is_daemon_running:
             local_deployment_utils.stop_kfp_ui_daemon(
                 pid_file_path=self._pid_file_path
@@ -640,7 +716,11 @@ class KubeflowOrchestrator(BaseOrchestrator):
         # will never happen, but mypy doesn't know that
         assert kubernetes_context is not None
 
-        if self.is_local and not self.is_cluster_running:
+        if (
+            not self.skip_cluster_provisioning
+            and self.is_local
+            and not self.is_cluster_running
+        ):
             # don't resume any resources if using a remote KFP installation
             local_deployment_utils.start_k3d_cluster(
                 cluster_name=self._k3d_cluster_name
@@ -650,7 +730,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
                 kubernetes_context=kubernetes_context
             )
 
-        if not self.is_daemon_running:
+        if not self.skip_ui_daemon_provisioning and not self.is_daemon_running:
             local_deployment_utils.start_kfp_ui_daemon(
                 pid_file_path=self._pid_file_path,
                 log_file_path=self.log_file,
@@ -664,12 +744,16 @@ class KubeflowOrchestrator(BaseOrchestrator):
             logger.info("Local kubeflow pipelines deployment not provisioned.")
             return
 
-        if self.is_daemon_running:
+        if not self.skip_ui_daemon_provisioning and self.is_daemon_running:
             local_deployment_utils.stop_kfp_ui_daemon(
                 pid_file_path=self._pid_file_path
             )
 
-        if self.is_local and self.is_cluster_running:
+        if (
+            not self.skip_cluster_provisioning
+            and self.is_local
+            and self.is_cluster_running
+        ):
             # don't suspend any resources if using a remote KFP installation
             local_deployment_utils.stop_k3d_cluster(
                 cluster_name=self._k3d_cluster_name

--- a/src/zenml/integrations/kubeflow/orchestrators/local_deployment_utils.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/local_deployment_utils.py
@@ -18,11 +18,21 @@ K3S_IMAGE_NAME = "rancher/k3s:v1.23.5-k3s1"
 logger = get_logger(__name__)
 
 
-def check_prerequisites() -> bool:
+def check_prerequisites(
+    skip_k3d: bool = False, skip_kubectl: bool = False
+) -> bool:
     """Checks whether all prerequisites for a local kubeflow pipelines
-    deployment are installed."""
-    k3d_installed = shutil.which("k3d") is not None
-    kubectl_installed = shutil.which("kubectl") is not None
+    deployment are installed.
+
+    Args:
+        skip_k3d: Whether to skip the check for the k3d command.
+        skip_kubectl: Whether to skip the check for the kubectl command.
+
+    Returns:
+        Whether all prerequisites are installed.
+    """
+    k3d_installed = skip_k3d or shutil.which("k3d") is not None
+    kubectl_installed = skip_kubectl or shutil.which("kubectl") is not None
     logger.debug(
         "Local kubeflow deployment prerequisites: K3D - %s, Kubectl - %s",
         k3d_installed,

--- a/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
@@ -140,7 +140,7 @@ def mlflow_model_deployer_step(
                 f"An MLflow model with name `{config.model_name}` was not "
                 f"logged in the current pipeline run and no running MLflow "
                 f"model server was found. Please ensure that your pipeline "
-                f"includes an `mlflow_enable` decorated step that trains a "
+                f"includes an `@enable_mlflow` decorated step that trains a "
                 f"model and logs it to MLflow. This could also happen if "
                 f"the current pipeline run did not log an MLflow model  "
                 f"because the training step was cached."

--- a/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
@@ -142,8 +142,8 @@ def mlflow_model_deployer_step(
                 f"model server was found. Please ensure that your pipeline "
                 f"includes an `mlflow_enable` decorated step that trains a "
                 f"model and logs it to MLflow. This could also happen if "
-                f"re-training a model in the current pipeline run was skipped "
-                f"due to caching."
+                f"the current pipeline run did not log an MLflow model  "
+                f"because the training step was cached."
             )
             # return an inactive service just because we have to return
             # something

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -37,8 +37,8 @@ class CustomFormatter(logging.Formatter):
     grey: str = "\x1b[38;21m"
     pink: str = "\x1b[35m"
     green: str = "\x1b[32m"
-    yellow: str = "\x1b[33;21m"
-    red: str = "\x1b[31;21m"
+    yellow: str = "\x1b[33m"
+    red: str = "\x1b[31m"
     bold_red: str = "\x1b[31;1m"
     purple: str = "\x1b[1;35m"
     reset: str = "\x1b[0m"
@@ -68,7 +68,7 @@ class CustomFormatter(logging.Formatter):
             A string formatted according to specifications.
         """
         log_fmt = (
-            self.COLORS[LoggingLevels[ZENML_LOGGING_VERBOSITY]]
+            self.COLORS[LoggingLevels(record.levelno)]
             + self.format_template
             + self.reset
         )
@@ -78,12 +78,10 @@ class CustomFormatter(logging.Formatter):
         for quoted in quoted_groups:
             formatted_message = formatted_message.replace(
                 "`" + quoted + "`",
-                "`"
-                + self.reset
+                self.reset
                 + self.yellow
                 + quoted
-                + "`"
-                + self.COLORS.get(LoggingLevels[ZENML_LOGGING_VERBOSITY]),
+                + self.COLORS.get(LoggingLevels(record.levelno)),
             )
         return formatted_message
 

--- a/src/zenml/services/local/local_service.py
+++ b/src/zenml/services/local/local_service.py
@@ -206,6 +206,20 @@ class LocalDaemonService(BaseService):
     # TODO [ENG-705]: allow multiple endpoints per service
     endpoint: Optional[LocalDaemonServiceEndpoint] = None
 
+    def get_service_status_message(self) -> str:
+        """Get a message providing information about the current operational
+        state of the service."""
+        msg = super().get_service_status_message()
+        pid = self.status.pid
+        if pid:
+            msg += f"  Daemon PID: `{self.status.pid}`\n"
+        if self.status.log_file:
+            msg += (
+                f"For more information on the service status, please see the "
+                f"following log file: {self.status.log_file}\n"
+            )
+        return msg
+
     def check_status(self) -> Tuple[ServiceState, str]:
         """Check the the current operational state of the daemon process.
 
@@ -327,7 +341,7 @@ class LocalDaemonService(BaseService):
             )
         else:
             logger.error(
-                "Daemon process for service '%s' failed to start",
+                "Daemon process for service '%s' failed to start.",
                 self,
             )
 

--- a/src/zenml/utils/daemon.py
+++ b/src/zenml/utils/daemon.py
@@ -167,10 +167,19 @@ else:
 
         # check if PID file exists
         if pid_file and os.path.exists(pid_file):
-            raise FileExistsError(
-                f"The PID file '{pid_file}' already exists, either the daemon "
-                f"process is already running or something went wrong."
+            pid = get_daemon_pid_if_running(pid_file)
+            if pid:
+                raise FileExistsError(
+                    f"The PID file '{pid_file}' already exists and a daemon "
+                    f"process with the same PID '{pid}' is already running."
+                    f"Please remove the PID file or kill the daemon process "
+                    f"before starting a new daemon."
+                )
+            logger.warning(
+                f"Removing left over PID file '{pid_file}' from a previous "
+                f"daemon process that didn't shut down correctly."
             )
+            os.remove(pid_file)
 
         # first fork
         try:

--- a/tests/unit/integrations/kubeflow/orchestrators/test_kubeflow_orchestrator.py
+++ b/tests/unit/integrations/kubeflow/orchestrators/test_kubeflow_orchestrator.py
@@ -33,9 +33,14 @@ def test_kubeflow_orchestrator_attributes():
     assert orchestrator.FLAVOR == "kubeflow"
 
 
-def test_kubeflow_orchestrator_stack_validation():
+def test_kubeflow_orchestrator_stack_validation(mocker):
     """Tests that the kubeflow orchestrator validates that it's stack has a
     container registry."""
+    mocker.patch(
+        "zenml.integrations.kubeflow.orchestrators.kubeflow_orchestrator.KubeflowOrchestrator.get_kubernetes_contexts",
+        return_value=([], ""),
+    )
+
     orchestrator = KubeflowOrchestrator(name="")
     metadata_store = SQLiteMetadataStore(name="", uri="./metadata.db")
     artifact_store = LocalArtifactStore(name="", path=".")


### PR DESCRIPTION
## Describe changes
This PR fixes a range of usability bugs:

1. Log an error instead of exiting on zenml version downgrades and point to the `zenml clean` command as an alternative to fixing potential schema validation errors
2. Don't fail `zenml service start/stop` if service schema changes
3. Highlight logged errors and warnings using the rich color schema
4. Ensure a model server is always running in the standard mlflow deployer step
5. Don't trim UUID in `zenml served-models list`
6. Ensure a model server is always running in the seldon deployer step
7. Improved Kubeflow orchestrator validations:

 * fail if the configured `kubernetes_context` is not locally available
 * warn if the default or configured `kubernetes_context` is not the same as the currently active kube context
 * improved error messages for validations involving local component flavors to show the configured (or default) `kubernetes_context` attribute and point out some possible corrective actions

8. Allow more flexibility in the Kubeflow orchestrator configurations, to allow for use-cases such as using the Kubeflow orchestrator with a user-managed k3d cluster or with a user-provided way of sharing the local folders with an external Kubernetes cluster:
 * add a `skip_local_validations` attribute that can be set to bypass the local validations
 * add `skip_cluster_provisioning` and `skip_ui_daemon_provisioning` attributes that can be used to skip the provisioning of the local cluster and KFP UI daemon

9.  Make stack and component name optional in update cli commands
10. Better logging messages and cleanup for failed local daemons

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

