### PR TITLE
Fix broken Feast integration

### DIFF
--- a/src/zenml/integrations/feast/__init__.py
+++ b/src/zenml/integrations/feast/__init__.py
@@ -43,7 +43,7 @@ class FeastIntegration(Integration):
         return [
             FlavorWrapper(
                 name=FEAST_FEATURE_STORE_FLAVOR,
-                source="zenml.integrations.feast.feature_store.FeastFeatureStore",
+                source="zenml.integrations.feast.feature_stores.FeastFeatureStore",
                 type=StackComponentType.FEATURE_STORE,
                 integration=cls.NAME,
             )


### PR DESCRIPTION
Referenced in #736, this small fix updates the source string passed in on initialising the Feast feature store integration.