### PR TITLE
Allow standard library types in steps 

### DIFF
--- a/src/zenml/utils/source_utils.py
+++ b/src/zenml/utils/source_utils.py
@@ -33,6 +33,7 @@ import site
 import sys
 import types
 from contextlib import contextmanager
+from distutils.sysconfig import get_python_lib
 from types import (
     CodeType,
     FrameType,
@@ -98,7 +99,10 @@ def is_third_party_module(file_path: str) -> bool:
     """
     absolute_file_path = pathlib.Path(file_path).resolve()
 
-    for path in site.getsitepackages() + [site.getusersitepackages()]:
+    for path in site.getsitepackages() + [
+        site.getusersitepackages(),
+        get_python_lib(standard_lib=True),
+    ]:
         if pathlib.Path(path).resolve() in absolute_file_path.parents:
             return True
 

--- a/tests/unit/utils/test_source_utils.py
+++ b/tests/unit/utils/test_source_utils.py
@@ -15,6 +15,7 @@
 import inspect
 import os
 import sys
+from collections import OrderedDict
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 from typing import Callable
@@ -32,6 +33,9 @@ def test_is_third_party_module():
 
     non_third_party_file = inspect.getfile(source_utils)
     assert not source_utils.is_third_party_module(non_third_party_file)
+
+    standard_lib_file = inspect.getfile(OrderedDict)
+    assert source_utils.is_third_party_module(standard_lib_file)
 
 
 class EmptyClass:


### PR DESCRIPTION
## Describe changes
Some types in the standard Python library, such as `collections.OrderedDict` were not correctly identified as built-in types in the source utils:

* they do have an associated source file and python module
* they are not part of the site packages or the user site packages
* they are part of the standard OS-wide Python distribution files

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

