### PR TITLE
Raised warning instead of AssertionError 

### DIFF
--- a/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
+++ b/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
@@ -25,6 +25,7 @@ from zenml.environment import Environment
 from zenml.logger import get_logger
 from zenml.post_execution import PipelineRunView
 from zenml.visualizers import BasePipelineRunVisualizer
+from zenml.cli.utils import warning
 
 logger = get_logger(__name__)
 
@@ -137,9 +138,10 @@ class PipelineRunLineageVisualizer(BasePipelineRunVisualizer):
                 mode = "inline"
             else:
                 # TODO [ENG-895]: Refactor this to raise a warning instead.
-                raise AssertionError(
-                    "Cannot set magic flag in non-notebook environments."
+                warning(
+                    text="Cannot set magic flag in non-notebook environments."
                 )
+
         else:
             app = dash.Dash(
                 __name__,

--- a/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
+++ b/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
@@ -25,7 +25,6 @@ from zenml.environment import Environment
 from zenml.logger import get_logger
 from zenml.post_execution import PipelineRunView
 from zenml.visualizers import BasePipelineRunVisualizer
-from zenml.cli.utils import warning
 
 logger = get_logger(__name__)
 
@@ -138,10 +137,9 @@ class PipelineRunLineageVisualizer(BasePipelineRunVisualizer):
                 mode = "inline"
             else:
                 # TODO [ENG-895]: Refactor this to raise a warning instead.
-                warning(
-                    text="Cannot set magic flag in non-notebook environments."
+                raise AssertionError(
+                    "Cannot set magic flag in non-notebook environments."
                 )
-
         else:
             app = dash.Dash(
                 __name__,

--- a/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
+++ b/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
@@ -136,9 +136,8 @@ class PipelineRunLineageVisualizer(BasePipelineRunVisualizer):
                 )
                 mode = "inline"
             else:
-                # TODO [ENG-895]: Refactor this to raise a warning instead.
-                raise AssertionError(
-                    "Cannot set magic flag in non-notebook environments."
+                warning(
+                    text="Cannot set magic flag in non-notebook environments."
                 )
         else:
             app = dash.Dash(


### PR DESCRIPTION
## Describe changes
I implemented/fixed to resolve : In our `pipeline_run_lineage_visualizer` we currently have a bit of code that raises an `AssertionError `when actually we'd rather just log a warning using our CLI utils module.
```
else:
    # TODO [ENG-895]: Refactor this to raise a warning instead.
    raise AssertionError(
        "Cannot set magic flag in non-notebook environments."
    )
```

to 
```
else:
     warning(
        "Cannot set magic flag in non-notebook environments."
    )
```
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

