### PR TITLE
Handle file-io with context manager

### DIFF
--- a/src/zenml/utils/io_utils.py
+++ b/src/zenml/utils/io_utils.py
@@ -71,7 +71,8 @@ def read_file_contents_as_string(file_path: str) -> str:
     """
     if not exists(file_path):
         raise FileNotFoundError(f"{file_path} does not exist!")
-    return open(file_path).read()  # type: ignore[no-any-return]
+    with open(file_path) as f:
+        return f.read() # type: ignore[no-any-return]
 
 
 def find_files(dir_path: PathType, pattern: str) -> Iterable[str]:

--- a/src/zenml/utils/io_utils.py
+++ b/src/zenml/utils/io_utils.py
@@ -72,7 +72,7 @@ def read_file_contents_as_string(file_path: str) -> str:
     if not exists(file_path):
         raise FileNotFoundError(f"{file_path} does not exist!")
     with open(file_path) as f:
-        return f.read() # type: ignore[no-any-return]
+        return f.read()  # type: ignore[no-any-return]
 
 
 def find_files(dir_path: PathType, pattern: str) -> Iterable[str]:


### PR DESCRIPTION
## Describe changes
I fixed the file open context manager to achieve safe closing of files and supress warnings regarding open files.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

I believe zenml is using this function generically to read different files. During the creation of a pipeline, i get multiple warnings because the file is not safely closed (using a context manager).
See the log output below:
```bash
(venv) ➜  project git:(zenml-pipeline-experiment) ✗ zenml stack update -c some-registry
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/hdfs/config.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  from imp import load_source
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/google/api_core/exceptions.py:37: ImportWarning: Please install grpcio-status to obtain helpful grpc error messages.
  warnings.warn(
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/config.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/project/.zen/config.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/profiles/default/stacks.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/profiles/default/pipeline_runs.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/profiles/default/artifact_stores/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/profiles/default/metadata_stores/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application Support/zenml/profiles/default/orchestrators/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Running with active profile: 'default' (local)
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application
Support/zenml/profiles/default/container_registries/data-core-registry.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application
Support/zenml/profiles/default/artifact_stores/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application
Support/zenml/profiles/default/metadata_stores/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application
Support/zenml/profiles/default/orchestrators/default.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/a.jaffri/project/venv/lib/python3.9/site-packages/zenml/utils/io_utils.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/a.jaffri/Library/Application
Support/zenml/profiles/default/container_registries/data-core-registry.yaml' mode='r' encoding='UTF-8'>
  return open(file_path).read()  # type: ignore[no-any-return]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
⠏ Updating stack `default`...
Stack `default` successfully updated!
```

The change has been tested locally and it solves the issue stated scenario. 