### PR TITLE
Use default local paths/URIs for the local artifact and metadata stores

### DIFF
--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -27,7 +27,6 @@ from typing import (
     Type,
 )
 
-from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import (
     ENV_ZENML_SECRET_VALIDATION_LEVEL,
     ZENML_IGNORE_STORE_COUPLINGS,
@@ -39,7 +38,7 @@ from zenml.runtime_configuration import (
     RUN_NAME_OPTION_KEY,
     RuntimeConfiguration,
 )
-from zenml.utils import io_utils, string_utils
+from zenml.utils import string_utils
 
 if TYPE_CHECKING:
     from zenml.alerter import BaseAlerter
@@ -269,27 +268,10 @@ class Stack:
         from zenml.artifact_stores import LocalArtifactStore
         from zenml.metadata_stores import SQLiteMetadataStore
         from zenml.orchestrators import LocalOrchestrator
-        from zenml.stack.stack_component import uuid_factory
 
         orchestrator = LocalOrchestrator(name="default")
-
-        artifact_store_uuid = uuid_factory()
-        artifact_store_path = os.path.join(
-            GlobalConfiguration().config_directory,
-            "local_stores",
-            str(artifact_store_uuid),
-        )
-        io_utils.create_dir_recursive_if_not_exists(artifact_store_path)
-        artifact_store = LocalArtifactStore(
-            name="default",
-            uuid=artifact_store_uuid,
-            path=artifact_store_path,
-        )
-
-        metadata_store_path = os.path.join(artifact_store_path, "metadata.db")
-        metadata_store = SQLiteMetadataStore(
-            name="default", uri=metadata_store_path
-        )
+        artifact_store = LocalArtifactStore(name="default")
+        metadata_store = SQLiteMetadataStore(name="default")
 
         return cls(
             name="default",

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -43,7 +43,10 @@ def test_default_local_stack():
         str(stack.artifact_store.uuid),
     )
     expected_metadata_store_uri = os.path.join(
-        expected_artifact_store_path, "metadata.db"
+        GlobalConfiguration().config_directory,
+        "local_stores",
+        str(stack.metadata_store.uuid),
+        "metadata.db",
     )
 
     assert stack.artifact_store.path == expected_artifact_store_path


### PR DESCRIPTION
## Describe changes
If the `--path` attribute is not supplied during the creation of a local artifact store, or if the `--uri` attribute is not supplied during the creation of a SQLite metadata store, a local path is automatically created and used.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

