### PR TITLE
Added --set flag to register stack command

### DIFF
--- a/docs/book/advanced-guide/cloud/continuous-training-and-deployment.md
+++ b/docs/book/advanced-guide/cloud/continuous-training-and-deployment.md
@@ -92,8 +92,7 @@ There are three major roles that a Model Deployer plays in a ZenML Stack:
     ```bash
     zenml integration install mlflow
     zenml model-deployer register mlflow --flavor=mlflow
-    zenml stack register local_with_mlflow -m default -a default -o default -d mlflow
-    zenml stack set local_with_mlflow
+    zenml stack register local_with_mlflow -m default -a default -o default -d mlflow --set
     ```
 
     ```bash

--- a/docs/book/advanced-guide/integrations/secrets.md
+++ b/docs/book/advanced-guide/integrations/secrets.md
@@ -44,8 +44,8 @@ zenml stack register STACK_NAME \
     -m METADATA_STORE_NAME \
     -a ARTIFACT_STORE_NAME \
     -o ORCHESTRATOR_NAME \
-    -x SECRETS_MANAGER_NAME
-zenml stack set STACK_NAME
+    -x SECRETS_MANAGER_NAME \
+    --set
 ```
 
 ## Interacting with the Secrets Manager

--- a/examples/airflow_orchestration/README.md
+++ b/examples/airflow_orchestration/README.md
@@ -53,8 +53,8 @@ zenml orchestrator register airflow_orchestrator --flavor=airflow
 zenml stack register airflow_stack \
     -m default \
     -a default \
-    -o airflow_orchestrator
-zenml stack set airflow_stack
+    -o airflow_orchestrator \
+    --set
 ```
 
 ### 🏁️ Starting up Airflow

--- a/examples/aws_secret_manager/README.md
+++ b/examples/aws_secret_manager/README.md
@@ -49,8 +49,7 @@ set up properly.
 
 ```shell
 zenml secrets-manager register aws_secrets_manager --flavor aws
-zenml stack register secrets_stack -m default -o default -a default -x aws_secrets_manager
-zenml stack set secrets_stack
+zenml stack register secrets_stack -m default -o default -a default -x aws_secrets_manager --set
 ```
 
 In case you run into issues here, feel free to use a local secret manager. Just

--- a/examples/cloud_secrets_manager/README.md
+++ b/examples/cloud_secrets_manager/README.md
@@ -57,8 +57,7 @@ set up properly.
 
 ```shell
 zenml secrets-manager register aws_secrets_manager -t aws
-zenml stack register secrets_stack -m default -o default -a default -x aws_secrets_manager
-zenml stack set aws_secrets_stack
+zenml stack register secrets_stack -m default -o default -a default -x aws_secrets_manager --set
 ```
 
 ### 🥞 Set up your stack for GCP
@@ -71,8 +70,7 @@ secrets manager API within your gcp project.
 
 ```shell
 zenml secrets-manager register gcp_secrets_manager -t gcp_secrets_manager
-zenml stack register secrets_stack -m default -o default -a default -x gcp_secrets_manager
-zenml stack set gcp_secrets_stack
+zenml stack register secrets_stack -m default -o default -a default -x gcp_secrets_manager --set
 ```
 
 ### Or stay on a local stack

--- a/examples/feast_feature_store/README.md
+++ b/examples/feast_feature_store/README.md
@@ -104,11 +104,8 @@ part of your current working stack:
 # register the feature store stack component
 zenml feature-store register feast_store --flavor=feast --feast_repo="./feast_feature_repo"
 
-# register the sagemaker stack
-zenml stack register fs_stack -m default -o default -a default -f feast_store
-
-# activate the stack
-zenml stack set fs_stack
+# register and activate the feature store stack
+zenml stack register fs_stack -m default -o default -a default -f feast_store --set
 
 # view the current active stack
 zenml stack describe

--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -123,10 +123,8 @@ zenml stack register local_kubeflow_stack \
     -m default \
     -a default \
     -o kubeflow_orchestrator \
-    -c local_registry
-
-# Activate the newly created stack
-zenml stack set local_kubeflow_stack
+    -c local_registry \
+    --set
 ```
 
 ### 🏁 Start up Kubeflow Pipelines locally
@@ -223,7 +221,7 @@ When running the upcoming commands, make sure to replace `$PATH_TO_YOUR_CONTAINE
 # In order to create the GCP artifact store, we need to install one additional ZenML integration:
 zenml integration install gcp
 
-# Create the stack and its components
+# Create and activatethe stack and its components
 zenml container-registry register gcp_registry --uri=$PATH_TO_YOUR_CONTAINER_REGISTRY
 zenml metadata-store register kubeflow_metadata_store --flavor=kubeflow
 zenml artifact-store register gcp_artifact_store --flavor=gcp --path=$PATH_TO_YOUR_GCP_BUCKET
@@ -231,10 +229,9 @@ zenml stack register gcp_kubeflow_stack \
     -m kubeflow_metadata_store \
     -a gcp_artifact_store \
     -o kubeflow_orchestrator \
-    -c gcp_registry
+    -c gcp_registry \
+    --set
     
-# Activate the newly created stack
-zenml stack set gcp_kubeflow_stack
 ```
 
 ### ▶️ Run the pipeline

--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -221,7 +221,7 @@ When running the upcoming commands, make sure to replace `$PATH_TO_YOUR_CONTAINE
 # In order to create the GCP artifact store, we need to install one additional ZenML integration:
 zenml integration install gcp
 
-# Create and activatethe stack and its components
+# Create and activate the stack and its components
 zenml container-registry register gcp_registry --uri=$PATH_TO_YOUR_CONTAINER_REGISTRY
 zenml metadata-store register kubeflow_metadata_store --flavor=kubeflow
 zenml artifact-store register gcp_artifact_store --flavor=gcp --path=$PATH_TO_YOUR_GCP_BUCKET

--- a/examples/mlflow_deployment/README.md
+++ b/examples/mlflow_deployment/README.md
@@ -207,8 +207,8 @@ zenml stack register local_mlflow_stack \
   -a default \
   -o default \
   -d mlflow_deployer \
-  -e mlflow_tracker
-zenml stack set local_mlflow_stack
+  -e mlflow_tracker \
+  --set
 ```
 
 ### ▶️ Run the Code

--- a/examples/mlflow_tracking/README.md
+++ b/examples/mlflow_tracking/README.md
@@ -89,16 +89,14 @@ cd zenml_examples/mlflow_tracking
 # Initialize ZenML repo
 zenml init
 
-# Create the stack with the mlflow experiment tracker component
+# Create and activate the stack with the mlflow experiment tracker component
 zenml experiment-tracker register mlflow_tracker --type=mlflow
 zenml stack register mlflow_stack \
     -m default \
     -a default \
     -o default \
     -e mlflow_tracker
-    
-# Activate the newly created stack
-zenml stack set mlflow_stack
+    --set
 ```
 
 ### ▶️ Run the Code

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -238,8 +238,7 @@ zenml model-deployer register seldon_eks --flavor=seldon \
   --secret=s3-store
 zenml artifact-store register aws --flavor=s3 --path s3://mybucket
 zenml secrets-manager register local --flavor=local
-zenml stack register local_with_aws_storage -m default -a aws -o default -d seldon_eks -x local
-zenml stack set local_with_aws_storage
+zenml stack register local_with_aws_storage -m default -a aws -o default -d seldon_eks -x local --set
 ```
 
 As the last step in setting up the stack, we need to configure a ZenML secret
@@ -304,8 +303,7 @@ zenml container-registry register aws --flavor=default --uri=715803424590.dkr.ec
 zenml metadata-store register aws --flavor=kubeflow
 zenml orchestrator register aws --flavor=kubeflow --kubernetes_context=zenml-eks --synchronous=True
 zenml secrets-manager register aws --flavor=aws
-zenml stack register aws -m aws -a aws -o aws -c aws -d seldon_aws -x aws
-zenml stack set aws
+zenml stack register aws -m aws -a aws -o aws -c aws -d seldon_aws -x aws --set
 ```
 
 ZenML will manage the Seldon Core deployments inside the same `kubeflow`

--- a/examples/step_operator_remote_training/README.md
+++ b/examples/step_operator_remote_training/README.md
@@ -70,16 +70,14 @@ zenml step-operator register sagemaker \
 # register the container registry
 zenml container-registry register ecr_registry --flavor=default --uri=<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
 
-# register the sagemaker stack
+# register and activate the sagemaker stack
 zenml stack register sagemaker_stack \
     -m default \
     -o default \
     -c ecr_registry \
     -a s3-store \
-    -s sagemaker
-
-# activate the stack
-zenml stack set sagemaker_stack
+    -s sagemaker \
+    --set
 ```
 
 ### 🪟 Microsoft AzureML
@@ -118,9 +116,8 @@ zenml stack register azureml_stack \
     -m default \
     -o default \
     -a azure_store \
-    -s azureml
-    
-zenml stack set azureml_stack
+    -s azureml \
+    --set
 ```
 
 ### 📐 GCP Vertex AI
@@ -158,16 +155,14 @@ zenml step-operator register vertex \
 # register the container registry
 zenml container-registry register gcr_registry --flavor=default --uri=gcr.io/<PROJECT-ID>/<IMAGE>
 
-# register the sagemaker stack
+# register and activate the vertex ai stack
 zenml stack register vertex_training_stack \
     -m default \
     -o default \
     -c gcr_registry \
     -a gcs-store \
-    -s vertex
-
-# activate the stack
-zenml stack set vertex_training_stack
+    -s vertex \
+    --set
 ```
 
 ### ▶️ Run the Code

--- a/examples/wandb_tracking/README.md
+++ b/examples/wandb_tracking/README.md
@@ -67,10 +67,8 @@ zenml stack register wandb_stack \
     -m default \
     -a default \
     -o default \
-    -e wandb_tracker
-    
-# Activate the newly created stack
-zenml stack set wandb_stack
+    -e wandb_tracker \
+    --set
 ```
 
 ### ▶ Run the project

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -552,10 +552,18 @@ zenml stack register STACK_NAME \
        -a ARTIFACT_STORE_NAME \
        -o ORCHESTRATOR_NAME
 ```
+
 Each corresponding argument should be the name you passed in as an
 identifier for the artifact store, metadata store or orchestrator when
 you originally registered it. (If you want to use your secrets manager, you
 should pass its name in with the `-x` option flag.)
+
+If you want to immediately set this newly created stack as your active stack,
+simply pass along the `--set` flag.
+
+```bash
+zenml stack register STACK_NAME -m METADATA_STORE_NAME ... --set
+```
 
 To list the stacks that you have registered within your current ZenML
 project, type:

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -118,6 +118,13 @@ def stack() -> None:
     type=str,
     required=False,
 )
+@click.option(
+    "--set",
+    "set_stack",
+    is_flag=True,
+    help="Immediately set this stack as active.",
+    type=click.BOOL,
+)
 def register_stack(
     stack_name: str,
     metadata_store_name: str,
@@ -129,6 +136,7 @@ def register_stack(
     feature_store_name: Optional[str] = None,
     model_deployer_name: Optional[str] = None,
     experiment_tracker_name: Optional[str] = None,
+    set_stack: bool = False,
 ) -> None:
     """Register a stack."""
     cli_utils.print_active_profile()
@@ -200,6 +208,9 @@ def register_stack(
         )
         repo.register_stack(stack_)
         cli_utils.declare(f"Stack '{stack_name}' successfully registered!")
+
+    if set_stack:
+        set_active_stack(stack_name=stack_name)
 
 
 @stack.command("update", context_settings=dict(ignore_unknown_options=True))
@@ -644,18 +655,30 @@ def delete_stack(
     is_flag=True,
     help="Set the active stack globally.",
 )
-def set_active_stack(stack_name: str, global_profile: bool = False) -> None:
+def set_active_stack_command(
+    stack_name: str, global_profile: bool = False
+) -> None:
     """Sets a stack as active.
 
     If the '--global' flag is set, the global active stack will be set,
     otherwise the repository active stack takes precedence.
     """
+    set_active_stack(stack_name, global_profile)
+
+
+def set_active_stack(stack_name: str, global_profile: bool = False) -> None:
+    """Sets a stack as active.
+
+    If the '--global' flag is set, the global active stack will be set,
+    otherwise the repository active stack takes precedence.
+
+    Args:
+        stack_name: Unique name of the stack
+        global_profile: If the stack should be created on the global profile
+    """
     cli_utils.print_active_profile()
-
     scope = " global" if global_profile else ""
-
     repo = Repository()
-
     with console.status(
         f"Setting the{scope} active stack to '{stack_name}'..."
     ):


### PR DESCRIPTION
## Describe changes
After running into this myself and hearing from @bcdurak  about how he always updates his current stack, I thought we could add a --set flag to our register command to save on step in the overall cli workflow. This would mean that when you register a stack you can immediately make it your active stack (which in my opinion represents 90% of current uses).

How to do it previously:
------------------------------

```shell
zenml stack register oldschoolstack -o default -a default -m default 
zenml stack set oldschoolstack
```

How it could be done now:
-----------------------------------

```shell
zenml stack register baristack -o default -a default -m default --set
```

What do you think?

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

