### PR TITLE
Add sleep before docker builds in release GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,15 @@ jobs:
     uses: ./.github/workflows/publish_to_pypi.yml
     secrets: inherit
 
-  publish-docker-image:
+  wait-for-package-release:
+    runs-on: ubuntu-latest
     needs: publish-python-package
+    steps:
+      - name: Sleep for 60 seconds
+        run: sleep 60
+        shell: bash
+
+  publish-docker-image:
+    needs: wait-for-package-release
     uses: ./.github/workflows/publish_docker_image.yml
     secrets: inherit


### PR DESCRIPTION
## Describe changes

Our release GH workflow first publishes the new package to PyPI and then builds Docker images which download this latest release. This sometimes leads to issues where the PyPI index doesn't refresh quick enough and the Docker builds fail. This PR adds a simple timeout to hopefully prevent this issue.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

