### PR TITLE
Add ignore columns for evidently drift detection

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tags:
-        description: "Use tmate session for debugging"
+        description: 'Use tmate session for debugging'
         required: false
         type: boolean
   workflow_call:
@@ -16,7 +16,7 @@ jobs:
     env:
       ZENML_DEBUG: 1
       ZENML_ANALYTICS_OPT_IN: false
-      PYTHONIOENCODING: "utf-8"
+      PYTHONIOENCODING: 'utf-8'
     # Exit if it's a commit from Gitbook
     if: ${{ ! startsWith(github.event.head_commit.message, 'GitBook:') }}
 
@@ -26,8 +26,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        python-version: [ 3.7, 3.8, 3.9 ]
       fail-fast: false
 
     steps:
@@ -41,7 +41,12 @@ jobs:
       - name: Install Prerequisites
         run: |
           source $VENV
-          zenml integration install kubeflow s3 gcp azure gcp_secrets_manager vertex vault pillow -f
+          zenml integration install kubeflow s3 gcp azure gcp_secrets_manager vertex vault evidently -f
+
+
+      - name: Setup tmate session
+        if: ${{ github.event.inputs.tags }}
+        uses: mxschmitt/action-tmate@v3
 
       - name: Setup tmate session
         if: ${{ github.event.inputs.tags }}

--- a/tests/unit/integrations/evidently/__init__.py
+++ b/tests/unit/integrations/evidently/__init__.py
@@ -1,0 +1,21 @@
+#  Copyright (c) ZenML GmbH 2021. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Initialization of the Evidently Standard Steps."""
+
+from zenml.integrations.evidently.steps.evidently_profile import (
+    EvidentlyColumnMapping,
+    EvidentlyProfileConfig,
+    EvidentlyProfileStep,
+    evidently_profile_step,
+)

--- a/tests/unit/integrations/evidently/__init__.py
+++ b/tests/unit/integrations/evidently/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2021. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -11,11 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Initialization of the Evidently Standard Steps."""
-
-from zenml.integrations.evidently.steps.evidently_profile import (
-    EvidentlyColumnMapping,
-    EvidentlyProfileConfig,
-    EvidentlyProfileStep,
-    evidently_profile_step,
-)

--- a/tests/unit/integrations/evidently/steps/__init__.py
+++ b/tests/unit/integrations/evidently/steps/__init__.py
@@ -1,0 +1,21 @@
+#  Copyright (c) ZenML GmbH 2021. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Initialization of the Evidently Standard Steps."""
+
+from zenml.integrations.evidently.steps.evidently_profile import (
+    EvidentlyColumnMapping,
+    EvidentlyProfileConfig,
+    EvidentlyProfileStep,
+    evidently_profile_step,
+)

--- a/tests/unit/integrations/evidently/steps/__init__.py
+++ b/tests/unit/integrations/evidently/steps/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2021. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -11,11 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Initialization of the Evidently Standard Steps."""
-
-from zenml.integrations.evidently.steps.evidently_profile import (
-    EvidentlyColumnMapping,
-    EvidentlyProfileConfig,
-    EvidentlyProfileStep,
-    evidently_profile_step,
-)

--- a/tests/unit/integrations/evidently/steps/test_ignore_columns.py
+++ b/tests/unit/integrations/evidently/steps/test_ignore_columns.py
@@ -1,0 +1,189 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from zenml.integrations.evidently.steps.evidently_profile import (
+    EvidentlyColumnMapping,
+    EvidentlyProfileConfig,
+    EvidentlyProfileStep,
+)
+
+ref = pd.DataFrame()
+ref["target"] = ["A", "B", "B", "C", "A"]
+ref["prediction"] = [0.12, -0.54, 0.08, 1.78, 0.03]
+ref["ignored_col"] = [1, 5, 1, 89, 0]
+ref["var_A"] = [1, 5, 3, 10, 25]
+ref["var_B"] = [0.58, 0.23, 1.25, -0.14, 0]
+
+comp = pd.DataFrame()
+comp["target"] = ["B", "C", "A", "A", "C"]
+comp["prediction"] = [0.12, -0.54, 0.08, 1.78, 0.03]
+comp["ignored_col"] = [3, 1, 1, 120, 1]
+comp["var_A"] = [0, 27, 3, 4, 8]
+comp["var_B"] = [0.12, -0.54, 0.08, 1.78, 0.03]
+
+
+def test_ignore_cols_succeeds() -> None:
+    """Tests ignored_cols parameter with features ignore_col and var_C
+    to be ignored"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols=["ignored_col", "var_B"],
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    drift_obj, dash_obj = profile_step.entrypoint(
+        reference_dataset=ref,
+        comparison_dataset=comp,
+        config=profile_config,
+    )
+
+    target = [drift_obj["data_drift"]["data"]["utility_columns"]["target"]]
+    prediction = [
+        drift_obj["data_drift"]["data"]["utility_columns"]["prediction"]
+    ]
+    cat_feat_names = drift_obj["data_drift"]["data"]["cat_feature_names"]
+    num_feat_names = drift_obj["data_drift"]["data"]["num_feature_names"]
+
+    assert (
+        "ignored_col"
+        not in target + prediction + cat_feat_names + num_feat_names
+    )
+    assert "var_B" not in target + prediction + cat_feat_names + num_feat_names
+
+
+def test_do_not_ignore_any_columns() -> None:
+    """Tests ignored_cols parameter with nothing to ignore
+    i.e pass all features"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols=None,
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    drift_obj, dash_obj = profile_step.entrypoint(
+        reference_dataset=ref,
+        comparison_dataset=comp,
+        config=profile_config,
+    )
+    target = [drift_obj["data_drift"]["data"]["utility_columns"]["target"]]
+    prediction = [
+        drift_obj["data_drift"]["data"]["utility_columns"]["prediction"]
+    ]
+    cat_feat_names = drift_obj["data_drift"]["data"]["cat_feature_names"]
+    num_feat_names = drift_obj["data_drift"]["data"]["num_feature_names"]
+
+    all_cols = target + prediction + cat_feat_names + num_feat_names
+    assert "target" in all_cols
+    assert "prediction" in all_cols
+    assert "ignored_col" in all_cols
+    assert "var_A" in all_cols
+    assert "var_B" in all_cols
+
+
+def test_ignoring_non_existing_column() -> None:
+    """Tests ignored_cols parameter for non existing
+    features and raises Error"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols=["var_A", "test_1"],
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    with pytest.raises(ValueError):
+        drift_obj, dash_obj = profile_step.entrypoint(
+            reference_dataset=ref,
+            comparison_dataset=comp,
+            config=profile_config,
+        )
+
+
+def test_ignoring_incorrect_datatype() -> None:
+    """Tests ignored_cols parameter for incorrect datatype
+    and raises Error"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols="var_A",
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    with pytest.raises(ValidationError):
+        drift_obj, dash_obj = profile_step.entrypoint(
+            reference_dataset=ref,
+            comparison_dataset=comp,
+            config=profile_config,
+        )
+
+
+def test_ignored_cols_elements() -> None:
+    """Tests ignored_cols parameter for type of its elements
+    and raises Error"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols=["Housing", "Region", 25, True],
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    with pytest.raises(ValueError):
+        drift_obj, dash_obj = profile_step.entrypoint(
+            reference_dataset=ref,
+            comparison_dataset=comp,
+            config=profile_config,
+        )
+
+
+def test_empty_ignored_cols() -> None:
+    """Tests for empty ignored_cols parameter
+    and raises Error"""
+
+    column_map = EvidentlyColumnMapping(target_names=["target"])
+    profile_config = EvidentlyProfileConfig(
+        profile_sections=["datadrift"],
+        column_mapping=column_map,
+        ignored_cols=[],
+    )
+
+    profile_step = EvidentlyProfileStep()
+
+    with pytest.raises(ValueError):
+        drift_obj, dash_obj = profile_step.entrypoint(
+            reference_dataset=ref,
+            comparison_dataset=comp,
+            config=profile_config,
+        )


### PR DESCRIPTION
## Describe changes
Issue: #600 
Add  ignore columns to evidently profile config to ignore columns during drift detection.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

