### PR TITLE
Fix index page links and Heading links.

### DIFF
--- a/docs/book/developer-guide/class-based-api.md
+++ b/docs/book/developer-guide/class-based-api.md
@@ -7,7 +7,7 @@ of using the `@step` and `@pipeline` decorators that you have used in the previo
 users to maintain a higher level of control while they are creating a step definition and using it within the context of 
 a pipeline.
 
-We'll be using the code for the [Chapter on Runtime Configuration](./runtime-configuration.md) as a point of comparison.
+We'll be using the code for the [Runtime Configuration](./runtime-configuration.md) as a point of comparison.
 
 ### Subclassing the BaseStep
 

--- a/docs/book/developer-guide/class-based-api.md
+++ b/docs/book/developer-guide/class-based-api.md
@@ -7,7 +7,7 @@ of using the `@step` and `@pipeline` decorators that you have used in the previo
 users to maintain a higher level of control while they are creating a step definition and using it within the context of 
 a pipeline.
 
-We'll be using the code for the [Chapter on Runtime Configuration](#configure-at-runtime) as a point of comparison.
+We'll be using the code for the [Chapter on Runtime Configuration](./runtime-configuration.md) as a point of comparison.
 
 ### Subclassing the BaseStep
 

--- a/docs/book/developer-guide/fetching-historic-runs.md
+++ b/docs/book/developer-guide/fetching-historic-runs.md
@@ -15,7 +15,7 @@ executing step. Examples of this:
 ### Utilizing `StepContext`
 
 ZenML allows users to fetch historical parameters and artifacts using the `StepContext` 
-[fixture](step-fixtures.md).
+[fixture](./step-fixtures.md).
 
 As an example, see this step that uses the `StepContext` to query the metadata store while running a step.
 We use this to evaluate all models of past training pipeline runs and store the current best model. 

--- a/docs/book/developer-guide/runtime-configuration.md
+++ b/docs/book/developer-guide/runtime-configuration.md
@@ -43,7 +43,7 @@ first_pipeline(step_1=my_first_step(),
                ).run()
 ```
 
-This functionality is based on [Step Fixtures](#step-fixtures) which you will
+This functionality is based on [Step Fixtures](./step-fixtures.md) which you will
 learn more about below.
 
 ### Setting step parameters using a config file
@@ -111,7 +111,7 @@ name: <name_of_your_pipeline>
 
 In case you defined your pipeline using decorators this name is the name of the
 decorated function. If you used the
-[Class Based API](#class-based-api), it will be the name of your class.
+[Class Based API](./class-based-api.md), it will be the name of your class.
 
 ```python
 from zenml.pipelines import pipeline, BasePipeline
@@ -149,7 +149,7 @@ In total the step functions can be supplied with 3 arguments here:
 {% hint style="info" %}
 Materializers are responsible for reading and writing. You can learn more about
 Materializers in the
-[materializer section](materializer.md).
+[materializer section](./materializer.md).
 {% endhint %}
 
 ```yaml

--- a/docs/book/developer-guide/step-fixtures.md
+++ b/docs/book/developer-guide/step-fixtures.md
@@ -10,7 +10,7 @@ However, there are some exceptions.
 
 * An object which is a subclass of `BaseStepConfig`: This object is used to pass run-time parameters to a pipeline run. 
 It can be used to send parameters to a step that are not artifacts. You learned about this one already in the chapter
-on [Step Configuration](#step-configuration)
+on [Step Configuration](./runtime-configuration.md#step-configuration)
 * A `StepContext` object: This object gives access to the active stack, materializers, and special 
 integration-specific libraries.
 
@@ -111,5 +111,5 @@ def my_step(
 
 For more information, check the [API reference](https://apidocs.zenml.io/latest/api_docs/steps/)
 
-The next [section](#fetching-historic-runs) will directly address one important
+The next [section](./fetching-historic-runs.md) will directly address one important
 use for the Step Context.

--- a/docs/book/developer-guide/steps-and-pipelines.md
+++ b/docs/book/developer-guide/steps-and-pipelines.md
@@ -20,7 +20,7 @@ def my_first_step() -> Output(output_int=int, output_float=float):
 
 As this step has multiple outputs, we need to use the `zenml.steps.step_output.Output` class to indicate the names 
 of each output. These names can be used to directly access an output within the 
-[post execution workflow](#post-execution-workflow).
+[post execution workflow](./post-execution-workflow.md).
 
 Let's come up with a second step that consumes the output of our first step and performs some sort of transformation
 on it. In this case, let's double the input.
@@ -77,7 +77,7 @@ Step `my_second_step` has finished in 0.067s.
 Pipeline run `first_pipeline-20_Apr_22-16_07_14_577771` has finished in 0.128s.
 ```
 
-You'll learn how to inspect the finished run within the chapter on our [Post Execution Workflow](#post-execution-workflow).
+You'll learn how to inspect the finished run within the chapter on our [Post Execution Workflow](./post-execution-workflow.md).
 
 ### Summary in Code
 

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -23,14 +23,14 @@ standard abstraction to write and build your workflows.
 Every journey has to start somewhere, if you are new to ZenML, you might want to
 get acquainted with the [core concepts](introduction/core-concepts.md) first, 
 to understand what makes ZenML so special. Afterwards, you could jump right 
-into our [developer guide](developer-guide/getting-started/README.md) that will 
+into our [developer guide](developer-guide/installation.md) that will 
 take you from zero to hero in no time and explain the necessary knowledge of 
 **how to use ZenML**.
 
 ## **Stacking** - Customize your Stack
 
 Already ran your first pipelines and want to know about integrations and
-production use cases? Our [Advanced Guides](advanced-guide/advanced-zenml/README.md) are the 
+production use cases? Our [Advanced Guides](advanced-guide/integrations.md) are the 
 right place for you. You'll find some more detailed descriptions of specific
 use cases and features here. This is where you'll learn how to take your 
 MLOps stack from basic to fully loaded.
@@ -40,7 +40,7 @@ MLOps stack from basic to fully loaded.
 ZenML does not natively support your favorite tool? Don't you worry! ZenML is 
 built from the ground up with extensibility in mind. Find out how to integrate 
 other tools or proprietary on-prem solutions for you and your team in our 
-section on [Stack Components](extending-zenml/stacks-components-flavors.md). 
+section on [Stack Components](advanced-guide/stacks-components-flavors.md). 
 
 ## **Collaborating** - Work together with your team
 

--- a/docs/book/resources/faq.md
+++ b/docs/book/resources/faq.md
@@ -48,7 +48,7 @@ helpful.
 #### How can I make ZenML work with my custom tool? How can I extend or build on ZenML?
 
 This depends on the tool and its respective MLOps category. We have a full guide
-on this over [here](../advanced-guide/stacks-components-flavors)!
+on this over [here](../advanced-guide/stacks-components-flavors.md)!
 
 #### Why did you build ZenML?
 


### PR DESCRIPTION
## Describe changes
Links in the ` index.md ` page and some heading are broken. 
I'm not sure there is a way to test links like this when the headline doesn't exist without manually reading and verifying the docs. ex : 

``` 
[fixture](#step-fixtures) 
```
should be since it's now moved to a new page
```
[fixture](./step-fixtures.md) 
```
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

