### PR TITLE
Fix shared stacks not being allowed to be set as active.

### DIFF
--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -306,10 +306,14 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
                         config_name,
                     )
                     active_stack = default_stack
-                elif active_stack.user != self.active_user.id:
+                elif (
+                    not active_stack.is_shared
+                    and active_stack.user != self.active_user.id
+                ):
                     logger.warning(
-                        "The current %s active stack is not owned by the "
-                        "active user. Resetting the active stack to default.",
+                        "The current %s active stack is not shared and not "
+                        "owned by the active user. "
+                        "Resetting the active stack to default.",
                         config_name,
                     )
                     active_stack = default_stack


### PR DESCRIPTION
## Describe changes
We previously had a check that automatically set the default stack as active if the currently active stack was not owned by the active user, which prevented shared stacks from being used by other users.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

