### PR TITLE
Allow fetching secrets from within a step

### DIFF
--- a/src/zenml/metadata_stores/mysql_metadata_store.py
+++ b/src/zenml/metadata_stores/mysql_metadata_store.py
@@ -133,7 +133,7 @@ class MySQLMetadataStore(BaseMetadataStore):
             RuntimeError: If you don't have a secrets manager as part of your stack.
         """
         if self.secret:
-            active_stack = Repository().active_stack
+            active_stack = Repository(skip_repository_check=True).active_stack  # type: ignore[call-arg]
             secret_manager = active_stack.secrets_manager
             if secret_manager is None:
                 raise RuntimeError(

--- a/src/zenml/stack/authentication_mixin.py
+++ b/src/zenml/stack/authentication_mixin.py
@@ -52,7 +52,8 @@ class AuthenticationMixin(BaseModel):
         if not self.authentication_secret:
             return None
 
-        secrets_manager = Repository().active_stack.secrets_manager
+        active_stack = Repository(skip_repository_check=True).active_stack  # type: ignore[call-arg]
+        secrets_manager = active_stack.secrets_manager
         if not secrets_manager:
             raise RuntimeError(
                 f"Unable to retrieve secret '{self.authentication_secret}' "


### PR DESCRIPTION
## Describe changes

This PR fixes a bug which prevented users from querying the metadata store if using an authentication secret.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

