### PR TITLE
Fix GCP artifact store

### DIFF
--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -127,7 +127,7 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Returns:
             A list of paths that match the given glob pattern.
         """
-        return self.filesystem.glob(path=pattern)  # type: ignore[no-any-return]
+        return [f"gs://{path}" for path in self.filesystem.glob(path=pattern)]
 
     def isdir(self, path: PathType) -> bool:
         """Check whether a path is a directory.
@@ -149,7 +149,10 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Returns:
             A list of paths of files in the directory.
         """
-        return self.filesystem.listdir(path=path)  # type: ignore[no-any-return]
+        return [
+            f"gs://{info_dict['name']}"
+            for info_dict in self.filesystem.listdir(path=path)
+        ]
 
     def makedirs(self, path: PathType) -> None:
         """Create a directory at the given path.
@@ -241,4 +244,9 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
             and a list of files inside the current directory.
         """
         # TODO [ENG-153]: Additional params
-        return self.filesystem.walk(path=top)  # type: ignore[no-any-return]
+        for (
+            directory,
+            subdirectories,
+            files,
+        ) in self.filesystem.walk(path=top):
+            yield f"gs://{directory}", subdirectories, files

--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -37,6 +37,9 @@ from zenml.utils.io_utils import convert_to_str
 PathType = Union[bytes, str]
 
 
+GCP_PATH_PREFIX = "gs://"
+
+
 class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
     """Artifact Store for Google Cloud Storage based artifacts."""
 
@@ -44,7 +47,7 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
 
     # Class Configuration
     FLAVOR: ClassVar[str] = GCP_ARTIFACT_STORE_FLAVOR
-    SUPPORTED_SCHEMES: ClassVar[Set[str]] = {"gs://"}
+    SUPPORTED_SCHEMES: ClassVar[Set[str]] = {GCP_PATH_PREFIX}
 
     @property
     def filesystem(self) -> gcsfs.GCSFileSystem:
@@ -127,7 +130,10 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Returns:
             A list of paths that match the given glob pattern.
         """
-        return [f"gs://{path}" for path in self.filesystem.glob(path=pattern)]
+        return [
+            f"{GCP_PATH_PREFIX}{path}"
+            for path in self.filesystem.glob(path=pattern)
+        ]
 
     def isdir(self, path: PathType) -> bool:
         """Check whether a path is a directory.
@@ -150,7 +156,7 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
             A list of paths of files in the directory.
         """
         return [
-            f"gs://{info_dict['name']}"
+            f"{GCP_PATH_PREFIX}{info_dict['name']}"
             for info_dict in self.filesystem.listdir(path=path)
         ]
 
@@ -249,4 +255,4 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
             subdirectories,
             files,
         ) in self.filesystem.walk(path=top):
-            yield f"gs://{directory}", subdirectories, files
+            yield f"{GCP_PATH_PREFIX}{directory}", subdirectories, files

--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -262,7 +262,7 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
             topdown: Unused argument to conform to interface.
             onerror: Unused argument to conform to interface.
 
-        Returns:
+        Yields:
             An Iterable of Tuples, each of which contain the path of the current
             directory path, a list of directories inside the current directory
             and a list of files inside the current directory.


### PR DESCRIPTION
## Describe changes

- The GCP artifact store `listdir` method didn't return a list of strings but dictionaries instead
- The paths returned by the `glob` and `walk` methods didn't include the `gs://` prefix

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

