### PR TITLE
Remove autocomplete + alerter from documentation

### DIFF
--- a/docs/book/developer-guide/installation.md
+++ b/docs/book/developer-guide/installation.md
@@ -59,36 +59,3 @@ If you would like to learn more about the current release, please visit our
 ```
 docker run -it zenmldocker/zenml /bin/bash
 ```
-
-## Enabling auto-completion on the CLI
-
-
-{% hint style="warning" %}
-The following commands will only work if you have zenml installed in your global python env. If you are using 
-virtual environments, you'll have to manually export the environment variable whenever you are using that env.
-{% endhint %}
-
-{% tabs %}
-{% tab title="Bash" %}
-For Bash, add this to `~/.bashrc`:
-```bash
-eval "$(_ZENML_COMPLETE=source_bash zenml)"
-```
-{% endtab %}
-
-{% tab title="Zsh" %}
-For Zsh, add this to `~/.zshrc`:
-
-```bash
-eval "$(_ZENML_COMPLETE=source_zsh zenml)"
-```
-{% endtab %}
-
-{% tab title="Fish" %}
-For Fish, add this to `~/.config/fish/completions/foo-bar.fish`:
-
-```bash
-eval (env _ZENML_COMPLETE=source_fish zenml)
-```
-{% endtab %}
-{% endtabs %}

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -56,7 +56,6 @@
 * [Model Deployers](extending-zenml/model-deployer.md)
 * [Experiment Trackers](extending-zenml/experiment-tracker.md)
 * [Feature Stores](extending-zenml/feature-store.md)
-* [Alerters](extending-zenml/alerter.md)
 
 ## Resources
 


### PR DESCRIPTION
- I deleted the autocomplete instructions from our 'installation' page
- I deleted the 'alerter' docs from the TOC so that it no longer is displayed.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

