### PR TITLE
Fix Pipeline Run Status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,12 @@ uvicorn = { extras = ["standard"], version = "~0.17.5",  optional = true}
 python-multipart = { version = "~0.0.5", optional = true}
 python-jose = { extras = ["cryptography"], version = "~3.3.0", optional = true}
 pymysql = { version = "~1.0.2", optional = true}
+fastapi-utils = { version = "~0.2.1", optional = true}
 
 # optional dependencies for stack recipes
 
 [tool.poetry.extras]
-server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "pymysql"]
+server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "pymysql", "fastapi-utils"]
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -178,6 +178,7 @@ EMAIL_ANALYTICS = "/email-opt-in"
 ACTIVATE = "/activate"
 INFO = "/info"
 VERSION_1 = "/v1"
+STATUS = "/status"
 
 # mandatory stack component attributes
 MANDATORY_COMPONENT_ATTRIBUTES = ["name", "uuid"]

--- a/src/zenml/models/pipeline_models.py
+++ b/src/zenml/models/pipeline_models.py
@@ -82,6 +82,7 @@ class PipelineRunModel(ProjectScopedDomainModel, AnalyticsTrackedModelMixin):
     pipeline_id: Optional[UUID]  # Unlisted runs have this as None.
 
     pipeline_configuration: Dict[str, Any]
+    num_steps: int
     zenml_version: Optional[str] = current_zenml_version
     git_sha: Optional[str] = Field(default_factory=get_git_sha)
 

--- a/src/zenml/post_execution/pipeline_run.py
+++ b/src/zenml/post_execution/pipeline_run.py
@@ -147,18 +147,7 @@ class PipelineRunView:
         Returns:
             The current status of the pipeline run.
         """
-        step_statuses = (step.status for step in self.steps)
-
-        if any(status == ExecutionStatus.FAILED for status in step_statuses):
-            return ExecutionStatus.FAILED
-        elif all(
-            status == ExecutionStatus.COMPLETED
-            or status == ExecutionStatus.CACHED
-            for status in step_statuses
-        ):
-            return ExecutionStatus.COMPLETED
-        else:
-            return ExecutionStatus.RUNNING
+        return Client().zen_store.get_run_status(self.id)
 
     @property
     def steps(self) -> List[StepView]:

--- a/src/zenml/utils/proto_utils.py
+++ b/src/zenml/utils/proto_utils.py
@@ -32,6 +32,7 @@ MLMD_CONTEXT_STACK_PROPERTY_NAME = "stack"
 MLMD_CONTEXT_PIPELINE_CONFIG_PROPERTY_NAME = "pipeline_configuration"
 MLMD_CONTEXT_STEP_CONFIG_PROPERTY_NAME = "step_configuration"
 MLMD_CONTEXT_MODEL_IDS_PROPERTY_NAME = "model_ids"
+MLMD_CONTEXT_NUM_STEPS_PROPERTY_NAME = "num_steps"
 
 
 def add_pipeline_node_context(
@@ -95,6 +96,7 @@ def add_mlmd_contexts(
         MLMD_CONTEXT_PIPELINE_CONFIG_PROPERTY_NAME: pipeline_config,
         MLMD_CONTEXT_STEP_CONFIG_PROPERTY_NAME: step_config,
         MLMD_CONTEXT_MODEL_IDS_PROPERTY_NAME: model_ids,
+        MLMD_CONTEXT_NUM_STEPS_PROPERTY_NAME: str(len(deployment.steps)),
     }
 
     properties_json = json.dumps(context_properties, sort_keys=True)

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -23,9 +23,11 @@ from zenml.constants import (
     GRAPH,
     PIPELINE_CONFIGURATION,
     RUNS,
+    STATUS,
     STEPS,
     VERSION_1,
 )
+from zenml.enums import ExecutionStatus
 from zenml.models.pipeline_models import PipelineRunModel, StepRunModel
 from zenml.post_execution.lineage.lineage_graph import LineageGraph
 from zenml.zen_server.auth import authorize
@@ -201,3 +203,21 @@ def get_pipeline_configuration(run_id: UUID) -> Dict[str, Any]:
         The pipeline configuration of the pipeline run.
     """
     return zen_store.get_run(run_id=run_id).pipeline_configuration
+
+
+@router.get(
+    "/{run_id}" + STATUS,
+    response_model=ExecutionStatus,
+    responses={401: error_response, 404: error_response, 422: error_response},
+)
+@handle_exceptions
+def get_run_status(run_id: UUID) -> ExecutionStatus:
+    """Get the status of a specific pipeline run.
+
+    Args:
+        run_id: ID of the pipeline run for which to get the status.
+
+    Returns:
+        The status of the pipeline run.
+    """
+    return zen_store.get_run_status(run_id)

--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -22,10 +22,12 @@ from zenml.constants import (
     API,
     INPUTS,
     OUTPUTS,
+    STATUS,
     STEP_CONFIGURATION,
     STEPS,
     VERSION_1,
 )
+from zenml.enums import ExecutionStatus
 from zenml.models.pipeline_models import ArtifactModel, StepRunModel
 from zenml.zen_server.auth import authorize
 from zenml.zen_server.utils import error_response, handle_exceptions, zen_store
@@ -108,3 +110,21 @@ def get_step_configuration(step_id: UUID) -> Dict[str, Any]:
         The step configuration.
     """
     return zen_store.get_run_step(step_id).step_configuration
+
+
+@router.get(
+    "/{step_id}" + STATUS,
+    response_model=ExecutionStatus,
+    responses={401: error_response, 404: error_response, 422: error_response},
+)
+@handle_exceptions
+def get_step_status(step_id: UUID) -> ExecutionStatus:
+    """Get the status of a specific step.
+
+    Args:
+        step_id: ID of the step for which to get the status.
+
+    Returns:
+        The status of the step.
+    """
+    return zen_store.get_run_step_status(step_id)

--- a/src/zenml/zen_stores/metadata_store.py
+++ b/src/zenml/zen_stores/metadata_store.py
@@ -51,6 +51,7 @@ class MLMDPipelineRunModel(BaseModel):
     pipeline_id: Optional[UUID]
     stack_id: UUID
     pipeline_configuration: Dict[str, Any]
+    num_steps: int
 
 
 class MLMDStepRunModel(BaseModel):
@@ -249,6 +250,7 @@ class MetadataStore:
         pipeline_configuration = json.loads(
             context_properties.get("pipeline_configuration").string_value
         )
+        num_steps = int(context_properties.get("num_steps").string_value)
         return MLMDPipelineRunModel(
             mlmd_id=context.id,
             name=context.name,
@@ -257,6 +259,7 @@ class MetadataStore:
             pipeline_id=model_ids["pipeline_id"],
             stack_id=model_ids["stack_id"],
             pipeline_configuration=pipeline_configuration,
+            num_steps=num_steps,
         )
 
     def get_all_runs(self) -> Dict[str, MLMDPipelineRunModel]:

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1307,7 +1307,7 @@ class RestZenStore(BaseZenStore):
 
         Args:
             run_id: The ID of the pipeline run to get the status for.
-        
+
         Returns:
             The execution status of the pipeline run.
         """
@@ -1380,7 +1380,7 @@ class RestZenStore(BaseZenStore):
 
         Args:
             step_id: The ID of the step to get the status for.
-        
+
         Returns:
             The execution status of the step.
         """

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1833,3 +1833,12 @@ class RestZenStore(BaseZenStore):
             route: The resource REST API route to use.
         """
         self.delete(f"{route}/{str(resource_id)}")
+
+    def _sync_runs(self) -> None:
+        """Syncs runs from MLMD.
+
+        Raises:
+            NotImplementedError: This internal method may not be called on a
+                `RestZenStore`.
+        """
+        raise NotImplementedError

--- a/src/zenml/zen_stores/schemas/pipeline_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_schemas.py
@@ -139,6 +139,7 @@ class PipelineRunSchema(SQLModel, table=True):
     pipeline: PipelineSchema = Relationship(back_populates="runs")
 
     pipeline_configuration: str = Field(max_length=4096)
+    num_steps: int
     zenml_version: str
     git_sha: Optional[str] = Field(nullable=True)
 
@@ -170,6 +171,7 @@ class PipelineRunSchema(SQLModel, table=True):
             user_id=run.user,
             pipeline_id=run.pipeline_id,
             pipeline_configuration=json.dumps(run.pipeline_configuration),
+            num_steps=run.num_steps,
             git_sha=run.git_sha,
             zenml_version=run.zenml_version,
             pipeline=pipeline,
@@ -208,6 +210,7 @@ class PipelineRunSchema(SQLModel, table=True):
             user=self.user_id,
             pipeline_id=self.pipeline_id,
             pipeline_configuration=json.loads(self.pipeline_configuration),
+            num_steps=self.num_steps,
             git_sha=self.git_sha,
             zenml_version=self.zenml_version,
             mlmd_id=self.mlmd_id,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2640,6 +2640,7 @@ class SqlZenStore(BaseZenStore):
         Raises:
             KeyError: if the step doesn't exist.
         """
+        self._sync_run_step_artifacts(step_id)
         with Session(self.engine) as session:
             step = session.exec(
                 select(StepRunSchema).where(StepRunSchema.id == step_id)
@@ -2670,6 +2671,7 @@ class SqlZenStore(BaseZenStore):
         Raises:
             KeyError: if the step doesn't exist.
         """
+        self._sync_run_step_artifacts(step_id)
         with Session(self.engine) as session:
             step = session.exec(
                 select(StepRunSchema).where(StepRunSchema.id == step_id)
@@ -2710,6 +2712,7 @@ class SqlZenStore(BaseZenStore):
         Returns:
             A mapping from step names to step models for all steps in the run.
         """
+        self._sync_run_steps(run_id)
         with Session(self.engine) as session:
             steps = session.exec(
                 select(StepRunSchema).where(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -3011,7 +3011,10 @@ class SqlZenStore(BaseZenStore):
                     num_steps=mlmd_run.num_steps,
                 )
                 new_run = self._create_run(new_run)
-                self._sync_run_steps(new_run.id)
+                zenml_runs[run_name] = new_run
+
+        for run_ in zenml_runs.values():
+            self._sync_run_steps(run_.id)
 
     def _sync_run_steps(self, run_id: UUID) -> None:
         """Sync run steps from MLMD into the database.

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2598,7 +2598,7 @@ class SqlZenStore(BaseZenStore):
         """
         steps = self.list_run_steps(run_id)
 
-        # If any step is failed or running, return running
+        # If any step is failed or running, return that status respectively
         for step in steps:
             step_status = self.get_run_step_status(step.id)
             if step_status == ExecutionStatus.FAILED:

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1159,3 +1159,7 @@ class ZenStoreInterface(ABC):
         Returns:
             A list of all artifacts.
         """
+
+    @abstractmethod
+    def _sync_runs(self) -> None:
+        """Syncs runs from MLMD."""

--- a/tests/unit/post_execution/test_pipeline_run.py
+++ b/tests/unit/post_execution/test_pipeline_run.py
@@ -61,6 +61,7 @@ def sample_pipeline_run_view(sample_stepview: StepView) -> PipelineRunView:
             user=uuid4(),
             project=uuid4(),
             pipeline_configuration={},
+            num_steps=1,
         )
     )
     setattr(sample_pipeline_run_view, "_steps", {"some_step": sample_stepview})


### PR DESCRIPTION
## Describe changes
I fixed the run status in the UI to only display completed once ALL steps are completed.

This required several major changes:
- PipelineRunModel now has `num_steps` as an attribute.
- When running inside a ZenServer, the syncing of runs from MLMD now happens on a schedule instead of on every get/list method call.
- The API now has endpoints for the status of runs and steps.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

