### PR TITLE
Update cli docs

### DIFF
--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -59,7 +59,7 @@ Beginning a Project
 -------------------
 
 In order to start working on your project, initialize a ZenML repository
-within your current directory with ZenML’s own config and resource management
+within your current directory with ZenML's own config and resource management
 tools:
 
 ```bash
@@ -97,13 +97,13 @@ version.*
 Loading and using pre-built examples
 ------------------------------------
 
-If you don’t have a project of your own that you’re currently working
+If you don't have a project of your own that you're currently working
 on, or if you just want to play around a bit and see some functional
-code, we’ve got your back! You can use the ZenML CLI tool to download
+code, we've got your back! You can use the ZenML CLI tool to download
 some pre-built examples.
 
 We know that working examples are a great way to get to know a tool, so
-we’ve made some examples for you to use to get started. (This is
+we've made some examples for you to use to get started. (This is
 something that will grow as we add more).
 
 To list all the examples available to you, type:
@@ -121,13 +121,13 @@ zenml example info quickstart
 If you want to pull all the examples into your current working directory
 (wherever you are executing the ``zenml`` command from in your
 terminal), the CLI will create a ``zenml_examples`` folder for you if it
-doesn’t already exist whenever you use the ``pull`` subcommand. The
+doesn't already exist whenever you use the ``pull`` subcommand. The
 default is to copy all the examples, like this:
 
 ```bash
 zenml example pull
 ```
-If you’d only like to pull a single example, add the name of that
+If you'd only like to pull a single example, add the name of that
 example (for example, ``quickstart``) as an argument to the same
 command, as follows:
 

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -204,12 +204,16 @@ to register a new artifact store, do so with the ``register`` command:
 ```bash
 zenml artifact-store register ARTIFACT_STORE_NAME --flavor=ARTIFACT_STORE_FLAVOR [--OPTIONS]
 ```
+
 If you wish to list the artifact stores that have already been
 registered within your ZenML project / repository, type:
 
 ```bash
 zenml artifact-store list
 ```
+
+If you wish to update/share
+
 If you wish to delete a particular artifact store, pass the name of the
 artifact store into the CLI with the following command:
 
@@ -461,6 +465,48 @@ zenml feature-store register FEATURE_STORE_NAME --flavor=feast
 Once you have registered your feature store as a stack component, you can use it
 in your ZenML Stack.
 
+Interacting with Model Deployers
+-----------------------------------------
+
+Model deployers are stack components responsible for online model serving.
+They are responsible for deploying models to a remote server. Model deployers
+also act as a registry for models that are served with ZenML.
+
+If you wish to register a new model deployer, do so with the
+`register` command:
+
+```bash
+zenml model-deployer register MODEL_DEPLOYER_NAME --flavor=MODEL_DEPLOYER_FLAVOR [--OPTIONS]
+```
+
+If you wish to list the model-deployers that have already been registered
+within your ZenML project / repository, type:
+
+```bash
+zenml model-deployer list
+```
+
+If you wish to get more detailed information about a particular model deployer
+within your ZenML project / repository, type:
+
+```bash
+zenml model-deployer describe MODEL_DEPLOYER_NAME
+```
+
+If you wish to delete a particular model deployer, pass the name of the
+model deployers into the CLI with the following command:
+
+```bash
+zenml model-deployer delete MODEL_DEPLOYER_NAME
+```
+
+If you wish to retrieve logs corresponding to a particular model deployer, pass the name
+of the model deployer into the CLI with the following command:
+
+```bash
+zenml model-deployer logs MODEL_DEPLOYER_NAME
+```
+
 Interacting with Deployed Models
 --------------------------------
 
@@ -525,16 +571,30 @@ zenml stack register STACK_NAME \
        -o ORCHESTRATOR_NAME
 ```
 
-Each corresponding argument should be the name you passed in as an
-identifier for the artifact store or orchestrator when
-you originally registered it. (If you want to use your secrets manager, you
-should pass its name in with the `-x` option flag.)
+Each corresponding argument should be the name, id or even the first few letters
+ of the id that uniquely identify the artifact store or orchestrator.
+(If you want to use your secrets manager, you should pass its name in with the
+`-x` option flag.)
 
 If you want to immediately set this newly created stack as your active stack,
 simply pass along the `--set` flag.
 
 ```bash
 zenml stack register STACK_NAME ... --set
+```
+
+If you want to share the stack and all of its components with everyone using
+the same ZenML deployment, simply pass along the `--share` flag.
+
+```bash
+zenml stack register STACK_NAME ... --share
+```
+
+Even if you haven't done so at creation time of the stack, you can always
+decide to do so at a later stage.
+
+```bash
+zenml stack share STACK_NAME
 ```
 
 To list the stacks that you have registered within your current ZenML
@@ -725,48 +785,6 @@ You can see a list of all current role assignments by running:
 
 ```bash
 zenml role assignment list
-```
-
-Interacting with Model Deployers
------------------------------------------
-
-Model deployers are stack components responsible for online model serving.
-They are responsible for deploying models to a remote server. Model deployers
-also act as a registry for models that are served with ZenML. 
-
-If you wish to register a new model deployer, do so with the
-`register` command:
-
-```bash
-zenml model-deployer register MODEL_DEPLOYER_NAME --flavor=MODEL_DEPLOYER_FLAVOR [--OPTIONS]
-```
-
-If you wish to list the model-deployers that have already been registered
-within your ZenML project / repository, type:
-
-```bash
-zenml model-deployer list
-```
-
-If you wish to get more detailed information about a particular model deployer
-within your ZenML project / repository, type:
-
-```bash
-zenml model-deployer describe MODEL_DEPLOYER_NAME
-```
-
-If you wish to delete a particular model deployer, pass the name of the
-model deployers into the CLI with the following command:
-
-```bash
-zenml model-deployer delete MODEL_DEPLOYER_NAME
-```
-
-If you wish to retrieve logs corresponding to a particular model deployer, pass the name
-of the model deployer into the CLI with the following command:
-
-```bash
-zenml model-deployer logs MODEL_DEPLOYER_NAME
 ```
 
 Deploying cloud resources using Stack Recipes

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -712,6 +712,69 @@ following command:
 zenml stack register-secrets [<STACK_NAME>]
 ```
 
+Managing the local ZenML Dashboard
+----------------------------------
+
+The ZenML dashboard is a web-based UI that allows you to visualize and navigate
+the stack configurations, pipelines and pipeline runs tracked by ZenML among
+other things. You can start the ZenML dashboard locally by running the following
+command:
+
+```bash
+zenml up
+```
+
+This will start the dashboard on your local machine where you can access it at
+the URL printed to the console. If you want to stop the dashboard, simply run:
+
+```bash
+zenml down
+```
+
+The `zenml up` command has a few additional options that you can use to
+customize how the ZenML dashboard is running.
+
+By default, the dashboard is started as a background process. On some operating
+systems, this capability is not available. In this case, you can use the
+`--blocking` flag to start the dashboard in the foreground:
+
+```bash
+zenml up --blocking
+```
+
+This will block the terminal until you stop the dashboard with CTRL-C.
+
+Another option you can use, if you have Docker installed on your machine, is to
+run the dashboard in a Docker container. This is useful if you don't want to
+install all the Zenml server dependencies on your machine. To do so, simply run:
+
+```bash
+zenml up --docker
+```
+
+The TCP port and the host address that the dashboard uses to listen for
+connections can also be customized. Using an IP address that is not the default
+`localhost` or 127.0.0.1 is especially useful if you're running some type of
+local ZenML orchestrator, such as the k3d Kubeflow orchestrator or Docker
+orchestrator, that can't directly access you loopback interface and therefore
+cannot connect to the local ZenML server.
+
+For example, to start the dashboard on port 9000 and have it listen
+on all locally available interfaces on your machine, run:
+
+```bash
+zenml up --port 9000 --ip-address 0.0.0.0
+```
+
+Note that the above 0.0.0.0 IP address also exposes your ZenML dashboard
+externally through your public interface. Alternatively, you can choose an
+explicit IP address that is configured on one of your local interfaces, such as
+the Docker bridge interface, which usually has the IP address `172.17.0.1`:
+
+```bash
+zenml up --port 9000 --ip-address 172.17.0.1
+```
+
 Managing users, teams, projects and roles
 -----------------------------------------
 

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -459,7 +459,7 @@ def status() -> None:
 
       * to connect to a ZenML deployment using command line arguments:
 
-        zenml connect --url=http://zenml.example.com:8080 --username=admin --project=default
+        zenml connect --url=http://zenml.example.com:8080 --username=admin
 
       * to use a configuration file:
 
@@ -544,6 +544,11 @@ def status() -> None:
     required=False,
     type=str,
 )
+@click.option(
+    "--raw-config",
+    is_flag=True,
+    help="Whether to use the configuration without prompting for missing fields.",
+)
 def connect(
     url: Optional[str] = None,
     username: Optional[str] = None,
@@ -552,6 +557,7 @@ def connect(
     no_verify_ssl: bool = False,
     ssl_ca_cert: Optional[str] = None,
     config: Optional[str] = None,
+    raw_config: bool = False,
 ) -> None:
     """Connect to a remote ZenML server.
 
@@ -567,7 +573,10 @@ def connect(
         ssl_ca_cert: A path to a CA bundle to use to verify the server's TLS
             certificate or the CA bundle value itself.
         config: A YAML or JSON configuration or configuration file to use.
+        raw_config: Whether to use the configuration without prompting for
+            missing fields.
     """
+    from zenml.config.store_config import StoreConfiguration
     from zenml.zen_stores.rest_zen_store import RestZenStoreConfiguration
 
     store_dict: Dict[str, Any] = {}
@@ -584,6 +593,11 @@ def connect(
                 "The configuration argument must be JSON/YAML content or "
                 "point to a valid configuration file."
             )
+
+        if raw_config:
+            store_config = StoreConfiguration.parse_obj(store_dict)
+            GlobalConfiguration().set_store(store_config)
+            return
 
         url = store_dict.get("url", url)
         username = username or store_dict.get("username")

--- a/src/zenml/services/service_endpoint.py
+++ b/src/zenml/services/service_endpoint.py
@@ -14,8 +14,8 @@
 """Implementation of a ZenML service endpoint."""
 
 from typing import Any, Optional, Tuple
-from zenml.constants import DEFAULT_LOCAL_SERVICE_IP_ADDRESS
 
+from zenml.constants import DEFAULT_LOCAL_SERVICE_IP_ADDRESS
 from zenml.logger import get_logger
 from zenml.services.service_monitor import BaseServiceEndpointHealthMonitor
 from zenml.services.service_status import ServiceState, ServiceStatus

--- a/src/zenml/services/service_endpoint.py
+++ b/src/zenml/services/service_endpoint.py
@@ -14,6 +14,7 @@
 """Implementation of a ZenML service endpoint."""
 
 from typing import Any, Optional, Tuple
+from zenml.constants import DEFAULT_LOCAL_SERVICE_IP_ADDRESS
 
 from zenml.logger import get_logger
 from zenml.services.service_monitor import BaseServiceEndpointHealthMonitor
@@ -79,7 +80,11 @@ class ServiceEndpointStatus(ServiceStatus):
             # port and protocol are known
             return None
 
-        return f"{self.protocol.value}://{self.hostname}:{self.port}"
+        hostname = self.hostname
+        if hostname == "0.0.0.0":
+            hostname = DEFAULT_LOCAL_SERVICE_IP_ADDRESS
+
+        return f"{self.protocol.value}://{hostname}:{self.port}"
 
 
 class BaseServiceEndpoint(BaseTypedModel):

--- a/src/zenml/zen_server/deploy/deployer.py
+++ b/src/zenml/zen_server/deploy/deployer.py
@@ -235,7 +235,7 @@ class ServerDeployer(metaclass=SingletonMetaClass):
         if not server.status or not server.status.url:
             raise ServerDeploymentError(
                 f"The {provider_name} {server_name} ZenML "
-                f"server is not currently running or is unreachableI."
+                f"server is not currently running or is unreachable."
             )
 
         store_config = RestZenStoreConfiguration(

--- a/src/zenml/zen_server/deploy/docker/docker_provider.py
+++ b/src/zenml/zen_server/deploy/docker/docker_provider.py
@@ -79,7 +79,7 @@ class DockerServerProvider(BaseServerProvider):
             ),
             ContainerServiceEndpointConfig(
                 protocol=ServiceEndpointProtocol.HTTP,
-                ip_address=str(server_config.address),
+                ip_address=str(server_config.ip_address),
                 port=server_config.port,
                 allocate_port=False,
             ),

--- a/src/zenml/zen_server/deploy/docker/docker_zen_server.py
+++ b/src/zenml/zen_server/deploy/docker/docker_zen_server.py
@@ -78,7 +78,7 @@ class DockerServerDeploymentConfig(ServerDeploymentConfig):
 
     port: int = 8238
     image: str = DOCKER_ZENML_SERVER_DEFAULT_IMAGE
-    address: Union[
+    ip_address: Union[
         ipaddress.IPv4Address, ipaddress.IPv6Address
     ] = ipaddress.IPv4Address(DEFAULT_LOCAL_SERVICE_IP_ADDRESS)
     store: Optional[StoreConfiguration] = None
@@ -216,7 +216,7 @@ class DockerZenServer(ContainerService):
         try:
             uvicorn.run(
                 ZEN_SERVER_ENTRYPOINT,
-                host="0.0.0.0",  # self.endpoint.config.ip_address,
+                host="0.0.0.0",
                 port=self.endpoint.config.port,
                 log_level="info",
             )


### PR DESCRIPTION
Add shareable stacks to cli docs. Currently, some stack components are explicitely mentioned, it might make sense for us to have one generic section about how to interact with stack components, in that section we should also mention the same things. Also we need to add teh ZenServer CLI commands there: `zenml up, down, connect, etc.`

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

