### PR TITLE
Improve error message for missing return type annotations of `@step` functions

### DIFF
--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -169,7 +169,7 @@ class BaseStepMeta(type):
                 f"Missing return type annotation when "
                 f"trying to create step '{name}'. Please make sure to "
                 f"include type annotations for all your step inputs "
-                f"and outputs."
+                f"and outputs. If your step returns nothing, please annotate it with `-> None`."
             )
         return_type = step_function_signature.annotations.get("return", None)
         if return_type is not None:

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -164,6 +164,13 @@ class BaseStepMeta(type):
                 cls.INPUT_SIGNATURE.update({arg: arg_type})
 
         # Parse the returns of the step function
+        if "return" not in step_function_signature.annotations:
+            raise StepInterfaceError(
+                f"Missing return type annotation when "
+                f"trying to create step '{name}'. Please make sure to "
+                f"include type annotations for all your step inputs "
+                f"and outputs."
+            )
         return_type = step_function_signature.annotations.get("return", None)
         if return_type is not None:
             if isinstance(return_type, Output):

--- a/src/zenml/steps/step_decorator.py
+++ b/src/zenml/steps/step_decorator.py
@@ -86,9 +86,6 @@ def step(
     Returns:
         the inner decorator which creates the step class based on the
         ZenML BaseStep
-
-    Raises:
-        StepInterfaceError: raises an error if _func is not type annotated.
     """
 
     def inner_decorator(func: F) -> Type[BaseStep]:
@@ -100,9 +97,6 @@ def step(
 
         Returns:
             The class of a newly generated ZenML Step.
-
-        Raises:
-            StepInterfaceError: raises an error if _func is not type annotated.
         """
         step_name = name or func.__name__
         output_spec = output_types or {}

--- a/src/zenml/steps/step_decorator.py
+++ b/src/zenml/steps/step_decorator.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,7 +23,6 @@ from typing import (
     overload,
 )
 
-from zenml.exceptions import StepInterfaceError
 from zenml.steps import BaseStep
 from zenml.steps.utils import (
     INSTANCE_CONFIGURATION,
@@ -39,42 +37,6 @@ if TYPE_CHECKING:
     from zenml.artifacts.base_artifact import BaseArtifact
 
 F = TypeVar("F", bound=Callable[..., Any])
-
-
-def _check_function_is_type_annotated(_func: F) -> None:
-    """
-    Check if given function has full type annotations.
-
-    Args:
-        _func: function to be checked.
-
-    Raises:
-        StepInterfaceError: raises an error if an annotation is missing.
-    """
-    func_name = _func.__name__
-    argspec = inspect.getfullargspec(_func)
-
-    # check if function has return type annotations
-    annotations = argspec.annotations
-    if "return" not in annotations:
-        raise StepInterfaceError(
-            f"All `@step` annotated functions must have type annotations. "
-            f"Function '{func_name}' has no return type annotation."
-        )
-
-    # for all args (incl. *args, **kwargs), check type annotations exist
-    args = argspec.args
-    if argspec.varargs is not None:
-        args.append(argspec.varargs)
-    if argspec.varkw is not None:
-        args.append(argspec.varkw)
-    for arg in args:
-        if arg in annotations:
-            continue
-        raise StepInterfaceError(
-            f"All `@step` annotated functions must have type annotations. "
-            f"Function '{func_name}' has no type annotation for arg '{arg}'."
-        )
 
 
 @overload
@@ -142,7 +104,6 @@ def step(
         Raises:
             StepInterfaceError: raises an error if _func is not type annotated.
         """
-        _check_function_is_type_annotated(func)
         step_name = name or func.__name__
         output_spec = output_types or {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,7 +241,7 @@ def empty_step():
     """Pytest fixture that returns an empty (no input, no output) step."""
 
     @step
-    def _empty_step():
+    def _empty_step() -> None:
         pass
 
     return _empty_step
@@ -258,7 +258,7 @@ def generate_empty_steps():
         for i in range(count):
 
             @step(name=f"step_{i}")
-            def _step_function():
+            def _step_function() -> None:
                 pass
 
             output.append(_step_function)
@@ -305,7 +305,7 @@ def int_step_output():
 @pytest.fixture
 def step_with_two_int_inputs():
     @step
-    def _step(input_1: int, input_2: int):
+    def _step(input_1: int, input_2: int) -> None:
         pass
 
     return _step

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -40,7 +40,7 @@ def test_get_cache_status_works_when_running_pipeline_twice():
     from zenml.steps import step
 
     @step
-    def step_one():
+    def step_one() -> int:
         return 1
 
     @pipeline

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -35,7 +35,7 @@ def create_pipeline_with_config_value(config_value: int):
         value: int
 
     @step
-    def step_with_config(config: Config):
+    def step_with_config(config: Config) -> None:
         pass
 
     @pipeline
@@ -319,7 +319,7 @@ def test_pipeline_run_fails_when_required_step_operator_is_missing(
     operator fails if the active stack does not contain this step operator."""
 
     @step(custom_step_operator="azureml")
-    def step_that_requires_step_operator():
+    def step_that_requires_step_operator() -> None:
         pass
 
     assert not Repository().active_stack.step_operator

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -34,7 +34,7 @@ def test_step_decorator_creates_class_in_same_module_as_decorated_function():
     creates the class in the same module as the decorated function."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     assert some_step.__module__ == __name__
@@ -58,7 +58,7 @@ def test_define_step_with_multiple_configs():
         @step
         def some_step(
             first_config: BaseStepConfig, second_config: BaseStepConfig
-        ):
+        ) -> None:
             pass
 
 
@@ -68,7 +68,9 @@ def test_define_step_with_multiple_contexts():
     with pytest.raises(StepInterfaceError):
 
         @step
-        def some_step(first_context: StepContext, second_context: StepContext):
+        def some_step(
+            first_context: StepContext, second_context: StepContext
+        ) -> None:
             pass
 
 
@@ -77,7 +79,7 @@ def test_step_without_context_has_caching_enabled_by_default():
     default."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     assert some_step().enable_cache is True
@@ -88,7 +90,7 @@ def test_step_with_context_has_caching_disabled_by_default():
     default."""
 
     @step
-    def some_step(context: StepContext):
+    def some_step(context: StepContext) -> None:
         pass
 
     assert some_step().enable_cache is False
@@ -99,7 +101,7 @@ def test_enable_caching_for_step_with_context():
     context."""
 
     @step(enable_cache=True)
-    def some_step(context: StepContext):
+    def some_step(context: StepContext) -> None:
         pass
 
     assert some_step().enable_cache is True
@@ -111,7 +113,17 @@ def test_define_step_without_input_annotation():
     with pytest.raises(StepInterfaceError):
 
         @step
-        def some_step(some_argument, some_other_argument: int):
+        def some_step(some_argument, some_other_argument: int) -> None:
+            pass
+
+
+def test_define_step_without_return_annotation():
+    """Tests that defining a step with a missing return annotation raises
+    a StepInterfaceError."""
+    with pytest.raises(StepInterfaceError):
+
+        @step
+        def some_step(some_argument: int, some_other_argument: int):
             pass
 
 
@@ -121,7 +133,7 @@ def test_define_step_with_variable_args():
     with pytest.raises(StepInterfaceError):
 
         @step
-        def some_step(*args: int):
+        def some_step(*args: int) -> None:
             pass
 
 
@@ -131,7 +143,7 @@ def test_define_step_with_variable_kwargs():
     with pytest.raises(StepInterfaceError):
 
         @step
-        def some_step(**kwargs: int):
+        def some_step(**kwargs: int) -> None:
             pass
 
 
@@ -140,7 +152,7 @@ def test_define_step_with_keyword_only_arguments():
     or a step."""
 
     @step
-    def some_step(some_argument: int, *, keyword_only_argument: int):
+    def some_step(some_argument: int, *, keyword_only_argument: int) -> None:
         pass
 
     assert "keyword_only_argument" in some_step.INPUT_SIGNATURE
@@ -246,7 +258,7 @@ def test_unrecognized_output_in_output_artifact_types():
     exist raises an exception."""
 
     @step(output_types={"non-existent": DataArtifact})
-    def some_step():
+    def some_step() -> None:
         pass
 
     with pytest.raises(StepInterfaceError):
@@ -258,11 +270,11 @@ def test_enabling_a_custom_step_operator_for_a_step():
     using the step decorator."""
 
     @step
-    def step_without_step_operator():
+    def step_without_step_operator() -> None:
         pass
 
     @step(custom_step_operator="some_step_operator")
-    def step_with_step_operator():
+    def step_with_step_operator() -> None:
         pass
 
     assert step_without_step_operator().custom_step_operator is None
@@ -275,11 +287,11 @@ def test_step_executor_operator():
     """Tests that the step returns the correct executor operator."""
 
     @step(custom_step_operator=None)
-    def step_without_step_operator():
+    def step_without_step_operator() -> None:
         pass
 
     @step(custom_step_operator="some_step_operator")
-    def step_with_step_operator():
+    def step_with_step_operator() -> None:
         pass
 
     assert (
@@ -293,7 +305,7 @@ def test_pipeline_parameter_name_is_empty_when_initializing_a_step():
     a step is initialized."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     assert some_step().pipeline_parameter_name is None
@@ -304,7 +316,7 @@ def test_access_step_component_before_calling():
     a StepInterfaceError."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     with pytest.raises(StepInterfaceError):
@@ -315,7 +327,7 @@ def test_access_step_component_after_calling():
     """Tests that a step component exists after the step was called."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     step_instance = some_step()
@@ -432,7 +444,7 @@ def test_step_with_disabled_cache_has_random_string_as_execution_property():
     execution property to disable caching."""
 
     @step(enable_cache=False)
-    def some_step():
+    def some_step() -> None:
         pass
 
     step_instance_1 = some_step()
@@ -449,7 +461,7 @@ def test_step_source_execution_parameter_stays_the_same_if_step_is_not_modified(
     creating multiple steps from the same source code."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     step_1 = some_step()
@@ -499,13 +511,13 @@ def test_step_source_execution_parameter_changes_when_function_body_changes():
     source execution parameter."""
 
     @step
-    def some_step():
+    def some_step() -> None:
         pass
 
     step_1 = some_step()
 
     @step
-    def some_step():
+    def some_step() -> None:
         # this is new
         pass
 
@@ -659,7 +671,7 @@ def test_step_uses_config_class_default_values_if_no_config_is_passed():
         some_parameter: int = 1
 
     @step
-    def some_step(config: ConfigWithDefaultValues):
+    def some_step(config: ConfigWithDefaultValues) -> None:
         pass
 
     # don't pass the config when initializing the step
@@ -677,7 +689,7 @@ def test_step_fails_if_config_parameter_value_is_missing():
         some_parameter: int
 
     @step
-    def some_step(config: ConfigWithoutDefaultValues):
+    def some_step(config: ConfigWithoutDefaultValues) -> None:
         pass
 
     # don't pass the config when initializing the step
@@ -695,7 +707,7 @@ def test_step_config_allows_none_as_default_value():
         some_parameter: Optional[int] = None
 
     @step
-    def some_step(config: ConfigWithNoneDefaultValue):
+    def some_step(config: ConfigWithNoneDefaultValue) -> None:
         pass
 
     # don't pass the config when initializing the step
@@ -709,7 +721,7 @@ def test_calling_a_step_twice_raises_an_exception():
     """Tests that calling once step instance twice raises an exception."""
 
     @step
-    def my_step():
+    def my_step() -> None:
         pass
 
     step_instance = my_step()
@@ -726,7 +738,7 @@ def test_step_sets_global_execution_status_on_environment(one_step_pipeline):
     True during step execution."""
 
     @step
-    def my_step():
+    def my_step() -> None:
         assert Environment().step_is_running is True
 
     assert Environment().step_is_running is False
@@ -741,7 +753,7 @@ def test_step_resets_global_execution_status_even_if_the_step_crashes(
     False after step execution even if the step crashes."""
 
     @step
-    def my_step():
+    def my_step() -> None:
         raise RuntimeError()
 
     assert Environment().step_is_running is False


### PR DESCRIPTION
## Describe changes
I added an error message for when the return type annotation of an `@step` function is missing.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)