### PR TITLE
Made Pipeline and Stack optional on the HydratedPipelineRunModel

### DIFF
--- a/src/zenml/zen_server/models/pipeline_models.py
+++ b/src/zenml/zen_server/models/pipeline_models.py
@@ -117,8 +117,10 @@ class HydratedPipelineModel(PipelineModel):
 class HydratedPipelineRunModel(PipelineRunModel):
     """Pipeline model with User and Project fully hydrated."""
 
-    pipeline: PipelineModel = Field(title="The pipeline this run belongs to.")
-    stack: StackModel = Field(title="The stack that was used fro this run.")
+    pipeline: Optional[PipelineModel] = Field(
+        title="The pipeline this run belongs to.")
+    stack: Optional[StackModel] = Field(
+        title="The stack that was used fro this run.")
     user: UserModel = Field(  # type: ignore[assignment]
         title="The user that ran this pipeline.",
     )


### PR DESCRIPTION
## Describe changes
Pipeline and Stack are Optional[UUID] in the PipelineRunModel but not in the HydratedPipelineRunModel, the logic was already there, just not the correct typing. 

Refers to: https://www.notion.so/zenml/Final-Stretch-ZenServer-September-Oct-22-85d7f41b2a34480aa6574fdc29abc536#419df969716f4f03afff02588aee44ba

This PR is untested, just thought it would a quick win

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

