### PR TITLE
Allow setting caching via the `config.yaml`

### DIFF
--- a/docs/book/developer-guide/steps-pipelines/caching.md
+++ b/docs/book/developer-guide/steps-pipelines/caching.md
@@ -70,6 +70,26 @@ You can get a graphical visualization of which steps were cached using
 [ZenML's Pipeline Run Visualization Tool](./pipeline-visualization.md).
 {% endhint %}
 
+You can disable caching for individual steps via the `config.yaml` file and
+specifying parameters for a specific step (as described [in the section on YAML
+config
+files](https://docs.zenml.io/developer-guide/steps-and-pipelines/runtime-configuration#configuring-with-yaml-config-files).)
+In this case, you would specify `True` or `False` in the place of the
+`<ENABLE_CACHE_VALUE>` below.
+
+```yaml
+steps:
+  <STEP_NAME_IN_PIPELINE>:
+    parameters:
+      enable_cache: <ENABLE_CACHE_VALUE>
+      ...
+    ...
+```
+
+You can see an example of this in action in our [PyTorch
+Example](https://github.com/zenml-io/zenml/blob/develop/examples/pytorch/config.yaml),
+where caching is disabled for the `trainer` step.
+
 ### Dynamically disabling caching for a pipeline run
 
 Sometimes you want to have control over caching at runtime instead of defaulting to the backed in configurations of 

--- a/examples/pytorch/config.yaml
+++ b/examples/pytorch/config.yaml
@@ -8,6 +8,8 @@ steps:
     source:
       file: steps/trainers
       name: trainer
+    parameters:
+      enable_cache: False
   evaluator:
     source:
       file: steps/evaluators

--- a/examples/pytorch/steps/trainers.py
+++ b/examples/pytorch/steps/trainers.py
@@ -39,7 +39,7 @@ class NeuralNetwork(nn.Module):
         return logits
 
 
-@step
+@step(enable_cache=False)
 def trainer(train_dataloader: DataLoader) -> nn.Module:
     """Trains on the train dataloader"""
     model = NeuralNetwork().to(DEVICE)

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -519,7 +519,6 @@ class BasePipeline(metaclass=BasePipelineMeta):
             The pipeline object that this method was called on.
         """
         config_yaml = yaml_utils.read_yaml(config_file)
-        breakpoint()
 
         if PipelineConfigurationKeys.STEPS in config_yaml:
             self._read_config_steps(

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -519,6 +519,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
             The pipeline object that this method was called on.
         """
         config_yaml = yaml_utils.read_yaml(config_file)
+        breakpoint()
 
         if PipelineConfigurationKeys.STEPS in config_yaml:
             self._read_config_steps(
@@ -559,8 +560,8 @@ class BasePipeline(metaclass=BasePipelineMeta):
             )
             parameters = step_dict.get(StepConfigurationKeys.PARAMETERS_, {})
             # pop the enable_cache
-            if "enable_cache" in parameters.keys():
-                enable_cache = parameters.pop("enable_cache")
+            if PARAM_ENABLE_CACHE in parameters:
+                enable_cache = parameters.pop(PARAM_ENABLE_CACHE)
                 self.steps[step_name].enable_cache = enable_cache
 
             for parameter, value in parameters.items():

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -558,6 +558,11 @@ class BasePipeline(metaclass=BasePipelineMeta):
                 step.CONFIG_CLASS.__fields__.keys() if step.CONFIG_CLASS else {}
             )
             parameters = step_dict.get(StepConfigurationKeys.PARAMETERS_, {})
+            # pop the enable_cache
+            if "enable_cache" in parameters.keys():
+                enable_cache = parameters.pop("enable_cache")
+                self.steps[step_name].enable_cache = enable_cache
+
             for parameter, value in parameters.items():
                 if parameter not in step_parameters:
                     raise PipelineConfigurationError(

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -254,6 +254,21 @@ def test_yaml_configuration_with_invalid_parameter_name(tmp_path):
         _ = pipeline_instance.with_config(yaml_path)
 
 
+def test_yaml_configuration_allows_enabling_cache(tmp_path):
+    """Test that a config yaml allows you to disable the cache for a step."""
+    pipeline_instance = create_pipeline_with_config_value(13)
+
+    yaml_path = os.path.join(tmp_path, "config.yaml")
+    cache_value = False
+    write_yaml(
+        yaml_path,
+        {"steps": {"step_": {"parameters": {"enable_cache": cache_value}}}},
+    )
+    pipeline_instance = pipeline_instance.with_config(yaml_path)
+    step_instance = pipeline_instance.steps["step_"]
+    assert step_instance.enable_cache == cache_value
+
+
 def test_setting_pipeline_parameter_name_when_initializing_pipeline(
     one_step_pipeline, empty_step
 ):


### PR DESCRIPTION
Following a user request, I enabled the ability to set caching statuses on steps via the `config.yaml` file by passing in a parameter.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

