### PR TITLE
Refresh Examples on `zenml examples pull`

### DIFF
--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -17,7 +17,7 @@ without wanting to fiddle around with all the individual installation and
 configuration steps, just run the following:
 
 ```shell
-zenml example run kubeflow_pipelines_orchestrator
+zenml example run kubeflow_pipelines_orchestration
 ```
 
 
@@ -49,8 +49,8 @@ pip install notebook  # if you want to run the example on the notebook
 zenml integration install kubeflow tensorflow
 
 # Pull the kubeflow example
-zenml example pull kubeflow_pipelines_orchestrator
-cd zenml_examples/kubeflow_pipelines_orchestrator
+zenml example pull kubeflow_pipelines_orchestration
+cd zenml_examples/kubeflow_pipelines_orchestration
 
 # Initialize a ZenML repository
 zenml init

--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -390,6 +390,14 @@ class ExamplesRepo:
             self.delete()
             logger.error("Canceled download of repository.. Rolled back.")
 
+    def pull(self) -> None:
+        """Pull or clone the latest repository version."""
+        if not self.cloning_path.exists():
+            self.clone()
+        else:
+            logger.info("Fetching latest examples repository")
+            self.repo.git.pull()
+
     def delete(self) -> None:
         """Delete `cloning_path` if it exists.
 
@@ -517,11 +525,9 @@ class GitExamplesHandler(object):
         """
         from git.exc import GitCommandError
 
-        if not self.examples_repo.is_cloned:
-            self.examples_repo.clone()
-        elif force:
+        if self.examples_repo.is_cloned and force:
             self.examples_repo.delete()
-            self.examples_repo.clone()
+        self.examples_repo.pull()
 
         try:
             self.examples_repo.checkout(branch=branch)


### PR DESCRIPTION
## Describe changes
I changed `zenml example pull` to automatically call `git pull` in the example repository if it exists, so new examples / release versions will correctly become available.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/features/integrations) table.
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
