### PR TITLE
Fixed GitHub/Colab JSON formatting error on quickstart.

### DIFF
--- a/examples/quickstart/notebooks/quickstart.ipynb
+++ b/examples/quickstart/notebooks/quickstart.ipynb
@@ -113,7 +113,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, for the quickstart, we need to install some dependencies. Once you have ZenML installed, you can use our CLI to install the required integrations.\n",
+    "Now, for the quickstart, we need to install some dependencies. Once you have ZenML installed, you can use our CLI to install the required integrations."
    ]
   },
   {


### PR DESCRIPTION
## Describe changes

Quickstart was not displayed correctly on GitHub/Colab due to a trailing comma.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

