### PR TITLE
Use github secret value to enable manual cache invaliation

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -40,7 +40,7 @@ runs:
           poetry.lock
         # Cache the complete venv dir for a given os, python version,
         # pyproject.toml, and the current calendar week
-        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ steps.date.outputs.date }}
+        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ steps.date.outputs.date }}-${{ secrets.GH_ACTIONS_CACHE_KEY }}
 
     - name: Install Project
       shell: bash


### PR DESCRIPTION
## Describe changes
This PR appends a secret value to the key used to check whether the poetry installation should be loaded from a cache or not. This allows us to manually invalidate the cache by changing the value of this secret if necessary.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

