### PR TITLE
Seprated code docs into `core` and `integration` docs

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # fetch all commits/branches including gh-pages
 
       - name: Get the version from the github branch name
         id: get_version

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ instance/
 .scrapy
 
 # mkdocs documentation
-docs/mkdocs/api_docs
+docs/mkdocs/integration_code_docs
+docs/mkdocs/core_code_docs
 docs/mkdocs/index.md
 
 # PyBuilder

--- a/docs/mkdocstrings_helper.py
+++ b/docs/mkdocstrings_helper.py
@@ -1,25 +1,23 @@
-import argparse
+from typing import List, Optional
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+import argparse
 
-PYDOCSTYLE_CMD = (
-    "pydocstyle --convention=google --add-ignore=D100,D101,D102,"
-    "D103,D104,D105,D107,D202"
-)
+PYDOCSTYLE_CMD = "pydocstyle --convention=google --add-ignore=D100,D101,D102," \
+                 "D103,D104,D105,D107,D202"
 
-API_DOCS_TITLE = "# Welcome to the ZenML Api Docs\n"
-INTEGRATION_DOCS_TITLE = "# Welcome to the ZenML Integration Docs\n"
+API_DOCS_TITLE = '# Welcome to the ZenML Api Docs\n'
+INTEGRATION_DOCS_TITLE = '# Welcome to the ZenML Integration Docs\n'
 
-API_DOCS = "core_code_docs"
-INTEGRATION_DOCS = "integration_code_docs"
+API_DOCS = 'core_code_docs'
+INTEGRATION_DOCS = 'integration_code_docs'
 
 
 def to_md_file(
-    markdown_str: str,
-    filename: str,
-    out_path: Path = Path("."),
+        markdown_str: str,
+        filename: str,
+        out_path: Path = Path("."),
 ) -> None:
     """Creates an API docs file from a provided text.
 
@@ -59,19 +57,18 @@ def _is_module_ignored(module_name: str, ignored_modules: List[str]) -> bool:
 
 def generate_title(s: str) -> str:
     """Remove underscores and capitalize first letter to each word"""
-    s = s.replace("_", " ")
+    s = s.replace('_', ' ')
     s = s.title()
     return s
 
 
-def create_entity_docs(
-    api_doc_file_dir: Path,
-    ignored_modules: List[str],
-    sources_path: Path,
-    index_file_contents: Optional[List[str]],
-    md_prefix: Optional[str],
-) -> Optional[List[str]]:
-    """Create structure for mkdocs with separate md files for each top level
+def create_entity_docs(api_doc_file_dir: Path,
+                       ignored_modules: List[str],
+                       sources_path: Path,
+                       index_file_contents: Optional[List[str]],
+                       md_prefix: Optional[str]
+                       ) -> Optional[List[str]]:
+    """ Create structure for mkdocs with separate md files for each top level
     entity.
 
     Args:
@@ -85,26 +82,24 @@ def create_entity_docs(
     for item in sources_path.iterdir():
         if item.name not in ignored_modules:
             is_python_file = item.is_file() and item.name.endswith(".py")
-            is_non_empty_dir = item.is_dir() and any(item.iterdir())
+            is_non_empty_dir = (item.is_dir() and any(item.iterdir()))
 
             if is_python_file or is_non_empty_dir:
                 item_name = generate_title(item.stem)
 
                 # Extract zenml import path from sources path
                 # Example: src/zenml/cli/function.py ->  zenml.cli
-                zenml_import_path = ".".join(item.parts[1:-1])
+                zenml_import_path = '.'.join(item.parts[1:-1])
 
-                module_md = (
-                    f"# {item_name}\n\n"
-                    f"::: {zenml_import_path}.{item.stem}\n"
-                    f"    handler: python\n"
-                    f"    rendering:\n"
-                    f"      show_root_heading: true\n"
-                    f"      show_source: true\n"
-                )
+                module_md = f"# {item_name}\n\n" \
+                            f"::: {zenml_import_path}.{item.stem}\n" \
+                            f"    handler: python\n" \
+                            f"    rendering:\n" \
+                            f"      show_root_heading: true\n" \
+                            f"      show_source: true\n"
 
                 if md_prefix:
-                    file_name = md_prefix + "-" + item.stem
+                    file_name = md_prefix + '-' + item.stem
                 else:
                     file_name = item.stem
                 to_md_file(
@@ -113,27 +108,24 @@ def create_entity_docs(
                     out_path=api_doc_file_dir,
                 )
 
-                relative_base_path = "/".join(item.parts[1:-1])
+                relative_base_path = '/'.join(item.parts[1:-1])
                 if index_file_contents:
-                    index_entry = (
-                        f"# [{item_name}]"
-                        f"({relative_base_path}/{item.stem})\n\n"
-                        f"::: {zenml_import_path}.{item.stem}\n"
-                        f"    handler: python\n"
-                        f"    selection:\n"
-                        f"        members: false\n"
-                    )
+                    index_entry = f"# [{item_name}]" \
+                                  f"({relative_base_path}/{item.stem})\n\n" \
+                                  f"::: {zenml_import_path}.{item.stem}\n" \
+                                  f"    handler: python\n" \
+                                  f"    selection:\n" \
+                                  f"        members: false\n"
 
                     index_file_contents.append(index_entry)
 
     return index_file_contents
 
 
-def create_cli_docs(
-    cli_dev_doc_file_dir: Path,
-    ignored_modules: List[str],
-    sources_path: Path,
-) -> None:
+def create_cli_docs(cli_dev_doc_file_dir: Path,
+                    ignored_modules: List[str],
+                    sources_path: Path,
+                    ) -> None:
     # TODO [MEDIUM]: Find Solution for issue with click-decorated functions
     #  Some resources concerning this issue can be found here
     #  https://github.com/mkdocstrings/mkdocstrings/issues/162
@@ -143,15 +135,15 @@ def create_cli_docs(
         ignored_modules=ignored_modules,
         sources_path=sources_path,
         index_file_contents=None,
-        md_prefix="cli",
+        md_prefix="cli"
     )
 
 
 def generate_docs(
-    path: Path,
-    output_path: Path,
-    ignored_modules: Optional[List[str]] = None,
-    validate: bool = False,
+        path: Path,
+        output_path: Path,
+        ignored_modules: Optional[List[str]] = None,
+        validate: bool = False
 ) -> None:
     """Generates top level separation of primary entities inside th zenml source
     directory for the purpose of generating mkdocstring markdown files.
@@ -164,7 +156,7 @@ def generate_docs(
     """
     # Set up output paths for the generated md files
     api_doc_file_dir = output_path / API_DOCS
-    cli_dev_doc_file_dir = output_path / API_DOCS / "cli"
+    cli_dev_doc_file_dir = output_path / API_DOCS / 'cli'
     integrations_dev_doc_file_dir = output_path / INTEGRATION_DOCS
 
     api_doc_file_dir.mkdir(parents=True, exist_ok=True)
@@ -176,15 +168,12 @@ def generate_docs(
 
     # The Cli docs are treated differently as the user facing docs need to be
     # split from the developer-facing docs
-    ignored_modules.append("cli")
-    ignored_modules.append("integrations")
+    ignored_modules.append('cli')
+    ignored_modules.append('integrations')
 
     # Validate that all docstrings conform to pydocstyle rules
-    if (
-        validate
-        and Path(path).is_dir()
-        and subprocess.call(f"{PYDOCSTYLE_CMD} {path}", shell=True) > 0
-    ):
+    if (validate and Path(path).is_dir() and
+            subprocess.call(f"{PYDOCSTYLE_CMD} {path}", shell=True) > 0):
         raise Exception(f"Validation for {path} failed.")
 
     index_file_contents = [API_DOCS_TITLE]
@@ -194,13 +183,13 @@ def generate_docs(
         ignored_modules=ignored_modules,
         sources_path=path,
         index_file_contents=index_file_contents,
-        md_prefix="core",
+        md_prefix="core"
     )
 
-    index_file_str = "\n".join(index_file_contents)
+    index_file_str = '\n'.join(index_file_contents)
     to_md_file(
         index_file_str,
-        "index.md",
+        'index.md',
         out_path=output_path,
     )
 
@@ -208,52 +197,44 @@ def generate_docs(
     integrations_file_content = create_entity_docs(
         api_doc_file_dir=integrations_dev_doc_file_dir,
         ignored_modules=["__init__.py", "__pycache__"],
-        sources_path=path / "integrations",
+        sources_path=path / 'integrations',
         index_file_contents=integration_file_contents,
-        md_prefix="integrations",
+        md_prefix='integrations'
     )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Arguments to run the" "mkdocstrings helper"
-    )
+    parser = argparse.ArgumentParser(description='Arguments to run the'
+                                                 'mkdocstrings helper')
     # Required positional argument
-    parser.add_argument(
-        "--path",
-        type=str,
-        default="src/zenml",
-        help="Location of the source code",
-    )
+    parser.add_argument('--path',
+                        type=str,
+                        default='src/zenml',
+                        help='Location of the source code')
 
     # Optional positional argument
-    parser.add_argument(
-        "--output_path",
-        type=str,
-        default="docs/mkdocs",
-        help="Location at which to generate the markdown file",
-    )
+    parser.add_argument('--output_path',
+                        type=str,
+                        default='docs/mkdocs',
+                        help='Location at which to generate the markdown file')
 
     # Optional argument
-    parser.add_argument(
-        "--ignored_modules",
-        type=List[str],
-        default=["VERSION", "README.md", "__init__.py", "__pycache__"],
-        help="Top level entities that should not end up in "
-        "the api docs (e.g. README.md, __init__",
-    )
+    parser.add_argument('--ignored_modules',
+                        type=List[str],
+                        default=['VERSION', 'README.md',
+                                 '__init__.py', '__pycache__'],
+                        help='Top level entities that should not end up in '
+                             'the api docs (e.g. README.md, __init__')
 
     # Switch
-    parser.add_argument(
-        "--validate", action="store_true", help="A boolean switch"
-    )
+    parser.add_argument('--validate',
+                        action='store_true',
+                        help='A boolean switch')
 
     args = parser.parse_args()
     print(args.validate)
 
-    generate_docs(
-        path=Path(args.path),
-        output_path=Path(args.output_path),
-        ignored_modules=args.ignored_modules,
-        validate=args.validate,
-    )
+    generate_docs(path=Path(args.path),
+                  output_path=Path(args.output_path),
+                  ignored_modules=args.ignored_modules,
+                  validate=args.validate)

--- a/docs/mkdocstrings_helper.py
+++ b/docs/mkdocstrings_helper.py
@@ -201,12 +201,6 @@ def generate_docs(
         index_file_contents=integration_file_contents,
         md_prefix='integrations'
     )
-    # integrations_file_str = '\n'.join(integrations_file_content)
-    # to_md_file(
-    #     integrations_file_str,
-    #     'integrations.md',
-    #     out_path=output_path,
-    # )
 
 
 if __name__ == "__main__":

--- a/docs/mkdocstrings_helper.py
+++ b/docs/mkdocstrings_helper.py
@@ -1,23 +1,25 @@
-from typing import List, Optional
+import argparse
 import os
 import subprocess
 from pathlib import Path
-import argparse
+from typing import List, Optional
 
-PYDOCSTYLE_CMD = "pydocstyle --convention=google --add-ignore=D100,D101,D102," \
-                 "D103,D104,D105,D107,D202"
+PYDOCSTYLE_CMD = (
+    "pydocstyle --convention=google --add-ignore=D100,D101,D102,"
+    "D103,D104,D105,D107,D202"
+)
 
-API_DOCS_TITLE = '# Welcome to the ZenML Api Docs\n'
-INTEGRATION_DOCS_TITLE = '# Welcome to the ZenML Integration Docs\n'
+API_DOCS_TITLE = "# Welcome to the ZenML Api Docs\n"
+INTEGRATION_DOCS_TITLE = "# Welcome to the ZenML Integration Docs\n"
 
-API_DOCS = 'core_code_docs'
-INTEGRATION_DOCS = 'integration_code_docs'
+API_DOCS = "core_code_docs"
+INTEGRATION_DOCS = "integration_code_docs"
 
 
 def to_md_file(
-        markdown_str: str,
-        filename: str,
-        out_path: Path = Path("."),
+    markdown_str: str,
+    filename: str,
+    out_path: Path = Path("."),
 ) -> None:
     """Creates an API docs file from a provided text.
 
@@ -57,18 +59,19 @@ def _is_module_ignored(module_name: str, ignored_modules: List[str]) -> bool:
 
 def generate_title(s: str) -> str:
     """Remove underscores and capitalize first letter to each word"""
-    s = s.replace('_', ' ')
+    s = s.replace("_", " ")
     s = s.title()
     return s
 
 
-def create_entity_docs(api_doc_file_dir: Path,
-                       ignored_modules: List[str],
-                       sources_path: Path,
-                       index_file_contents: Optional[List[str]],
-                       md_prefix: Optional[str]
-                       ) -> Optional[List[str]]:
-    """ Create structure for mkdocs with separate md files for each top level
+def create_entity_docs(
+    api_doc_file_dir: Path,
+    ignored_modules: List[str],
+    sources_path: Path,
+    index_file_contents: Optional[List[str]],
+    md_prefix: Optional[str],
+) -> Optional[List[str]]:
+    """Create structure for mkdocs with separate md files for each top level
     entity.
 
     Args:
@@ -82,24 +85,26 @@ def create_entity_docs(api_doc_file_dir: Path,
     for item in sources_path.iterdir():
         if item.name not in ignored_modules:
             is_python_file = item.is_file() and item.name.endswith(".py")
-            is_non_empty_dir = (item.is_dir() and any(item.iterdir()))
+            is_non_empty_dir = item.is_dir() and any(item.iterdir())
 
             if is_python_file or is_non_empty_dir:
                 item_name = generate_title(item.stem)
 
                 # Extract zenml import path from sources path
                 # Example: src/zenml/cli/function.py ->  zenml.cli
-                zenml_import_path = '.'.join(item.parts[1:-1])
+                zenml_import_path = ".".join(item.parts[1:-1])
 
-                module_md = f"# {item_name}\n\n" \
-                            f"::: {zenml_import_path}.{item.stem}\n" \
-                            f"    handler: python\n" \
-                            f"    rendering:\n" \
-                            f"      show_root_heading: true\n" \
-                            f"      show_source: true\n"
+                module_md = (
+                    f"# {item_name}\n\n"
+                    f"::: {zenml_import_path}.{item.stem}\n"
+                    f"    handler: python\n"
+                    f"    rendering:\n"
+                    f"      show_root_heading: true\n"
+                    f"      show_source: true\n"
+                )
 
                 if md_prefix:
-                    file_name = md_prefix + '-' + item.stem
+                    file_name = md_prefix + "-" + item.stem
                 else:
                     file_name = item.stem
                 to_md_file(
@@ -108,24 +113,27 @@ def create_entity_docs(api_doc_file_dir: Path,
                     out_path=api_doc_file_dir,
                 )
 
-                relative_base_path = '/'.join(item.parts[1:-1])
+                relative_base_path = "/".join(item.parts[1:-1])
                 if index_file_contents:
-                    index_entry = f"# [{item_name}]" \
-                                  f"({relative_base_path}/{item.stem})\n\n" \
-                                  f"::: {zenml_import_path}.{item.stem}\n" \
-                                  f"    handler: python\n" \
-                                  f"    selection:\n" \
-                                  f"        members: false\n"
+                    index_entry = (
+                        f"# [{item_name}]"
+                        f"({relative_base_path}/{item.stem})\n\n"
+                        f"::: {zenml_import_path}.{item.stem}\n"
+                        f"    handler: python\n"
+                        f"    selection:\n"
+                        f"        members: false\n"
+                    )
 
                     index_file_contents.append(index_entry)
 
     return index_file_contents
 
 
-def create_cli_docs(cli_dev_doc_file_dir: Path,
-                    ignored_modules: List[str],
-                    sources_path: Path,
-                    ) -> None:
+def create_cli_docs(
+    cli_dev_doc_file_dir: Path,
+    ignored_modules: List[str],
+    sources_path: Path,
+) -> None:
     # TODO [MEDIUM]: Find Solution for issue with click-decorated functions
     #  Some resources concerning this issue can be found here
     #  https://github.com/mkdocstrings/mkdocstrings/issues/162
@@ -135,15 +143,15 @@ def create_cli_docs(cli_dev_doc_file_dir: Path,
         ignored_modules=ignored_modules,
         sources_path=sources_path,
         index_file_contents=None,
-        md_prefix="cli"
+        md_prefix="cli",
     )
 
 
 def generate_docs(
-        path: Path,
-        output_path: Path,
-        ignored_modules: Optional[List[str]] = None,
-        validate: bool = False
+    path: Path,
+    output_path: Path,
+    ignored_modules: Optional[List[str]] = None,
+    validate: bool = False,
 ) -> None:
     """Generates top level separation of primary entities inside th zenml source
     directory for the purpose of generating mkdocstring markdown files.
@@ -156,7 +164,7 @@ def generate_docs(
     """
     # Set up output paths for the generated md files
     api_doc_file_dir = output_path / API_DOCS
-    cli_dev_doc_file_dir = output_path / API_DOCS / 'cli'
+    cli_dev_doc_file_dir = output_path / API_DOCS / "cli"
     integrations_dev_doc_file_dir = output_path / INTEGRATION_DOCS
 
     api_doc_file_dir.mkdir(parents=True, exist_ok=True)
@@ -168,12 +176,15 @@ def generate_docs(
 
     # The Cli docs are treated differently as the user facing docs need to be
     # split from the developer-facing docs
-    ignored_modules.append('cli')
-    ignored_modules.append('integrations')
+    ignored_modules.append("cli")
+    ignored_modules.append("integrations")
 
     # Validate that all docstrings conform to pydocstyle rules
-    if (validate and Path(path).is_dir() and
-            subprocess.call(f"{PYDOCSTYLE_CMD} {path}", shell=True) > 0):
+    if (
+        validate
+        and Path(path).is_dir()
+        and subprocess.call(f"{PYDOCSTYLE_CMD} {path}", shell=True) > 0
+    ):
         raise Exception(f"Validation for {path} failed.")
 
     index_file_contents = [API_DOCS_TITLE]
@@ -183,13 +194,13 @@ def generate_docs(
         ignored_modules=ignored_modules,
         sources_path=path,
         index_file_contents=index_file_contents,
-        md_prefix="core"
+        md_prefix="core",
     )
 
-    index_file_str = '\n'.join(index_file_contents)
+    index_file_str = "\n".join(index_file_contents)
     to_md_file(
         index_file_str,
-        'index.md',
+        "index.md",
         out_path=output_path,
     )
 
@@ -197,44 +208,52 @@ def generate_docs(
     integrations_file_content = create_entity_docs(
         api_doc_file_dir=integrations_dev_doc_file_dir,
         ignored_modules=["__init__.py", "__pycache__"],
-        sources_path=path / 'integrations',
+        sources_path=path / "integrations",
         index_file_contents=integration_file_contents,
-        md_prefix='integrations'
+        md_prefix="integrations",
     )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Arguments to run the'
-                                                 'mkdocstrings helper')
+    parser = argparse.ArgumentParser(
+        description="Arguments to run the" "mkdocstrings helper"
+    )
     # Required positional argument
-    parser.add_argument('--path',
-                        type=str,
-                        default='src/zenml',
-                        help='Location of the source code')
+    parser.add_argument(
+        "--path",
+        type=str,
+        default="src/zenml",
+        help="Location of the source code",
+    )
 
     # Optional positional argument
-    parser.add_argument('--output_path',
-                        type=str,
-                        default='docs/mkdocs',
-                        help='Location at which to generate the markdown file')
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="docs/mkdocs",
+        help="Location at which to generate the markdown file",
+    )
 
     # Optional argument
-    parser.add_argument('--ignored_modules',
-                        type=List[str],
-                        default=['VERSION', 'README.md',
-                                 '__init__.py', '__pycache__'],
-                        help='Top level entities that should not end up in '
-                             'the api docs (e.g. README.md, __init__')
+    parser.add_argument(
+        "--ignored_modules",
+        type=List[str],
+        default=["VERSION", "README.md", "__init__.py", "__pycache__"],
+        help="Top level entities that should not end up in "
+        "the api docs (e.g. README.md, __init__",
+    )
 
     # Switch
-    parser.add_argument('--validate',
-                        action='store_true',
-                        help='A boolean switch')
+    parser.add_argument(
+        "--validate", action="store_true", help="A boolean switch"
+    )
 
     args = parser.parse_args()
     print(args.validate)
 
-    generate_docs(path=Path(args.path),
-                  output_path=Path(args.output_path),
-                  ignored_modules=args.ignored_modules,
-                  validate=args.validate)
+    generate_docs(
+        path=Path(args.path),
+        output_path=Path(args.output_path),
+        ignored_modules=args.ignored_modules,
+        validate=args.validate,
+    )

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 set -x
 
-SRC=${1:-"src/zenml tests examples docs/mkdocstrings_helper.py"}
+SRC=${1:-"src/zenml tests examples"}
 
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 set -x
 
-SRC=${1:-"src/zenml tests examples"}
+SRC=${1:-"src/zenml tests examples docs/mkdocstrings_helper.py"}
 
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -39,7 +39,8 @@ done
 
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false
-rm -rf docs/mkdocs/api_docs || true
+rm -rf docs/mkdocs/core_code_docs || true
+rm -rf docs/mkdocs/integration_code_docs || true
 rm docs/mkdocs/index.md || true
 
 python docs/mkdocstrings_helper.py --path $SRC --output_path docs/mkdocs/


### PR DESCRIPTION
## Describe changes
I tried to fix the github action for the API docs, let's hope it works in the next release.

While I was at it I also separated out the Integrations from the Core code.

Before:
![before](https://user-images.githubusercontent.com/38859294/196472160-df40c7ae-697d-4af4-abdc-4eb41fdcc6fb.png)

New:
![integration](https://user-images.githubusercontent.com/38859294/196472362-23e612e1-8b79-4aae-a4a8-9207d7fd082c.png)
![core](https://user-images.githubusercontent.com/38859294/196473962-3671cce9-99ab-4596-b3af-4cf791f1ff21.png)



## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

