### PR TITLE
Split docstring check into a separate action that only runs once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,8 @@ jobs:
   spell-check:
     uses: ./.github/workflows/spellcheck.yml
 
+  docstring-check:
+    uses: ./.github/workflows/docstring.yml
+
   markdown-link-check:
     uses: ./.github/workflows/markdown-link-check.yml

--- a/.github/workflows/docstring.yml
+++ b/.github/workflows/docstring.yml
@@ -1,13 +1,6 @@
 name: Docstring Check
 
-on:
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: "Use tmate session for debugging"
-        required: false
-        type: boolean
-  workflow_call:
+on: workflow_call
 
 jobs:
   spellcheck:

--- a/.github/workflows/docstring.yml
+++ b/.github/workflows/docstring.yml
@@ -1,0 +1,32 @@
+name: Docstring Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Use tmate session for debugging"
+        required: false
+        type: boolean
+  workflow_call:
+
+jobs:
+  spellcheck:
+    name: docstringcheck
+    runs-on: ubuntu-latest
+    env:
+      ZENML_DEBUG: 1
+      ZENML_ANALYTICS_OPT_IN: false
+      PYTHONIOENCODING: "utf-8"
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install interrogate darglint pydocstyle
+      - name: Docstring Check
+        run: bash scripts/docstring.sh

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        use-quiet-mode: 'no'
+        use-quiet-mode: 'yes'
         use-verbose-mode: 'no'
         config-file: .github/workflows/markdown_check_config.json
-    
+      continue-on-error: true

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -1,7 +1,6 @@
 name: Publish Docker image
 
-on:
-  workflow_call:
+on: workflow_call
 
 jobs:
   publish_to_pypi:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,13 +1,6 @@
 name: Spellcheck
 
-on:
-  workflow_dispatch:
-    inputs:
-      tags:
-        description: "Use tmate session for debugging"
-        required: false
-        type: boolean
-  workflow_call:
+on: workflow_call
 
 jobs:
   spellcheck:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: docstringcheck
+        name: docstringcheck
+        entry: poetry run bash scripts/docstring.sh
+        language: system
+        files: ^src/zenml/
+        types: [file, python]
+        pass_filenames: false
+
+  - repo: local
+    hooks:
       - id: pytest
         name: pytest
         entry: poetry run bash scripts/test-coverage-xml.sh unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,14 +135,13 @@ Warning: This might take a while for both (~ 15 mins each, depending on your mac
 time, please run it as it will make the
 next commands error-free.
 
-It is easy to run the following scripts via Poetry to ensure code formatting and
-linting is in order:
+You can now run the following scripts via Poetry to automatically format your
+code and to check whether the code formatting, linting, docstrings, and
+spelling is in order:
 
 ```
 poetry run bash scripts/format.sh
-poetry run bash scripts/lint.sh
-poetry run bash scripts/docstring.sh
-poetry run bash scripts/check-spelling.sh
+poetry run bash scripts/run-ci-checks.sh
 ```
 
 If the spell checker catches errors, you will have to add the words to `.pyspelling-ignore-words`. (Note that if you wish to run the spellchecks manually on your local machine, first install `aspell` (using `brew` or `apt-get` or whatever package manager Windows uses).)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,7 @@ linting is in order:
 ```
 poetry run bash scripts/format.sh
 poetry run bash scripts/lint.sh
+poetry run bash scripts/docstring.sh
 poetry run bash scripts/check-spelling.sh
 ```
 

--- a/scripts/docstring.sh
+++ b/scripts/docstring.sh
@@ -2,9 +2,6 @@
 set -e
 set -x
 
-# separate env variable while incrementally completing the docstring task.
-# add modules to this list as/when they are completed.
-# When we're done we can remove this and just use `SRC_NO_TESTS`.
 DOCSTRING_SRC=${1:-"src/zenml"}
 
 export ZENML_DEBUG=1

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -12,10 +12,5 @@ autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in
 isort $SRC scripts --check-only
 black $SRC  --check
 
-# check for docstrings
-interrogate $SRC_NO_TESTS -c pyproject.toml
-pydocstyle $SRC_NO_TESTS -e --count --convention=google --add-ignore=D403
-darglint -v 2 $SRC_NO_TESTS
-
 # check type annotations
 mypy $SRC_NO_TESTS

--- a/scripts/run-ci-checks.sh
+++ b/scripts/run-ci-checks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+scripts/lint.sh
+scripts/check-spelling.sh
+scripts/docstring.sh


### PR DESCRIPTION
## Describe changes
I made two changes to our GitHub Actions:
- Docstring checking was removed from linting is now in a separate job that is only run on once machine.
- Markdown checking now runs in quiet mode (only prints links that are broken) and its job can no longer fail so it does not affect the overall CI result

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

