### PR TITLE
Fix GH action cache

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -35,6 +35,12 @@ runs:
       id: date
       run: echo "::set-output name=date::$(date +'calendar-week-%W')"
 
+    - name: Write cache version
+      shell: bash
+      run: echo $CACHE_VERSION >> cache_version
+      env:
+        CACHE_VERSION : ${{inputs.cache_version}}
+
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v2.1.6
@@ -46,7 +52,7 @@ runs:
         # pyproject.toml, the current calendar week and the cache version.
         # Providing a different value for the cache version enables manual
         # invalidation of the cache in case it is in some erroneous state.
-        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ steps.date.outputs.date }}-${{ inputs.cache_version }}
+        key: venv-${{ runner.os }}-python-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ steps.date.outputs.date }}-${{ hashFiles('cache_version') }}
 
     - name: Install Project
       shell: bash

--- a/.github/workflows/poetry-install.yml
+++ b/.github/workflows/poetry-install.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Setup environment with Poetry
         uses: ./.github/actions/setup_environment
         with:
-          cache_version: a #${{ secrets.GH_ACTIONS_CACHE_KEY }}
+          cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}

--- a/.github/workflows/poetry-install.yml
+++ b/.github/workflows/poetry-install.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Setup environment with Poetry
         uses: ./.github/actions/setup_environment
         with:
-          cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
+          cache_version: a #${{ secrets.GH_ACTIONS_CACHE_KEY }}


### PR DESCRIPTION
## Describe changes
Fixes the GH action cache invalidation. Currently this wasn't working as github apparently doesn't allow you to pass secrets to third party GH actions, but simply replace it with an emtpy string.
The solution: Write the secret to a file and use a hash of this file as part of the cache key.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

