### PR TITLE
Fix error in checking Great Expectations results when exit_on_error=True

### DIFF
--- a/src/zenml/integrations/great_expectations/steps/ge_validator.py
+++ b/src/zenml/integrations/great_expectations/steps/ge_validator.py
@@ -89,7 +89,7 @@ class GreatExpectationsValidatorStep(BaseStep):
             action_list=config.action_list,
         )
 
-        if config.exit_on_error and not results.success():
+        if config.exit_on_error and not results.success:
             raise RuntimeError(
                 "The Great Expectations validation failed. Check "
                 "the logs or the Great Expectations data docs for more "


### PR DESCRIPTION
## Describe changes
I fixed `results.success` accessor to achieve correct functionality for `config.exit_on_error` in `GreatExpectationsValidatorStep`. `success` is a property of `CheckpointResult`, not a method.

This is a fix for issue #887 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes. _(there is no test suite yet for the great_expectations integration)_


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

