### PR TITLE
Pin MLflow to <1.26.0 to prevent issues when matplotlib is not installed

### DIFF
--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -31,7 +31,7 @@ class MlflowIntegration(Integration):
 
     NAME = MLFLOW
     REQUIREMENTS = [
-        "mlflow>=1.2.0",
+        "mlflow>=1.2.0,<1.26.0",
         "mlserver>=0.5.3",
         "mlserver-mlflow>=0.5.3",
     ]


### PR DESCRIPTION
## Describe changes
MLflow currently fails to log experiments if matplotlib is not installed due to a bug in their recent releases. I fixed the bug in their code and created a [PR](https://github.com/mlflow/mlflow/pull/5995) for it, but it will still take time till this is fixed in their next pip release. In the meanwhile, we should pin mlflow to an older version.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

