### PR TITLE
K3d local registry pod spec updated

### DIFF
--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -549,7 +549,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
         if (
             self.is_local
             and stack.container_registry.flavor
-            is ContainerRegistryFlavor.DEFAULT.value
+            == ContainerRegistryFlavor.DEFAULT.value
         ):
             image_name = f"k3d-zenml-kubeflow-registry.{image_name}"
         is_scheduled_run = bool(deployment.schedule)

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -47,7 +47,7 @@ from zenml.client import Client
 from zenml.config.base_settings import BaseSettings
 from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import ORCHESTRATOR_DOCKER_IMAGE_KEY
-from zenml.enums import ContainerRegistryFlavor, StackComponentType
+from zenml.enums import StackComponentType
 from zenml.environment import Environment
 from zenml.exceptions import ProvisioningError
 from zenml.integrations.kubeflow.flavors.kubeflow_orchestrator_flavor import (
@@ -546,11 +546,7 @@ class KubeflowOrchestrator(BaseOrchestrator):
             )
 
         image_name = deployment.pipeline.extra[ORCHESTRATOR_DOCKER_IMAGE_KEY]
-        if (
-            self.is_local
-            and stack.container_registry.flavor
-            == ContainerRegistryFlavor.DEFAULT.value
-        ):
+        if self.is_local and stack.container_registry.config.is_local:
             image_name = f"k3d-zenml-kubeflow-registry.{image_name}"
         is_scheduled_run = bool(deployment.schedule)
 

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -47,7 +47,7 @@ from zenml.client import Client
 from zenml.config.base_settings import BaseSettings
 from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import ORCHESTRATOR_DOCKER_IMAGE_KEY
-from zenml.enums import StackComponentType
+from zenml.enums import ContainerRegistryFlavor, StackComponentType
 from zenml.environment import Environment
 from zenml.exceptions import ProvisioningError
 from zenml.integrations.kubeflow.flavors.kubeflow_orchestrator_flavor import (
@@ -546,6 +546,12 @@ class KubeflowOrchestrator(BaseOrchestrator):
             )
 
         image_name = deployment.pipeline.extra[ORCHESTRATOR_DOCKER_IMAGE_KEY]
+        if (
+            self.is_local
+            and stack.container_registry.flavor
+            is ContainerRegistryFlavor.DEFAULT.value
+        ):
+            image_name = f"k3d-zenml-kubeflow-registry.{image_name}"
         is_scheduled_run = bool(deployment.schedule)
 
         # Create a callable for future compilation into a dsl.Pipeline.


### PR DESCRIPTION
## Describe changes
I fixed a problem with the k3d cluster when a default container registry is used. 
The pod spec should have the `k3d-zenml...` prefix on the image name for it to be pulled successfully inside the pod. This PR adds that.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

