### PR TITLE
Warn when registering non-local component with local ZenServer

### DIFF
--- a/src/zenml/artifact_stores/local_artifact_store.py
+++ b/src/zenml/artifact_stores/local_artifact_store.py
@@ -99,6 +99,18 @@ class LocalArtifactStoreConfig(BaseArtifactStoreConfig):
             )
         return path
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return True
+
 
 class LocalArtifactStore(BaseArtifactStore):
     """Artifact Store for local artifacts."""

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -27,18 +27,20 @@ from zenml.constants import (
     REPOSITORY_DIRECTORY_NAME,
     handle_bool_env_var,
 )
-from zenml.enums import StackComponentType
+from zenml.enums import StackComponentType, StoreType
 from zenml.environment import Environment
 from zenml.exceptions import (
     AlreadyExistsException,
     IllegalOperationError,
     InitializationException,
+    ValidationError,
 )
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.models import ComponentModel, FlavorModel, ProjectModel, StackModel
 from zenml.models.pipeline_models import PipelineModel
 from zenml.stack import Flavor
+from zenml.stack.stack_component import StackComponentConfig
 from zenml.utils import io_utils
 from zenml.utils.analytics_utils import AnalyticsEvent, track
 from zenml.utils.filesync_model import FileSyncModel
@@ -656,6 +658,68 @@ class Client(metaclass=ClientMetaClass):
             # a local configuration
             GlobalConfiguration().active_stack_id = stack.id
 
+    def _validate_stack_configuration(self, stack: "StackModel") -> None:
+        """Validates the configuration of a stack.
+
+        Args:
+            stack: The stack to validate.
+
+        Raises:
+            KeyError: If the stack references missing components.
+            ValidationError: If the stack configuration is invalid.
+        """
+        local_components: List[str] = []
+        remote_components: List[str] = []
+        for component_type, component_ids in stack.components.items():
+            for component_id in component_ids:
+                try:
+                    component = self.get_stack_component_by_id(
+                        component_id=component_id
+                    )
+                except KeyError:
+                    raise KeyError(
+                        f"Cannot register stack '{stack.name}' since it has an "
+                        f"unregistered {component_type} with id "
+                        f"'{component_id}'."
+                    )
+            # Get the flavor model
+            flavor_model = self.get_flavor_by_name_and_type(
+                name=component.flavor, component_type=component.type
+            )
+
+            # Create and validate the configuration
+            flavor = Flavor.from_model(flavor_model)
+            configuration = flavor.config_class(**component.configuration)
+            if configuration.is_local:
+                local_components.append(
+                    f"{component.type.value}: {component.name}"
+                )
+            elif configuration.is_remote:
+                remote_components.append(
+                    f"{component.type.value}: {component.name}"
+                )
+
+        if local_components and remote_components:
+            logger.warn(
+                f"You are configuring a stack that is composed of components "
+                f"that are relying on local resources "
+                f"({','.join(local_components)}) as well as "
+                f"components that are running remotely "
+                f"({','.join(local_components)}). This is not recommended as it "
+                f"can lead to unexpected behavior, especially if the remote "
+                f"components need to access the local resources. Please make "
+                f"sure that your stack is configured correctly, or try to use "
+                f"component flavors or configurations that do not require "
+                f"local resources."
+            )
+
+        if not stack.is_valid:
+            raise ValidationError(
+                "Stack configuration is invalid. A valid"
+                "stack must contain an Artifact Store and "
+                "an Orchestrator."
+            )
+
     def register_stack(self, stack: "StackModel") -> "StackModel":
         """Registers a stack and its components.
 
@@ -664,33 +728,13 @@ class Client(metaclass=ClientMetaClass):
 
         Returns:
             The model of the registered stack.
-
-        Raises:
-            KeyError: If one of the components is not registered.
-            RuntimeError: If the stack configuration is invalid.
         """
-        for component_type, component_ids in stack.components.items():
-            for component_id in component_ids:
-                try:
-                    self.get_stack_component_by_id(component_id=component_id)
-                except KeyError:
-                    raise KeyError(
-                        f"Cannot register stack '{stack.name}' since it has an "
-                        f"unregistered {component_type} with id "
-                        f"'{component_id}'."
-                    )
+        self._validate_stack_configuration(stack=stack)
 
-        if stack.is_valid:
-            created_stack = self.zen_store.create_stack(
-                stack=stack,
-            )
-            return created_stack
-        else:
-            raise RuntimeError(
-                "Stack configuration is invalid. A valid"
-                "stack must contain an Artifact Store and "
-                "an Orchestrator."
-            )
+        created_stack = self.zen_store.create_stack(
+            stack=stack,
+        )
+        return created_stack
 
     def update_stack(self, stack: "StackModel") -> None:
         """Updates a stack and its components.
@@ -701,14 +745,9 @@ class Client(metaclass=ClientMetaClass):
         Raises:
             RuntimeError: If the stack configuration is invalid.
         """
-        if stack.is_valid:
-            self.zen_store.update_stack(stack=stack)
-        else:
-            raise RuntimeError(
-                "Stack configuration is invalid. A valid"
-                "stack must contain an Artifact Store and "
-                "an Orchestrator."
-            )
+        self._validate_stack_configuration(stack=stack)
+
+        self.zen_store.update_stack(stack=stack)
 
     def deregister_stack(self, stack: "StackModel") -> None:
         """Deregisters a stack.
@@ -750,6 +789,40 @@ class Client(metaclass=ClientMetaClass):
         """
         return self.get_stack_components()
 
+    def _validate_stack_component_configuration(
+        self, configuration: StackComponentConfig
+    ) -> None:
+        """Validates the configuration of a stack component.
+
+        Args:
+            configuration: The component configuration to validate.
+        """
+        if configuration.is_remote and self.zen_store.is_local_store():
+            if self.zen_store.type == StoreType.REST:
+                logger.warn(
+                    "You are configuring a stack component that is running "
+                    "remotely while using a local database. The component "
+                    "may not be able to reach the local database and will "
+                    "therefore not be functional. Please consider deploying "
+                    "and/or using a remote ZenML server instead."
+                )
+            else:
+                logger.warn(
+                    "You are configuring a stack component that is running "
+                    "remotely while using a local ZenML server. The component "
+                    "may not be able to reach the local ZenML server and will "
+                    "therefore not be functional. Please consider deploying "
+                    "and/or using a remote ZenML server instead."
+                )
+        elif configuration.is_local and not self.zen_store.is_local_store():
+            logger.warn(
+                "You are configuring a stack component that is using "
+                "local resources to a remote ZenML server. The stack "
+                "component will not be usable from other hosts or by other "
+                "users. You should consider using a non-local stack component "
+                "alternative instead."
+            )
+
     def register_stack_component(
         self,
         component: "ComponentModel",
@@ -768,13 +841,15 @@ class Client(metaclass=ClientMetaClass):
         )
 
         # Create and validate the configuration
-        flavor_class = Flavor.from_model(flavor_model)
-        configuration = flavor_class.config_class(
-            **component.configuration
-        ).dict()
+        flavor = Flavor.from_model(flavor_model)
+        configuration = flavor.config_class(**component.configuration)
 
         # Update the configuration in the model
-        component.configuration = configuration
+        component.configuration = configuration.dict()
+
+        self._validate_stack_component_configuration(
+            configuration=configuration
+        )
 
         # Register the new model
         return self.zen_store.create_stack_component(component=component)
@@ -804,7 +879,14 @@ class Client(metaclass=ClientMetaClass):
 
         # Use the flavor class to validate the new configuration
         flavor = Flavor.from_model(flavor_model)
-        _ = flavor.config_class(**component.configuration)
+        configuration = flavor.config_class(**component.configuration)
+
+        # Update the configuration in the model
+        component.configuration = configuration.dict()
+
+        self._validate_stack_component_configuration(
+            configuration=configuration
+        )
 
         # Send the updated component to the ZenStore
         return self.zen_store.update_stack_component(component=component)

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -703,10 +703,10 @@ class Client(metaclass=ClientMetaClass):
             logger.warn(
                 f"You are configuring a stack that is composed of components "
                 f"that are relying on local resources "
-                f"({','.join(local_components)}) as well as "
+                f"({', '.join(local_components)}) as well as "
                 f"components that are running remotely "
-                f"({','.join(local_components)}). This is not recommended as it "
-                f"can lead to unexpected behavior, especially if the remote "
+                f"({', '.join(remote_components)}). This is not recommended as "
+                f"it can lead to unexpected behavior, especially if the remote "
                 f"components need to access the local resources. Please make "
                 f"sure that your stack is configured correctly, or try to use "
                 f"component flavors or configurations that do not require "
@@ -741,9 +741,6 @@ class Client(metaclass=ClientMetaClass):
 
         Args:
             stack: The new stack to use as the updated version.
-
-        Raises:
-            RuntimeError: If the stack configuration is invalid.
         """
         self._validate_stack_configuration(stack=stack)
 

--- a/src/zenml/container_registries/base_container_registry.py
+++ b/src/zenml/container_registries/base_container_registry.py
@@ -49,6 +49,18 @@ class BaseContainerRegistryConfig(AuthenticationConfigMixin):
         """
         return uri.rstrip("/")
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return bool(re.fullmatch(r"localhost:[0-9]{4,5}", self.uri))
+
 
 class BaseContainerRegistry(AuthenticationMixin):
     """Base class for all ZenML container registries."""
@@ -87,15 +99,6 @@ class BaseContainerRegistry(AuthenticationMixin):
             return secret.username, secret.password
 
         return None
-
-    @property
-    def is_local(self) -> bool:
-        """Returns whether the container registry is local or not.
-
-        Returns:
-            True if the container registry is local, False otherwise.
-        """
-        return bool(re.fullmatch(r"localhost:[0-9]{4,5}", self.config.uri))
 
     def prepare_image_push(self, image_name: str) -> None:
         """Preparation before an image gets pushed.

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -45,6 +45,19 @@ class SagemakerStepOperatorConfig(BaseStepOperatorConfig):
     bucket: Optional[str] = None
     experiment_name: Optional[str] = None
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class SagemakerStepOperatorFlavor(BaseStepOperatorFlavor):
     """Flavor for the Sagemaker step operator."""

--- a/src/zenml/integrations/azure/flavors/azureml_step_operator_flavor.py
+++ b/src/zenml/integrations/azure/flavors/azureml_step_operator_flavor.py
@@ -60,6 +60,19 @@ class AzureMLStepOperatorConfig(BaseStepOperatorConfig):
     service_principal_id: Optional[str] = SecretField()
     service_principal_password: Optional[str] = SecretField()
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class AzureMLStepOperatorFlavor(BaseStepOperatorFlavor):
     """Flavor for the AzureML step operator."""

--- a/src/zenml/integrations/feast/flavors/feast_feature_store_flavor.py
+++ b/src/zenml/integrations/feast/flavors/feast_feature_store_flavor.py
@@ -32,6 +32,20 @@ class FeastFeatureStoreConfig(BaseFeatureStoreConfig):
     online_port: int = 6379
     feast_repo: str
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return (
+            self.online_host == "localhost" or self.online_host == "127.0.0.1"
+        )
+
 
 class FeastFeatureStoreFlavor(BaseFeatureStoreFlavor):
     """Feast Feature store flavor."""

--- a/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
@@ -98,6 +98,19 @@ class VertexOrchestratorConfig(
     node_selector_constraint: Optional[Tuple[str, str]] = None
     gpu_limit: Optional[int] = None
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class VertexOrchestratorFlavor(BaseOrchestratorFlavor):
     """Vertex Orchestrator flavor."""

--- a/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
@@ -55,6 +55,19 @@ class VertexStepOperatorConfig(
     # will be applied to all Vertex AI resources if set
     encryption_spec_key_name: Optional[str] = None
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class VertexStepOperatorFlavor(BaseStepOperatorFlavor):
     """Vertex Step Operator flavor."""

--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -114,7 +114,7 @@ class VertexOrchestrator(BaseOrchestrator, GoogleCredentialsMixin):
             """
             # Validate that the container registry is not local.
             container_registry = stack.container_registry
-            if container_registry and container_registry.is_local:
+            if container_registry and container_registry.config.is_local:
                 return False, (
                     f"The Vertex orchestrator does not support local "
                     f"container registries. You should replace the component '"

--- a/src/zenml/integrations/github/flavors/github_actions_orchestrator_flavor.py
+++ b/src/zenml/integrations/github/flavors/github_actions_orchestrator_flavor.py
@@ -43,6 +43,19 @@ class GitHubActionsOrchestratorConfig(BaseOrchestratorConfig):
     skip_github_repository_check: bool = False
     push: bool = False
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class GitHubActionsOrchestratorFlavor(BaseOrchestratorFlavor):
     """GitHub Actions orchestrator flavor."""

--- a/src/zenml/integrations/github/orchestrators/github_actions_orchestrator.py
+++ b/src/zenml/integrations/github/orchestrators/github_actions_orchestrator.py
@@ -137,7 +137,7 @@ class GitHubActionsOrchestrator(BaseOrchestrator):
             container_registry = stack.container_registry
             assert container_registry is not None
 
-            if container_registry.is_local:
+            if container_registry.config.is_local:
                 return False, (
                     "The GitHub Actions orchestrator requires a remote "
                     f"container registry, but the '{container_registry.name}' "

--- a/src/zenml/integrations/great_expectations/flavors/great_expectations_data_validator_flavor.py
+++ b/src/zenml/integrations/great_expectations/flavors/great_expectations_data_validator_flavor.py
@@ -78,6 +78,21 @@ class GreatExpectationsDataValidatorConfig(BaseDataValidatorConfig):
                 )
         return context_root_dir
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        # If an existing local GE data context is used, it is
+        # interpreted as a local path that needs to be accessible in
+        # all runtime environments.
+        return self.context_root_dir is not None
+
 
 class GreatExpectationsDataValidatorFlavor(BaseDataValidatorFlavor):
     """Great Expectations data validator flavor."""

--- a/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
@@ -75,6 +75,35 @@ class KubeflowOrchestratorConfig(BaseOrchestratorConfig):
     skip_cluster_provisioning: bool = False
     skip_ui_daemon_provisioning: bool = False
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        if self.kubernetes_context is not None:
+            return True
+        return False
+
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        if self.kubernetes_context is None:
+            return True
+        return False
+
 
 class KubeflowOrchestratorFlavor(BaseOrchestratorFlavor):
     """Kubeflow orchestrator flavor."""

--- a/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
@@ -86,7 +86,10 @@ class KubeflowOrchestratorConfig(BaseOrchestratorConfig):
         Returns:
             True if this config is for a remote component, False otherwise.
         """
-        if self.kubernetes_context is not None:
+        if (
+            self.kubernetes_context is not None
+            and not self.kubernetes_context.startswith("k3d-zenml-kubeflow-")
+        ):
             return True
         return False
 
@@ -100,7 +103,10 @@ class KubeflowOrchestratorConfig(BaseOrchestratorConfig):
         Returns:
             True if this config is for a local component, False otherwise.
         """
-        if self.kubernetes_context is None:
+        if (
+            self.kubernetes_context is None
+            or self.kubernetes_context.startswith("k3d-zenml-kubeflow-")
+        ):
             return True
         return False
 

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -263,7 +263,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
 
                 # if the orchestrator is remote, the container registry must
                 # also be remote.
-                if container_registry.is_local:
+                if container_registry.config.is_local:
                     return False, (
                         f"The Kubeflow orchestrator is configured to run "
                         f"pipelines in a remote Kubernetes cluster designated "
@@ -284,7 +284,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
 
                 # if the orchestrator is local, the container registry must
                 # also be local.
-                if not container_registry.is_local:
+                if not container_registry.config.is_local:
                     return False, (
                         f"The Kubeflow orchestrator is configured to run "
                         f"pipelines in a local k3d Kubernetes cluster "

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -45,6 +45,19 @@ class KubernetesOrchestratorConfig(BaseOrchestratorConfig):
     synchronous: bool = False
     skip_config_loading: bool = False
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class KubernetesOrchestratorFlavor(BaseOrchestratorFlavor):
     """Kubernetes orchestrator flavor."""

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -185,7 +185,7 @@ class KubernetesOrchestrator(BaseOrchestrator):
 
             # if the orchestrator is remote, the container registry must
             # also be remote.
-            if container_registry.is_local:
+            if container_registry.config.is_local:
                 return False, (
                     f"The Kubernetes orchestrator requires a remote container "
                     f"registry, but the '{container_registry.name}' container "

--- a/src/zenml/integrations/mlflow/flavors/mlflow_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/mlflow/flavors/mlflow_experiment_tracker_flavor.py
@@ -163,6 +163,22 @@ class MLFlowExperimentTrackerConfig(BaseExperimentTrackerConfig):
 
         return values
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        if not self.tracking_uri or not is_remote_mlflow_tracking_uri(
+            self.tracking_uri
+        ):
+            return True
+        return False
+
 
 class MLFlowExperimentTrackerFlavor(BaseExperimentTrackerFlavor):
     """Class for the `MLFlowExperimentTrackerFlavor`."""

--- a/src/zenml/integrations/mlflow/flavors/mlflow_model_deployer_flavor.py
+++ b/src/zenml/integrations/mlflow/flavors/mlflow_model_deployer_flavor.py
@@ -35,6 +35,18 @@ class MLFlowModelDeployerConfig(BaseModelDeployerConfig):
 
     service_path: str = ""
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return True
+
 
 class MLFlowModelDeployerFlavor(BaseModelDeployerFlavor):
     """Model deployer flavor for MLFlow models."""

--- a/src/zenml/integrations/tekton/flavors/tekton_orchestrator_flavor.py
+++ b/src/zenml/integrations/tekton/flavors/tekton_orchestrator_flavor.py
@@ -43,6 +43,19 @@ class TektonOrchestratorConfig(BaseOrchestratorConfig):
     tekton_ui_port: int = DEFAULT_TEKTON_UI_PORT
     skip_ui_daemon_provisioning: bool = False
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return True
+
 
 class TektonOrchestratorFlavor(BaseOrchestratorFlavor):
     """Flavor for the Tekton orchestrator."""

--- a/src/zenml/integrations/tekton/orchestrators/tekton_orchestrator.py
+++ b/src/zenml/integrations/tekton/orchestrators/tekton_orchestrator.py
@@ -125,7 +125,7 @@ class TektonOrchestrator(BaseOrchestrator):
                     f"'{stack_component.flavor}'."
                 )
 
-            if container_registry.is_local:
+            if container_registry.config.is_local:
                 return False, (
                     f"The Tekton orchestrator is configured to run "
                     f"pipelines in a remote Kubernetes cluster designated "

--- a/src/zenml/orchestrators/local/local_orchestrator.py
+++ b/src/zenml/orchestrators/local/local_orchestrator.py
@@ -17,7 +17,10 @@ from typing import TYPE_CHECKING, Any, Type
 
 from zenml.logger import get_logger
 from zenml.orchestrators import BaseOrchestrator
-from zenml.orchestrators.base_orchestrator import BaseOrchestratorFlavor
+from zenml.orchestrators.base_orchestrator import (
+    BaseOrchestratorConfig,
+    BaseOrchestratorFlavor,
+)
 from zenml.stack import Stack
 
 if TYPE_CHECKING:
@@ -66,6 +69,22 @@ class LocalOrchestrator(BaseOrchestrator):
             )
 
 
+class LocalOrchestratorConfig(BaseOrchestratorConfig):
+    """Local orchestrator config."""
+
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return True
+
+
 class LocalOrchestratorFlavor(BaseOrchestratorFlavor):
     """Class for the `LocalOrchestratorFlavor`."""
 
@@ -77,6 +96,15 @@ class LocalOrchestratorFlavor(BaseOrchestratorFlavor):
             The flavor name.
         """
         return "local"
+
+    @property
+    def config_class(self) -> Type[BaseOrchestratorConfig]:
+        """Config class for the base orchestrator flavor.
+
+        Returns:
+            The config class.
+        """
+        return LocalOrchestratorConfig
 
     @property
     def implementation_class(self) -> Type[LocalOrchestrator]:

--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -21,7 +21,10 @@ from zenml.constants import ORCHESTRATOR_DOCKER_IMAGE_KEY
 from zenml.entrypoints import StepEntrypointConfiguration
 from zenml.logger import get_logger
 from zenml.orchestrators import BaseOrchestrator
-from zenml.orchestrators.base_orchestrator import BaseOrchestratorFlavor
+from zenml.orchestrators.base_orchestrator import (
+    BaseOrchestratorConfig,
+    BaseOrchestratorFlavor,
+)
 from zenml.stack import Stack
 from zenml.utils.pipeline_docker_image_builder import PipelineDockerImageBuilder
 
@@ -146,6 +149,22 @@ class LocalDockerOrchestrator(BaseOrchestrator):
                 logger.info(line.strip().decode())
 
 
+class LocalDockerOrchestratorConfig(BaseOrchestratorConfig):
+    """Local Docker orchestrator config."""
+
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return True
+
+
 class LocalDockerOrchestratorFlavor(BaseOrchestratorFlavor):
     """Flavor for the local Docker orchestrator."""
 
@@ -157,6 +176,15 @@ class LocalDockerOrchestratorFlavor(BaseOrchestratorFlavor):
             Name of the orchestrator flavor.
         """
         return "local_docker"
+
+    @property
+    def config_class(self) -> Type[BaseOrchestratorConfig]:
+        """Config class for the base orchestrator flavor.
+
+        Returns:
+            The config class.
+        """
+        return BaseOrchestratorConfig
 
     @property
     def implementation_class(self) -> Type["LocalDockerOrchestrator"]:

--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -184,7 +184,7 @@ class LocalDockerOrchestratorFlavor(BaseOrchestratorFlavor):
         Returns:
             The config class.
         """
-        return BaseOrchestratorConfig
+        return LocalDockerOrchestratorConfig
 
     @property
     def implementation_class(self) -> Type["LocalDockerOrchestrator"]:

--- a/src/zenml/secrets_managers/local/local_secrets_manager.py
+++ b/src/zenml/secrets_managers/local/local_secrets_manager.py
@@ -51,6 +51,18 @@ class LocalSecretsManagerConfig(BaseSecretsManagerConfig):
 
     secrets_file: str = ""
 
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return True
+
 
 class LocalSecretsManager(BaseSecretsManager):
     """Class for ZenML local file-based secret manager."""

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -108,6 +108,53 @@ class StackComponentConfig(BaseModel, ABC):
             if secret_utils.is_secret_reference(v)
         }
 
+    @property
+    def is_remote(self) -> bool:
+        """Checks if this stack component is running remotely.
+
+        Concrete stack component configuration classes should override this
+        method to return True if the stack component is running in a remote
+        location and it needs to access the ZenML database.
+
+        This designation is used to determine if the stack component can be
+        used with a local ZenML database or if it requires a remote ZenML
+        server.
+
+        Examples:
+
+          * Orchestrators that are running pipelines in the cloud or in a
+          location other than the local host
+          * Step Operators that are running steps in the cloud or in a location
+          other than the local host
+
+        Returns:
+            True if this config is for a remote component, False otherwise.
+        """
+        return False
+
+    @property
+    def is_local(self) -> bool:
+        """Checks if this stack component is running locally.
+
+        Concrete stack component configuration classes should override this
+        method to return True if the stack component is relying on local
+        resources or capabilities (e.g. local filesystem, local database or
+        other services).
+
+        This designation is used to determine if the stack component can be
+        shared with other users or if it is only usable on the local host.
+
+        Examples:
+
+          * Artifact Stores that store artifacts in the local filesystem
+          * Orchestrators that are connected to local orchestration runtime
+          services (e.g. local Kubernetes clusters, Docker containers etc).
+
+        Returns:
+            True if this config is for a local component, False otherwise.
+        """
+        return False
+
     def __custom_getattribute__(self, key: str) -> Any:
         """Returns the (potentially resolved) attribute value for the given key.
 

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -121,7 +121,6 @@ class StackComponentConfig(BaseModel, ABC):
         server.
 
         Examples:
-
           * Orchestrators that are running pipelines in the cloud or in a
           location other than the local host
           * Step Operators that are running steps in the cloud or in a location
@@ -145,7 +144,6 @@ class StackComponentConfig(BaseModel, ABC):
         shared with other users or if it is only usable on the local host.
 
         Examples:
-
           * Artifact Stores that store artifacts in the local filesystem
           * Orchestrators that are connected to local orchestration runtime
           services (e.g. local Kubernetes clusters, Docker containers etc).

--- a/tests/unit/container_registries/test_base_container_registry.py
+++ b/tests/unit/container_registries/test_base_container_registry.py
@@ -83,7 +83,7 @@ def test_base_container_registry_local_property():
             project=uuid4(),
             created=datetime.now(),
             updated=datetime.now(),
-        ).is_local
+        ).config.is_local
         is True
     )
     assert (
@@ -99,7 +99,7 @@ def test_base_container_registry_local_property():
             project=uuid4(),
             created=datetime.now(),
             updated=datetime.now(),
-        ).is_local
+        ).config.is_local
         is False
     )
 


### PR DESCRIPTION
- Added stack component configuration properties to determine whether a component is local (uses local resources) or is remote (running in a location different than the local host)
- I use this property inside the `client` when registering and updating stacks and stack components to warn in the following cases:
  a) a user is trying to register a remote component while using a local database or connected to a local ZenML Server
  b) a user is trying to register a local component while connected to a remote ZenML Server
  c) a user is trying to register a stack that combines local and remote components

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

