### PR TITLE
Add ability to give in-line pip requirements for pipeline

### DIFF
--- a/docs/book/advanced_guide/run_on_kubeflow.md
+++ b/docs/book/advanced_guide/run_on_kubeflow.md
@@ -164,7 +164,7 @@ creates for you. We do that by passing a file
 path as a parameter to the `@pipeline` decorator:
 
 ```python
-@pipeline(requirements_file="path_to_requirements.txt")
+@pipeline(requirements="path_to_requirements.txt")
 def mnist_pipeline(...)
 ```
 
@@ -175,7 +175,7 @@ Make sure to not add the `.zen`
 folder to the `.dockerignore`.
 
 ```python
-@pipeline(requirements_file="path_to_requirements.txt",
+@pipeline(requirements="path_to_requirements.txt",
           dockerignore_file="path_to_dockerignore")
 def mnist_pipeline(...)
 ```

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -29,6 +29,7 @@ from typing import (
     cast,
 )
 
+import zenml.cli.utils as cli_utils
 from zenml.config.config_keys import (
     PipelineConfigurationKeys,
     StepConfigurationKeys,
@@ -279,6 +280,10 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         for requirement in f.read().split("\n")
                     }
                 )
+            if self.requirements_file:
+                cli_utils.warning(
+                    f"Using the file path passed in as `requirements` and ignoring the file '{self.requirements_file}'."
+                )
         # Add this logic back in (described in #ENG-882)
         #
         # elif isinstance(self._requirements, str) and self._requirements:
@@ -301,6 +306,10 @@ class BasePipeline(metaclass=BasePipelineMeta):
         #                 )
         elif isinstance(self._requirements, List):
             requirements.update(self._requirements)
+            if self.requirements_file:
+                cli_utils.warning(
+                    f"Using the values passed in as `requirements` and ignoring the file '{self.requirements_file}'."
+                )
         elif self.requirements_file and fileio.exists(self.requirements_file):
             # TODO [MEDIUM]: Deprecate the `requirements_file` option
             with fileio.open(self.requirements_file, "r") as f:

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -12,7 +12,6 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import inspect
-import os
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -102,8 +101,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
 
     Attributes:
         name: The name of this pipeline.
-        enable_cache: A boolean indicating if
-        caching is enabled for this
+        enable_cache: A boolean indicating if caching is enabled for this
             pipeline.
         requirements_file: DEPRECATED: Optional path to a pip requirements file
             that contains all requirements to run the pipeline. (Use
@@ -271,10 +269,8 @@ class BasePipeline(metaclass=BasePipelineMeta):
                     f"'{integration_name}'."
                 ) from e
 
-        if (
-            isinstance(self._requirements, str)
-            and self._requirements
-            and fileio.exists(self._requirements)
+        if isinstance(self._requirements, str) and fileio.exists(
+            self._requirements
         ):
             with fileio.open(self._requirements, "r") as f:
                 requirements.update(
@@ -283,25 +279,27 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         for requirement in f.read().split("\n")
                     }
                 )
-        elif isinstance(self._requirements, str) and self._requirements:
-            root = str(Repository().root)
-            if root:
-                assumed_requirements_file = os.path.join(
-                    root, "requirements.txt"
-                )
-                if fileio.exists(assumed_requirements_file):
-                    with fileio.open(assumed_requirements_file, "r") as f:
-                        requirements.update(
-                            {
-                                requirement.strip()
-                                for requirement in f.read().split("\n")
-                            }
-                        )
-                        logger.info(
-                            "Using requirements file: `%s`",
-                            assumed_requirements_file,
-                        )
-        elif isinstance(self._requirements, List) and self._requirements:
+        # Add this logic back in (described in #ENG-882)
+        #
+        # elif isinstance(self._requirements, str) and self._requirements:
+        #     root = str(Repository().root)
+        #     if root:
+        #         assumed_requirements_file = os.path.join(
+        #             root, "requirements.txt"
+        #         )
+        #         if fileio.exists(assumed_requirements_file):
+        #             with fileio.open(assumed_requirements_file, "r") as f:
+        #                 requirements.update(
+        #                     {
+        #                         requirement.strip()
+        #                         for requirement in f.read().split("\n")
+        #                     }
+        #                 )
+        #                 logger.info(
+        #                     "Using requirements file: `%s`",
+        #                     assumed_requirements_file,
+        #                 )
+        elif isinstance(self._requirements, List):
             requirements.update(self._requirements)
         elif self.requirements_file and fileio.exists(self.requirements_file):
             # TODO [MEDIUM]: Deprecate the `requirements_file` option

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -12,6 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import inspect
+import os
 from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -100,7 +101,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
     """Abstract base class for all ZenML pipelines.
 
     Attributes:
-        name: The name of this pipeline. 
+        name: The name of this pipeline.
         enable_cache: A boolean indicating if
         caching is enabled for this
             pipeline.
@@ -282,6 +283,24 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         for requirement in f.read().split("\n")
                     }
                 )
+        elif isinstance(self._requirements, str) and self._requirements:
+            root = str(Repository().root)
+            if root:
+                assumed_requirements_file = os.path.join(
+                    root, "requirements.txt"
+                )
+                if fileio.exists(assumed_requirements_file):
+                    with fileio.open(assumed_requirements_file, "r") as f:
+                        requirements.update(
+                            {
+                                requirement.strip()
+                                for requirement in f.read().split("\n")
+                            }
+                        )
+                        logger.info(
+                            "Using requirements file: `%s`",
+                            assumed_requirements_file,
+                        )
         elif isinstance(self._requirements, List) and self._requirements:
             requirements.update(self._requirements)
         elif self.requirements_file and fileio.exists(self.requirements_file):

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -284,7 +284,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         elif isinstance(self._requirements, List) and self._requirements:
             requirements.update(self._requirements)
         elif self.requirements_file and fileio.exists(self.requirements_file):
-            # TODO: [MEDIUM] deprecate this requirements_file option
+            # TODO [MEDIUM]: Deprecate the `requirements_file` option
             with fileio.open(self.requirements_file, "r") as f:
                 requirements.update(
                     {

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -18,6 +18,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    List,
     NoReturn,
     Optional,
     Set,
@@ -61,6 +62,7 @@ PIPELINE_INNER_FUNC_NAME: str = "connect"
 PARAM_ENABLE_CACHE: str = "enable_cache"
 PARAM_REQUIRED_INTEGRATIONS: str = "required_integrations"
 PARAM_REQUIREMENTS_FILE: str = "requirements_file"
+PARAM_REQUIREMENTS: str = "requirements"
 PARAM_DOCKERIGNORE_FILE: str = "dockerignore_file"
 INSTANCE_CONFIGURATION = "INSTANCE_CONFIGURATION"
 PARAM_SECRETS: str = "secrets"
@@ -98,11 +100,13 @@ class BasePipeline(metaclass=BasePipelineMeta):
     """Abstract base class for all ZenML pipelines.
 
     Attributes:
-        name: The name of this pipeline.
-        enable_cache: A boolean indicating if caching is enabled for this
+        name: The name of this pipeline. enable_cache: A boolean indicating if
+        caching is enabled for this
             pipeline.
-        requirements_file: Optional path to a pip requirements file that
-            contains all requirements to run the pipeline.
+        requirements_file: DEPRECATED: Optional path to a pip requirements file
+            that contains all requirements to run the pipeline. (Use
+            `requirements` instead.)
+        requirements: Optional list of (string) pip requirements to run the pipeline, or a string path to a requirements file.
         required_integrations: Optional set of integrations that need to be
             installed for this pipeline to run.
     """
@@ -116,6 +120,11 @@ class BasePipeline(metaclass=BasePipelineMeta):
         self.enable_cache = kwargs.pop(PARAM_ENABLE_CACHE, True)
         self.required_integrations = kwargs.pop(PARAM_REQUIRED_INTEGRATIONS, ())
         self.requirements_file = kwargs.pop(PARAM_REQUIREMENTS_FILE, None)
+        if self.requirements_file:
+            logger.warning(
+                "The `requirements_file` argument has been deprecated. Please use `requirements` instead to pass in either a string path to a file listing your 'requirements' or a list of the individual requirements."
+            )
+        self._requirements = kwargs.pop(PARAM_REQUIREMENTS, None)
         self.dockerignore_file = kwargs.pop(PARAM_DOCKERIGNORE_FILE, None)
         self.secrets = kwargs.pop(PARAM_SECRETS, [])
 
@@ -238,11 +247,11 @@ class BasePipeline(metaclass=BasePipelineMeta):
 
     @property
     def requirements(self) -> Set[str]:
-        """Set of python requirements of this pipeline.
+        """Set of Python requirements of this pipeline.
 
         This property is a combination of the requirements of
         - required integrations for this pipeline
-        - the `requirements_file` specified for this pipeline
+        - the `requirements` specified for this pipeline
         """
         requirements = set()
 
@@ -260,7 +269,22 @@ class BasePipeline(metaclass=BasePipelineMeta):
                     f"'{integration_name}'."
                 ) from e
 
-        if self.requirements_file and fileio.exists(self.requirements_file):
+        if (
+            isinstance(self._requirements, str)
+            and self._requirements
+            and fileio.exists(self._requirements)
+        ):
+            with fileio.open(self._requirements, "r") as f:
+                requirements.update(
+                    {
+                        requirement.strip()
+                        for requirement in f.read().split("\n")
+                    }
+                )
+        elif isinstance(self._requirements, List) and self._requirements:
+            requirements.update(self._requirements)
+        elif self.requirements_file and fileio.exists(self.requirements_file):
+            # TODO: [MEDIUM] deprecate this requirements_file option
             with fileio.open(self.requirements_file, "r") as f:
                 requirements.update(
                     {

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -100,7 +100,8 @@ class BasePipeline(metaclass=BasePipelineMeta):
     """Abstract base class for all ZenML pipelines.
 
     Attributes:
-        name: The name of this pipeline. enable_cache: A boolean indicating if
+        name: The name of this pipeline. 
+        enable_cache: A boolean indicating if
         caching is enabled for this
             pipeline.
         requirements_file: DEPRECATED: Optional path to a pip requirements file

--- a/src/zenml/pipelines/pipeline_decorator.py
+++ b/src/zenml/pipelines/pipeline_decorator.py
@@ -27,6 +27,7 @@ from zenml.pipelines.base_pipeline import (
     PARAM_DOCKERIGNORE_FILE,
     PARAM_ENABLE_CACHE,
     PARAM_REQUIRED_INTEGRATIONS,
+    PARAM_REQUIREMENTS,
     PARAM_REQUIREMENTS_FILE,
     PARAM_SECRETS,
     PIPELINE_INNER_FUNC_NAME,
@@ -49,6 +50,7 @@ def pipeline(
     enable_cache: bool = True,
     required_integrations: Sequence[str] = (),
     requirements_file: Optional[str] = None,
+    requirements: Optional[Union[str, List[str]]] = None,
     dockerignore_file: Optional[str] = None,
     secrets: Optional[List[str]] = [],
 ) -> Callable[[F], Type[BasePipeline]]:
@@ -63,6 +65,7 @@ def pipeline(
     enable_cache: bool = True,
     required_integrations: Sequence[str] = (),
     requirements_file: Optional[str] = None,
+    requirements: Optional[Union[str, List[str]]] = None,
     dockerignore_file: Optional[str] = None,
     secrets: Optional[List[str]] = [],
 ) -> Union[Type[BasePipeline], Callable[[F], Type[BasePipeline]]]:
@@ -79,8 +82,10 @@ def pipeline(
         required_integrations: Optional list of ZenML integrations that are
             required to run this pipeline. Run `zenml integration list` for
             a full list of available integrations.
-        requirements_file: Optional path to a pip requirements file that
-            contains requirements to run the pipeline.
+        requirements_file: DEPRECATED: Optional path to a pip requirements file
+        that contains requirements to run the pipeline. Please use
+        'requirements' instead.
+        requirements: Optional path to a requirements file or a list of requirements.
         dockerignore_file: Optional path to a dockerignore file to use when
             building docker images for running this pipeline.
             **Note**: If you pass a file, make sure it does not include the
@@ -111,6 +116,7 @@ def pipeline(
                     PARAM_ENABLE_CACHE: enable_cache,
                     PARAM_REQUIRED_INTEGRATIONS: required_integrations,
                     PARAM_REQUIREMENTS_FILE: requirements_file,
+                    PARAM_REQUIREMENTS: requirements,
                     PARAM_DOCKERIGNORE_FILE: dockerignore_file,
                     PARAM_SECRETS: secrets,
                 },

--- a/src/zenml/services/local/local_daemon_entrypoint.py
+++ b/src/zenml/services/local/local_daemon_entrypoint.py
@@ -45,7 +45,6 @@ def run(
         from zenml.integrations.registry import integration_registry
         from zenml.logger import get_logger
         from zenml.services import LocalDaemonService, ServiceRegistry
-
         from zenml.zen_service.zen_service import ZenService  # noqa
 
         logger = get_logger(__name__)

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -284,8 +284,8 @@ def test_pipeline_requirements(tmp_path):
     requirements file."""
     from zenml.integrations.sklearn import SklearnIntegration
 
-    requirements_file = tmp_path / "requirements.txt"
-    requirements_file.write_text("any_requirement")
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("any_requirement")
 
     @pipeline(required_integrations=[SklearnIntegration.NAME])
     def my_pipeline():
@@ -293,7 +293,7 @@ def test_pipeline_requirements(tmp_path):
 
     assert my_pipeline().requirements == set(SklearnIntegration.REQUIREMENTS)
 
-    @pipeline(requirements_file=str(requirements_file))
+    @pipeline(requirements=str(requirements))
     def my_pipeline():
         pass
 
@@ -301,7 +301,41 @@ def test_pipeline_requirements(tmp_path):
 
     @pipeline(
         required_integrations=[SklearnIntegration.NAME],
-        requirements_file=str(requirements_file),
+        requirements=str(requirements),
+    )
+    def my_pipeline():
+        pass
+
+    assert my_pipeline().requirements == {
+        "any_requirement",
+        *SklearnIntegration.REQUIREMENTS,
+    }
+
+
+def test_pipeline_requirements_takes_list(tmp_path):
+    """Tests that the pipeline requirements are a combination of the
+    requirements of integrations and requirements of the specified
+    requirements file."""
+    from zenml.integrations.sklearn import SklearnIntegration
+
+    requirements = tmp_path / "requirements.txt"
+    requirements.write_text("any_requirement")
+
+    @pipeline(required_integrations=[SklearnIntegration.NAME])
+    def my_pipeline():
+        pass
+
+    assert my_pipeline().requirements == set(SklearnIntegration.REQUIREMENTS)
+
+    @pipeline(requirements=["any_requirement"])
+    def my_pipeline():
+        pass
+
+    assert my_pipeline().requirements == {"any_requirement"}
+
+    @pipeline(
+        required_integrations=[SklearnIntegration.NAME],
+        requirements=["any_requirement"],
     )
     def my_pipeline():
         pass


### PR DESCRIPTION
## Describe changes
I added:

- the ability to specify a `requirements` property when creating your pipeline decorator (it takes either a string/path or a list of requirements
- some deprecation warnings if someone continues to use the `requirements_file` argument, which we can remove at a later date
- documentation change where we mention this `requirements_file` argument

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

In a few weeks we'll remove so it'll become a breaking change, but for now we're just deprecating the old argument.