### PR TITLE
Update custom deployment to use ArtifactModel 

### DIFF
--- a/src/zenml/integrations/seldon/__init__.py
+++ b/src/zenml/integrations/seldon/__init__.py
@@ -33,7 +33,7 @@ class SeldonIntegration(Integration):
     NAME = SELDON
     REQUIREMENTS = [
         "kubernetes==18.20.0",
-        "seldon-core==1.13.1",
+        "seldon-core==1.14.1",
     ]
 
     @classmethod

--- a/src/zenml/utils/materializer_utils.py
+++ b/src/zenml/utils/materializer_utils.py
@@ -23,6 +23,7 @@ from zenml.constants import MODEL_METADATA_YAML_FILE_NAME
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.materializers.base_materializer import BaseMaterializer
+from zenml.models.pipeline_models import ArtifactModel
 from zenml.utils import source_utils
 from zenml.utils.yaml_utils import read_yaml, write_yaml
 
@@ -32,7 +33,7 @@ METADATA_DATATYPE = "datatype"
 METADATA_MATERIALIZER = "materializer"
 
 
-def save_model_metadata(model_artifact: Artifact) -> str:
+def save_model_metadata(model_artifact: ArtifactModel) -> str:
     """Save a zenml model artifact metadata to a YAML file.
 
     This function is used to extract and save information from a zenml model artifact
@@ -49,12 +50,8 @@ def save_model_metadata(model_artifact: Artifact) -> str:
         The path to the temporary file where the model metadata is saved
     """
     metadata = dict()
-    metadata[METADATA_DATATYPE] = model_artifact.properties[
-        METADATA_DATATYPE
-    ].string_value
-    metadata[METADATA_MATERIALIZER] = model_artifact.properties[
-        METADATA_MATERIALIZER
-    ].string_value
+    metadata[METADATA_DATATYPE] = model_artifact.data_type
+    metadata[METADATA_MATERIALIZER] = model_artifact.materializer
 
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".yaml", delete=False


### PR DESCRIPTION
## Describe changes
Update the save_model_metadata to use the new `ArtifactModel` instead of `ml_metadata Artifact`.
Update Seldon-core dependency to 1.14.1

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)


