### PR TITLE
[Bugfix] Fix bug in auto-import of stack after recipe deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ zenml stack export <STACK_NAME> <FILENAME.yaml>
 
 Similarly, you can import a stack by running:
 ```
-zenml stack import <STACK_NAME> <FILENAME.yaml>
+zenml stack import <STACK_NAME> -f <FILENAME.yaml>
 ```
 
 Learn more on importing/exporting stacks [here](https://docs.zenml.io/collaborate/stack-export-import).

--- a/docs/book/collaborate/stack-export-import.md
+++ b/docs/book/collaborate/stack-export-import.md
@@ -18,7 +18,7 @@ This will create a FILENAME.yaml containing the config of your stack and all
 of its components, which you can then import again like this:
 
 ```bash
-zenml stack import STACK_NAME FILENAME.yaml
+zenml stack import STACK_NAME -f FILENAME.yaml
 ```
 
 ## Known Limitations

--- a/docs/book/stack-deployment-guide/stack-recipes.md
+++ b/docs/book/stack-deployment-guide/stack-recipes.md
@@ -50,7 +50,7 @@ Detailed steps are available in the README of the respective recipe but here's w
 6. You'll notice that a ZenML stack configuration file gets created after the previous command executes 🤯! This YAML file can be imported as a ZenML stack manually by running the following command.
 
     ```
-    zenml stack import <STACK_NAME> <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
     ```
 
 ## Deleting resources

--- a/examples/kserve_deployment/README.md
+++ b/examples/kserve_deployment/README.md
@@ -114,10 +114,10 @@ The flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create a secret for the CloudSQL instance that will allow ZenML to connect to it. Use the following command:

--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -231,10 +231,10 @@ The flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create a secret for the CloudSQL instance that will allow ZenML to connect to it. Use the following command:

--- a/examples/kubernetes_orchestration/README.md
+++ b/examples/kubernetes_orchestration/README.md
@@ -79,10 +79,10 @@ The flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually. You either need to have the `aws`, `mlflow` and `seldon` integrations installed before importing the stack or you can go into the YAML file and delete the sections on the `experiment_tracker` and `model_deployer` to not have them importer at all.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create a secret for the RDS MySQL instance that will allow ZenML to connect to it. Use the following command:

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -52,10 +52,10 @@ A flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create secrets for your newly-created MySQL instance. If you're using a GCP recipe, you can refer to the [Kubeflow example README](../kubeflow_pipelines_orchestration/README.md#🚅-that-seems-like-a-lot-of-infrastructure-work-is-there-a-zen-🧘-way-to-run-this-example) for the necessary commands. For AWS, check out the [Kubernetes Orchestrator example README.](../kubernetes_orchestration/README.md#🚅-that-seems-like-a-lot-of-infrastructure-work-is-there-a-zen-🧘-way-to-run-this-example)

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -127,10 +127,10 @@ The flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually. You either need to have the `aws`, `mlflow` and `seldon` integrations installed before importing the stack or you can go into the YAML file and delete the sections on the `experiment_tracker` and `model_deployer` to not have them importer at all.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create a secret for the RDS MySQL instance that will allow ZenML to connect to it. Use the following command:

--- a/examples/vertex_ai_orchestration/README.md
+++ b/examples/vertex_ai_orchestration/README.md
@@ -77,10 +77,10 @@ The flow to get started for this example can be the following:
 4. You'll notice that a ZenML stack configuration file gets created 🤯! You can run the following command to import the resources as a ZenML stack, manually.
 
     ```shell
-    zenml stack import <STACK-NAME> <PATH-TO-THE-CREATED-STACK-CONFIG-YAML>
+    zenml stack import <STACK_NAME> -f <PATH_TO_THE_CREATED_STACK_CONFIG_YAML>
 
     # set the imported stack as the active stack
-    zenml stack set <STACK-NAME>
+    zenml stack set <STACK_NAME>
     ```
 
 5. You should now create a secret for the CloudSQL instance that will allow ZenML to connect to it. Use the following command:

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -622,7 +622,7 @@ This will create a FILENAME.yaml containing the config of your stack and all
 of its components, which you can then import again like this:
 
 ```bash
-zenml stack import STACK_NAME FILENAME.yaml
+zenml stack import STACK_NAME -f FILENAME.yaml
 ```
 
 If you wish to update a stack that you have already registered, first make sure

--- a/src/zenml/cli/stack_recipes.py
+++ b/src/zenml/cli/stack_recipes.py
@@ -40,6 +40,7 @@ EXCLUDED_RECIPE_DIRS = [""]
 STACK_RECIPES_GITHUB_REPO = "https://github.com/zenml-io/mlops-stacks.git"
 STACK_RECIPES_REPO_DIR = "zenml_stack_recipes"
 VARIABLES_FILE = "values.tfvars.json"
+STACK_FILE_NAME = "stack-yaml-path"
 ALPHA_MESSAGE = (
     "The stack recipes CLI is in alpha and actively being developed. "
     "Please avoid running mission-critical workloads on resources deployed "
@@ -206,7 +207,7 @@ class Terraform:
         )
 
         # return the path of the stack yaml file
-        stack_file_path = self.tf.output("stack-yaml-path", full_value=True)
+        stack_file_path = self.tf.output(STACK_FILE_NAME, full_value=True)
         return str(stack_file_path)
 
     def _get_vars(self, path: str) -> Any:

--- a/src/zenml/cli/stack_recipes.py
+++ b/src/zenml/cli/stack_recipes.py
@@ -206,9 +206,7 @@ class Terraform:
         )
 
         # return the path of the stack yaml file
-        _, stack_file_path, _ = self.tf.output(
-            "stack-yaml-path", full_value=True
-        )
+        stack_file_path = self.tf.output("stack-yaml-path", full_value=True)
         return str(stack_file_path)
 
     def _get_vars(self, path: str) -> Any:


### PR DESCRIPTION
## Describe changes
- Fixed a bug that didn't let users import a stack using the `--import` option in stack recipes CLI.
- Updated all references to `zenml stack import` to reflect the new syntax.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

