### PR TITLE
retrieve pipeline requirement within running step

### DIFF
--- a/src/zenml/step_operators/step_executor_operator.py
+++ b/src/zenml/step_operators/step_executor_operator.py
@@ -30,16 +30,13 @@ from tfx.proto.orchestration import (
 
 import zenml
 import zenml.constants
-from zenml.constants import (
-    MLMD_CONTEXT_PIPELINE_REQUIREMENTS_PROPERTY_NAME,
-    ZENML_MLMD_CONTEXT_TYPE,
-)
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.repository import Repository
 from zenml.steps.utils import (
     INTERNAL_EXECUTION_PARAMETER_PREFIX,
     PARAM_CUSTOM_STEP_OPERATOR,
+    collect_requirements,
 )
 from zenml.utils import source_utils, yaml_utils
 
@@ -102,38 +99,6 @@ class StepExecutorOperator(BaseExecutorOperator):
         executable_spec_pb2.PythonClassExecutableSpec
     ]
     SUPPORTED_PLATFORM_CONFIG_TYPE: List[Any] = []
-
-    @staticmethod
-    def _collect_requirements(
-        stack: "Stack",
-        pipeline_node: pipeline_pb2.PipelineNode,
-    ) -> List[str]:
-        """Collects all requirements necessary to run a step.
-
-        Args:
-            stack: Stack on which the step is being executed.
-            pipeline_node: Pipeline node info for a step.
-
-        Returns:
-            Alphabetically sorted list of pip requirements.
-        """
-        requirements = stack.requirements()
-
-        # Add pipeline requirements from the corresponding node context
-        for context in pipeline_node.contexts.contexts:
-            if context.type.name == ZENML_MLMD_CONTEXT_TYPE:
-                pipeline_requirements = context.properties[
-                    MLMD_CONTEXT_PIPELINE_REQUIREMENTS_PROPERTY_NAME
-                ].field_value.string_value.split(" ")
-                requirements.update(pipeline_requirements)
-                break
-
-        # TODO [ENG-696]: Find a nice way to set this if the running version of
-        #  ZenML is not an official release (e.g. on a development branch)
-        # Add the current ZenML version as a requirement
-        requirements.add(f"zenml=={zenml.__version__}")
-
-        return sorted(requirements)
 
     @staticmethod
     def _resolve_user_modules(
@@ -228,7 +193,7 @@ class StepExecutorOperator(BaseExecutorOperator):
             stack=stack, execution_info=execution_info
         )
 
-        requirements = self._collect_requirements(
+        requirements = collect_requirements(
             stack=stack, pipeline_node=execution_info.pipeline_node
         )
 

--- a/src/zenml/steps/step_environment.py
+++ b/src/zenml/steps/step_environment.py
@@ -13,6 +13,8 @@
 #  permissions and limitations under the License.
 """Step environment class."""
 
+from typing import List
+
 from zenml.environment import BaseEnvironmentComponent
 
 STEP_ENVIRONMENT_NAME = "step_environment"
@@ -45,6 +47,7 @@ class StepEnvironment(BaseEnvironmentComponent):
         pipeline_run_id: str,
         step_name: str,
         cache_enabled: bool,
+        pipeline_requirements: List[str],
     ):
         """Initialize the environment of the currently running step.
 
@@ -53,12 +56,14 @@ class StepEnvironment(BaseEnvironmentComponent):
             pipeline_run_id: the ID of the currently running pipeline
             step_name: the name of the currently running step
             cache_enabled: whether cache is enabled for this step
+            pipeline_requirements: the requirements of the currently running pipeline
         """
         super().__init__()
         self._pipeline_name = pipeline_name
         self._pipeline_run_id = pipeline_run_id
         self._step_name = step_name
         self._cache_enabled = cache_enabled
+        self._pipeline_requirements = pipeline_requirements
 
     @property
     def pipeline_name(self) -> str:
@@ -95,3 +100,12 @@ class StepEnvironment(BaseEnvironmentComponent):
             True if cache is enabled for the step, otherwise False.
         """
         return self._cache_enabled
+
+    @property
+    def pipeline_requirements(self) -> List[str]:
+        """The name of the currently running step.
+
+        Returns:
+            The List of the currently running pipeline requirements.
+        """
+        return self._pipeline_requirements

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -58,11 +58,13 @@ from tfx.types import component_spec
 from tfx.types.channel import Channel
 from tfx.utils import json_utils
 
+import zenml
 from zenml.artifacts.base_artifact import BaseArtifact
 from zenml.exceptions import MissingStepParameterError, StepInterfaceError
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.materializers.base_materializer import BaseMaterializer
+from zenml.repository import Repository
 from zenml.steps.base_step_config import BaseStepConfig
 from zenml.steps.step_context import StepContext
 from zenml.steps.step_environment import StepEnvironment
@@ -452,6 +454,33 @@ class _FunctionExecutor(BaseExecutor):
                 f"{getattr(self, PARAM_STEP_NAME)}"
             )
 
+    def _collect_requirements(
+        self,
+    ) -> List[str]:
+        """Collects all requirements necessary to run a step.
+
+        Returns:
+            Alphabetically sorted list of pip requirements.
+        """
+        requirements = Repository().active_stack.requirements()
+
+        if self._context:
+            # Add pipeline requirements from the corresponding node context
+            for context in self._context.pipeline_node.contexts.contexts:
+                if context.type.name == "pipeline_requirements":
+                    pipeline_requirements = context.properties[
+                        "pipeline_requirements"
+                    ].field_value.string_value.split(" ")
+                    requirements.update(pipeline_requirements)
+                    break
+
+        # TODO [ENG-696]: Find a nice way to set this if the running version of
+        #  ZenML is not an official release (e.g. on a development branch)
+        # Add the current ZenML version as a requirement
+        requirements.add(f"zenml=={zenml.__version__}")
+
+        return sorted(requirements)
+
     def Do(
         self,
         input_dict: Dict[str, List[BaseArtifact]],
@@ -537,6 +566,7 @@ class _FunctionExecutor(BaseExecutor):
             pipeline_run_id=self._context.pipeline_run_id,
             step_name=getattr(self, PARAM_STEP_NAME),
             cache_enabled=getattr(self, PARAM_ENABLE_CACHE),
+            pipeline_requirements=self._collect_requirements(),
         ):
             return_values = self._FUNCTION(**function_params)
 

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -49,7 +49,7 @@ def test_step_is_running():
         pipeline_run_id="run_id",
         step_name="step",
         cache_enabled=True,
-        pipeline_requirements=["zenml"],
+        pipeline_requirements=[""],
     ):
         assert Environment().step_is_running is True
 

--- a/tests/unit/test_environment.py
+++ b/tests/unit/test_environment.py
@@ -49,6 +49,7 @@ def test_step_is_running():
         pipeline_run_id="run_id",
         step_name="step",
         cache_enabled=True,
+        pipeline_requirements=["zenml"],
     ):
         assert Environment().step_is_running is True
 


### PR DESCRIPTION
## Describe changes
This code is to get running pipeline requirements with a step environment. 

This will be mainly used for the custom code deployment and particularly building docker image for custom deployment when a local orchestrator is used! Unlike the remote orchestrator where we can use the same created docker image to run the pipeline on the deployment, the local orchestrator requires building a new docker image and this build happens when the custom deployment step is running, for that we need the requirement to be already within step environment.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

