### PR TITLE
Sync the repository and local store with the disk configuration files and other fixes

### DIFF
--- a/scripts/test-coverage-xml.sh
+++ b/scripts/test-coverage-xml.sh
@@ -18,6 +18,7 @@ if [ -n "$1" ]; then
     coverage run -m pytest $TEST_SRC --color=yes -vv
 else
     coverage run -m pytest tests/unit --color=yes -vv
+    coverage run -m pytest tests/unit --store-type=sql --color=yes -vv
     coverage run -m pytest tests/integration --use-virtualenv --color=yes -vv
 fi
 coverage combine

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -505,12 +505,15 @@ def rename_stack(
             )
         stack_components = current_stack.components
 
-        registered_stacks = {stack.name for stack in repo.stacks}
-        if new_stack_name in registered_stacks:
+        try:
+            repo.zen_store.get_stack(new_stack_name)
             cli_utils.error(
                 f"Stack `{new_stack_name}` already exists. Please choose a "
                 f"different name.",
             )
+        except KeyError:
+            pass
+
         new_stack_ = Stack.from_components(
             name=new_stack_name, components=stack_components
         )

--- a/src/zenml/integrations/azureml/step_operators/azureml_step_operator.py
+++ b/src/zenml/integrations/azureml/step_operators/azureml_step_operator.py
@@ -187,7 +187,7 @@ class AzureMLStepOperator(BaseStepOperator):
             # active profile contents into the build context, to have
             # the configured stacks accessible from within the Azure ML
             # environment.
-            GlobalConfiguration().copy_config_with_active_profile(
+            GlobalConfiguration().copy_active_configuration(
                 config_path,
                 load_config_path=f"./{CONTAINER_ZENML_CONFIG_DIR}",
             )

--- a/src/zenml/repository.py
+++ b/src/zenml/repository.py
@@ -75,11 +75,12 @@ class LegacyRepositoryConfig(BaseModel):
     stacks: Dict[str, Dict[StackComponentType, Optional[str]]]
     stack_components: Dict[StackComponentType, Dict[str, str]]
 
-    def get_stack_data(self) -> "ZenStoreModel":
+    def get_stack_data(self, config_file: str) -> "ZenStoreModel":
         """Extract stack data from Legacy Repository file."""
         from zenml.zen_stores.models import ZenStoreModel
 
         return ZenStoreModel(
+            config_file=config_file,
             stacks={
                 name: {
                     component_type: value
@@ -438,14 +439,13 @@ class Repository(BaseConfiguration, metaclass=RepositoryMetaClass):
             f"This warning will not be shown again for this Repository."
         )
 
-        stack_data = legacy_config.get_stack_data()
+        stack_data = legacy_config.get_stack_data(config_file=config_file)
 
         from zenml.config.profile_config import ProfileConfiguration
         from zenml.zen_stores import LocalZenStore
 
         store = LocalZenStore()
         store.initialize(url=config_path, store_data=stack_data)
-        store._write_store()
         profile = ProfileConfiguration(
             name=profile_name,
             store_url=store.url,

--- a/src/zenml/services/local/local_daemon_entrypoint.py
+++ b/src/zenml/services/local/local_daemon_entrypoint.py
@@ -45,7 +45,6 @@ def run(
         from zenml.integrations.registry import integration_registry
         from zenml.logger import get_logger
         from zenml.services import LocalDaemonService, ServiceRegistry
-
         from zenml.zen_service.zen_service import ZenService  # noqa
 
         logger = get_logger(__name__)

--- a/src/zenml/utils/filesync_model.py
+++ b/src/zenml/utils/filesync_model.py
@@ -18,7 +18,10 @@ from typing import Any, Optional
 from pydantic import BaseModel
 
 from zenml.io import fileio
+from zenml.logger import get_logger
 from zenml.utils import yaml_utils
+
+logger = get_logger(__name__)
 
 
 class FileSyncModel(BaseModel):
@@ -92,6 +95,9 @@ class FileSyncModel(BaseModel):
         file_timestamp = os.path.getmtime(self._config_file)
         if file_timestamp == self._config_file_timestamp:
             return
+
+        if self._config_file_timestamp is not None:
+            logger.info(f"Reloading configuration file {self._config_file}")
 
         # refresh the model from the configuration file values
         config_dict = yaml_utils.read_yaml(self._config_file)

--- a/src/zenml/utils/filesync_model.py
+++ b/src/zenml/utils/filesync_model.py
@@ -1,0 +1,108 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+import json
+import os
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from zenml.io import fileio
+from zenml.utils import yaml_utils
+
+
+class FileSyncModel(BaseModel):
+    """Pydantic model synchronized with a configuration file.
+
+    Use this class as a base Pydantic model that is automatically synchronized
+    with a configuration file on disk.
+
+    This class overrides the __setattr__ and __getattr__ magic methods to
+    ensure that the FileSyncModel instance acts as an in-memory cache of the
+    information stored in the associated configuration file.
+    """
+
+    _config_file: str
+    _config_file_timestamp: Optional[float]
+
+    def __init__(self, config_file: str, **kwargs: Any) -> None:
+        """Create a FileSyncModel instance synchronized with a configuration
+        file on disk.
+
+        Args:
+            config_file: configuration file path. If the file exists, the model
+                will be initialized with the values from the file.
+            **kwargs: additional keyword arguments to pass to the Pydantic model
+                constructor. If supplied, these values will override those
+                loaded from the configuration file.
+        """
+        config_dict = {}
+        if fileio.exists(config_file):
+            config_dict = yaml_utils.read_yaml(config_file)
+
+        self._config_file = config_file
+        self._config_file_timestamp = None
+
+        config_dict.update(kwargs)
+        super(FileSyncModel, self).__init__(**config_dict)
+
+        # write the configuration file to disk, to reflect new attributes
+        # and schema changes
+        self.write_config()
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        """Sets an attribute on the model and persists the new value in the
+        configuration file.
+
+        """
+        super(FileSyncModel, self).__setattr__(key, value)
+        if key.startswith("_"):
+            return
+        self.write_config()
+
+    def __getattribute__(self, key: str) -> Any:
+        """Gets an attribute value for a specific key."""
+        if not key.startswith("_") and key in self.__dict__:
+            self.load_config()
+        return super(FileSyncModel, self).__getattribute__(key)
+
+    def write_config(self) -> None:
+        """Writes the model to the configuration file."""
+        config_dict = json.loads(self.json())
+        yaml_utils.write_yaml(self._config_file, config_dict)
+        self._config_file_timestamp = os.path.getmtime(self._config_file)
+
+    def load_config(self) -> None:
+        """Loads the model from the configuration file on disk."""
+        if not fileio.exists(self._config_file):
+            return
+
+        # don't reload the configuration if the file hasn't
+        # been updated since the last load
+        file_timestamp = os.path.getmtime(self._config_file)
+        if file_timestamp == self._config_file_timestamp:
+            return
+
+        # refresh the model from the configuration file values
+        config_dict = yaml_utils.read_yaml(self._config_file)
+        for key, value in config_dict.items():
+            super(FileSyncModel, self).__setattr__(key, value)
+
+        self._config_file_timestamp = file_timestamp
+
+    class Config:
+        """Pydantic configuration class."""
+
+        # all attributes with leading underscore are private and therefore
+        # are mutable and not included in serialization
+        underscore_attrs_are_private = True

--- a/src/zenml/zen_stores/models/zen_store_model.py
+++ b/src/zenml/zen_stores/models/zen_store_model.py
@@ -15,9 +15,10 @@
 from collections import defaultdict
 from typing import DefaultDict, Dict, List, Set
 
-from pydantic import BaseModel, validator
+from pydantic import Field, validator
 
 from zenml.enums import StackComponentType
+from zenml.utils.filesync_model import FileSyncModel
 from zenml.zen_stores.models import (
     FlavorWrapper,
     Project,
@@ -28,7 +29,7 @@ from zenml.zen_stores.models import (
 )
 
 
-class ZenStoreModel(BaseModel):
+class ZenStoreModel(FileSyncModel):
     """Pydantic object used for serializing a ZenStore.
 
     Attributes:
@@ -48,15 +49,21 @@ class ZenStoreModel(BaseModel):
             the team.
     """
 
-    stacks: Dict[str, Dict[StackComponentType, str]]
-    stack_components: DefaultDict[StackComponentType, Dict[str, str]]
-    stack_component_flavors: List[FlavorWrapper] = []
-    users: List[User] = []
-    teams: List[Team] = []
-    projects: List[Project] = []
-    roles: List[Role] = []
-    role_assignments: List[RoleAssignment] = []
-    team_assignments: DefaultDict[str, Set[str]] = defaultdict(set)
+    stacks: Dict[str, Dict[StackComponentType, str]] = Field(
+        default_factory=dict
+    )
+    stack_components: DefaultDict[StackComponentType, Dict[str, str]] = Field(
+        default=defaultdict(dict)
+    )
+    stack_component_flavors: List[FlavorWrapper] = Field(default_factory=list)
+    users: List[User] = Field(default_factory=list)
+    teams: List[Team] = Field(default_factory=list)
+    projects: List[Project] = Field(default_factory=list)
+    roles: List[Role] = Field(default_factory=list)
+    role_assignments: List[RoleAssignment] = Field(default_factory=list)
+    team_assignments: DefaultDict[str, Set[str]] = Field(
+        default=defaultdict(set)
+    )
 
     @validator("stack_components")
     def _construct_stack_components_defaultdict(
@@ -73,11 +80,6 @@ class ZenStoreModel(BaseModel):
         """Ensures that `team_assignments` is a defaultdict so users
         of a new teams can be added without issues."""
         return defaultdict(set, team_assignments)
-
-    @classmethod
-    def empty_store(cls) -> "ZenStoreModel":
-        """Initialize a new empty zen store with current zen version."""
-        return cls(stacks={}, stack_components={})
 
     class Config:
         """Pydantic configuration class."""


### PR DESCRIPTION
## Describe changes

This PR changes the implementation of the Repository and Local Zen Store so that they
automatically reload any changes done to the corresponding files stored on disk (e.g.
by an asynchronous CLI command that changes the active stack or registers new stacks).

NOTE: this only works in an initialized ZenML repository and only applies to the stack
configurations (active stack, configured stacks and stack components). Global configuration
changes and changes to the local (in the .zen repository) active profile require some more
refactoring of the relationships between the Repository, GlobalConfiguration and ZenStore
components (see TODO).

Other fixes included in this PR:

* fix the SQL store (currently broken) and update the CI to test it regularly
* fix the Azure step operator (currently broken)
* fix the currently broken migration from legacy .zen repository formats
* make it so that the `zenml stack rename` doesn't need all the integrations installed

Implementation details:

* add a new type of Pydantic Model class, `FileSyncModel`,  that synchronizes the field values
to a designated configuration file stored on the local filesystem automatically, every time an attribute
is read (`__getattribute__`) or set (`__setattr__`).
* change the existing Pydantic classes used to represent the Repository configuration and the Local
Stack Store model to inherit from this new `FileSyncModel` class
* some additional changes were done to remove the code dealing with reading/writing the
Repository configuration and Local Stack Store model from file and rely solely on the functionality
available in the base `FileSyncModel` class

TODO:
- [ ] changing the active profile in the Repository configuration asynchronously is still not automatically reflected in the
currently running ZenML code (switching the active stack works though)
- [ ] same thing with changes in the global configuration (e.g. global active profile and global active stack)


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

