### PR TITLE
Allow duplicate step classes inside a pipeline

### DIFF
--- a/docs/book/legacy/developer-guide/steps-pipelines/steps-and-pipelines.md
+++ b/docs/book/legacy/developer-guide/steps-pipelines/steps-and-pipelines.md
@@ -110,13 +110,6 @@ first_pipeline_instance = first_pipeline(
 )
 ```
 
-{% hint style="info" %}
-Currently, you cannot use the same step twice in a pipeline because step names
-must be unique. If you would like to reuse a step, use the 
-[`clone_step()`](https://apidocs.zenml.io/latest/api_docs/steps/#zenml.steps.utils.clone_step)
-utility function to create a copy of the step with a new name.
-{% endhint %}
-
 You can then execute your pipeline instance with the `.run()` method:
 
 ```python

--- a/docs/book/starter-guide/pipelines/pipelines.md
+++ b/docs/book/starter-guide/pipelines/pipelines.md
@@ -169,13 +169,6 @@ first_pipeline_instance = first_pipeline(
 )
 ```
 
-{% hint style="info" %}
-Currently, you cannot use the same step twice in a pipeline because step names
-must be unique. If you would like to reuse a step, use the 
-[`clone_step()`](https://apidocs.zenml.io/latest/api_docs/steps/#zenml.steps.utils.clone_step)
-utility function to create a copy of the step with a new name.
-{% endhint %}
-
 You can then execute your pipeline instance with the `.run()` method:
 
 ```python

--- a/examples/great_expectations_data_validation/steps/validator.py
+++ b/examples/great_expectations_data_validation/steps/validator.py
@@ -14,9 +14,8 @@
 
 from zenml.integrations.great_expectations.steps import (
     GreatExpectationsValidatorParameters,
-    GreatExpectationsValidatorStep,
+    great_expectations_validator_step,
 )
-from zenml.steps.utils import clone_step
 
 ge_validate_train_params = GreatExpectationsValidatorParameters(
     expectation_suite_name="steel_plates_suite",
@@ -27,12 +26,9 @@ ge_validate_test_params = GreatExpectationsValidatorParameters(
     data_asset_name="steel_plates_test_df",
 )
 
-# We clone the builtin step by calling the `clone_step` utility to use it twice
-# in our pipeline: on the training set and on the validation set.
-# This is necessary because a step cannot be used twice in the same pipeline.
-ge_validate_train_step = clone_step(
-    GreatExpectationsValidatorStep, "ge_validate_train_step_class"
-)(params=ge_validate_train_params)
-ge_validate_test_step = clone_step(
-    GreatExpectationsValidatorStep, "ge_validate_test_step_class"
-)(params=ge_validate_test_params)
+ge_validate_train_step = great_expectations_validator_step(
+    step_name="ge_validate_train_step_class", params=ge_validate_train_params
+)
+ge_validate_test_step = great_expectations_validator_step(
+    step_name="ge_validate_test_step_class", params=ge_validate_test_params
+)

--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -154,7 +154,7 @@ class Compiler:
         Raises:
             PipelineInterfaceError: If multiple steps share the same name.
         """
-        step_names = {}
+        step_names: Dict[str, str] = {}
 
         for step_argument_name, step in pipeline.steps.items():
             previous_argument_name = step_names.get(step.name, None)

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -39,6 +39,7 @@ class ArtifactConfiguration(PartialArtifactConfiguration):
 class StepConfigurationUpdate(StrictBaseModel):
     """Class for step configuration updates."""
 
+    name: Optional[str] = None
     enable_cache: Optional[bool] = None
     step_operator: Optional[str] = None
     experiment_tracker: Optional[str] = None

--- a/src/zenml/integrations/deepchecks/steps/deepchecks_data_drift.py
+++ b/src/zenml/integrations/deepchecks/steps/deepchecks_data_drift.py
@@ -27,7 +27,6 @@ from zenml.integrations.deepchecks.validation_checks import (
 )
 from zenml.steps import BaseParameters
 from zenml.steps.base_step import BaseStep
-from zenml.steps.utils import clone_step
 
 
 class DeepchecksDataDriftCheckStepParameters(BaseParameters):
@@ -105,4 +104,4 @@ def deepchecks_data_drift_check_step(
     Returns:
         a DeepchecksDataDriftCheckStep step instance
     """
-    return clone_step(DeepchecksDataDriftCheckStep, step_name)(params=params)
+    return DeepchecksDataDriftCheckStep(name=step_name, params=params)

--- a/src/zenml/integrations/deepchecks/steps/deepchecks_data_integrity.py
+++ b/src/zenml/integrations/deepchecks/steps/deepchecks_data_integrity.py
@@ -27,7 +27,6 @@ from zenml.integrations.deepchecks.validation_checks import (
 )
 from zenml.steps import BaseParameters
 from zenml.steps.base_step import BaseStep
-from zenml.steps.utils import clone_step
 
 
 class DeepchecksDataIntegrityCheckStepParameters(BaseParameters):
@@ -102,6 +101,4 @@ def deepchecks_data_integrity_check_step(
     Returns:
         a DeepchecksDataIntegrityCheckStep step instance
     """
-    return clone_step(DeepchecksDataIntegrityCheckStep, step_name)(
-        params=params
-    )
+    return DeepchecksDataIntegrityCheckStep(name=step_name, params=params)

--- a/src/zenml/integrations/deepchecks/steps/deepchecks_model_drift.py
+++ b/src/zenml/integrations/deepchecks/steps/deepchecks_model_drift.py
@@ -27,7 +27,6 @@ from zenml.integrations.deepchecks.validation_checks import (
     DeepchecksModelDriftCheck,
 )
 from zenml.steps import BaseParameters, BaseStep
-from zenml.steps.utils import clone_step
 
 
 class DeepchecksModelDriftCheckStepParameters(BaseParameters):
@@ -109,4 +108,4 @@ def deepchecks_model_drift_check_step(
     Returns:
         a DeepchecksModelDriftCheckStep step instance
     """
-    return clone_step(DeepchecksModelDriftCheckStep, step_name)(params=params)
+    return DeepchecksModelDriftCheckStep(name=step_name, params=params)

--- a/src/zenml/integrations/deepchecks/steps/deepchecks_model_validation.py
+++ b/src/zenml/integrations/deepchecks/steps/deepchecks_model_validation.py
@@ -27,7 +27,6 @@ from zenml.integrations.deepchecks.validation_checks import (
     DeepchecksModelValidationCheck,
 )
 from zenml.steps import BaseParameters, BaseStep
-from zenml.steps.utils import clone_step
 
 
 class DeepchecksModelValidationCheckStepParameters(BaseParameters):
@@ -106,6 +105,4 @@ def deepchecks_model_validation_check_step(
     Returns:
         a DeepchecksModelValidationCheckStep step instance
     """
-    return clone_step(DeepchecksModelValidationCheckStep, step_name)(
-        params=params
-    )
+    return DeepchecksModelValidationCheckStep(name=step_name, params=params)

--- a/src/zenml/integrations/evidently/steps/evidently_profile.py
+++ b/src/zenml/integrations/evidently/steps/evidently_profile.py
@@ -30,7 +30,6 @@ from zenml.steps.step_interfaces.base_drift_detection_step import (
     BaseDriftDetectionParameters,
     BaseDriftDetectionStep,
 )
-from zenml.steps.utils import clone_step
 
 
 class EvidentlyColumnMapping(BaseModel):
@@ -214,4 +213,4 @@ def evidently_profile_step(
     Returns:
         a EvidentlyProfileStep step instance
     """
-    return clone_step(EvidentlyProfileStep, step_name)(params=params)
+    return EvidentlyProfileStep(name=step_name, params=params)

--- a/src/zenml/integrations/great_expectations/steps/ge_profiler.py
+++ b/src/zenml/integrations/great_expectations/steps/ge_profiler.py
@@ -24,7 +24,6 @@ from zenml.integrations.great_expectations.data_validators.ge_data_validator imp
 )
 from zenml.logger import get_logger
 from zenml.steps import BaseParameters, BaseStep
-from zenml.steps.utils import clone_step
 
 logger = get_logger(__name__)
 
@@ -99,4 +98,4 @@ def great_expectations_profiler_step(
     Returns:
         a GreatExpectationsProfilerStep step instance
     """
-    return clone_step(GreatExpectationsProfilerStep, step_name)(params=params)
+    return GreatExpectationsProfilerStep(name=step_name, params=params)

--- a/src/zenml/integrations/great_expectations/steps/ge_validator.py
+++ b/src/zenml/integrations/great_expectations/steps/ge_validator.py
@@ -24,7 +24,6 @@ from zenml.integrations.great_expectations.data_validators.ge_data_validator imp
     GreatExpectationsDataValidator,
 )
 from zenml.steps import BaseParameters, BaseStep
-from zenml.steps.utils import clone_step
 
 
 class GreatExpectationsValidatorParameters(BaseParameters):
@@ -117,4 +116,4 @@ def great_expectations_validator_step(
     Returns:
         a GreatExpectationsProfilerStep step instance
     """
-    return clone_step(GreatExpectationsValidatorStep, step_name)(params=params)
+    return GreatExpectationsValidatorStep(name=step_name, params=params)

--- a/src/zenml/integrations/whylogs/steps/whylogs_profiler.py
+++ b/src/zenml/integrations/whylogs/steps/whylogs_profiler.py
@@ -31,7 +31,6 @@ from zenml.steps.step_interfaces.base_analyzer_step import (
     BaseAnalyzerParameters,
     BaseAnalyzerStep,
 )
-from zenml.steps.utils import clone_step
 from zenml.utils import settings_utils
 
 
@@ -92,9 +91,7 @@ def whylogs_profiler_step(
     Returns:
         a WhylogsProfilerStep step instance
     """
-    step_class = clone_step(WhylogsProfilerStep, step_name)
-    step_instance = step_class(params=params)
-
+    step_instance = WhylogsProfilerStep(name=step_name, params=params)
     key = settings_utils.get_flavor_setting_key(WhylogsDataValidatorFlavor())
 
     settings = WhylogsDataValidatorSettings(

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -53,7 +53,6 @@ from zenml.logger import get_logger
 from zenml.stack import Stack
 from zenml.steps import BaseStep
 from zenml.steps.base_step import BaseStepMeta
-from zenml.steps.utils import clone_step
 from zenml.utils import (
     dashboard_utils,
     dict_utils,
@@ -186,12 +185,12 @@ class BasePipeline(metaclass=BasePipelineMeta):
         return self.__steps
 
     def configure(
-        self,
+        self: T,
         enable_cache: Optional[bool] = None,
         settings: Optional[Mapping[str, "SettingsOrDict"]] = None,
         extra: Optional[Dict[str, Any]] = None,
         merge: bool = True,
-    ) -> None:
+    ) -> T:
         """Configures the pipeline.
 
         Configuration merging example:
@@ -223,6 +222,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
         )
         config = PipelineConfigurationUpdate(**values)
         self._apply_configuration(config, merge=merge)
+        return self
 
     def _apply_class_configuration(self, options: Dict[str, Any]) -> None:
         """Applies the configurations specified on the pipeline class.
@@ -258,7 +258,7 @@ class BasePipeline(metaclass=BasePipelineMeta):
             )
 
         combined_steps = {}
-        step_classes: Dict[Type[BaseStep], str] = {}
+        step_ids: Dict[int, str] = {}
 
         def _verify_step(key: str, step: BaseStep) -> None:
             """Verifies a single step of the pipeline.
@@ -294,21 +294,21 @@ class BasePipeline(metaclass=BasePipelineMeta):
                     f"a pipeline."
                 )
 
-            if step_class in step_classes:
-                previous_key = step_classes[step_class]
+            if id(step) in step_ids:
+                previous_key = step_ids[id(step)]
                 raise PipelineInterfaceError(
-                    f"Found multiple step objects of the same class "
-                    f"(`{step_class}`) for arguments '{previous_key}' and "
-                    f"'{key}' in pipeline '{self.name}'. Only one step object "
-                    f"per class is allowed inside a ZenML pipeline. A possible "
-                    f"solution is to use the "
-                    f"{clone_step.__module__}.{clone_step.__name__} utility to "
-                    f"create multiple copies of the same step."
+                    f"Found the same step object for arguments "
+                    f"'{previous_key}' and '{key}' in pipeline '{self.name}'. "
+                    "Step object cannot be reused inside a ZenML pipeline. "
+                    "A possible solution is to create two instances of the "
+                    "same step class and assigning them different names: "
+                    "`first_instance = step_class(name='s1')` and "
+                    "`second_instance = step_class(name='s2')`."
                 )
 
             step.pipeline_parameter_name = key
+            step_ids[id(step)] = key
             combined_steps[key] = step
-            step_classes[step_class] = key
 
         # verify args
         for i, step in enumerate(steps):

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -212,6 +212,9 @@ class BasePipeline(metaclass=BasePipelineMeta):
                 configurations. If `False` the given configurations will
                 overwrite all existing ones. See the general description of this
                 method for an example.
+
+        Returns:
+            The pipeline instance that this method was called on.
         """
         values = dict_utils.remove_none_values(
             {

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -781,6 +781,9 @@ class BaseStep(metaclass=BaseStepMeta):
                 overwrite all existing ones. See the general description of this
                 method for an example.
 
+        Returns:
+            The step instance that this method was called on.
+
         Raises:
             StepInterfaceError: If a materializer or artifact for a non-existent
                 output name are configured.

--- a/src/zenml/steps/step_decorator.py
+++ b/src/zenml/steps/step_decorator.py
@@ -36,6 +36,7 @@ from zenml.steps.utils import (
     PARAM_OUTPUT_ARTIFACTS,
     PARAM_OUTPUT_MATERIALIZERS,
     PARAM_SETTINGS,
+    PARAM_STEP_NAME,
     PARAM_STEP_OPERATOR,
     STEP_INNER_FUNC_NAME,
 )
@@ -130,14 +131,13 @@ def step(
         Returns:
             The class of a newly generated ZenML Step.
         """
-        step_name = name or func.__name__
-
         return type(  # noqa
-            step_name,
+            func.__name__,
             (BaseStep,),
             {
                 STEP_INNER_FUNC_NAME: staticmethod(func),
                 INSTANCE_CONFIGURATION: {
+                    PARAM_STEP_NAME: name,
                     PARAM_CREATED_BY_FUNCTIONAL_API: True,
                     PARAM_ENABLE_CACHE: enable_cache,
                     PARAM_EXPERIMENT_TRACKER: experiment_tracker,

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -40,7 +40,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    cast,
 )
 
 import pydantic
@@ -521,72 +520,3 @@ class _ZenMLStepExecutor(BaseExecutor):
         )
         with fileio.open(self._context.executor_output_uri, "wb") as f:
             f.write(executor_output.SerializeToString())
-
-
-def clone_step(step: Type["BaseStep"], step_name: str) -> Type["BaseStep"]:
-    """Returns a clone of the given step.
-
-    Call this function when you want to use several copies of the same step
-    in a pipeline.
-
-    Args:
-        step: the step to clone
-        step_name: name to use for the cloned step. This name will be used
-            to uniquely identify the cloned step in the Python module from
-            which this function is called.
-
-    Returns:
-        A clone of the given step.
-
-    Raises:
-        TypeError: if the given step is not a subclass of BaseStep.
-        ImportError: if the the calling Python module cannot be determined
-            or if the given step name cannot be used because the calling
-            Python module already contains a symbol with the same name.
-    """
-    from zenml.steps.base_step import BaseStep
-
-    if not issubclass(step, BaseStep):
-        raise TypeError(
-            f"The step source `{step}` is not a `{BaseStep}` subclass."
-        )
-
-    # get the python module from which this function is called
-    frm = inspect.stack()[1]
-    mod = inspect.getmodule(frm[0])
-
-    if not mod:
-        raise ImportError(
-            f"Cannot clone step `{step}` because the calling Python module "
-            f"cannot be determined."
-        )
-
-    if step_name in mod.__dict__:
-        raise ImportError(
-            f"The step name `{step_name}` cannot be used because the "
-            f"`{mod.__name__}` Python module already contains an identifier "
-            f"with the same name. Try using a different step name."
-        )
-
-    config = getattr(step, INSTANCE_CONFIGURATION, {}).copy()
-    # mark the step as being created by the functional API,
-    # otherwise the base class will try to use the class source code
-    # to compute the hash for the cache key (instead of the entrypoint
-    # source code)
-    config[PARAM_CREATED_BY_FUNCTIONAL_API] = True
-
-    step_clone = cast(
-        Type[BaseStep],
-        type(  # noqa
-            step_name,
-            (step,),
-            {
-                INSTANCE_CONFIGURATION: config,
-                "__module__": mod.__name__,
-                "__doc__": step.__doc__,
-            },
-        ),
-    )
-
-    mod.__dict__[step_name] = step_clone
-    return step_clone

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -72,7 +72,7 @@ logger = get_logger(__name__)
 
 STEP_INNER_FUNC_NAME = "entrypoint"
 SINGLE_RETURN_OUT_NAME = "output"
-PARAM_STEP_NAME = "step_name"
+PARAM_STEP_NAME = "name"
 PARAM_ENABLE_CACHE = "enable_cache"
 PARAM_PIPELINE_PARAMETER_NAME = "pipeline_parameter_name"
 PARAM_CREATED_BY_FUNCTIONAL_API = "created_by_functional_api"

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -127,8 +127,9 @@ def test_initialize_pipeline_with_repeated_args(
 ):
     """Test that pipeline initialization fails when same step
     object is used"""
+    step_instance = empty_step()
     with pytest.raises(PipelineInterfaceError):
-        unconnected_two_step_pipeline(empty_step(), empty_step())
+        unconnected_two_step_pipeline(step_instance, step_instance)
 
 
 def test_initialize_pipeline_with_repeated_kwargs(
@@ -136,8 +137,11 @@ def test_initialize_pipeline_with_repeated_kwargs(
 ):
     """Test that pipeline initialization fails when same step
     object is used"""
+    step_instance = empty_step()
     with pytest.raises(PipelineInterfaceError):
-        unconnected_two_step_pipeline(step_1=empty_step(), step_2=empty_step())
+        unconnected_two_step_pipeline(
+            step_1=step_instance, step_2=step_instance
+        )
 
 
 def test_initialize_pipeline_with_repeated_args_and_kwargs(
@@ -145,8 +149,9 @@ def test_initialize_pipeline_with_repeated_args_and_kwargs(
 ):
     """Test that pipeline initialization fails when same step
     object is used"""
+    step_instance = empty_step()
     with pytest.raises(PipelineInterfaceError):
-        unconnected_two_step_pipeline(empty_step(), step_2=empty_step())
+        unconnected_two_step_pipeline(step_instance, step_2=step_instance)
 
 
 def test_initialize_pipeline_with_wrong_arg_type(


### PR DESCRIPTION
## Describe changes
This PR allows using the same step class multiple time as long as as the step instances have different names.
This allows us to remove the `clone_step` function which was causing troubles in notebooks as well as containerized executions under certain conditions.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

