### PR TITLE
Adjusted handling of duplicated configuration

### DIFF
--- a/src/zenml/exceptions.py
+++ b/src/zenml/exceptions.py
@@ -219,3 +219,7 @@ class ProvisioningError(ZenMLBaseException):
 class GitNotFoundError(ImportError):
     """Raised when ZenML CLI is used to interact with examples on a machine
     with no git installation"""
+
+
+class DuplicatedConfigurationError(ZenMLBaseException):
+    """Raised when a configuration parameter is set twice"""

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -37,10 +37,10 @@ from zenml.constants import (
     SHOULD_PREVENT_PIPELINE_EXECUTION,
 )
 from zenml.exceptions import (
+    DuplicatedConfigurationError,
     PipelineConfigurationError,
     PipelineInterfaceError,
     StackValidationError,
-    DuplicatedConfigurationError
 )
 from zenml.integrations.registry import integration_registry
 from zenml.io import fileio, utils
@@ -70,7 +70,7 @@ class BasePipelineMeta(type):
     """Pipeline Metaclass responsible for validating the pipeline definition."""
 
     def __new__(
-            mcs, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]
+        mcs, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]
     ) -> "BasePipelineMeta":
         """Saves argument names for later verification purposes"""
         cls = cast(Type["BasePipeline"], super().__new__(mcs, name, bases, dct))
@@ -291,9 +291,8 @@ class BasePipeline(metaclass=BasePipelineMeta):
 
         for step in self.steps.values():
             if (
-                    step.custom_step_operator
-                    and step.custom_step_operator not in
-                    available_step_operators
+                step.custom_step_operator
+                and step.custom_step_operator not in available_step_operators
             ):
                 raise StackValidationError(
                     f"Step '{step.name}' requires custom step operator "
@@ -309,11 +308,11 @@ class BasePipeline(metaclass=BasePipelineMeta):
             step._has_been_called = False
 
     def run(
-            self,
-            *,
-            run_name: Optional[str] = None,
-            schedule: Optional[Schedule] = None,
-            **additional_parameters: Any,
+        self,
+        *,
+        run_name: Optional[str] = None,
+        schedule: Optional[Schedule] = None,
+        **additional_parameters: Any,
     ) -> Any:
         """Runs the pipeline on the active stack of the current repository.
 
@@ -377,7 +376,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         )
 
     def with_config(
-            self: T, config_file: str, overwrite_step_parameters: bool = False
+        self: T, config_file: str, overwrite_step_parameters: bool = False
     ) -> T:
         """Configures this pipeline using a yaml file.
 
@@ -405,7 +404,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         return self
 
     def _read_config_steps(
-            self, steps: Dict[str, Dict[str, Any]], overwrite: bool = False
+        self, steps: Dict[str, Dict[str, Any]], overwrite: bool = False
     ) -> None:
         """Reads and sets step parameters from a config file.
 
@@ -464,8 +463,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         "While it is not recommended you can overwrite the "
                         "step configuration using the configuration file: \n"
                         "`.with_config('config.yaml', "
-                        "overwrite_step_parameters=True)".format(parameter,
-                                                                 step_name,
-                                                                 previous_value,
-                                                                 value)
+                        "overwrite_step_parameters=True)".format(
+                            parameter, step_name, previous_value, value
+                        )
                     )

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -343,8 +343,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         # the airflow orchestrator so it knows which file to copy into the DAG
         # directory
         dag_filepath = utils.resolve_relative_path(
-            inspect.currentframe().f_back.f_code.co_filename
-            # type: ignore[union-attr] # noqa
+            inspect.currentframe().f_back.f_code.co_filename  # type: ignore[union-attr]
         )
         runtime_configuration = RuntimeConfiguration(
             run_name=run_name,
@@ -460,7 +459,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         "parameter within a config file that is added to the "
                         "pipeline instance using the `.with_config()` method. "
                         "Make sure each parameter is only defined **once**. \n"
-                        "While it is not recommended you can overwrite the "
+                        "While it is not recommended, you can overwrite the "
                         "step configuration using the configuration file: \n"
                         "`.with_config('config.yaml', "
                         "overwrite_step_parameters=True)".format(


### PR DESCRIPTION
## Describe changes
Running code like this:

```python
    p = some_pipe(
        step_1=some_step(StepConfig(some_option=6))
    ).with_config(config_file='config.yaml')
```

Would give you this message:

```
The configuration of the pipeline has been supplied twice. Once as  Parameter 'some_option'='3' from configuration yaml will NOT be set as a configuration object was given when creating the step. Set `overwrite_step_parameters=True` when setting the configuration yaml to always use the options specified in the yaml file.
```

This has now been changed to raise an exception:

![DuplicatedConfig](https://user-images.githubusercontent.com/38859294/167106826-8cc77058-a4df-4823-814a-520bbc0a45b0.png)


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

