### PR TITLE
Fix airflow orchestrator

### DIFF
--- a/src/zenml/integrations/airflow/orchestrators/airflow_component.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_component.py
@@ -20,7 +20,7 @@ import airflow
 from airflow.operators import python
 from google.protobuf import message
 from tfx.orchestration import metadata
-from tfx.orchestration.portable import launcher
+from tfx.orchestration.portable import launcher, runtime_parameter_utils
 from tfx.proto.orchestration import pipeline_pb2
 
 from zenml.orchestrators.utils import execute_step
@@ -28,34 +28,44 @@ from zenml.repository import Repository
 
 
 def _airflow_component_launcher(
+    pb2_pipeline: pipeline_pb2.Pipeline,
     pipeline_node: pipeline_pb2.PipelineNode,
     mlmd_connection: metadata.Metadata,
-    pipeline_info: pipeline_pb2.PipelineInfo,
-    pipeline_runtime_spec: pipeline_pb2.PipelineRuntimeSpec,
     executor_spec: Optional[message.Message] = None,
     custom_driver_spec: Optional[message.Message] = None,
     custom_executor_operators: Optional[
         Dict[Any, Type[launcher.ExecutorOperator]]
     ] = None,
+    **kwargs: Any,
 ) -> None:
     """Helper function to launch TFX component execution.
 
     Args:
+        pb2_pipeline: Protobuf pipeline definition.
         pipeline_node: The specification of the node to launch.
         mlmd_connection: ML metadata connection info.
-        pipeline_info: The information of the pipeline that this node runs in.
-        pipeline_runtime_spec: The runtime information of the pipeline that this
-            node runs in.
         executor_spec: Specification for the executor of the node.
         custom_driver_spec: Specification for custom driver.
         custom_executor_operators: Map of executable specs to executor
             operators.
     """
+    # get the run name from the airflow task instance
+    run_name = kwargs["ti"].get_dagrun().run_id
+
+    # Replace pipeline run id in both the pipeline and node proto files
+    for proto in [pb2_pipeline, pipeline_node]:
+        runtime_parameter_utils.substitute_runtime_parameter(
+            proto,
+            {
+                "pipeline-run-id": run_name,
+            },
+        )
+
     component_launcher = launcher.Launcher(
         pipeline_node=pipeline_node,
         mlmd_connection=metadata.Metadata(mlmd_connection),
-        pipeline_info=pipeline_info,
-        pipeline_runtime_spec=pipeline_runtime_spec,
+        pipeline_info=pb2_pipeline.pipeline_info,
+        pipeline_runtime_spec=pb2_pipeline.runtime_spec,
         executor_spec=executor_spec,
         custom_driver_spec=custom_driver_spec,
         custom_executor_operators=custom_executor_operators,
@@ -75,10 +85,9 @@ class AirflowComponent(python.PythonOperator):
         self,
         *,
         parent_dag: airflow.DAG,
+        pb2_pipeline: pipeline_pb2.Pipeline,
         pipeline_node: pipeline_pb2.PipelineNode,
         mlmd_connection: metadata.Metadata,
-        pipeline_info: pipeline_pb2.PipelineInfo,
-        pipeline_runtime_spec: pipeline_pb2.PipelineRuntimeSpec,
         executor_spec: Optional[message.Message] = None,
         custom_driver_spec: Optional[message.Message] = None,
         custom_executor_operators: Optional[
@@ -89,12 +98,9 @@ class AirflowComponent(python.PythonOperator):
 
         Args:
             parent_dag: The airflow DAG that this component is contained in.
+            pb2_pipeline: Protobuf pipeline definition.
             pipeline_node: The specification of the node to launch.
             mlmd_connection: ML metadata connection info.
-            pipeline_info: The information of the pipeline that this node
-                runs in.
-            pipeline_runtime_spec: The runtime information of the pipeline
-                that this node runs in.
             executor_spec: Specification for the executor of the node.
             custom_driver_spec: Specification for custom driver.
             custom_executor_operators: Map of executable specs to executor
@@ -102,10 +108,9 @@ class AirflowComponent(python.PythonOperator):
         """
         launcher_callable = functools.partial(
             _airflow_component_launcher,
+            pb2_pipeline=pb2_pipeline,
             pipeline_node=pipeline_node,
             mlmd_connection=mlmd_connection,
-            pipeline_info=pipeline_info,
-            pipeline_runtime_spec=pipeline_runtime_spec,
             executor_spec=executor_spec,
             custom_driver_spec=custom_driver_spec,
             custom_executor_operators=custom_executor_operators,

--- a/src/zenml/integrations/airflow/orchestrators/airflow_dag_runner.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_dag_runner.py
@@ -145,14 +145,6 @@ class AirflowDagRunner:
             self._replace_runtime_params(component)
 
         pb2_pipeline: Pb2Pipeline = compiler.Compiler().compile(tfx_pipeline)
-
-        # Substitute the runtime parameter to be a concrete run_id
-        # runtime_parameter_utils.substitute_runtime_parameter(
-        #     pb2_pipeline,
-        #     {
-        #         "pipeline-run-id": runtime_configuration.run_name,
-        #     },
-        # )
         deployment_config = runner_utils.extract_local_deployment_config(
             pb2_pipeline
         )

--- a/src/zenml/integrations/airflow/orchestrators/airflow_dag_runner.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_dag_runner.py
@@ -24,7 +24,6 @@ from tfx.dsl.components.base import base_component, base_node
 from tfx.orchestration.config import pipeline_config
 from tfx.orchestration.data_types import RuntimeParameter
 from tfx.orchestration.local import runner_utils
-from tfx.orchestration.portable import runtime_parameter_utils
 from tfx.proto.orchestration import executable_spec_pb2
 from tfx.proto.orchestration.pipeline_pb2 import Pipeline as Pb2Pipeline
 from tfx.proto.orchestration.pipeline_pb2 import PipelineNode
@@ -148,19 +147,18 @@ class AirflowDagRunner:
         pb2_pipeline: Pb2Pipeline = compiler.Compiler().compile(tfx_pipeline)
 
         # Substitute the runtime parameter to be a concrete run_id
-        runtime_parameter_utils.substitute_runtime_parameter(
-            pb2_pipeline,
-            {
-                "pipeline-run-id": runtime_configuration.run_name,
-            },
-        )
+        # runtime_parameter_utils.substitute_runtime_parameter(
+        #     pb2_pipeline,
+        #     {
+        #         "pipeline-run-id": runtime_configuration.run_name,
+        #     },
+        # )
         deployment_config = runner_utils.extract_local_deployment_config(
             pb2_pipeline
         )
         connection_config = (
             Repository().active_stack.metadata_store.get_tfx_metadata_config()
         )
-
         component_impl_map = {}
 
         for node in pb2_pipeline.nodes:
@@ -204,10 +202,9 @@ class AirflowDagRunner:
 
             current_airflow_component = airflow_component.AirflowComponent(
                 parent_dag=airflow_dag,
+                pb2_pipeline=pb2_pipeline,
                 pipeline_node=pipeline_node,
                 mlmd_connection=connection_config,
-                pipeline_info=pb2_pipeline.pipeline_info,
-                pipeline_runtime_spec=pb2_pipeline.runtime_spec,
                 executor_spec=executor_spec,
                 custom_driver_spec=custom_driver_spec,
                 custom_executor_operators=custom_executor_operators,

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -28,8 +28,8 @@ from zenml.integrations.airflow.orchestrators.airflow_dag_runner import (
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.orchestrators import BaseOrchestrator
-from zenml.repository import Repository
 from zenml.utils import daemon
+from zenml.utils.source_utils import get_source_root_path
 
 logger = get_logger(__name__)
 
@@ -234,7 +234,7 @@ class AirflowOrchestrator(BaseOrchestrator):
                 command.run,
                 pid_file=self.pid_file,
                 log_file=self.log_file,
-                working_directory=str(Repository().root),
+                working_directory=get_source_root_path(),
             )
             while not self.is_running:
                 # Wait until the daemon started all the relevant airflow

--- a/src/zenml/integrations/kubeflow/container_entrypoint.py
+++ b/src/zenml/integrations/kubeflow/container_entrypoint.py
@@ -513,7 +513,7 @@ def main() -> None:
 
     repo.active_stack.prepare_step_run()
     execution_info = execute_step(component_launcher)
-    repo.active_stack.prepare_step_run()
+    repo.active_stack.cleanup_step_run()
 
     if execution_info:
         _dump_ui_metadata(pipeline_node, execution_info, args.metadata_ui_path)


### PR DESCRIPTION
## Describe changes

This PR fixes two issues with the airflow orchestrator:
- it allows provisioning resources even if you don't have a local `Repository` set up
- there was an issue that each step had it's own `pipeline_run_name`, which made it impossible to run steps with inputs as the input resolution would fail. This was fixed by setting the run name based on the airflow run id

Additionally, the `cleanup_step_run()` function is now called correctly inside of the kubeflow container entrypoint.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

