### PR TITLE
Fix Text Help for CLI Groups

### DIFF
--- a/src/zenml/cli/config.py
+++ b/src/zenml/cli/config.py
@@ -36,7 +36,11 @@ if TYPE_CHECKING:
 
 
 # Analytics
-@cli.group(cls=TagGroup, tag=CliCategories.MANAGEMENT_TOOLS)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.MANAGEMENT_TOOLS,
+    help="Analytics for opt-in and opt-out.",
+)
 def analytics() -> None:
     """Analytics for opt-in and opt-out."""
 
@@ -69,7 +73,11 @@ def opt_out() -> None:
 
 
 # Logging
-@cli.group(cls=TagGroup, tag=CliCategories.MANAGEMENT_TOOLS)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.MANAGEMENT_TOOLS,
+    help="Configuration of logging for ZenML pipelines.",
+)
 def logging() -> None:
     """Configuration of logging for ZenML pipelines."""
 
@@ -100,7 +108,11 @@ def set_logging_verbosity(verbosity: str) -> None:
 
 
 # Profiles
-@cli.group(cls=TagGroup, tag=CliCategories.IDENTITY_AND_SECURITY)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.IDENTITY_AND_SECURITY,
+    help="Configuration of ZenML profiles.",
+)
 def profile() -> None:
     """Configuration of ZenML profiles."""
 

--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -587,7 +587,10 @@ def check_for_version_mismatch(
             )
 
 
-@cli.group(cls=TagGroup)
+@cli.group(
+    cls=TagGroup,
+    help="Access all ZenML examples.",
+)
 def example() -> None:
     """Access all ZenML examples."""
 

--- a/src/zenml/cli/feature.py
+++ b/src/zenml/cli/feature.py
@@ -30,7 +30,10 @@ if TYPE_CHECKING:
 
 
 # Features
-@cli.group(cls=TagGroup)
+@cli.group(
+    cls=TagGroup,
+    help="Features as obtained from a feature store.",
+)
 @click.pass_context
 def feature(ctx: click.Context) -> None:
     """Features as obtained from a feature store.

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -41,6 +41,7 @@ logger = get_logger(__name__)
 @cli.group(
     cls=TagGroup,
     tag=CliCategories.INTEGRATIONS,
+    help="Interact with the requirements of external integrations.",
 )
 def integration() -> None:
     """Interact with the requirements of external integrations."""

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -24,7 +24,11 @@ from zenml.pipelines.run_pipeline import run_pipeline
 logger = get_logger(__name__)
 
 
-@cli.group(cls=TagGroup, tag=CliCategories.MANAGEMENT_TOOLS)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.MANAGEMENT_TOOLS,
+    help="Run pipelines from Command-Line.",
+)
 def pipeline() -> None:
     """Run pipelines."""
 

--- a/src/zenml/cli/secret.py
+++ b/src/zenml/cli/secret.py
@@ -39,7 +39,11 @@ if TYPE_CHECKING:
 
 
 # Secrets
-@cli.group(cls=TagGroup, tag=CliCategories.IDENTITY_AND_SECURITY)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.IDENTITY_AND_SECURITY,
+    help="List and manage your secrets.",
+)
 @click.pass_context
 def secret(ctx: click.Context) -> None:
     """List and manage your secrets.

--- a/src/zenml/cli/served_models.py
+++ b/src/zenml/cli/served_models.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 @cli.group(
     cls=TagGroup,
     tag=CliCategories.MODEL_DEPLOYMENT,
+    help="List and manage served models with the active model deployer.",
 )
 @click.pass_context
 def served_models(ctx: click.Context) -> None:

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -39,6 +39,7 @@ from zenml.utils.yaml_utils import read_yaml, write_yaml
 @cli.group(
     cls=TagGroup,
     tag=CliCategories.MANAGEMENT_TOOLS,
+    help="Stacks to define various environments.",
 )
 def stack() -> None:
     """Stacks to define various environments."""

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -24,7 +24,11 @@ from zenml.exceptions import EntityExistsError
 from zenml.repository import Repository
 
 
-@cli.group(cls=TagGroup, tag=CliCategories.IDENTITY_AND_SECURITY)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.IDENTITY_AND_SECURITY,
+    help="Commands for user management.",
+)
 def user() -> None:
     """Commands for user management."""
 
@@ -98,7 +102,11 @@ def delete_user(user_name: str) -> None:
         cli_utils.warning(f"No user found for name '{user_name}'.")
 
 
-@cli.group(cls=TagGroup, tag=CliCategories.IDENTITY_AND_SECURITY)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.IDENTITY_AND_SECURITY,
+    help="Commands for team management.",
+)
 def team() -> None:
     """Commands for team management."""
 
@@ -210,7 +218,11 @@ def remove_users(team_name: str, user_names: Tuple[str]) -> None:
             )
 
 
-@cli.group(cls=TagGroup, tag=CliCategories.MANAGEMENT_TOOLS)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.MANAGEMENT_TOOLS,
+    help="Commands for project management.",
+)
 def project() -> None:
     """Commands for project management."""
 
@@ -353,7 +365,11 @@ def delete_project(project_name: str) -> None:
     cli_utils.declare(f"Deleted project '{project_name}'.")
 
 
-@cli.group(cls=TagGroup, tag=CliCategories.IDENTITY_AND_SECURITY)
+@cli.group(
+    cls=TagGroup,
+    tag=CliCategories.IDENTITY_AND_SECURITY,
+    help="Commands for role management.",
+)
 def role() -> None:
     """Commands for role management."""
 


### PR DESCRIPTION
## Describe changes
This fixes the provided text in the group CLI commands! Previously it was getting docstring which may have additions args that users have no need for! This force the help text to be specified to avoid that!

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

