### PR TITLE
Extend Post Execution Class Properties

### DIFF
--- a/src/zenml/post_execution/pipeline.py
+++ b/src/zenml/post_execution/pipeline.py
@@ -174,6 +174,10 @@ class PipelineView:
     def spec(self) -> "PipelineSpec":
         """Returns the spec of the pipeline.
 
+        The pipeline spec contains the source paths of all steps, as well as
+        each of their upstream step names. This is primarily used to compare
+        whether two pipelines are the same.
+
         Returns:
             The spec of the pipeline.
         """

--- a/src/zenml/post_execution/pipeline.py
+++ b/src/zenml/post_execution/pipeline.py
@@ -23,6 +23,7 @@ from zenml.post_execution.pipeline_run import PipelineRunView
 from zenml.utils.analytics_utils import AnalyticsEvent, track
 
 if TYPE_CHECKING:
+    from zenml.config.pipeline_configurations import PipelineSpec
     from zenml.pipelines.base_pipeline import BasePipeline
 
 logger = get_logger(__name__)
@@ -159,6 +160,24 @@ class PipelineView:
             The name of the pipeline.
         """
         return self._model.name
+
+    @property
+    def docstring(self) -> Optional[str]:
+        """Returns the docstring of the pipeline.
+
+        Returns:
+            The docstring of the pipeline.
+        """
+        return self._model.docstring
+
+    @property
+    def spec(self) -> "PipelineSpec":
+        """Returns the spec of the pipeline.
+
+        Returns:
+            The spec of the pipeline.
+        """
+        return self._model.spec
 
     @property
     def runs(self) -> List["PipelineRunView"]:

--- a/src/zenml/post_execution/pipeline_run.py
+++ b/src/zenml/post_execution/pipeline_run.py
@@ -14,7 +14,7 @@
 """Implementation of the post-execution pipeline run class."""
 
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from uuid import UUID
 
 from zenml.client import Client
@@ -118,6 +118,36 @@ class PipelineRunView:
             The pipeline configuration.
         """
         return self._model.pipeline_configuration
+
+    @property
+    def settings(self) -> Dict[str, Any]:
+        """Returns the pipeline settings.
+
+        Returns:
+            The pipeline settings.
+        """
+        settings = self.pipeline_configuration["settings"]
+        return cast(Dict[str, Any], settings)
+
+    @property
+    def extra(self) -> Dict[str, Any]:
+        """Returns the pipeline extras.
+
+        Returns:
+            The pipeline extras.
+        """
+        extra = self.pipeline_configuration["extra"]
+        return cast(Dict[str, Any], extra)
+
+    @property
+    def enable_cache(self) -> bool:
+        """Returns whether caching is enabled for this pipeline run.
+
+        Returns:
+            True if caching is enabled for this pipeline run.
+        """
+        enable_cache = self.pipeline_configuration["enable_cache"]
+        return cast(bool, enable_cache)
 
     @property
     def zenml_version(self) -> Optional[str]:

--- a/src/zenml/post_execution/pipeline_run.py
+++ b/src/zenml/post_execution/pipeline_run.py
@@ -123,6 +123,9 @@ class PipelineRunView:
     def settings(self) -> Dict[str, Any]:
         """Returns the pipeline settings.
 
+        These are runtime settings passed down to stack components, which
+        can be set at pipeline level.
+
         Returns:
             The pipeline settings.
         """
@@ -132,6 +135,9 @@ class PipelineRunView:
     @property
     def extra(self) -> Dict[str, Any]:
         """Returns the pipeline extras.
+
+        This dict is meant to be used to pass any configuration down to the
+        pipeline or stack components that the user has use of.
 
         Returns:
             The pipeline extras.

--- a/src/zenml/post_execution/step.py
+++ b/src/zenml/post_execution/step.py
@@ -138,6 +138,9 @@ class StepView:
     def settings(self) -> Dict[str, Any]:
         """Returns the step settings.
 
+        These are runtime settings passed down to stack components, which
+        can be set at step level.
+
         Returns:
             The step settings.
         """
@@ -147,6 +150,9 @@ class StepView:
     @property
     def extra(self) -> Dict[str, Any]:
         """Returns the extra dictionary.
+
+        This dict is meant to be used to pass any configuration down to the
+        step that the user has use of.
 
         Returns:
             The extra dictionary.
@@ -166,20 +172,20 @@ class StepView:
 
     @property
     def step_operator(self) -> Optional[str]:
-        """Returns the step operator of the step.
+        """Returns the name of the step operator of the step.
 
         Returns:
-            The step operator of the step.
+            The name of the step operator of the step.
         """
         step_operator = self.step_configuration["config"]["step_operator"]
         return cast(Optional[str], step_operator)
 
     @property
     def experiment_tracker(self) -> Optional[str]:
-        """Returns the experiment tracker of the step.
+        """Returns the name of the experiment tracker of the step.
 
         Returns:
-            The experiment tracker of the step.
+            The name of the experiment tracker of the step.
         """
         experiment_tracker = self.step_configuration["config"][
             "experiment_tracker"
@@ -190,10 +196,12 @@ class StepView:
     def spec(self) -> Dict[str, Any]:
         """Returns the step spec.
 
+        The step spec defines the source path and upstream steps of a step and
+        is used primarily to compare whether two steps are the same.
+
         Returns:
             The step spec.
         """
-
         spec = self.step_configuration["spec"]
         return cast(Dict[str, Any], spec)
 

--- a/src/zenml/post_execution/step.py
+++ b/src/zenml/post_execution/step.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Implementation of a post-execution step class."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 from uuid import UUID
 
 from zenml.client import Client
@@ -133,6 +133,69 @@ class StepView:
             The step configuration.
         """
         return self._model.step_configuration
+
+    @property
+    def settings(self) -> Dict[str, Any]:
+        """Returns the step settings.
+
+        Returns:
+            The step settings.
+        """
+        settings = self.step_configuration["config"]["settings"]
+        return cast(Dict[str, Any], settings)
+
+    @property
+    def extra(self) -> Dict[str, Any]:
+        """Returns the extra dictionary.
+
+        Returns:
+            The extra dictionary.
+        """
+        extra = self.step_configuration["config"]["extra"]
+        return cast(Dict[str, Any], extra)
+
+    @property
+    def enable_cache(self) -> bool:
+        """Returns whether caching is enabled for this step.
+
+        Returns:
+            Whether caching is enabled for this step.
+        """
+        enable_cache = self.step_configuration["config"]["enable_cache"]
+        return cast(bool, enable_cache)
+
+    @property
+    def step_operator(self) -> Optional[str]:
+        """Returns the step operator of the step.
+
+        Returns:
+            The step operator of the step.
+        """
+        step_operator = self.step_configuration["config"]["step_operator"]
+        return cast(Optional[str], step_operator)
+
+    @property
+    def experiment_tracker(self) -> Optional[str]:
+        """Returns the experiment tracker of the step.
+
+        Returns:
+            The experiment tracker of the step.
+        """
+        experiment_tracker = self.step_configuration["config"][
+            "experiment_tracker"
+        ]
+        return cast(Optional[str], experiment_tracker)
+
+    @property
+    def spec(self) -> Dict[str, Any]:
+        """Returns the step spec.
+
+        Returns:
+            The step spec.
+        """
+
+        spec = self.step_configuration["spec"]
+        return cast(Dict[str, Any], spec)
 
     @property
     def status(self) -> ExecutionStatus:


### PR DESCRIPTION
## Describe changes
I extended the post execution classes to have all config contents directly accessible as properties.

The following properties were added:
- `pipeline.docstring`
- `pipeline.spec`
- `run.settings`
- `run.extra`
- `run.enable_cache`
- `step.settings`
- `step.extra`
- `step.enable_cache`
- `step.step_operator`
- `step.experiment_tracker`
- `step.spec`

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

