### PR TITLE
Improve error message for subscripted generic step output types.

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1092,6 +1092,7 @@ subnetIds
 subnets
 subpath
 subprocess
+subscripted
 subtypes
 superclass
 superclasses

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -94,7 +94,7 @@ class BaseStepMeta(type):
             StepInterfaceError: If the return type is missing or not supported.
 
         Returns:
-            Output signature of the new step clas.
+            Output signature of the new step class.
         """
         if "return" not in step_annotations:
             raise StepInterfaceError(

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -30,7 +30,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_args,
 )
 
 from tfx.orchestration.portable.base_executor_operator import (
@@ -187,26 +186,26 @@ class BaseStepMeta(type):
             )
         return_type = step_function_signature.annotations.get("return", None)
         if return_type is not None:
-            if isinstance(return_type, Output):
-                # Raise error if subscripted generics used as output type.
-                # E.g., `Outputs(a=List[str])` must be `Outputs(a=List)`.
-                for output_name, output_type in return_type.items():
-                    if get_args(output_type):
-                        non_subscripted_type = str(output_type).split("[")[0]
-                        raise StepInterfaceError(
-                            "Subscripted generics cannot be used as step "
-                            f"outputs. For step '{name}', use "
-                            f"`{output_name}={non_subscripted_type}` instead "
-                            f"of `{output_name}={output_type}`."
-                        )
-                cls.OUTPUT_SIGNATURE = {
-                    name: resolve_type_annotation(type_)
-                    for (name, type_) in return_type.items()
-                }
-            else:
-                cls.OUTPUT_SIGNATURE[
-                    SINGLE_RETURN_OUT_NAME
-                ] = resolve_type_annotation(return_type)
+            # Cast simple output types to `Output`.
+            if not isinstance(return_type, Output):
+                return_type = Output(**{SINGLE_RETURN_OUT_NAME: return_type})
+            # Raise error if subscripted generics used as output type.
+            # E.g., `Outputs(a=List[str])` must be `Outputs(a=List)`.
+            for output_name, output_type in return_type.items():
+                type_parts = str(output_type).split("[")
+                if len(type_parts) > 1:  # type is of the form <TYPE>[...]
+                    non_subscripted_type = type_parts[0]  # just <TYPE>
+                    raise StepInterfaceError(
+                        "Subscripted generics cannot be used as step "
+                        f"outputs. For step '{name}', use "
+                        f"`{output_name}={non_subscripted_type}` instead "
+                        f"of `{output_name}={output_type}`."
+                    )
+            # Resolve type annotations.
+            cls.OUTPUT_SIGNATURE = {
+                output_name: resolve_type_annotation(output_type)
+                for output_name, output_type in return_type.items()
+            }
 
         # Raise an exception if input and output names of a step overlap as
         # tfx requires them to be unique

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -854,6 +854,21 @@ def test_step_can_output_generic_types(one_step_pipeline):
             pipeline_.run()
 
 
+def test_step_cannot_output_subscripted_generic_types(one_step_pipeline):
+    """Tests that a step cannot output subscripted generic types."""
+    with pytest.raises(StepInterfaceError):
+
+        @step
+        def some_step_1() -> List[str]:
+            return []
+
+    with pytest.raises(StepInterfaceError):
+
+        @step
+        def some_step_2() -> Output(str_output=str, dict_output=Dict[str, int]):
+            return "", {}
+
+
 def test_step_can_have_generic_input_types():
     """Tests that a step can have generic typing classes as input."""
 


### PR DESCRIPTION
## Describe changes
I modified the step interface to raise an error during initialization if subscripted generics were specified as a step output, e.g., `Outputs(a=List[str], b=Dict[str, str])` should be `Outputs(a=List, b=Dict)` instead.

### Previous behavior:
Step would get created, but raise `TypeError: Subscripted generics cannot be used with class and instance checks` at runtime.

### New behavior:
A more concise error is raised during step initialization, e.g.: `StepInterfaceError: Subscripted generics cannot be used as step outputs. For step 'load_image_data', use images=typing.Dict instead of images=typing.Dict[str, PIL.Image.Image].`

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

