### PR TITLE
Small CLI fixes regarding stack components

### DIFF
--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -156,19 +156,18 @@ class BaseArtifactStore(StackComponent, ABC):
             getattr(cls, "SUPPORTED_SCHEMES")
         except AttributeError:
             raise ArtifactStoreInterfaceError(
-                textwrap.dedent(
+                "When you are working with any classes which subclass from "
+                "'zenml.artifact_store.BaseArtifactStore' please make sure "
+                "that your class has a ClassVar named `SUPPORTED_SCHEMES` "
+                "which should hold a set of supported file schemes such "
+                "as {'s3://'} or {'gcs://'}. \n"
+                + textwrap.dedent(
                     """
-                    When you are working with any classes which subclass from
-                    zenml.artifact_store.BaseArtifactStore please make sure 
-                    that your class has a ClassVar named `SUPPORTED_SCHEMES` 
-                    which should hold a set of supported file schemes such 
-                    as {"s3://"} or {"gcs://"}.
-                    
                     Example:
+
                     class S3ArtifactStore(StackComponent):
                         ...
                         # Class Variables
-                        ...
                         SUPPORTED_SCHEMES: ClassVar[Set[str]] = {"s3://"}
                         ...
                     """
@@ -176,14 +175,10 @@ class BaseArtifactStore(StackComponent, ABC):
             )
         if not any(values["path"].startswith(i) for i in cls.SUPPORTED_SCHEMES):
             raise ArtifactStoreInterfaceError(
-                textwrap.dedent(
-                    f"""
-                    The path: "{values["path"]}" you defined for your artifact
-                    store is not supported by the implementation of
-                    {cls.schema()["title"]}, because it does not start with
-                    one of its supported schemes: {cls.SUPPORTED_SCHEMES}.
-                    """
-                )
+                f"The path: '{values['path']}' you defined for your "
+                f"artifact store is not supported by the implementation of "
+                f"{cls.schema()['title']}, because it does not start with "
+                f"one of its supported schemes: {cls.SUPPORTED_SCHEMES}."
             )
 
         return values

--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -148,7 +148,7 @@ class BaseArtifactStore(StackComponent, ABC):
         """Return an iterator that walks the contents of the given directory."""
         raise NotImplementedError()
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def _ensure_artifact_store(cls, values: Dict[str, Any]) -> Any:
         """Validator function for the Artifact Stores. Checks whether
         supported schemes are defined and the given path is supported"""
@@ -159,9 +159,11 @@ class BaseArtifactStore(StackComponent, ABC):
                 textwrap.dedent(
                     """
                     When you are working with any classes which subclass from
-                    zenml.artifact_store.BaseArtifactStore please make sure that your class
-                    has a ClassVar named `SUPPORTED_SCHEMES` which should hold a set of
-                    supported file schemes such as {"s3://"} or {"gcs://"}.
+                    zenml.artifact_store.BaseArtifactStore please make sure 
+                    that your class has a ClassVar named `SUPPORTED_SCHEMES` 
+                    which should hold a set of supported file schemes such 
+                    as {"s3://"} or {"gcs://"}.
+                    
                     Example:
                     class S3ArtifactStore(StackComponent):
                         ...

--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -203,7 +203,7 @@ class Example:
             name: The name of the example, specifically the name of the folder
                   on git
             path_in_repo: Path to the local example within the global zenml
-                          folder.
+                  folder.
         """
         self.name = name
         self.path_in_repo = path_in_repo
@@ -576,8 +576,7 @@ def info(git_examples_handler: GitExamplesHandler, example_name: str) -> None:
     "old_force",
     is_flag=True,
     help="DEPRECATED: Force the redownload of the examples folder to the ZenML "
-    "config. Use `-y/--yes` instead."
-    "folder.",
+    "config folder. Use `-y/--yes` instead.",
 )
 @click.option(
     "--version",

--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -541,7 +541,8 @@ def clean(git_examples_handler: GitExamplesHandler, path: str) -> None:
 @pass_git_examples_handler
 @click.argument("example_name")
 def info(git_examples_handler: GitExamplesHandler, example_name: str) -> None:
-    """Find out more about an example. Outputs a pager view of the example's README.md file."""
+    """Find out more about an example. Outputs a pager view of the example's
+    README.md file."""
     check_for_version_mismatch(git_examples_handler)
 
     try:
@@ -574,7 +575,8 @@ def info(git_examples_handler: GitExamplesHandler, example_name: str) -> None:
     "-f",
     "old_force",
     is_flag=True,
-    help="DEPRECATED: Force the redownload of the examples folder to the ZenML config. Use `-y/--yes` instead."
+    help="DEPRECATED: Force the redownload of the examples folder to the ZenML "
+    "config. Use `-y/--yes` instead."
     "folder.",
 )
 @click.option(
@@ -616,7 +618,8 @@ def pull(
     if old_force:
         force = old_force
         warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` or `-y` instead."
+            "The `--force` flag will soon be deprecated. Use `--yes` or "
+            "`-y` instead."
         )
 
     branch = branch.strip() if branch else f"release/{version}"
@@ -681,9 +684,9 @@ def pull(
     "-f",
     "old_force",
     is_flag=True,
-    help="DEPRECATED: Force the run of the example. This deletes the .zen folder from the "
-    "example folder and force installs all necessary integration "
-    "requirements. Use `-y/--yes` instead.",
+    help="DEPRECATED: Force the run of the example. This deletes the .zen "
+    "folder from the example folder and force installs all necessary "
+    "integration requirements. Use `-y/--yes` instead.",
 )
 @click.option(
     "--shell-executable",
@@ -713,7 +716,8 @@ def run(
     if old_force:
         force = old_force
         warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` or `-y` instead."
+            "The `--force` flag will soon be deprecated. Use `--yes` or "
+            "`-y` instead."
         )
     check_for_version_mismatch(git_examples_handler)
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -277,10 +277,10 @@ def generate_stack_component_register_command(
                         f"the flavor."
                     )
                 flavor = old_flavor
-            cli_utils.warning(
-                "The option '--type'/'-t' will soon be DEPRECATED, please "
-                "use '--flavor'/'-f' instead. "
-            )
+                cli_utils.warning(
+                    "The option '--type'/'-t' will soon be DEPRECATED, please "
+                    "use '--flavor'/'-f' instead. "
+                )
         else:
             cli_utils.error(
                 "Please use the option to specify '--flavor'/'-f' of the "
@@ -303,10 +303,12 @@ def generate_stack_component_register_command(
                 )
             except ValidationError as e:
                 cli_utils.error(
-                    f"When you are registering a new {flavor}, make "
-                    f"sure that you are utilizing the right attributes. "
-                    f"Current problems:\n\n{e}"
+                    f"When you are registering a new {display_name} with the "
+                    f"flavor `{flavor}`, make sure that you are utilizing "
+                    f"the right attributes. Current problems:\n\n{e}"
                 )
+            except Exception as e:
+                cli_utils.error(e)  # type: ignore[arg-type]
 
         cli_utils.declare(f"Successfully registered {display_name} `{name}`.")
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -248,16 +248,44 @@ def generate_stack_component_register_command(
         "--flavor",
         "-f",
         "flavor",
-        help=f"The type of the {display_name} to register.",
-        required=True,
+        help=f"The flavor of the {display_name} to register.",
+        type=str,
+    )
+    @click.option(
+        "--type",
+        "-t",
+        "old_flavor",
+        help=f"DEPRECATED: The flavor of the {display_name} to register.",
         type=str,
     )
     @click.argument("args", nargs=-1, type=click.UNPROCESSED)
     def register_stack_component_command(
-        name: str, flavor: str, args: List[str]
+        name: str, flavor: str, old_flavor: str, args: List[str]
     ) -> None:
         """Registers a stack component."""
         cli_utils.print_active_profile()
+
+        if flavor or old_flavor:
+            if old_flavor:
+                if flavor:
+                    cli_utils.error(
+                        f"You have used both '--type': {old_flavor} and a "
+                        f"'--flavor': {flavor}, which is not allowed. "
+                        f"The option '--type' will soon be DEPRECATED and "
+                        f"please just use the option '--flavor' to specify "
+                        f"the flavor."
+                    )
+            flavor = old_flavor
+            cli_utils.warning(
+                "The option '--type'/'-t' will soon be DEPRECATED, please"
+                "use '--flavor'/'-f' instead. "
+            )
+        else:
+            cli_utils.error(
+                "Please use the option to specify '--flavor'/'-f' of the "
+                f"{display_name} you want to register."
+            )
+
         with console.status(f"Registering {display_name} '{name}'...\n"):
             try:
                 parsed_args = cli_utils.parse_unknown_options(args)

--- a/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
+++ b/src/zenml/integrations/airflow/orchestrators/airflow_orchestrator.py
@@ -178,7 +178,7 @@ class AirflowOrchestrator(BaseOrchestrator):
         # Return the finished airflow dag
         return airflow_dag
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def set_airflow_home(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Sets airflow home according to orchestrator UUID."""
         if "uuid" not in values:

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -139,7 +139,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
         UUID."""
         return f"k3d-{KubeflowOrchestrator._get_k3d_cluster_name(uuid)}"
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def set_default_kubernetes_context(
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -100,7 +100,7 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
                 )
         return tracking_uri
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def _ensure_authentication_if_necessary(
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:

--- a/src/zenml/integrations/mlflow/model_deployers/mlflow_model_deployer.py
+++ b/src/zenml/integrations/mlflow/model_deployers/mlflow_model_deployer.py
@@ -56,7 +56,7 @@ class MLFlowModelDeployer(BaseModelDeployer):
     # Class Configuration
     FLAVOR: ClassVar[str] = MLFLOW_MODEL_DEPLOYER_FLAVOR
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def set_service_path(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Sets the service_path attribute value according to the component
         UUID."""

--- a/src/zenml/secrets_managers/local/local_secrets_manager.py
+++ b/src/zenml/secrets_managers/local/local_secrets_manager.py
@@ -44,7 +44,7 @@ class LocalSecretsManager(BaseSecretsManager):
     # Class configuration
     FLAVOR: ClassVar[str] = "local"
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def set_secrets_file(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """Sets the secrets_file attribute value according to the component
         UUID."""

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -201,7 +201,7 @@ class StackComponent(BaseModel, ABC):
         """String representation of the stack component."""
         return self.__repr__()
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def _ensure_stack_component_complete(cls, values: Dict[str, Any]) -> Any:
         try:
             stack_component_type = getattr(cls, "TYPE")
@@ -213,10 +213,11 @@ class StackComponent(BaseModel, ABC):
                     When you are working with any classes which subclass from
                     `zenml.stack.StackComponent` please make sure that your
                     class has a ClassVar named `TYPE` and its value is set to a
-                    `StackComponentType` from `from zenml.enums import StackComponentType`.
+                    `StackComponentType` from `from zenml.enums import 
+                    StackComponentType`.
 
-                    In most of the cases, this is already done for you within the
-                    implementation of the base concept.
+                    In most of the cases, this is already done for you within 
+                    the implementation of the base concept.
 
                     Example:
 

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -213,10 +213,10 @@ class StackComponent(BaseModel, ABC):
                     When you are working with any classes which subclass from
                     `zenml.stack.StackComponent` please make sure that your
                     class has a ClassVar named `TYPE` and its value is set to a
-                    `StackComponentType` from `from zenml.enums import 
+                    `StackComponentType` from `from zenml.enums import
                     StackComponentType`.
 
-                    In most of the cases, this is already done for you within 
+                    In most of the cases, this is already done for you within
                     the implementation of the base concept.
 
                     Example:


### PR DESCRIPTION
## Describe changes
Added the soon-to-be-deprecated `-t` and `--type` options back with a clear warning and error message
Adjusted the validators in a way that the false registration of a stack component fails with a better error

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

