### PR TITLE
Fix broken GCP Secrets example CLI command

### DIFF
--- a/examples/cloud_secrets_manager/README.md
+++ b/examples/cloud_secrets_manager/README.md
@@ -66,10 +66,12 @@ To get going with gcp make sure to have gcloud set up locally with a user or
 ideally a service account with permissions to access the secret manager. 
 [This](https://cloud.google.com/sdk/docs/install-sdk) guide should help you get 
 started. Once everything is set up on your machine, make sure to enable the 
-secrets manager API within your gcp project.
+secrets manager API within your GCP project. You will need to create a project
+and get the `project_id` which will need to be specified when you register the
+secrets manager.
 
 ```shell
-zenml secrets-manager register gcp_secrets_manager --flavor=gcp_secrets_manager
+zenml secrets-manager register gcp_secrets_manager --flavor=gcp_secrets_manager --project_id=PROJECT_ID
 zenml stack register secrets_stack -m default -o default -a default -x gcp_secrets_manager --set
 ```
 


### PR DESCRIPTION
I fixed the documentation error we came across today during the live coding (where we were missing an argument for the GCP store).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

