### PR TITLE
Add stack component copy command

### DIFF
--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -589,9 +589,20 @@ To see which stack is currently set as the default active stack, type:
 zenml stack get
 ```
 
-If you wish to transfer one of your stacks to another profile or even another
-machine, you can do so by exporting the stack configuration and then importing
-it again.
+If you want to copy a stack, run the following command:
+```bash
+zenml stack copy SOURCE_STACK_NAME TARGET_STACK_NAME
+```
+You can optionally specify profiles from which the stack should be copied 
+from and to:
+```bash
+zenml stack copy SOURCE_STACK_NAME TARGET_STACK_NAME \
+   [--from SOURCE_PROFILE_NAME] \
+   [--to TARGET_PROFILE_NAME]
+```
+
+If you wish to transfer one of your stacks to another machine, you can do so 
+by exporting the stack configuration and then importing it again.
 
 To export a stack to YAML, run the following command:
 
@@ -636,6 +647,18 @@ If you wish to rename your stack, use the following command:
 
 ```shell
 zenml stack rename STACK_NAME NEW_STACK_NAME
+```
+
+If you want to copy a stack component, run the following command:
+```bash
+zenml STACK_COMPONENT copy SOURCE_COMPONENT_NAME TARGET_COMPONENT_NAME
+```
+You can optionally specify profiles from which the component should be copied 
+from and to:
+```bash
+zenml STACK_COMPONENT copy SOURCE_COMPONENT_NAME TARGET_COMPONENT_NAME \
+   [--from SOURCE_PROFILE_NAME] \
+   [--to TARGET_PROFILE_NAME]
 ```
 
 If you wish to update a specific stack component, use the following command,

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -590,12 +590,12 @@ zenml stack get
 ```
 
 If you want to copy a stack, run the following command:
-```bash
+```shell
 zenml stack copy SOURCE_STACK_NAME TARGET_STACK_NAME
 ```
 You can optionally specify profiles from which the stack should be copied 
-from and to:
-```bash
+to and from:
+```shell
 zenml stack copy SOURCE_STACK_NAME TARGET_STACK_NAME \
    [--from SOURCE_PROFILE_NAME] \
    [--to TARGET_PROFILE_NAME]

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -654,7 +654,7 @@ If you want to copy a stack component, run the following command:
 zenml STACK_COMPONENT copy SOURCE_COMPONENT_NAME TARGET_COMPONENT_NAME
 ```
 You can optionally specify profiles from which the component should be copied 
-from and to:
+to and from:
 ```bash
 zenml STACK_COMPONENT copy SOURCE_COMPONENT_NAME TARGET_COMPONENT_NAME \
    [--from SOURCE_PROFILE_NAME] \

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -1051,50 +1051,71 @@ def import_stack(
 @click.argument("target_stack", type=str, required=True)
 @click.option(
     "--from",
-    "source_profile",
+    "source_profile_name",
     type=str,
     required=False,
     help="The profile from which to copy the stack.",
 )
+@click.option(
+    "--to",
+    "target_profile_name",
+    type=str,
+    required=False,
+    help="The profile to which to copy the stack.",
+)
 def copy_stack(
-    source_stack: str, target_stack: str, source_profile: Optional[str] = None
+    source_stack: str,
+    target_stack: str,
+    source_profile_name: Optional[str] = None,
+    target_profile_name: Optional[str] = None,
 ) -> None:
     """Copy a stack.
 
     Args:
         source_stack: The name of the stack to copy.
         target_stack: Name of the copied stack.
-        source_profile: Name of the profile to copy from.
+        source_profile_name: Name of the profile to copy from.
+        target_profile_name: Name of the profile to copy to.
     """
     track_event(AnalyticsEvent.COPIED_STACK)
 
-    repo = Repository()
-    if source_profile:
+    if source_profile_name:
         try:
-            profile = GlobalConfiguration().profiles[source_profile]
+            source_profile = GlobalConfiguration().profiles[source_profile_name]
         except KeyError:
             cli_utils.error(
-                f"Unable to find source profile '{source_profile}'."
+                f"Unable to find source profile '{source_profile_name}'."
             )
     else:
-        profile = repo.active_profile
+        source_profile = Repository().active_profile
+
+    if target_profile_name:
+        try:
+            target_profile = GlobalConfiguration().profiles[target_profile_name]
+        except KeyError:
+            cli_utils.error(
+                f"Unable to find target profile '{target_profile_name}'."
+            )
+    else:
+        target_profile = Repository().active_profile
+
+    # Use different repositories for fetching/registering the stack depending
+    # on the source/target profile
+    source_repo = Repository(profile=source_profile)
+    target_repo = Repository(profile=target_profile)
 
     with console.status(f"Copying stack `{source_stack}`...\n"):
         try:
-            # Use a different `Repository` here which is configured to read from
-            # the source profile
-            stack_wrapper = Repository(profile=profile).zen_store.get_stack(
-                source_stack
-            )
+            stack_wrapper = source_repo.zen_store.get_stack(source_stack)
         except KeyError:
             cli_utils.error(
                 f"Stack `{source_stack}` cannot be copied as it does not exist."
             )
 
-        if target_stack in repo.stack_configurations:
+        if target_stack in target_repo.stack_configurations:
             cli_utils.error(
                 f"Can't copy stack as a stack with the name '{target_stack}' "
                 "already exists."
             )
         stack_wrapper.name = target_stack
-        repo.zen_store.register_stack(stack_wrapper)
+        target_repo.zen_store.register_stack(stack_wrapper)

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -1074,8 +1074,8 @@ def copy_stack(
     Args:
         source_stack: The name of the stack to copy.
         target_stack: Name of the copied stack.
-        source_profile_name: Name of the profile to copy from.
-        target_profile_name: Name of the profile to copy to.
+        source_profile_name: Name of the profile from which to copy.
+        target_profile_name: Name of the profile to which to copy.
     """
     track_event(AnalyticsEvent.COPIED_STACK)
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -870,8 +870,8 @@ def generate_stack_component_copy_command(
         Args:
             source_component: Name of the component to copy.
             target_component: Name of the copied component.
-            source_profile_name: Name of the profile to copy from.
-            target_profile_name: Name of the profile to copy to.
+            source_profile_name: Name of the profile from which to copy.
+            target_profile_name: Name of the profile to which to copy.
         """
         track_event(AnalyticsEvent.COPIED_STACK_COMPONENT)
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -899,7 +899,7 @@ def generate_stack_component_copy_command(
         else:
             target_profile = Repository().active_profile
 
-        # Use different repositories for fetching/registering the stack 
+        # Use different repositories for fetching/registering the stack
         # depending on the source/target profile
         source_repo = Repository(profile=source_profile)
         target_repo = Repository(profile=target_profile)

--- a/src/zenml/utils/analytics_utils.py
+++ b/src/zenml/utils/analytics_utils.py
@@ -41,6 +41,7 @@ class AnalyticsEvent(str, Enum):
     # Components
     REGISTERED_STACK_COMPONENT = "Stack component registered"
     UPDATED_STACK_COMPONENT = "Stack component updated"
+    COPIED_STACK_COMPONENT = "Stack component copied"
 
     # Stack
     REGISTERED_STACK = "Stack registered"


### PR DESCRIPTION
## Describe changes
This PR adds functionality to copy an existing `StackComponent`.

Other small changes:
- The`zenml stack copy` command now doesn't load the actual stack components anymore and is therefore much quicker
- The `zenml stack-component down` command `--yes` flag is updated to `--force` to be inline with `zenml stack down`

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

