### PR TITLE
Fix the docstring attribute of pipeline models.

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -292,7 +292,7 @@ def deploy(
         password: The initial password to use for the provisioned admin account.
         timeout: Time in seconds to wait for the server to start.
         config: A YAML or JSON configuration or configuration file to use.
-        gcp_project_id: The project in GCP to deploy the server to. 
+        gcp_project_id: The project in GCP to deploy the server to.
     """
     config_dict: Dict[str, Any] = {}
 

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -1143,7 +1143,10 @@ class Client(metaclass=ClientMetaClass):
         )
 
     def register_pipeline(
-        self, pipeline_name: str, pipeline_spec: PipelineSpec
+        self,
+        pipeline_name: str,
+        pipeline_spec: PipelineSpec,
+        pipeline_docstring: Optional[str],
     ) -> UUID:
         """Registers a pipeline in the ZenStore within the active project.
 
@@ -1173,6 +1176,7 @@ class Client(metaclass=ClientMetaClass):
                 user=self.active_user.id,
                 name=pipeline_name,
                 spec=pipeline_spec,
+                docstring=pipeline_docstring,
             )
             pipeline = self.zen_store.create_pipeline(pipeline=pipeline)
             logger.info(f"Registered new pipeline with name {pipeline.name}.")

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -506,6 +506,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
             pipeline_id = Client().register_pipeline(
                 pipeline_name=pipeline_deployment.pipeline.name,
                 pipeline_spec=pipeline_spec,
+                pipeline_docstring=self.__doc__,
             )
             pipeline_deployment = pipeline_deployment.copy(
                 update={"pipeline_id": pipeline_id}


### PR DESCRIPTION
## Describe changes
I fixed the docstring attribute of the pipeline model.

E.g., when the user defines a pipeline like this:
```
@pipeline
def mypipeline():
   """Do something."""
   ...
```
Then `pipeline.docstring` will now give you "Do something." in the post execution.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/mlops-stacks/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

