### PR TITLE
Prevent extra attributes when initializing StackComponents

### DIFF
--- a/src/zenml/integrations/aws/secrets_managers/aws_secrets_manager.py
+++ b/src/zenml/integrations/aws/secrets_managers/aws_secrets_manager.py
@@ -27,7 +27,6 @@ from zenml.secrets_managers.base_secrets_manager import BaseSecretsManager
 
 logger = get_logger(__name__)
 
-DEFAULT_AWS_REGION = "us-east-1"
 ZENML_SCHEMA_NAME = "zenml_schema_name"
 
 
@@ -52,7 +51,7 @@ def jsonify_secret_contents(secret: BaseSecretSchema) -> str:
 class AWSSecretsManager(BaseSecretsManager):
     """Class to interact with the AWS secrets manager."""
 
-    region_name: str = DEFAULT_AWS_REGION
+    region_name: str
 
     # Class configuration
     FLAVOR: ClassVar[str] = AWS_SECRET_MANAGER_FLAVOR

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -18,7 +18,7 @@ from abc import ABC
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Set
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Extra, Field, root_validator
 
 from zenml.enums import StackComponentType
 from zenml.exceptions import StackComponentInterfaceError
@@ -339,3 +339,5 @@ class StackComponent(BaseModel, ABC):
         # all attributes with leading underscore are private and therefore
         # are mutable and not included in serialization
         underscore_attrs_are_private = True
+        # prevent extra attributes during model initialization
+        extra = Extra.forbid

--- a/tests/unit/stack/test_stack_component.py
+++ b/tests/unit/stack/test_stack_component.py
@@ -14,6 +14,7 @@
 from contextlib import ExitStack as does_not_raise
 
 import pytest
+from pydantic import ValidationError
 
 
 def test_stack_component_default_method_implementations(stub_component):
@@ -59,3 +60,14 @@ def test_stack_component_public_attributes_are_immutable(stub_component):
 
     with does_not_raise():
         stub_component._some_private_attribute_name = "Woof"
+
+
+def test_stack_component_prevents_extra_attributes(stub_component):
+    """Tests that passing extra attributes to a StackComponent fails."""
+    component_class = stub_component.__class__
+
+    with does_not_raise():
+        component_class(some_public_attribute_name="test")
+
+    with pytest.raises(ValidationError):
+        component_class(not_an_attribute_name="test")


### PR DESCRIPTION
## Describe changes

Previous to this PR, our StackComponent class allowed you to pass arbitrary parameters to its __init__ method and silently ignores them. This could lead to unexpected behavior when accidently mistyping an attribute name when registering a component on the CLI.

Example:
`zenml secrets-manager register NAME --flavor=aws --region=eu-west-1` (Note that the attribute on the `AWSSecretsManager` is called `region_name`, not `region` as passed in the command here).

When later running with this secrets manager, it would unexpectedly create secrets in the default region, not the one (wrongly) specified on the CLI.

After this PR, the CLI call would fail instead and let the user know that they passed a value for an attribute that doesn't exist.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

