### PR TITLE
Fix duplicate results in pipeline run lists and unlisted flag.

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -27,6 +27,7 @@ from pydantic import root_validator
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError, NoResultFound
+from sqlalchemy.sql.operators import is_
 from sqlmodel import Session, SQLModel, create_engine, or_, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
 from tfx.orchestration import metadata
@@ -2547,6 +2548,9 @@ class SqlZenStore(BaseZenStore):
                     project_name_or_id, session=session
                 )
                 query = query.where(StackSchema.project_id == project.id)
+                query = query.where(
+                    PipelineRunSchema.stack_id == StackSchema.id
+                )
             if stack_id is not None:
                 query = query.where(PipelineRunSchema.stack_id == stack_id)
             if component_id:
@@ -2561,7 +2565,7 @@ class SqlZenStore(BaseZenStore):
                     PipelineRunSchema.pipeline_id == pipeline_id
                 )
             elif unlisted:
-                query = query.where(PipelineRunSchema.pipeline_id is None)
+                query = query.where(is_(PipelineRunSchema.pipeline_id, None))
             if user_name_or_id is not None:
                 user = self._get_user_schema(user_name_or_id, session=session)
                 query = query.where(PipelineRunSchema.user_id == user.id)


### PR DESCRIPTION
## Describe changes
- `zenml pipeline run list` no longer contains duplicate entries.
- `zenml pipeline run list --unlisted` now works as expected.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

