### PR TITLE
Fix the SQL zenstore to work with MySQL

### DIFF
--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -1040,6 +1040,8 @@ class BaseZenStore(ABC):
         a local artifact store and a local SQLite metadata store.
         """
         stack = Stack.default_local_stack()
+        sw = StackWrapper.from_stack(stack)
+        self._register_stack(sw)
         # For the default stack, we have to set up the association manually.
         # As we can not use the repo/store yet to check the previously defined
         # associations.
@@ -1047,8 +1049,6 @@ class BaseZenStore(ABC):
             artifact_store_uuid=stack.artifact_store.uuid,
             metadata_store_uuid=stack.metadata_store.uuid,
         )
-        sw = StackWrapper.from_stack(stack)
-        self._register_stack(sw)
         metadata = {c.type.value: c.flavor for c in sw.components}
         metadata["store_type"] = self.type.value
         self._track_event(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -87,9 +87,9 @@ class ZenStackComponent(SQLModel, table=True):
     """SQL Model for stack components."""
 
     id: UUID = Field(primary_key=True)
-    component_type: StackComponentType
+    type: StackComponentType
     name: str
-    component_flavor: str
+    flavor: str
     configuration: bytes  # e.g. base64 encoded json string
 
 
@@ -109,11 +109,8 @@ class ZenStackDefinition(SQLModel, table=True):
     """
 
     stack_name: str = Field(primary_key=True, foreign_key="zenstack.name")
-    component_type: StackComponentType = Field(
-        primary_key=True, foreign_key="zenstackcomponent.component_type"
-    )
-    component_name: str = Field(
-        primary_key=True, foreign_key="zenstackcomponent.name"
+    component_id: UUID = Field(
+        primary_key=True, foreign_key="zenstackcomponent.id"
     )
 
 
@@ -166,12 +163,8 @@ class RoleAssignmentTable(RoleAssignment, SQLModel, table=True):
 class StoreAssociationTable(SQLModel, table=True):
     """SQL Model for team assignments."""
 
-    artifact_store_uuid: UUID = Field(
-        primary_key=True, foreign_key="zenstackcomponent.id"
-    )
-    metadata_store_uuid: UUID = Field(
-        primary_key=True, foreign_key="zenstackcomponent.id"
-    )
+    artifact_store_uuid: UUID = Field(primary_key=True)
+    metadata_store_uuid: UUID = Field(primary_key=True)
 
 
 class PipelineRunTable(SQLModel, table=True):
@@ -187,13 +180,12 @@ class PipelineRunTable(SQLModel, table=True):
     runtime_configuration: str
 
     user_id: UUID = Field(foreign_key="usertable.id")
-    project_name: Optional[str] = Field(
-        default=None, foreign_key="projecttable.name"
-    )
+    project_name: Optional[str] = Field(default=None)
 
     @classmethod
     def from_pipeline_run_wrapper(
-        cls, wrapper: PipelineRunWrapper
+        cls,
+        wrapper: PipelineRunWrapper,
     ) -> "PipelineRunTable":
         """Creates a PipelineRunTable from a PipelineRunWrapper.
 
@@ -406,17 +398,11 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             definitions_and_components = session.exec(
                 select(ZenStackDefinition, ZenStackComponent)
-                .where(
-                    ZenStackDefinition.component_type
-                    == ZenStackComponent.component_type
-                )
-                .where(
-                    ZenStackDefinition.component_name == ZenStackComponent.name
-                )
+                .where(ZenStackDefinition.component_id == ZenStackComponent.id)
                 .where(ZenStackDefinition.stack_name == name)
             )
             params = {
-                component.component_type: component.name
+                component.type: component.name
                 for _, component in definitions_and_components
             }
         return {StackComponentType(typ): name for typ, name in params.items()}
@@ -447,7 +433,7 @@ class SqlZenStore(BaseZenStore):
             existing_component = session.exec(
                 select(ZenStackComponent)
                 .where(ZenStackComponent.name == component.name)
-                .where(ZenStackComponent.component_type == component.type)
+                .where(ZenStackComponent.type == component.type)
             ).first()
             if existing_component is not None:
                 raise StackComponentExistsError(
@@ -457,9 +443,9 @@ class SqlZenStore(BaseZenStore):
                 )
             new_component = ZenStackComponent(
                 id=component.uuid,
-                component_type=component.type,
+                type=component.type,
                 name=component.name,
-                component_flavor=component.flavor,
+                flavor=component.flavor,
                 configuration=component.config,
             )
             session.add(new_component)
@@ -489,7 +475,7 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             updated_component = session.exec(
                 select(ZenStackComponent)
-                .where(ZenStackComponent.component_type == component_type)
+                .where(ZenStackComponent.type == component_type)
                 .where(ZenStackComponent.name == name)
             ).first()
 
@@ -502,7 +488,7 @@ class SqlZenStore(BaseZenStore):
 
             new_name_component = session.exec(
                 select(ZenStackComponent)
-                .where(ZenStackComponent.component_type == component_type)
+                .where(ZenStackComponent.type == component_type)
                 .where(ZenStackComponent.name == component.name)
             ).first()
             if (name != component.name) and new_name_component is not None:
@@ -516,16 +502,6 @@ class SqlZenStore(BaseZenStore):
 
             # handle any potential renamed component
             updated_component.name = component.name
-
-            # rename components inside stacks
-            updated_stack_definitions = session.exec(
-                select(ZenStackDefinition)
-                .where(ZenStackDefinition.component_type == component_type)
-                .where(ZenStackDefinition.component_name == name)
-            ).all()
-            for stack_definition in updated_stack_definitions:
-                stack_definition.component_name = component.name
-                session.add(stack_definition)
 
             session.add(updated_component)
             session.commit()
@@ -574,6 +550,10 @@ class SqlZenStore(BaseZenStore):
         Args:
             name: The name to save the stack as.
             stack_configuration: Dict[StackComponentType, str] to persist.
+
+        Raises:
+            KeyError: If a stack components in the stack configuration could not
+                be found.
         """
         with Session(self.engine) as session:
             stack = session.exec(
@@ -592,25 +572,24 @@ class SqlZenStore(BaseZenStore):
                     session.delete(result)
 
             for ctype, cname in stack_configuration.items():
-                statement = (
-                    select(ZenStackDefinition)
-                    .where(ZenStackDefinition.stack_name == name)
-                    .where(ZenStackDefinition.component_type == ctype)
-                )
-                results = session.exec(statement)
-                component = results.one_or_none()
-                if component is None:
-                    session.add(
-                        ZenStackDefinition(
-                            stack_name=name,
-                            component_type=ctype,
-                            component_name=cname,
-                        )
+                try:
+                    component = session.exec(
+                        select(ZenStackComponent)
+                        .where(ZenStackComponent.type == ctype)
+                        .where(ZenStackComponent.name == cname)
+                    ).one()
+                except NoResultFound:
+                    raise KeyError(
+                        "Unable to find a stack component (type: "
+                        f"{ctype.value}) with name '{cname}': No stack "
+                        "component exists with this name."
                     )
-                else:
-                    component.component_name = cname
-                    component.component_type = ctype
-                    session.add(component)
+                session.add(
+                    ZenStackDefinition(
+                        stack_name=name,
+                        component_id=component.id,
+                    )
+                )
             session.commit()
 
     def _get_component_flavor_and_config(
@@ -632,7 +611,7 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             component = session.exec(
                 select(ZenStackComponent)
-                .where(ZenStackComponent.component_type == component_type)
+                .where(ZenStackComponent.type == component_type)
                 .where(ZenStackComponent.name == name)
             ).one_or_none()
             if component is None:
@@ -640,7 +619,7 @@ class SqlZenStore(BaseZenStore):
                     f"Unable to find stack component (type: {component_type}) "
                     f"with name '{name}'."
                 )
-        return component.component_flavor, component.configuration
+        return component.flavor, component.configuration
 
     def _get_stack_component_names(
         self, component_type: StackComponentType
@@ -655,7 +634,7 @@ class SqlZenStore(BaseZenStore):
         """
         with Session(self.engine) as session:
             statement = select(ZenStackComponent).where(
-                ZenStackComponent.component_type == component_type
+                ZenStackComponent.type == component_type
             )
             return [component.name for component in session.exec(statement)]
 
@@ -674,7 +653,7 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             component = session.exec(
                 select(ZenStackComponent)
-                .where(ZenStackComponent.component_type == component_type)
+                .where(ZenStackComponent.type == component_type)
                 .where(ZenStackComponent.name == name)
             ).first()
             if component is not None:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -163,8 +163,12 @@ class RoleAssignmentTable(RoleAssignment, SQLModel, table=True):
 class StoreAssociationTable(SQLModel, table=True):
     """SQL Model for team assignments."""
 
-    artifact_store_uuid: UUID = Field(primary_key=True)
-    metadata_store_uuid: UUID = Field(primary_key=True)
+    artifact_store_uuid: UUID = Field(
+        primary_key=True, foreign_key="zenstackcomponent.id"
+    )
+    metadata_store_uuid: UUID = Field(
+        primary_key=True, foreign_key="zenstackcomponent.id"
+    )
 
 
 class PipelineRunTable(SQLModel, table=True):


### PR DESCRIPTION
## Describe changes
SQLModel doesn't support compound foreign keys at the moment and some other foreign key constraints modeled with SQLModel were incorrect. I had to removed or replace them to make the SQL zenstore work with MySQL.

Unfortunately, this also means that this change breaks backwards compatibility.

We should re-add the removed constraints when we redefine the store to match the ZenML REST API updates.

Fixes #788

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

