### PR TITLE
Detect failed executions

### DIFF
--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -440,6 +440,9 @@ class BaseOrchestrator(StackComponent, ABC):
 
         Returns:
             Optional execution info returned by the launcher.
+
+        Raises:
+            RuntimeError: If the execution failed during preparation.
         """
         pipeline_step_name = tfx_launcher._pipeline_node.node_info.id
         start_time = time.time()

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -31,6 +31,7 @@
 """Base orchestrator class."""
 import os
 import time
+import types
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -443,7 +444,36 @@ class BaseOrchestrator(StackComponent, ABC):
         pipeline_step_name = tfx_launcher._pipeline_node.node_info.id
         start_time = time.time()
         logger.info(f"Step `{pipeline_step_name}` has started.")
+
+        # There is no way to differentiate between a cached and a failed
+        # execution based on the execution info returned by the TFX launcher.
+        # We patch the _publish_failed_execution method in order to check
+        # if an execution failed.
+        execution_failed = False
+        original_publish_failed_execution = (
+            tfx_launcher._publish_failed_execution
+        )
+
+        def _new_publish_failed_execution(
+            self: launcher.Launcher, *args: Any, **kwargs: Any
+        ) -> None:
+            original_publish_failed_execution(*args, **kwargs)
+            nonlocal execution_failed
+            execution_failed = True
+
+        setattr(
+            tfx_launcher,
+            "_publish_failed_execution",
+            types.MethodType(_new_publish_failed_execution, tfx_launcher),
+        )
         execution_info = tfx_launcher.launch()
+        if execution_failed:
+            raise RuntimeError(
+                "Failed to execute step. This is probably because some input "
+                f"artifacts for the step {pipeline_step_name} could not be "
+                "found in the database."
+            )
+
         if execution_info and get_cache_status(execution_info):
             logger.info(f"Using cached version of `{pipeline_step_name}`.")
 


### PR DESCRIPTION
## Describe changes
Currently whenever an execution fails due to input resolving (this happens for example when the metadata store is not shared between steps), we wrongly log that the step was cached. This PR patches the TFX launcher to we can detect whether this happens and raise an exception.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

