### PR TITLE
Fix the API docs builder

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -43,6 +43,15 @@ jobs:
         with:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
 
+      # IMPORTANT: there's a strategy to installing integrations here in a way
+      # that avoids conflicts while at the same time making it possible for all
+      # ZenML Python modules to be imported, especially the integration modules:
+      # 1. install zenml with all extras with poetry
+      # 2. install more restrictive integrations first: feast, seldon and
+      # label_studio are currently the ones known to be very restrictive in
+      # terms of what versions of dependencies they require
+      # 3. install the rest of the integrations
+      # 4. as the last step, install zenml again (step 1. repeated)
       - name: Install Dependencies
         run: |
           source $VENV

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -46,8 +46,10 @@ jobs:
       - name: Install Dependencies
         run: |
           source $VENV
-          zenml integration install -y --ignore-integration feast --ignore-integration label_studio
-          pip install click~=8.0.3
+          zenml integration install -y feast
+          zenml integration install -y label_studio seldon
+          zenml integration install -y --ignore-integration feast --ignore-integration label_studio --ignore-integration seldon
+          poetry install --extras server
 
       - name: Setup git user
         run: |

--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1499,3 +1499,8 @@ zenmldocker
 zenmlregistry
 zenmlserver
 zenserver
+Homebrew
+Pipenv
+VSCode
+ZSH
+macos

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -46,9 +46,9 @@ python docs/mkdocstrings_helper.py --path $SRC --output_path docs/mkdocs/
 
 if [ -n "$PUSH" ]; then
   if [ -n "$LATEST" ]; then
-    mike deploy --push --update-aliases --config-file docs/mkdocs.yml $VERSION latest
+    mike deploy --push --rebase --update-aliases --config-file docs/mkdocs.yml $VERSION latest
   else
-    mike deploy --push --update-aliases --config-file docs/mkdocs.yml $VERSION
+    mike deploy --push --rebase --update-aliases --config-file docs/mkdocs.yml $VERSION
   fi
 else
   if [ -n "$LATEST" ]; then

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -46,9 +46,9 @@ python docs/mkdocstrings_helper.py --path $SRC --output_path docs/mkdocs/
 
 if [ -n "$PUSH" ]; then
   if [ -n "$LATEST" ]; then
-    mike deploy --push --rebase --update-aliases --config-file docs/mkdocs.yml $VERSION latest
+    mike deploy --push --update-aliases --config-file docs/mkdocs.yml $VERSION latest
   else
-    mike deploy --push --rebase --update-aliases --config-file docs/mkdocs.yml $VERSION
+    mike deploy --push --update-aliases --config-file docs/mkdocs.yml $VERSION
   fi
 else
   if [ -n "$LATEST" ]; then

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -154,6 +154,8 @@ def up(
         image: A custom Docker image to use for the server, when the
             `--docker` flag is set.
     """
+    gc = GlobalConfiguration()
+
     if docker:
         provider = ServerProviderType.DOCKER
     else:
@@ -182,8 +184,6 @@ def up(
 
     server = deployer.deploy_server(server_config)
 
-    gc = GlobalConfiguration()
-    assert gc.store is not None
     track_event(
         AnalyticsEvent.ZENML_SERVER_STARTED,
         metadata={
@@ -194,7 +194,7 @@ def up(
     )
 
     if not blocking:
-        gc = GlobalConfiguration()
+
         # Don't connect to the local server if the client is already connected
         # to a remote server.
         if (
@@ -251,13 +251,12 @@ def down() -> None:
     deployer.remove_server(server.config.name)
 
     gc = GlobalConfiguration()
-    assert gc.store is not None
     track_event(
         AnalyticsEvent.ZENML_SERVER_STOPPED,
         metadata={
             "server_id": str(gc.user_id),
             "server_deployment": str(server.config.provider),
-            "database_type": str(gc.store.type),
+            "database_type": str(gc.store.type) if gc.store else "",
         },
     )
 

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -105,16 +105,15 @@ def create_user(user_name: str, password: Optional[str] = None) -> None:
         user.active = True
 
     try:
-        user = Client().zen_store.create_user(user)
+        user = gc.zen_store.create_user(user)
     except EntityExistsError as err:
         cli_utils.error(str(err))
     cli_utils.declare(f"Created user '{user_name}'.")
     if not user.active and user.activation_token is not None:
-        assert gc.store is not None
         cli_utils.declare(
             f"The created user account is currently inactive. You can activate "
             f"it by visiting the dashboard at the following URL:\n"
-            f"{gc.store.url}/signup?user={str(user.id)}&username={user.name}&token={user.activation_token.get_secret_value()}\n"
+            f"{gc.zen_store.url}/signup?user={str(user.id)}&username={user.name}&token={user.activation_token.get_secret_value()}\n"
         )
 
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -365,6 +365,11 @@ def print_active_config() -> None:
 
     gc = GlobalConfiguration()
     client = Client()
+
+    # We use gc.store here instead of client.zen_store for two reasons:
+    # 1. to avoid initializing ZenML with the default store just because we want
+    # to print the active config
+    # 2. to avoid connecting to the active store and keep this call lightweight
     if not gc.store:
         return
 

--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -111,8 +111,6 @@ class GlobalConfigMetaClass(ModelMetaclass):
                 "GlobalConfiguration", super().__call__(*args, **kwargs)
             )
             cls._global_config._migrate_config()
-            if not cls._global_config.store:
-                cls._global_config.set_default_store()
         return cls._global_config
 
 

--- a/src/zenml/integrations/feast/__init__.py
+++ b/src/zenml/integrations/feast/__init__.py
@@ -32,7 +32,7 @@ class FeastIntegration(Integration):
     """Definition of Feast integration for ZenML."""
 
     NAME = FEAST
-    REQUIREMENTS = ["feast[redis]~=0.26.0", "redis-server"]
+    REQUIREMENTS = ["feast[redis]~=0.26.0", "redis-server>=6.0.9"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/feast/__init__.py
+++ b/src/zenml/integrations/feast/__init__.py
@@ -32,7 +32,7 @@ class FeastIntegration(Integration):
     """Definition of Feast integration for ZenML."""
 
     NAME = FEAST
-    REQUIREMENTS = ["feast[redis]>=0.19.4", "redis-server"]
+    REQUIREMENTS = ["feast[redis]~=0.26.0", "redis-server"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -42,7 +42,7 @@ class GcpIntegration(Integration):
 
     NAME = GCP
     REQUIREMENTS = [
-        "kfp==1.8.9",
+        "kfp==1.8.13",
         "gcsfs",
         "google-cloud-secret-manager",
         "google-cloud-aiplatform>=1.11.0",

--- a/src/zenml/integrations/kubeflow/__init__.py
+++ b/src/zenml/integrations/kubeflow/__init__.py
@@ -30,7 +30,7 @@ class KubeflowIntegration(Integration):
     """Definition of Kubeflow Integration for ZenML."""
 
     NAME = KUBEFLOW
-    REQUIREMENTS = ["kfp==1.8.9"]
+    REQUIREMENTS = ["kfp==1.8.13"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/tekton/__init__.py
+++ b/src/zenml/integrations/tekton/__init__.py
@@ -32,7 +32,7 @@ class TektonIntegration(Integration):
     """Definition of Tekton Integration for ZenML."""
 
     NAME = TEKTON
-    REQUIREMENTS = ["kfp-tekton==1.3.0"]
+    REQUIREMENTS = ["kfp-tekton==1.3.1"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/utils/analytics_utils.py
+++ b/src/zenml/utils/analytics_utils.py
@@ -157,24 +157,28 @@ class AnalyticsContext:
 
         from zenml.config.global_config import GlobalConfiguration
 
-        gc = GlobalConfiguration()
+        try:
+            gc = GlobalConfiguration()
 
-        self.analytics_opt_in = gc.analytics_opt_in
-        self.user_id = str(gc.user_id)
+            self.analytics_opt_in = gc.analytics_opt_in
+            self.user_id = str(gc.user_id)
 
-        # That means user opted out of analytics
-        if not gc.analytics_opt_in:
-            return
+            # That means user opted out of analytics
+            if not gc.analytics_opt_in:
+                return
 
-        if analytics.write_key is None:
-            analytics.write_key = get_segment_key()
+            if analytics.write_key is None:
+                analytics.write_key = get_segment_key()
 
-        assert (
-            analytics.write_key is not None
-        ), "Analytics key not set but trying to make telemetry call."
+            assert (
+                analytics.write_key is not None
+            ), "Analytics key not set but trying to make telemetry call."
 
-        # Set this to 1 to avoid backoff loop
-        analytics.max_retries = 1
+            # Set this to 1 to avoid backoff loop
+            analytics.max_retries = 1
+        except Exception as e:
+            self.analytics_opt_in = False
+            logger.debug(f"Analytics initialization failed: {e}")
 
     def __enter__(self) -> "AnalyticsContext":
         """Enter context manager.

--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -17,7 +17,6 @@ from typing import Optional
 from uuid import UUID
 
 from zenml.client import Client
-from zenml.config.global_config import GlobalConfiguration
 from zenml.enums import StoreType
 from zenml.logger import get_logger
 
@@ -37,8 +36,6 @@ def get_run_url(
         A direct url link to the pipeline run details page. If run does not exist,
         returns None.
     """
-    gc = GlobalConfiguration()
-
     # Connected to ZenML Server
     client = Client()
 
@@ -47,10 +44,10 @@ def get_run_url(
 
     url = ""
     # We should only do the log if runs exist
-    if runs and gc.store and gc.store.type == StoreType.REST:
+    if runs and client.zen_store.type == StoreType.REST:
         # For now, take the first index to get the latest run
         run = runs[0]
-        url = gc.store.url
+        url = client.zen_store.url
         # Add this for unlisted runs
         if pipeline_id:
             url += f"/pipelines/{str(pipeline_id)}"
@@ -65,16 +62,16 @@ def print_run_url(run_name: str, pipeline_id: Optional[UUID] = None) -> None:
         run_name: Name of the pipeline run.
         pipeline_id: Optional pipeline_id, to be sent when available.
     """
-    gc = GlobalConfiguration()
+    client = Client()
 
-    if gc.store and gc.store.type == StoreType.REST:
+    if client.zen_store.type == StoreType.REST:
         url = get_run_url(
             run_name,
             pipeline_id,
         )
         if url:
             logger.info(f"Dashboard URL: {url}")
-    elif gc.store and gc.store.type == StoreType.SQL:
+    elif client.zen_store.type == StoreType.SQL:
         # Connected to SQL Store Type, we're local
         logger.info(
             "Pipeline visualization can be seen in the ZenML Dashboard. "

--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -90,7 +90,7 @@ def authenticate_credentials(
     auth_context: Optional[AuthContext] = None
     if user_name_or_id:
         try:
-            user = zen_store.get_user(user_name_or_id)
+            user = zen_store().get_user(user_name_or_id)
             auth_context = AuthContext(user=user)
         except KeyError:
             # even when the user does not exist, we still want to execute the

--- a/src/zenml/zen_server/routers/artifacts_endpoints.py
+++ b/src/zenml/zen_server/routers/artifacts_endpoints.py
@@ -47,4 +47,4 @@ def list_runs(
     Returns:
         The artifacts according to query filters.
     """
-    return zen_store.list_artifacts(artifact_uri=artifact_uri)
+    return zen_store().list_artifacts(artifact_uri=artifact_uri)

--- a/src/zenml/zen_server/routers/flavors_endpoints.py
+++ b/src/zenml/zen_server/routers/flavors_endpoints.py
@@ -60,7 +60,7 @@ def list_flavors(
     Returns:
         All flavors.
     """
-    flavors_list = zen_store.list_flavors(
+    flavors_list = zen_store().list_flavors(
         project_name_or_id=project_name_or_id,
         component_type=component_type,
         user_name_or_id=user_name_or_id,
@@ -91,7 +91,7 @@ def get_flavor(flavor_id: UUID, hydrated: bool = False) -> FlavorModel:
     Returns:
         The requested stack.
     """
-    flavor = zen_store.get_flavor(flavor_id)
+    flavor = zen_store().get_flavor(flavor_id)
     # if hydrated:
     #     return flavor.to_hydrated_model()
     # else:
@@ -120,7 +120,7 @@ def update_flavor(
         The updated flavor.
     """
     flavor.id = flavor_id
-    updated_flavor = zen_store.update_flavor(flavor=flavor)
+    updated_flavor = zen_store().update_flavor(flavor=flavor)
     # if hydrated:
     #     return updated_flavor.to_hydrated_model()
     # else:
@@ -139,4 +139,4 @@ def delete_flavor(flavor_id: UUID) -> None:
     Args:
         flavor_id: ID of the flavor.
     """
-    zen_store.delete_flavor(flavor_id)
+    zen_store().delete_flavor(flavor_id)

--- a/src/zenml/zen_server/routers/metadata_config_endpoints.py
+++ b/src/zenml/zen_server/routers/metadata_config_endpoints.py
@@ -41,5 +41,5 @@ def get_metadata_config() -> str:
     """
     from google.protobuf.json_format import MessageToJson
 
-    config = zen_store.get_metadata_config(expand_certs=True)
+    config = zen_store().get_metadata_config(expand_certs=True)
     return MessageToJson(config)

--- a/src/zenml/zen_server/routers/pipelines_endpoints.py
+++ b/src/zenml/zen_server/routers/pipelines_endpoints.py
@@ -61,7 +61,7 @@ def list_pipelines(
     Returns:
         List of pipeline objects.
     """
-    pipelines_list = zen_store.list_pipelines(
+    pipelines_list = zen_store().list_pipelines(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         name=name,
@@ -94,7 +94,7 @@ def get_pipeline(
     Returns:
         A specific pipeline object.
     """
-    pipeline = zen_store.get_pipeline(pipeline_id=pipeline_id)
+    pipeline = zen_store().get_pipeline(pipeline_id=pipeline_id)
     if hydrated:
         return HydratedPipelineModel.from_model(pipeline)
     else:
@@ -123,9 +123,9 @@ def update_pipeline(
     Returns:
         The updated pipeline object.
     """
-    pipeline_in_db = zen_store.get_pipeline(pipeline_id)
+    pipeline_in_db = zen_store().get_pipeline(pipeline_id)
 
-    updated_pipeline = zen_store.update_pipeline(
+    updated_pipeline = zen_store().update_pipeline(
         pipeline=pipeline_update.apply_to_model(pipeline_in_db)
     )
     if hydrated:
@@ -145,7 +145,7 @@ def delete_pipeline(pipeline_id: UUID) -> None:
     Args:
         pipeline_id: ID of the pipeline to get.
     """
-    zen_store.delete_pipeline(pipeline_id=pipeline_id)
+    zen_store().delete_pipeline(pipeline_id=pipeline_id)
 
 
 @router.get(
@@ -180,7 +180,7 @@ def list_pipeline_runs(
     Returns:
         The pipeline runs according to query filters.
     """
-    runs = zen_store.list_runs(
+    runs = zen_store().list_runs(
         project_name_or_id=project_name_or_id,
         run_name=run_name,
         stack_id=stack_id,
@@ -209,4 +209,4 @@ def get_pipeline_spec(pipeline_id: UUID) -> PipelineSpec:
     Returns:
         The spec of the pipeline.
     """
-    return zen_store.get_pipeline(pipeline_id).spec
+    return zen_store().get_pipeline(pipeline_id).spec

--- a/src/zenml/zen_server/routers/projects_endpoints.py
+++ b/src/zenml/zen_server/routers/projects_endpoints.py
@@ -70,7 +70,7 @@ def list_projects() -> List[ProjectModel]:
     Returns:
         A list of projects.
     """
-    return zen_store.list_projects()
+    return zen_store().list_projects()
 
 
 @router.post(
@@ -90,7 +90,7 @@ def create_project(project: CreateProjectRequest) -> ProjectModel:
     Returns:
         The created project.
     """
-    return zen_store.create_project(project=project.to_model())
+    return zen_store().create_project(project=project.to_model())
 
 
 @router.get(
@@ -110,7 +110,7 @@ def get_project(project_name_or_id: Union[str, UUID]) -> ProjectModel:
     Returns:
         The requested project.
     """
-    return zen_store.get_project(project_name_or_id=project_name_or_id)
+    return zen_store().get_project(project_name_or_id=project_name_or_id)
 
 
 @router.put(
@@ -133,9 +133,9 @@ def update_project(
     Returns:
         The updated project.
     """
-    project_in_db = zen_store.get_project(project_name_or_id)
+    project_in_db = zen_store().get_project(project_name_or_id)
 
-    return zen_store.update_project(
+    return zen_store().update_project(
         project=project_update.apply_to_model(project_in_db),
     )
 
@@ -151,7 +151,7 @@ def delete_project(project_name_or_id: Union[str, UUID]) -> None:
     Args:
         project_name_or_id: Name or ID of the project.
     """
-    zen_store.delete_project(project_name_or_id=project_name_or_id)
+    zen_store().delete_project(project_name_or_id=project_name_or_id)
 
 
 @router.get(
@@ -177,7 +177,7 @@ def get_role_assignments_for_project(
     Returns:
         A list of all roles that are assigned to a team.
     """
-    return zen_store.list_role_assignments(
+    return zen_store().list_role_assignments(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         team_name_or_id=team_name_or_id,
@@ -214,7 +214,7 @@ def list_project_stacks(
     Returns:
         All stacks part of the specified project.
     """
-    stacks_list = zen_store.list_stacks(
+    stacks_list = zen_store().list_stacks(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         component_id=component_id,
@@ -251,13 +251,13 @@ def create_stack(
     Returns:
         The created stack.
     """
-    project = zen_store.get_project(project_name_or_id)
+    project = zen_store().get_project(project_name_or_id)
     full_stack = stack.to_model(
         project=project.id,
         user=auth_context.user.id,
     )
 
-    created_stack = zen_store.create_stack(stack=full_stack)
+    created_stack = zen_store().create_stack(stack=full_stack)
     if hydrated:
         return created_stack.to_hydrated_model()
     else:
@@ -296,7 +296,7 @@ def list_project_stack_components(
     Returns:
         All stack components part of the specified project.
     """
-    components_list = zen_store.list_stack_components(
+    components_list = zen_store().list_stack_components(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         type=type,
@@ -334,7 +334,7 @@ def create_stack_component(
     Returns:
         The created stack component.
     """
-    project = zen_store.get_project(project_name_or_id)
+    project = zen_store().get_project(project_name_or_id)
     full_component = component.to_model(
         project=project.id,
         user=auth_context.user.id,
@@ -343,7 +343,7 @@ def create_stack_component(
     # TODO: [server] if possible it should validate here that the configuration
     #  conforms to the flavor
 
-    created_component = zen_store.create_stack_component(
+    created_component = zen_store().create_stack_component(
         component=full_component,
     )
     if hydrated:
@@ -382,7 +382,7 @@ def list_project_flavors(
     Returns:
         All stack components of a certain type that are part of a project.
     """
-    flavors_list = zen_store.list_flavors(
+    flavors_list = zen_store().list_flavors(
         project_name_or_id=project_name_or_id,
         component_type=component_type,
         user_name_or_id=user_name_or_id,
@@ -420,10 +420,10 @@ def create_flavor(
     Returns:
         The created stack component flavor.
     """
-    project = zen_store.get_project(project_name_or_id)
+    project = zen_store().get_project(project_name_or_id)
     flavor.project = project.id
     flavor.user = auth_context.user.id
-    created_flavor = zen_store.create_flavor(
+    created_flavor = zen_store().create_flavor(
         flavor=flavor,
     )
     # if hydrated:
@@ -459,7 +459,7 @@ def list_project_pipelines(
     Returns:
         All pipelines within the project.
     """
-    pipelines_list = zen_store.list_pipelines(
+    pipelines_list = zen_store().list_pipelines(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         name=name,
@@ -497,12 +497,12 @@ def create_pipeline(
     Returns:
         The created pipeline.
     """
-    project = zen_store.get_project(project_name_or_id)
+    project = zen_store().get_project(project_name_or_id)
     pipeline_model = pipeline.to_model(
         project=project.id,
         user=auth_context.user.id,
     )
-    created_pipeline = zen_store.create_pipeline(pipeline=pipeline_model)
+    created_pipeline = zen_store().create_pipeline(pipeline=pipeline_model)
     if hydrated:
         return HydratedPipelineModel.from_model(created_pipeline)
     else:
@@ -530,18 +530,20 @@ def get_project_statistics(
     """
     # TODO: [server] instead of actually querying all the rows, we should
     #  use zen_store methods that just return counts
-    zen_store.list_runs()
+    zen_store().list_runs()
     return {
         "stacks": len(
-            zen_store.list_stacks(project_name_or_id=project_name_or_id)
+            zen_store().list_stacks(project_name_or_id=project_name_or_id)
         ),
         "components": len(
-            zen_store.list_stack_components(
+            zen_store().list_stack_components(
                 project_name_or_id=project_name_or_id
             )
         ),
         "pipelines": len(
-            zen_store.list_pipelines(project_name_or_id=project_name_or_id)
+            zen_store().list_pipelines(project_name_or_id=project_name_or_id)
         ),
-        "runs": len(zen_store.list_runs(project_name_or_id=project_name_or_id)),
+        "runs": len(
+            zen_store().list_runs(project_name_or_id=project_name_or_id)
+        ),
     }

--- a/src/zenml/zen_server/routers/roles_endpoints.py
+++ b/src/zenml/zen_server/routers/roles_endpoints.py
@@ -46,7 +46,7 @@ def list_roles() -> List[RoleModel]:
     Returns:
         List of all roles.
     """
-    return zen_store.list_roles()
+    return zen_store().list_roles()
 
 
 @router.post(
@@ -66,7 +66,7 @@ def create_role(role: CreateRoleRequest) -> RoleModel:
     Returns:
         The created role.
     """
-    return zen_store.create_role(role=role.to_model())
+    return zen_store().create_role(role=role.to_model())
 
 
 @router.get(
@@ -84,7 +84,7 @@ def get_role(role_name_or_id: Union[str, UUID]) -> RoleModel:
     Returns:
         A specific role.
     """
-    return zen_store.get_role(role_name_or_id=role_name_or_id)
+    return zen_store().get_role(role_name_or_id=role_name_or_id)
 
 
 @router.put(
@@ -107,8 +107,8 @@ def update_role(
     Returns:
         The created role.
     """
-    role_in_db = zen_store.get_role(role_name_or_id)
-    return zen_store.update_role(role=role_update.apply_to_model(role_in_db))
+    role_in_db = zen_store().get_role(role_name_or_id)
+    return zen_store().update_role(role=role_update.apply_to_model(role_in_db))
 
 
 @router.delete(
@@ -122,4 +122,4 @@ def delete_role(role_name_or_id: Union[str, UUID]) -> None:
     Args:
         role_name_or_id: Name or ID of the role.
     """
-    zen_store.delete_role(role_name_or_id=role_name_or_id)
+    zen_store().delete_role(role_name_or_id=role_name_or_id)

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -77,7 +77,7 @@ def list_runs(
     Returns:
         The pipeline runs according to query filters.
     """
-    runs = zen_store.list_runs(
+    runs = zen_store().list_runs(
         project_name_or_id=project_name_or_id,
         run_name=run_name,
         stack_id=stack_id,
@@ -112,7 +112,7 @@ def get_run(
     Returns:
         The pipeline run.
     """
-    run = zen_store.get_run(run_id=run_id)
+    run = zen_store().get_run(run_id=run_id)
     if hydrated:
         return HydratedPipelineRunModel.from_model(run)
     else:
@@ -138,7 +138,7 @@ def get_run_dag(
     """
     from zenml.post_execution.pipeline_run import PipelineRunView
 
-    run = zen_store.get_run(run_id=run_id)
+    run = zen_store().get_run(run_id=run_id)
     graph = LineageGraph()
     graph.generate_run_nodes_and_edges(PipelineRunView(run))
     return graph
@@ -159,7 +159,7 @@ def get_run_steps(run_id: UUID) -> List[StepRunModel]:
     Returns:
         The steps for a given pipeline run.
     """
-    return zen_store.list_run_steps(run_id)
+    return zen_store().list_run_steps(run_id)
 
 
 @router.get(
@@ -181,7 +181,7 @@ def get_run_component_side_effects(
     Returns:
         The component side-effects for a given pipeline run.
     """
-    return zen_store.get_run_component_side_effects(
+    return zen_store().get_run_component_side_effects(
         run_id=run_id,
         component_id=component_id,
     )
@@ -202,7 +202,7 @@ def get_pipeline_configuration(run_id: UUID) -> Dict[str, Any]:
     Returns:
         The pipeline configuration of the pipeline run.
     """
-    return zen_store.get_run(run_id=run_id).pipeline_configuration
+    return zen_store().get_run(run_id=run_id).pipeline_configuration
 
 
 @router.get(
@@ -220,4 +220,4 @@ def get_run_status(run_id: UUID) -> ExecutionStatus:
     Returns:
         The status of the pipeline run.
     """
-    return zen_store.get_run_status(run_id)
+    return zen_store().get_run_status(run_id)

--- a/src/zenml/zen_server/routers/server_endpoints.py
+++ b/src/zenml/zen_server/routers/server_endpoints.py
@@ -51,4 +51,4 @@ def server_info() -> ServerModel:
     Returns:
         Information about the server.
     """
-    return zen_store.get_store_info()
+    return zen_store().get_store_info()

--- a/src/zenml/zen_server/routers/stack_components_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_components_endpoints.py
@@ -70,7 +70,7 @@ def list_stack_components(
     Returns:
         List of stack components for a specific type.
     """
-    components_list = zen_store.list_stack_components(
+    components_list = zen_store().list_stack_components(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         type=type,
@@ -103,7 +103,7 @@ def get_stack_component(
     Returns:
         The requested stack component.
     """
-    component = zen_store.get_stack_component(component_id)
+    component = zen_store().get_stack_component(component_id)
     if hydrated:
         return component.to_hydrated_model()
     else:
@@ -132,9 +132,9 @@ def update_stack_component(
     Returns:
         Updated stack component.
     """
-    component_in_db = zen_store.get_stack_component(component_id)
+    component_in_db = zen_store().get_stack_component(component_id)
 
-    updated_component = zen_store.update_stack_component(
+    updated_component = zen_store().update_stack_component(
         component=component_update.apply_to_model(component_in_db)
     )
     if hydrated:
@@ -154,7 +154,7 @@ def deregister_stack_component(component_id: UUID) -> None:
     Args:
         component_id: ID of the stack component.
     """
-    zen_store.delete_stack_component(component_id)
+    zen_store().delete_stack_component(component_id)
 
 
 @types_router.get(

--- a/src/zenml/zen_server/routers/stacks_endpoints.py
+++ b/src/zenml/zen_server/routers/stacks_endpoints.py
@@ -61,7 +61,7 @@ def list_stacks(
     Returns:
         All stacks.
     """
-    stacks_list = zen_store.list_stacks(
+    stacks_list = zen_store().list_stacks(
         project_name_or_id=project_name_or_id,
         user_name_or_id=user_name_or_id,
         component_id=component_id,
@@ -93,7 +93,7 @@ def get_stack(
     Returns:
         The requested stack.
     """
-    stack = zen_store.get_stack(stack_id)
+    stack = zen_store().get_stack(stack_id)
     if hydrated:
         return stack.to_hydrated_model()
     else:
@@ -120,8 +120,8 @@ def update_stack(
     Returns:
         The updated stack.
     """
-    stack_in_db = zen_store.get_stack(stack_id)
-    updated_stack = zen_store.update_stack(
+    stack_in_db = zen_store().get_stack(stack_id)
+    updated_stack = zen_store().update_stack(
         stack=stack_update.apply_to_model(stack_in_db)
     )
     if hydrated:
@@ -141,4 +141,4 @@ def delete_stack(stack_id: UUID) -> None:
     Args:
         stack_id: Name of the stack.
     """
-    zen_store.delete_stack(stack_id)  # aka 'deregister_stack'
+    zen_store().delete_stack(stack_id)  # aka 'deregister_stack'

--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -55,7 +55,7 @@ def get_step(step_id: UUID) -> StepRunModel:
     Returns:
         The step.
     """
-    return zen_store.get_run_step(step_id)
+    return zen_store().get_run_step(step_id)
 
 
 @router.get(
@@ -73,7 +73,7 @@ def get_step_outputs(step_id: UUID) -> Dict[str, ArtifactModel]:
     Returns:
         All outputs of the step, mapping from output name to artifact model.
     """
-    return zen_store.get_run_step_outputs(step_id)
+    return zen_store().get_run_step_outputs(step_id)
 
 
 @router.get(
@@ -91,7 +91,7 @@ def get_step_inputs(step_id: UUID) -> Dict[str, ArtifactModel]:
     Returns:
         All inputs of the step, mapping from input name to artifact model.
     """
-    return zen_store.get_run_step_inputs(step_id)
+    return zen_store().get_run_step_inputs(step_id)
 
 
 @router.get(
@@ -109,7 +109,7 @@ def get_step_configuration(step_id: UUID) -> Dict[str, Any]:
     Returns:
         The step configuration.
     """
-    return zen_store.get_run_step(step_id).step_configuration
+    return zen_store().get_run_step(step_id).step_configuration
 
 
 @router.get(
@@ -127,4 +127,4 @@ def get_step_status(step_id: UUID) -> ExecutionStatus:
     Returns:
         The status of the step.
     """
-    return zen_store.get_run_step_status(step_id)
+    return zen_store().get_run_step_status(step_id)

--- a/src/zenml/zen_server/routers/teams_endpoints.py
+++ b/src/zenml/zen_server/routers/teams_endpoints.py
@@ -47,7 +47,7 @@ def list_teams() -> List[TeamModel]:
     Returns:
         List of all teams.
     """
-    return zen_store.list_teams()
+    return zen_store().list_teams()
 
 
 @router.post(
@@ -67,7 +67,7 @@ def create_team(team: CreateTeamRequest) -> TeamModel:
     Returns:
         The created team.
     """
-    return zen_store.create_team(team=team.to_model())
+    return zen_store().create_team(team=team.to_model())
 
 
 @router.get(
@@ -85,7 +85,7 @@ def get_team(team_name_or_id: Union[str, UUID]) -> TeamModel:
     Returns:
         A specific team.
     """
-    return zen_store.get_team(team_name_or_id=team_name_or_id)
+    return zen_store().get_team(team_name_or_id=team_name_or_id)
 
 
 @router.put(
@@ -108,8 +108,8 @@ def update_team(
     Returns:
         The created team.
     """
-    team_in_db = zen_store.get_team(team_name_or_id)
-    return zen_store.update_team(team=team_update.apply_to_model(team_in_db))
+    team_in_db = zen_store().get_team(team_name_or_id)
+    return zen_store().update_team(team=team_update.apply_to_model(team_in_db))
 
 
 @router.delete(
@@ -123,7 +123,7 @@ def delete_team(team_name_or_id: Union[str, UUID]) -> None:
     Args:
         team_name_or_id: Name or ID of the team.
     """
-    zen_store.delete_team(team_name_or_id=team_name_or_id)
+    zen_store().delete_team(team_name_or_id=team_name_or_id)
 
 
 @router.get(
@@ -146,7 +146,7 @@ def get_role_assignments_for_team(
     Returns:
         A list of all roles that are assigned to a team.
     """
-    return zen_store.list_role_assignments(
+    return zen_store().list_role_assignments(
         team_name_or_id=team_name_or_id,
         project_name_or_id=project_name_or_id,
     )

--- a/src/zenml/zen_server/routers/users_endpoints.py
+++ b/src/zenml/zen_server/routers/users_endpoints.py
@@ -83,7 +83,7 @@ def list_users() -> List[UserModel]:
     Returns:
         A list of all users.
     """
-    return zen_store.list_users()
+    return zen_store().list_users()
 
 
 @router.post(
@@ -115,7 +115,7 @@ def create_user(user: CreateUserRequest) -> CreateUserResponse:
         token = user_model.generate_activation_token()
     else:
         user_model.active = True
-    new_user = zen_store.create_user(user_model)
+    new_user = zen_store().create_user(user_model)
     # add back the original unhashed activation token, if generated, to
     # send it back to the client
     new_user.activation_token = token
@@ -137,7 +137,7 @@ def get_user(user_name_or_id: Union[str, UUID]) -> UserModel:
     Returns:
         A specific user.
     """
-    return zen_store.get_user(user_name_or_id=user_name_or_id)
+    return zen_store().get_user(user_name_or_id=user_name_or_id)
 
 
 @router.put(
@@ -158,9 +158,9 @@ def update_user(
     Returns:
         The updated user.
     """
-    existing_user = zen_store.get_user(user_name_or_id)
+    existing_user = zen_store().get_user(user_name_or_id)
     user_model = user.apply_to_model(existing_user)
-    return zen_store.update_user(user_model)
+    return zen_store().update_user(user_model)
 
 
 @activation_router.put(
@@ -196,7 +196,7 @@ def activate_user(
     user_model = user.apply_to_model(auth_context.user)
     user_model.active = True
     user_model.activation_token = None
-    return zen_store.update_user(user_model)
+    return zen_store().update_user(user_model)
 
 
 @router.put(
@@ -216,10 +216,10 @@ def deactivate_user(
     Returns:
         The generated activation token.
     """
-    user = zen_store.get_user(user_name_or_id)
+    user = zen_store().get_user(user_name_or_id)
     user.active = False
     token = user.generate_activation_token()
-    user = zen_store.update_user(user=user)
+    user = zen_store().update_user(user=user)
     # add back the original unhashed activation token
     user.activation_token = token
     return DeactivateUserResponse.from_model(user)
@@ -243,14 +243,14 @@ def delete_user(
     Raises:
         IllegalOperationError: If the user is not authorized to delete the user.
     """
-    user = zen_store.get_user(user_name_or_id)
+    user = zen_store().get_user(user_name_or_id)
 
     if auth_context.user.name == user.name:
         raise IllegalOperationError(
             "You cannot delete yourself. If you wish to delete your active "
             "user account, please contact your ZenML administrator."
         )
-    zen_store.delete_user(user_name_or_id=user_name_or_id)
+    zen_store().delete_user(user_name_or_id=user_name_or_id)
 
 
 @router.put(
@@ -271,7 +271,7 @@ def email_opt_in_response(
     Returns:
         The updated user.
     """
-    return zen_store.user_email_opt_in(
+    return zen_store().user_email_opt_in(
         user_name_or_id=user_name_or_id,
         email=user_response.email,
         user_opt_in_response=user_response.email_opted_in,
@@ -298,7 +298,7 @@ def get_role_assignments_for_user(
     Returns:
         A list of all roles that are assigned to a user.
     """
-    return zen_store.list_role_assignments(
+    return zen_store().list_role_assignments(
         user_name_or_id=user_name_or_id,
         project_name_or_id=project_name_or_id,
     )
@@ -323,7 +323,7 @@ def assign_role(
             role to the user. If this is not provided, the role will be
             assigned globally.
     """
-    zen_store.assign_role(
+    zen_store().assign_role(
         role_name_or_id=role_name_or_id,
         user_or_team_name_or_id=user_name_or_id,
         is_user=True,
@@ -349,7 +349,7 @@ def unassign_role(
         project_name_or_id: Name or ID of the project. If this is not
             provided, the role will be revoked globally.
     """
-    zen_store.revoke_role(
+    zen_store().revoke_role(
         role_name_or_id=role_name_or_id,
         user_or_team_name_or_id=user_name_or_id,
         is_user=True,

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -46,24 +46,35 @@ def zen_store() -> BaseZenStore:
 
     Returns:
         The ZenML Store.
+
+    Raises:
+        RuntimeError: If the ZenML Store has not been initialized.
     """
     global _zen_store
-
     if _zen_store is None:
-        _zen_store = GlobalConfiguration().zen_store
-
-        # We override track_analytics=False because we do not
-        # want to track anything server side.
-        _zen_store.track_analytics = False
-
-        if _zen_store.type == StoreType.REST:
-            raise ValueError(
-                "Server cannot be started with a REST store type. Make sure you "
-                "configure ZenML to use a non-networked store backend "
-                "when trying to start the ZenML Server."
-            )
-
+        raise RuntimeError("ZenML Store not initialized")
     return _zen_store
+
+
+def initialize_zen_store() -> None:
+    """Initialize the ZenML Store.
+
+    Raises:
+        ValueError: If the ZenML Store is using a REST back-end.
+    """
+    global _zen_store
+    _zen_store = GlobalConfiguration().zen_store
+
+    # We override track_analytics=False because we do not
+    # want to track anything server side.
+    _zen_store.track_analytics = False
+
+    if _zen_store.type == StoreType.REST:
+        raise ValueError(
+            "Server cannot be started with a REST store type. Make sure you "
+            "configure ZenML to use a non-networked store backend "
+            "when trying to start the ZenML Server."
+        )
 
 
 class ErrorModel(BaseModel):

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -15,7 +15,7 @@
 
 import os
 from functools import wraps
-from typing import Any, Callable, List, TypeVar, cast
+from typing import Any, Callable, List, Optional, TypeVar, cast
 
 from fastapi import HTTPException
 from pydantic import BaseModel
@@ -38,19 +38,32 @@ logger = get_logger(__name__)
 ROOT_URL_PATH = os.getenv(ENV_ZENML_SERVER_ROOT_URL_PATH, "")
 
 
-# TODO(Stefan): figure out how not to populate the ZenStore with default
-# user/stack and make this a method instead of a global variable
-zen_store: BaseZenStore = GlobalConfiguration().zen_store
-# We override track_analytics=False because we do not
-# want to track anything server side.
-zen_store.track_analytics = False
+_zen_store: Optional[BaseZenStore] = None
 
-if zen_store.type == StoreType.REST:
-    raise ValueError(
-        "Server cannot be started with a REST store type. Make sure you "
-        "configure ZenML to use a non-networked store backend "
-        "when trying to start the ZenML Server."
-    )
+
+def zen_store() -> BaseZenStore:
+    """Initialize the ZenML Store.
+
+    Returns:
+        The ZenML Store.
+    """
+    global _zen_store
+
+    if _zen_store is None:
+        _zen_store = GlobalConfiguration().zen_store
+
+        # We override track_analytics=False because we do not
+        # want to track anything server side.
+        _zen_store.track_analytics = False
+
+        if _zen_store.type == StoreType.REST:
+            raise ValueError(
+                "Server cannot be started with a REST store type. Make sure you "
+                "configure ZenML to use a non-networked store backend "
+                "when trying to start the ZenML Server."
+            )
+
+    return _zen_store
 
 
 class ErrorModel(BaseModel):

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -82,7 +82,7 @@ app.add_middleware(
 def initialize() -> None:
     """Initialize the ZenML server."""
     # IMPORTANT: this needs to be done before the fastapi app starts, to avoid
-    # race-conditions
+    # race conditions
     initialize_zen_store()
     sync_pipeline_runs()
 

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -145,7 +145,7 @@ app.include_router(users_endpoints.activation_router)
 def sync_pipeline_runs() -> None:
     """Sync pipeline runs."""
     logger.info("Syncing pipeline runs...")
-    zen_store._sync_runs()
+    zen_store()._sync_runs()
 
 
 def get_root_static_files() -> List[str]:

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -42,7 +42,11 @@ from zenml.zen_server.routers import (
     teams_endpoints,
     users_endpoints,
 )
-from zenml.zen_server.utils import ROOT_URL_PATH, zen_store
+from zenml.zen_server.utils import (
+    ROOT_URL_PATH,
+    initialize_zen_store,
+    zen_store,
+)
 
 DASHBOARD_DIRECTORY = "dashboard"
 
@@ -72,6 +76,16 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.on_event("startup")
+def initialize() -> None:
+    """Initialize the ZenML server."""
+    # IMPORTANT: this needs to be done before the fastapi app starts, to avoid
+    # race-conditions
+    initialize_zen_store()
+    sync_pipeline_runs()
+
 
 app.mount(
     "/static",
@@ -141,7 +155,7 @@ app.include_router(users_endpoints.activation_router)
 
 
 @app.on_event("startup")
-@repeat_every(seconds=3)
+@repeat_every(seconds=3, wait_first=True)
 def sync_pipeline_runs() -> None:
     """Sync pipeline runs."""
     logger.info("Syncing pipeline runs...")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,9 +81,10 @@ def base_client(
     session_mocker.patch("analytics.group")
     session_mocker.patch("analytics.identify")
 
-    # initialize global config and repo at the new path
+    # initialize global config, repo and zen store at the new path
     GlobalConfiguration()
     client = Client()
+    _ = client.zen_store
 
     # monkey patch original cwd in for later use and yield
     client.original_cwd = orig_cwd
@@ -154,9 +155,10 @@ def clean_client(
     # separate from those used in the global testing environment
     os.environ["ZENML_CONFIG_PATH"] = str(tmp_path / "zenml")
 
-    # initialize global config and repo at the new path
+    # initialize global config, repo and zen store at the new path
     GlobalConfiguration()
     client = Client()
+    _ = client.zen_store
 
     # monkey patch base repo cwd for later user and yield
     client.original_cwd = base_client.original_cwd


### PR DESCRIPTION
## Describe changes
Implemented a strategy for installing integrations in a way that doesn't break the API docs builder.
This also required a few additional changes:

1. no longer instantiating the ZenML store when the REST API utils module is being imported
2. using lazy initialization for the zen store in general, to avoid having to initializing the local sqlite zen store or having to connect to a zen server when not necessary (e.g. when running `zenml integration install`)
3. updating some integration package requirements:
  * kfp and kfp-tekton were out of sync with eachother
  * feast was using an older package version that was no longer working 

Tested that this works (i.e. it builds the API docs successfully in release branches) here: https://github.com/zenml-io/zenml/actions/runs/3245990909/jobs/5324213166

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

