### PR TITLE
Allow empty kubeconfig when using local kubeflow orchestrator

### DIFF
--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -188,7 +188,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
         """
         try:
             contexts, active_context = k8s_config.list_kube_config_contexts()
-        except k8s_config.config_exception.ConfigException as e:
+        except k8s_config.config_exception.ConfigException:
             return [], None
 
         context_names = [c["name"] for c in contexts]

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -179,22 +179,17 @@ class KubeflowOrchestrator(BaseOrchestrator):
 
         return values
 
-    def get_kubernetes_contexts(self) -> Tuple[List[str], str]:
+    def get_kubernetes_contexts(self) -> Tuple[List[str], Optional[str]]:
         """Get the list of configured Kubernetes contexts and the active context.
 
         Returns:
             A tuple containing the list of configured Kubernetes contexts and
             the active context.
-
-        Raises:
-            RuntimeError: if the Kubernetes configuration cannot be loaded
         """
         try:
             contexts, active_context = k8s_config.list_kube_config_contexts()
         except k8s_config.config_exception.ConfigException as e:
-            raise RuntimeError(
-                "Could not load the Kubernetes configuration"
-            ) from e
+            return [], None
 
         context_names = [c["name"] for c in contexts]
         active_context_name = active_context["name"]
@@ -231,7 +226,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
                         f"contexts, run:\n\n"
                         f"  `kubectl config get-contexts`\n"
                     )
-            elif self.kubernetes_context != active_context:
+            elif active_context and self.kubernetes_context != active_context:
                 logger.warning(
                     f"The Kubernetes context '{self.kubernetes_context}' "
                     f"configured for the Kubeflow orchestrator is not the "


### PR DESCRIPTION
## Describe changes

This PR allows having no/an empty kubeconfig when trying to run with a local `KubeflowOrchestrator`.
`k3d` will create/update the kubeconfig once it has created the cluster, but our validation during registration of the orchestrator prevented users from even coming to that point.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

