### PR TITLE
Add local path for mlflow experiment tracker

### DIFF
--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -214,6 +214,21 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
         mlflow.set_tracking_uri("")
 
     @property
+    def local_path(self) -> Optional[str]:
+        """Path to the local directory where the MLflow artifacts are stored.
+
+        Returns:
+            None if configured with a remote tracking URI, otherwise the
+            path to the local MLflow artifact store directory.
+        """
+        tracking_uri = self.get_tracking_uri()
+        if self.is_remote_tracking_uri(tracking_uri):
+            return None
+        else:
+            assert tracking_uri.startswith("file:")
+            return tracking_uri[5:]
+
+    @property
     def validator(self) -> Optional["StackValidator"]:
         """Checks the stack has a `LocalArtifactStore` if no tracking uri was specified.
 


### PR DESCRIPTION
## Describe changes

Currently the mlflow experiment tracker component didn't specify it's `local_path` if applicable.
This skipped a check in the local kubeflow orchestrator which makes sure that all local paths are inside the global config directory and therefore mounted inside the KFP pods.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

