### PR TITLE
Fix 'zenml stack export' if the stack contains a container registry

### DIFF
--- a/src/zenml/container_registries/azure_container_registry.py
+++ b/src/zenml/container_registries/azure_container_registry.py
@@ -30,4 +30,4 @@ class AzureContainerRegistry(BaseContainerRegistry):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.AZURE
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.AZURE.value

--- a/src/zenml/container_registries/base_container_registry.py
+++ b/src/zenml/container_registries/base_container_registry.py
@@ -32,7 +32,7 @@ class BaseContainerRegistry(StackComponent):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.DEFAULT
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.DEFAULT.value
 
     @validator("uri")
     def strip_trailing_slash(cls, uri: str) -> str:

--- a/src/zenml/container_registries/dockerhub_container_registry.py
+++ b/src/zenml/container_registries/dockerhub_container_registry.py
@@ -30,4 +30,4 @@ class DockerHubContainerRegistry(BaseContainerRegistry):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.DOCKERHUB
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.DOCKERHUB.value

--- a/src/zenml/container_registries/gcp_container_registry.py
+++ b/src/zenml/container_registries/gcp_container_registry.py
@@ -30,4 +30,4 @@ class GCPContainerRegistry(BaseContainerRegistry):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GCP
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GCP.value

--- a/src/zenml/container_registries/github_container_registry.py
+++ b/src/zenml/container_registries/github_container_registry.py
@@ -30,4 +30,4 @@ class GitHubContainerRegistry(BaseContainerRegistry):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GITHUB
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GITHUB.value

--- a/src/zenml/container_registries/gitlab_container_registry.py
+++ b/src/zenml/container_registries/gitlab_container_registry.py
@@ -30,4 +30,4 @@ class GitLabContainerRegistry(BaseContainerRegistry):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentType] = StackComponentType.CONTAINER_REGISTRY
-    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GITLAB
+    FLAVOR: ClassVar[str] = ContainerRegistryFlavor.GITLAB.value

--- a/src/zenml/services/local/local_daemon_entrypoint.py
+++ b/src/zenml/services/local/local_daemon_entrypoint.py
@@ -45,7 +45,6 @@ def run(
         from zenml.integrations.registry import integration_registry
         from zenml.logger import get_logger
         from zenml.services import LocalDaemonService, ServiceRegistry
-
         from zenml.zen_service.zen_service import ZenService  # noqa
 
         logger = get_logger(__name__)


### PR DESCRIPTION
## Describe changes
The flavor of some container registries were defined as an enum which messed with the `zenml stack export` command. We now use the enum value instead which fixes this issue.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

