### PR TITLE
Only build non-dev docker images on release

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,38 +22,12 @@ steps:
     args: ['-c', 'docker build --build-arg ZENML_VERSION=$TAG_NAME -t $$USERNAME/zenml:$TAG_NAME-cuda -t $$USERNAME/zenml:latest-cuda -f docker/cuda.Dockerfile .']
     secretEnv: ['USERNAME']
 
-  # push the non-development images. this happens early to get the images
-  # published as soon as possible after the release to provide the base
-  # container image for kubeflow etc.
+  # push the images
   - name: 'gcr.io/cloud-builders/docker'
     id: 'push'
     entrypoint: 'bash'
     args: [ '-c', 'docker push $$USERNAME/zenml' ]
     secretEnv: [ 'USERNAME' ]
-
-  # build base development image
-  - name : 'gcr.io/cloud-builders/docker'
-    id: 'build-base-dev'
-    waitFor: ['push']
-    entrypoint: 'bash'
-    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-dev -t $$USERNAME/zenml:latest-dev -f docker/base-dev.Dockerfile .']
-    secretEnv: ['USERNAME']
-
-  # build CUDA development image
-  - name : 'gcr.io/cloud-builders/docker'
-    id: 'build-cuda-dev'
-    waitFor: [ 'push' ]
-    entrypoint: 'bash'
-    args: ['-c', 'docker build -t $$USERNAME/zenml:$TAG_NAME-cuda-dev -t $$USERNAME/zenml:latest-cuda-dev -f docker/cuda-dev.Dockerfile .']
-    secretEnv: ['USERNAME']
-
-  # push the development images
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'push-dev'
-    entrypoint: 'bash'
-    args: [ '-c', 'docker push $$USERNAME/zenml' ]
-    secretEnv: [ 'USERNAME' ]
-
 
 availableSecrets:
   secretManager:
@@ -61,4 +35,4 @@ availableSecrets:
       env: 'PASSWORD'
     - versionName: projects/$PROJECT_ID/secrets/docker-username/versions/1
       env: 'USERNAME'
-timeout: 7200s
+timeout: 3600s


### PR DESCRIPTION
## Describe changes
This PR removes the `poetry install` docker images from the google cloudbuild file that is used to build docker images when we release a new version of ZenML.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

