### PR TITLE
Add option to specify task dependencies

### DIFF
--- a/docs/book/developer-guide/advanced-usage/advanced-usage.md
+++ b/docs/book/developer-guide/advanced-usage/advanced-usage.md
@@ -45,3 +45,5 @@ ZenML stacks to the newest version.
 * [Specifying Hardware Resources for Steps](./specify-step-resources.md) explains
 how to specify hardware resources like memory or the amount of CPUs and GPUs that
 a step requires to execute.
+* [Controlling the Step Execution Order](./step-execution-order.md) explains how
+to control the order in which steps of a pipeline get executed.

--- a/docs/book/developer-guide/advanced-usage/step-execution-order.md
+++ b/docs/book/developer-guide/advanced-usage/step-execution-order.md
@@ -1,0 +1,37 @@
+---
+description: How to control the order in which steps get executed
+---
+
+By default, ZenML uses the data flowing between steps of your pipeline to 
+determine the order in which steps get executed. The following example
+shows a pipeline in which `step_3` depends on the outputs of `step_1`
+and `step_2`. This means that ZenML can execute both `step_1` and `step_2` in
+parallel but needs to wait until both are finished before `step_3` can be
+started.
+
+```python
+from zenml.pipelines import pipeline
+
+@pipeline
+def example_pipeline(step_1, step_2, step_3):
+    step_1_output = step_1()
+    step_2_output = step_2()
+    step_3(step_1_output, step_2_output)
+```
+
+If you have additional constraints on the order in which steps get executed,
+you can specify non-data dependencies by calling `step.after(some_other_step)`:
+
+```python
+from zenml.pipelines import pipeline
+
+@pipeline
+def example_pipeline(step_1, step_2, step_3):
+    step_1.after(step_2)
+    step_1_output = step_1()
+    step_2_output = step_2()
+    step_3(step_1_output, step_2_output)
+```
+
+This pipeline is similar to the one explained above, but this time ZenML will
+make sure to only start `step_1` after `step_2` has finished.

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -35,6 +35,7 @@
   * [Manage External Services](./developer-guide/advanced-usage/manage-external-services.md)
   * [Manage Docker Images](./developer-guide/advanced-usage/docker.md)
   * [Set Stacks and Profiles with Environment Variables](./developer-guide/advanced-usage/stack-profile-environment-variables.md)
+  * [Control the Step Execution Order](./developer-guide/advanced-usage/step-execution-order.md)
 
 ## MLOps Stacks
 

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -41,6 +41,10 @@ def create_tfx_pipeline(
 
     Returns:
         The tfx pipeline.
+
+    Raises:
+        KeyError: If a step contains an upstream step which is not part of
+            the pipeline.
     """
     # Connect the inputs/outputs of all steps in the pipeline
     zenml_pipeline.connect(**zenml_pipeline.steps)
@@ -69,7 +73,7 @@ def create_tfx_pipeline(
     # step is executed (see `BaseOrchestrator.run_step(...)`)
     return tfx_pipeline.Pipeline(
         pipeline_name=zenml_pipeline.name,
-        components=list(tfx_components.values()),  # type: ignore[arg-type]
+        components=list(tfx_components.values()),
         pipeline_root=artifact_store.path,
         enable_cache=zenml_pipeline.enable_cache,
     )

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -45,7 +45,22 @@ def create_tfx_pipeline(
     # Connect the inputs/outputs of all steps in the pipeline
     zenml_pipeline.connect(**zenml_pipeline.steps)
 
-    tfx_components = [step.component for step in zenml_pipeline.steps.values()]
+    tfx_components = {
+        step.name: step.component for step in zenml_pipeline.steps.values()
+    }
+
+    # Add potential task dependencies that users specified
+    for step in zenml_pipeline.steps.values():
+        for upstream_step in step.upstream_steps:
+            try:
+                upstream_node = tfx_components[upstream_step]
+            except KeyError:
+                raise KeyError(
+                    f"Unable to find upstream step `{upstream_step}` for step "
+                    f"`{step.name}`. Available steps: {set(tfx_components)}."
+                )
+
+            step.component.add_upstream_node(upstream_node)
 
     artifact_store = stack.artifact_store
 
@@ -54,7 +69,7 @@ def create_tfx_pipeline(
     # step is executed (see `BaseOrchestrator.run_step(...)`)
     return tfx_pipeline.Pipeline(
         pipeline_name=zenml_pipeline.name,
-        components=tfx_components,  # type: ignore[arg-type]
+        components=list(tfx_components.values()),  # type: ignore[arg-type]
         pipeline_root=artifact_store.path,
         enable_cache=zenml_pipeline.enable_cache,
     )

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -363,7 +363,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         This ensures a pipeline instance can be called more than once.
         """
         for step in self.steps.values():
-            step._has_been_called = False
+            step._reset()
 
     def run(
         self,

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -357,8 +357,8 @@ class BasePipeline(metaclass=BasePipelineMeta):
                     f"{available_step_operators}."
                 )
 
-    def _reset_step_flags(self) -> None:
-        """Reset the `_has_been_called` flag at the beginning of a pipeline run.
+    def _reset_steps(self) -> None:
+        """Reset step values from previous pipeline runs.
 
         This ensures a pipeline instance can be called more than once.
         """
@@ -438,7 +438,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
             },
         )
 
-        self._reset_step_flags()
+        self._reset_steps()
         self.validate_stack(stack)
 
         # Prevent execution of nested pipelines which might lead to unexpected

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -390,6 +390,17 @@ class BaseStep(metaclass=BaseStepMeta):
         which is decorated with the `@pipeline` decorator. Any calls outside
         this function will be ignored.
 
+        Example:
+        The following pipeline will run its steps sequentially in the following
+        order: step_2 -> step_1 -> step_3
+
+        ```python
+        @pipeline
+        def example_pipeline(step_1, step_2, step_3):
+            step_1.after(step_2)
+            step_3(step_1(), step_2())
+        ```
+
         Args:
             step: A step which should finish executing before this step is
                 started.
@@ -398,7 +409,6 @@ class BaseStep(metaclass=BaseStepMeta):
 
     def _reset(self) -> None:
         """Resets internal values that get set during a pipeline run."""
-        self.pipeline_parameter_name = None
         self._component = None
         self._has_been_called = False
         self._upstream_steps.clear()

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -290,7 +290,7 @@ class BaseStep(metaclass=BaseStepMeta):
         self._explicit_materializers: Dict[str, Type[BaseMaterializer]] = {}
         self._component: Optional[_ZenMLSimpleComponent] = None
         self._has_been_called = False
-        self._upstream_steps = set()
+        self._upstream_steps: Set[str] = set()
 
         self._verify_init_arguments(*args, **kwargs)
         self._verify_output_spec()


### PR DESCRIPTION
## Describe changes
This PR adds a way to specify non-data dependencies between steps of a pipeline:
```python
@pipeline
def p(step_1, step_2, step_3):
    step_1.after(step_2)
    step_3(step_1(), step_2())
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

