### PR TITLE
Removed tf reference in sklearn step

### DIFF
--- a/src/zenml/integrations/sklearn/steps/sklearn_evaluator.py
+++ b/src/zenml/integrations/sklearn/steps/sklearn_evaluator.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 
 import pandas as pd
-import tensorflow as tf
+from sklearn.base import BaseEstimator
 from sklearn.metrics import classification_report
 
 from zenml.steps.step_interfaces.base_evaluator_step import (
@@ -35,7 +35,7 @@ class SklearnEvaluator(BaseEvaluatorStep):
     def entrypoint(  # type: ignore[override]
         self,
         dataset: pd.DataFrame,
-        model: tf.keras.Model,
+        model: BaseEstimator,
         config: SklearnEvaluatorConfig,
     ) -> dict:  # type: ignore[type-arg]
         """Method which is responsible for the computation of the evaluation

--- a/src/zenml/integrations/sklearn/steps/sklearn_evaluator.py
+++ b/src/zenml/integrations/sklearn/steps/sklearn_evaluator.py
@@ -42,7 +42,7 @@ class SklearnEvaluator(BaseEvaluatorStep):
 
         Args:
             dataset: a pandas Dataframe which represents the test dataset
-            model: a trained tensorflow Keras model
+            model: a trained sklearn model
             config: the configuration for the step
         Returns:
             a dictionary which has the evaluation report


### PR DESCRIPTION
## Describe changes
Noticed that tensorflow was imported in the sklearn integration! I used BaseEstimator now instead as I dont think its so important to fix this with all types of models.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

