### PR TITLE
Support subscripted generic step output types

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1092,6 +1092,7 @@ subnetIds
 subnets
 subpath
 subprocess
+subscripted
 subtypes
 superclass
 superclasses

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -94,7 +94,7 @@ class BaseStepMeta(type):
             StepInterfaceError: If the return type is missing or not supported.
 
         Returns:
-            Output signature of the new step clas.
+            Output signature of the new step class.
         """
         if "return" not in step_annotations:
             raise StepInterfaceError(

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -30,7 +30,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_args,
 )
 
 from tfx.orchestration.portable.base_executor_operator import (
@@ -187,26 +186,26 @@ class BaseStepMeta(type):
             )
         return_type = step_function_signature.annotations.get("return", None)
         if return_type is not None:
-            if isinstance(return_type, Output):
-                # Raise error if subscripted generics used as output type.
-                # E.g., `Outputs(a=List[str])` must be `Outputs(a=List)`.
-                for output_name, output_type in return_type.items():
-                    if get_args(output_type):
-                        non_subscripted_type = str(output_type).split("[")[0]
-                        raise StepInterfaceError(
-                            "Subscripted generics cannot be used as step "
-                            f"outputs. For step '{name}', use "
-                            f"`{output_name}={non_subscripted_type}` instead "
-                            f"of `{output_name}={output_type}`."
-                        )
-                cls.OUTPUT_SIGNATURE = {
-                    name: resolve_type_annotation(type_)
-                    for (name, type_) in return_type.items()
-                }
-            else:
-                cls.OUTPUT_SIGNATURE[
-                    SINGLE_RETURN_OUT_NAME
-                ] = resolve_type_annotation(return_type)
+            # Cast simple output types to `Output`.
+            if not isinstance(return_type, Output):
+                return_type = Output(**{SINGLE_RETURN_OUT_NAME: return_type})
+            # Raise error if subscripted generics used as output type.
+            # E.g., `Outputs(a=List[str])` must be `Outputs(a=List)`.
+            for output_name, output_type in return_type.items():
+                type_parts = str(output_type).split("[")
+                if len(type_parts) > 1:  # type is of the form <TYPE>[...]
+                    non_subscripted_type = type_parts[0]  # just <TYPE>
+                    raise StepInterfaceError(
+                        "Subscripted generics cannot be used as step "
+                        f"outputs. For step '{name}', use "
+                        f"`{output_name}={non_subscripted_type}` instead "
+                        f"of `{output_name}={output_type}`."
+                    )
+            # Resolve type annotations.
+            cls.OUTPUT_SIGNATURE = {
+                output_name: resolve_type_annotation(output_type)
+                for output_name, output_type in return_type.items()
+            }
 
         # Raise an exception if input and output names of a step overlap as
         # tfx requires them to be unique

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -51,7 +51,6 @@ from zenml.materializers.default_materializer_registry import (
 from zenml.step_operators.step_executor_operator import StepExecutorOperator
 from zenml.steps.base_step_config import BaseStepConfig
 from zenml.steps.step_context import StepContext
-from zenml.steps.step_output import Output
 from zenml.steps.utils import (
     INSTANCE_CONFIGURATION,
     INTERNAL_EXECUTION_PARAMETER_PREFIX,
@@ -59,9 +58,9 @@ from zenml.steps.utils import (
     PARAM_CUSTOM_STEP_OPERATOR,
     PARAM_ENABLE_CACHE,
     PARAM_PIPELINE_PARAMETER_NAME,
-    SINGLE_RETURN_OUT_NAME,
     _ZenMLSimpleComponent,
     generate_component_class,
+    parse_return_type_annotations,
     resolve_type_annotation,
 )
 from zenml.utils.source_utils import get_hashed_source
@@ -77,59 +76,6 @@ class BaseStepMeta(type):
     * Is a subclass of the Config class,
     * Is typed correctly.
     """
-
-    @staticmethod
-    def _parse_returns(
-        name: str, step_annotations: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Parse the returns of a step function.
-
-        Called within `__new__()` to define `cls.OUTPUT_SIGNATURE`.
-
-        Args:
-            name: The name of the step.
-            step_annotations: Type annotations of the step.
-
-        Raises:
-            StepInterfaceError: If the return type is missing or not supported.
-
-        Returns:
-            Output signature of the new step class.
-        """
-        if "return" not in step_annotations:
-            raise StepInterfaceError(
-                "Missing return type annotation when trying to create step "
-                f"'{name}'. Please make sure to include type annotations for "
-                "all your step inputs and outputs. If your step returns "
-                "nothing, please annotate it with `-> None`."
-            )
-        return_type = step_annotations["return"]
-        if return_type is None:
-            return {}
-
-        # Cast simple output types to `Output`.
-        if not isinstance(return_type, Output):
-            return_type = Output(**{SINGLE_RETURN_OUT_NAME: return_type})
-
-        # Raise error if subscripted generics used as output type.
-        # E.g., `Outputs(a=List[str])` must be `Outputs(a=List)`.
-        for output_name, output_type in return_type.items():
-            type_parts = str(output_type).split("[")
-            if len(type_parts) > 1:  # type is of the form <TYPE>[...]
-                non_subscripted_type = type_parts[0]  # just <TYPE>
-                raise StepInterfaceError(
-                    "Subscripted generics cannot be used as step "
-                    f"outputs. For step '{name}', use "
-                    f"`{output_name}={non_subscripted_type}` instead "
-                    f"of `{output_name}={output_type}`."
-                )
-
-        # Resolve type annotations of all outputs.
-        output_signature = {
-            output_name: resolve_type_annotation(output_type)
-            for output_name, output_type in return_type.items()
-        }
-        return output_signature
 
     def __new__(
         mcs, name: str, bases: Tuple[Type[Any], ...], dct: Dict[str, Any]
@@ -231,9 +177,15 @@ class BaseStepMeta(type):
                 cls.INPUT_SIGNATURE.update({arg: arg_type})
 
         # Parse the returns of the step function
-        cls.OUTPUT_SIGNATURE = BaseStepMeta._parse_returns(
-            name=name,
-            step_annotations=step_function_signature.annotations,
+        if "return" not in step_function_signature.annotations:
+            raise StepInterfaceError(
+                "Missing return type annotation when trying to create step "
+                f"'{name}'. Please make sure to include type annotations for "
+                "all your step inputs and outputs. If your step returns "
+                "nothing, please annotate it with `-> None`."
+            )
+        cls.OUTPUT_SIGNATURE = parse_return_type_annotations(
+            step_function_signature.annotations,
         )
 
         # Raise an exception if input and output names of a step overlap as

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -127,6 +127,36 @@ def resolve_type_annotation(obj: Any) -> Any:
             return obj
 
 
+def parse_return_type_annotations(
+    step_annotations: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Parse the returns of a step function into a dict of resolved types.
+
+    Called within `BaseStepMeta.__new__()` to define `cls.OUTPUT_SIGNATURE`.
+    Called within `Do()` to resolve type annotations.
+
+    Args:
+        step_annotations: Type annotations of the step function.
+
+    Returns:
+        Output signature of the new step class.
+    """
+    return_type = step_annotations.get("return", None)
+    if return_type is None:
+        return {}
+
+    # Cast simple output types to `Output`.
+    if not isinstance(return_type, Output):
+        return_type = Output(**{SINGLE_RETURN_OUT_NAME: return_type})
+
+    # Resolve type annotations of all outputs and save in new dict.
+    output_signature = {
+        output_name: resolve_type_annotation(output_type)
+        for output_name, output_type in return_type.items()
+    }
+    return output_signature
+
+
 def generate_component_spec_class(
     step_name: str,
     input_spec: Dict[str, Type[BaseArtifact]],
@@ -541,13 +571,8 @@ class _FunctionExecutor(BaseExecutor):
             return_values = self._FUNCTION(**function_params)
 
         spec = inspect.getfullargspec(inspect.unwrap(self._FUNCTION))
-        return_type: Type[Any] = spec.annotations.get("return", None)
-        if return_type is not None:
-            if isinstance(return_type, Output):
-                output_annotations = list(return_type.items())
-            else:
-                output_annotations = [(SINGLE_RETURN_OUT_NAME, return_type)]
-
+        output_annotations = parse_return_type_annotations(spec.annotations)
+        if len(output_annotations) > 0:
             # if there is only one output annotation (either directly specified
             # or contained in an `Output` tuple) we treat the step function
             # return value as the return for that output
@@ -573,7 +598,7 @@ class _FunctionExecutor(BaseExecutor):
                 )
 
             for return_value, (output_name, output_type) in zip(
-                return_values, output_annotations
+                return_values, output_annotations.items()
             ):
                 if not isinstance(return_value, output_type):
                     raise StepInterfaceError(

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -854,6 +854,21 @@ def test_step_can_output_generic_types(one_step_pipeline):
             pipeline_.run()
 
 
+def test_step_cannot_output_subscripted_generic_types(one_step_pipeline):
+    """Tests that a step cannot output subscripted generic types."""
+    with pytest.raises(StepInterfaceError):
+
+        @step
+        def some_step_1() -> List[str]:
+            return []
+
+    with pytest.raises(StepInterfaceError):
+
+        @step
+        def some_step_2() -> Output(str_output=str, dict_output=Dict[str, int]):
+            return "", {}
+
+
 def test_step_can_have_generic_input_types():
     """Tests that a step can have generic typing classes as input."""
 

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -854,19 +854,22 @@ def test_step_can_output_generic_types(one_step_pipeline):
             pipeline_.run()
 
 
-def test_step_cannot_output_subscripted_generic_types(one_step_pipeline):
-    """Tests that a step cannot output subscripted generic types."""
-    with pytest.raises(StepInterfaceError):
+def test_step_can_output_subscripted_generic_types(one_step_pipeline):
+    """Tests that a step can output subscripted generic types."""
 
-        @step
-        def some_step_1() -> List[str]:
-            return []
+    @step
+    def some_step_1() -> List[str]:
+        return []
 
-    with pytest.raises(StepInterfaceError):
+    @step
+    def some_step_2() -> Output(str_output=str, dict_output=Dict[str, int]):
+        return "", {}
 
-        @step
-        def some_step_2() -> Output(str_output=str, dict_output=Dict[str, int]):
-            return "", {}
+    for step_function in [some_step_1, some_step_2]:
+        pipeline_ = one_step_pipeline(step_function())
+
+        with does_not_raise():
+            pipeline_.run()
 
 
 def test_step_can_have_generic_input_types():
@@ -878,6 +881,25 @@ def test_step_can_have_generic_input_types():
 
     @step
     def step_2(dict_input: Dict, list_input: List) -> None:
+        pass
+
+    @pipeline
+    def p(s1, s2):
+        s2(*s1())
+
+    with does_not_raise():
+        p(step_1(), step_2()).run()
+
+
+def test_step_can_have_subscripted_generic_input_types():
+    """Tests that a step can have subscripted generic input types."""
+
+    @step
+    def step_1() -> Output(dict_output=Dict[str, int], list_output=List[str]):
+        return {}, []
+
+    @step
+    def step_2(dict_input: Dict[str, int], list_input: List[str]) -> None:
         pass
 
     @pipeline


### PR DESCRIPTION
## Describe changes

I fixed the `steps.utils._FunctionExecutor.Do()` method to support  subscripted generics as return types. E.g., users can now correctly specify `Outputs(a=List[str], b=Dict[str, str])`, which would have previously raised the following error at runtime: `TypeError: Subscripted generics cannot be used with class and instance checks at runtime.`

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

