### PR TITLE
Fix class resolving in Colab.

### DIFF
--- a/src/zenml/utils/source_utils.py
+++ b/src/zenml/utils/source_utils.py
@@ -117,9 +117,11 @@ def is_third_party_module(file_path: str) -> bool:
         if pathlib.Path(path).resolve() in absolute_file_path.parents:
             return True
 
-    return (
-        pathlib.Path(get_source_root_path()) not in absolute_file_path.parents
-    )
+    try:
+        source_root_path = pathlib.Path(get_source_root_path())
+        return source_root_path not in absolute_file_path.parents
+    except RuntimeError:
+        return False
 
 
 def create_zenml_pin() -> str:

--- a/src/zenml/utils/source_utils.py
+++ b/src/zenml/utils/source_utils.py
@@ -121,7 +121,7 @@ def is_third_party_module(file_path: str) -> bool:
         source_root_path = pathlib.Path(get_source_root_path())
         return source_root_path not in absolute_file_path.parents
     except RuntimeError:
-        return False
+        return True
 
 
 def create_zenml_pin() -> str:


### PR DESCRIPTION
## Describe changes
Class resolving previously failed on Colab when importing steps from other files.

E.g. in ZenBytes we do:
```
!git clone https://github.com/zenml-io/zenbytes.git  # noqa
!mv zenbytes/steps .
!mv zenbytes/pipelines .

from steps.evaluator import evaluator
from steps.importer import importer
from steps.sklearn_trainer import svc_trainer

digits_svc_pipeline = digits_pipeline(
    importer=importer(), trainer=svc_trainer(), evaluator=evaluator()
)
```

which failed with `RuntimeError: Main module was not started from a file. Cannot determine the module root path.`
raised in `get_source_root_path` in `is_third_party_module` in `resolve_class`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

