### PR TITLE
Fix `gpu_limit` condition in `VertexOrchestrator`

### DIFF
--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -235,8 +235,12 @@ class VertexOrchestrator(BaseOrchestrator, GoogleCredentialsMixin):
         if memory_limit is not None:
             container_op = container_op.set_memory_limit(memory_limit)
 
-        gpu_limit = resource_settings.gpu_count or self.config.gpu_limit
-        if gpu_limit is not None:
+        gpu_limit = (
+            resource_settings.gpu_count
+            if resource_settings.gpu_count is not None
+            else self.config.gpu_limit
+        )
+        if gpu_limit is not None and gpu_limit > 0:
             container_op = container_op.set_gpu_limit(gpu_limit)
 
         if self.config.node_selector_constraint is not None:

--- a/tests/unit/integrations/gcp/orchestrators/test_vertex_orchestrator.py
+++ b/tests/unit/integrations/gcp/orchestrators/test_vertex_orchestrator.py
@@ -137,7 +137,7 @@ def test_vertex_orchestrator_stack_validation(
         # ResourceSettings specified for the step, should take values from here
         (
             ResourceSettings(cpu_count=1, gpu_count=1, memory="1GB"),
-            {"cpu_limit": None, "gpu_limit": 1, "memory_limit": "1G"},
+            {"cpu_limit": 4, "gpu_limit": 4, "memory_limit": "4G"},
             {
                 "accelerator": {"count": "1", "type": "NVIDIA_TESLA_K80"},
                 "cpuLimit": 1.0,


### PR DESCRIPTION
## Describe changes

In #935, I added the condition to check if it was needed to add the node selector constraint if `gpu_limit` was `0`, but there was another bug when the value for `gpu_limit` was set, and the value could never be `0`. As `0` is evaluated like a falsy value, the value of `gpu_limit` would always be the value of `self.config.gpu_limit` in the case `resource_settings.gpu_count == 0`.

I've also added unit tests for `VertexOrchestrator._configure_container_resources` method.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

