### PR TITLE
Fix example list CLI command name

### DIFF
--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -485,7 +485,7 @@ def example() -> None:
     """Access all ZenML examples."""
 
 
-@example.command(help="List the available examples.")
+@example.command(name="list", help="List the available examples.")
 @pass_git_examples_handler
 def list_examples(git_examples_handler: GitExamplesHandler) -> None:
     """List all available examples."""


### PR DESCRIPTION
## Describe changes
Fix the name of the `zenml example list` cli command.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

