### PR TITLE
feat(user-dockerfile): Add user argument to DockerConfiguration

### DIFF
--- a/src/zenml/config/docker_configuration.py
+++ b/src/zenml/config/docker_configuration.py
@@ -136,7 +136,7 @@ class DockerConfiguration(BaseModel):
             `False`, ZenML will not copy this configuration and you're
             responsible for making sure the right stack is active inside the
             Docker image.
-        user: If not `None`, will use the USER to set the username and
+        user: If not `None`, will use the USER instruction to set the username and
             run the commands of the dockerfile as `user` instead of root.
             Specifically,  the specified user is used for RUN instructions
             and at runtime, runs the relevant ENTRYPOINT and CMD commands.

--- a/src/zenml/config/docker_configuration.py
+++ b/src/zenml/config/docker_configuration.py
@@ -136,6 +136,10 @@ class DockerConfiguration(BaseModel):
             `False`, ZenML will not copy this configuration and you're
             responsible for making sure the right stack is active inside the
             Docker image.
+        user: If not `None`, will use the USER to set the username and
+            run the commands of the dockerfile as `user` instead of root.
+            Specifically,  the specified user is used for RUN instructions
+            and at runtime, runs the relevant ENTRYPOINT and CMD commands.
     """
 
     parent_image: Optional[str] = None
@@ -156,6 +160,7 @@ class DockerConfiguration(BaseModel):
     dockerignore: Optional[str] = None
     copy_files: bool = True
     copy_profile: bool = True
+    user: Optional[str] = None
 
     class Config:
         """Pydantic configuration class."""

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -223,6 +223,9 @@ class PipelineDockerImageBuilder(BaseModel):
         """
         lines = [f"FROM {parent_image}", f"WORKDIR {DOCKER_IMAGE_WORKDIR}"]
 
+        if docker_configuration.user:
+            lines.append(f"USER {docker_configuration.user}")
+
         if docker_configuration.copy_profile:
             lines.append(
                 f"ENV {ENV_ZENML_CONFIG_PATH}={DOCKER_IMAGE_ZENML_CONFIG_PATH}"

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -57,7 +57,6 @@ def test_check_user_is_set():
         replicate_local_python_environment="pip_freeze",
     )
     generated_dockerfile = PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile("test:test", config)
-    print(generated_dockerfile)
     assert "USER test_user" in generated_dockerfile
 
 

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -60,6 +60,7 @@ def test_check_user_is_set():
     print(generated_dockerfile)
     assert "USER test_user" in generated_dockerfile
 
+
 def test_requirements_file_generation(mocker, tmp_path: Path):
     """Tests that the requirements get included in the correct order and only
     when configured."""

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -24,8 +24,6 @@ from zenml.utils.pipeline_docker_image_builder import (
 )
 
 
-
-
 def test_including_active_profile_in_build_context(tmp_path: Path):
     """Tests that the context manager includes the active profile in the build
     context."""

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -24,6 +24,8 @@ from zenml.utils.pipeline_docker_image_builder import (
 )
 
 
+
+
 def test_including_active_profile_in_build_context(tmp_path: Path):
     """Tests that the context manager includes the active profile in the build
     context."""
@@ -37,6 +39,28 @@ def test_including_active_profile_in_build_context(tmp_path: Path):
 
     assert not config_path.exists()
 
+
+def test_check_user_is_set(tmp_path: Path):
+    config = DockerConfiguration(
+        install_stack_requirements=False,
+        requirements=None,
+        required_integrations=[],
+        user=None,
+        replicate_local_python_environment="pip_freeze",
+    )
+    generated_dockerfile = PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile("test:test", config)
+    assert all(["USER" not in line for line in generated_dockerfile])
+
+    config = DockerConfiguration(
+        install_stack_requirements=False,
+        requirements=None,
+        required_integrations=[],
+        user="test_user",
+        replicate_local_python_environment="pip_freeze",
+    )
+    generated_dockerfile = PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile("test:test", config)
+    print(generated_dockerfile)
+    assert "USER test_user" in generated_dockerfile
 
 def test_requirements_file_generation(mocker, tmp_path: Path):
     """Tests that the requirements get included in the correct order and only

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -38,7 +38,7 @@ def test_including_active_profile_in_build_context(tmp_path: Path):
     assert not config_path.exists()
 
 
-def test_check_user_is_set(tmp_path: Path):
+def test_check_user_is_set():
     config = DockerConfiguration(
         install_stack_requirements=False,
         requirements=None,

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -46,7 +46,11 @@ def test_check_user_is_set():
         user=None,
         replicate_local_python_environment="pip_freeze",
     )
-    generated_dockerfile = PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile("test:test", config)
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "test:test", config
+        )
+    )
     assert all(["USER" not in line for line in generated_dockerfile])
 
     config = DockerConfiguration(
@@ -56,7 +60,11 @@ def test_check_user_is_set():
         user="test_user",
         replicate_local_python_environment="pip_freeze",
     )
-    generated_dockerfile = PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile("test:test", config)
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "test:test", config
+        )
+    )
     assert "USER test_user" in generated_dockerfile
 
 


### PR DESCRIPTION
## Describe changes
I implemented a `user` argument to achieve being able to set the user in the generated Dockerfile via the docker USER command.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

