### PR TITLE
fix the secret register command in kserve docs page

### DIFF
--- a/docs/book/mlops-stacks/model-deployers/kserve.md
+++ b/docs/book/mlops-stacks/model-deployers/kserve.md
@@ -114,9 +114,7 @@ The following is an example of registering an GS secret with the KServe model de
 $ zenml secret register -s kserve_gs kserve_secret \
     --namespace="zenml-workloads" \
     --credentials="@~/sa-deployment-temp.json" \
-```
 
-The following secret will be registered.
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━┓
 ┃             SECRET_KEY             │ SECRET_VALUE ┃
 ┠────────────────────────────────────┼──────────────┨
@@ -124,6 +122,7 @@ The following secret will be registered.
 ┃              namespace             │ ***          ┃
 ┃             credentials            │ ***          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━┛
+```
 
 ```bash
 $ zenml secret get kserve_secret


### PR DESCRIPTION
## Describe changes
Fix the broken formatting of the ZenML register secret table on the KServe docs page.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/advanced-guide/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

