### PR TITLE
Add Tolerations and NodeAffinity to Kubernetes executor

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1417,6 +1417,7 @@ tokenize
 tokenized
 tokenizer
 tokenizers
+tolerations
 tolist
 topdown
 torch-model-archiver

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,8 +129,8 @@ Optionally, you might want to run the following commands to ensure you have all
 integrations for `mypy` checks:
 
 ```
-zenml integration install -f
-zenml integration install -y -i feast
+poetry run zenml integration install -f
+poetry run zenml integration install -y -i feast
 pip install click~=8.0.3
 mypy --install-types
 ```

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -21,8 +21,8 @@ COPY src src
 RUN mkdir -p .zenconfig/local_stores/default_zen_store
 
 ENV ZENML_CONFIG_PATH=/zenml/.zenconfig \
-    ZENML_DEBUG=true \
+    ZENML_DEBUG=false \
     ZENML_ANALYTICS_OPT_IN=false
 
-ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "debug"]
+ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "info"]
 CMD ["--proxy-headers", "--port", "80", "--host",  "0.0.0.0"]

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -21,8 +21,8 @@ COPY src src
 RUN mkdir -p .zenconfig/local_stores/default_zen_store
 
 ENV ZENML_CONFIG_PATH=/zenml/.zenconfig \
-    ZENML_DEBUG=false \
+    ZENML_DEBUG=true \
     ZENML_ANALYTICS_OPT_IN=false
 
-ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "info"]
+ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "debug"]
 CMD ["--proxy-headers", "--port", "80", "--host",  "0.0.0.0"]

--- a/docs/book/component-gallery/orchestrators/kubernetes.md
+++ b/docs/book/component-gallery/orchestrators/kubernetes.md
@@ -73,16 +73,32 @@ For additional configuration of the Kubernetes orchestrator, you can pass
 from zenml.integrations.kubernetes.flavors import KubernetesOrchestratorSettings
 
 kubernetes_settings = KubernetesOrchestratorSettings(
-    node_affinity=[{
-        "key": "node.kubernetes.io/name",
-        "operator": "In",
-        "values": ['my_powerful_node_group']
-        }],
-    tolerations=[{"key": "node.kubernetes.io/name",
-                  "operator": "Exists",
-                  "value": "training",
-                  "effect": "NoSchedule"
-      }])
+    affinity={
+        "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    {
+                        "matchExpressions": [
+                            {
+                                "key": "node.kubernetes.io/name",
+                                "operator": "In",
+                                "values": ["my_powerful_node_group"],
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    tolerations=[
+        {
+            "key": "node.kubernetes.io/name",
+            "operator": "Exists",
+            "value": "",
+            "effect": "NoSchedule",
+        }
+    ],
+)
 
 @pipeline(
     settings={

--- a/docs/book/component-gallery/orchestrators/kubernetes.md
+++ b/docs/book/component-gallery/orchestrators/kubernetes.md
@@ -66,8 +66,8 @@ python file_that_runs_a_zenml_pipeline.py
 For additional configuration of the Kubernetes orchestrator, you can pass
 `KubernetesOrchestratorSettings` which allows you to configure the following attributes:
 
-* `node_affinity`: NodeAffinity match expressions.
-* `tolerations`: Toleration settings for the pod.
+* `affinity`: Affinity constraints (`spec.affinity`) that can be defined to a pod.
+* `tolerations`: Toleration (`spec.tolerations`) so the pod can be scheduled.
 
 ```python
 from zenml.integrations.kubernetes.flavors import KubernetesOrchestratorSettings

--- a/docs/book/component-gallery/orchestrators/kubernetes.md
+++ b/docs/book/component-gallery/orchestrators/kubernetes.md
@@ -63,6 +63,35 @@ You can now run any ZenML pipeline using the Kubernetes orchestrator:
 python file_that_runs_a_zenml_pipeline.py
 ```
 
+For additional configuration of the Kubernetes orchestrator, you can pass
+`KubernetesOrchestratorSettings` which allows you to configure the following attributes:
+
+* `node_affinity`: NodeAffinity match expressions.
+* `tolerations`: Toleration settings for the pod.
+
+```python
+from zenml.integrations.kubernetes.flavors import KubernetesOrchestratorSettings
+
+kubernetes_settings = KubernetesOrchestratorSettings(
+    node_affinity=[{
+        "key": "node.kubernetes.io/name",
+        "operator": "In",
+        "values": ['my_powerful_node_group']
+        }],
+    tolerations=[{"key": "node.kubernetes.io/name",
+                  "operator": "Exists",
+                  "value": "training",
+                  "effect": "NoSchedule"
+      }])
+
+@pipeline(
+    settings={
+        "orchestrator.kubernetes": kubernetes_settings
+    }
+)
+  ...
+```
+
 A concrete example of using the Kubernetes orchestrator can be found 
 [here](https://github.com/zenml-io/zenml/tree/main/examples/kubernetes_orchestration).
 

--- a/src/zenml/integrations/kubernetes/flavors/__init__.py
+++ b/src/zenml/integrations/kubernetes/flavors/__init__.py
@@ -16,9 +16,11 @@
 from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import (
     KubernetesOrchestratorConfig,
     KubernetesOrchestratorFlavor,
+    KubernetesOrchestratorSettings,
 )
 
 __all__ = [
     "KubernetesOrchestratorFlavor",
     "KubernetesOrchestratorConfig",
+    "KubernetesOrchestratorSettings",
 ]

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -13,8 +13,9 @@
 #  permissions and limitations under the License.
 """Kubernetes orchestrator flavor."""
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
 
+from zenml.config.base_settings import BaseSettings
 from zenml.integrations.kubernetes import KUBERNETES_ORCHESTRATOR_FLAVOR
 from zenml.orchestrators import BaseOrchestratorConfig, BaseOrchestratorFlavor
 
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
     from zenml.integrations.kubernetes.orchestrators import (
         KubernetesOrchestrator,
     )
+
+
+class KubernetesOrchestratorSettings(BaseSettings):
+    """Settings for the Kubernetes orchestrator.
+
+    Attributes:
+        node_selectors: Node selectors to apply to Kubernetes pods.
+        node_affinity: Node affinities to apply to Kubernetes pods.
+    """
+
+    tolerations: List[Dict[str, str]] = []
+    node_affinity: List[Dict[str, Union[str, List[str]]]] = []
 
 
 class KubernetesOrchestratorConfig(BaseOrchestratorConfig):

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -29,7 +29,7 @@ class KubernetesOrchestratorSettings(BaseSettings):
     """Settings for the Kubernetes orchestrator.
 
     Attributes:
-        node_selectors: Node selectors to apply to Kubernetes pods.
+        tolerations: Tolerations to apply to Kubernetes pods.
         node_affinity: Node affinities to apply to Kubernetes pods.
     """
 

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Kubernetes orchestrator flavor."""
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.kubernetes import KUBERNETES_ORCHESTRATOR_FLAVOR
@@ -30,11 +30,11 @@ class KubernetesOrchestratorSettings(BaseSettings):
 
     Attributes:
         tolerations: Tolerations to apply to Kubernetes pods.
-        node_affinity: Node affinities to apply to Kubernetes pods.
+        affinity: Pod affinity(s) to apply to Kubernetes pods.
     """
 
     tolerations: List[Dict[str, str]] = []
-    node_affinity: List[Dict[str, Union[str, List[str]]]] = []
+    affinity: Dict[str, Dict[str, Any]] = {}
 
 
 class KubernetesOrchestratorConfig(BaseOrchestratorConfig):

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -30,16 +30,18 @@
 # inspired by the Kubernetes dag runner implementation of tfx
 """Kubernetes-native orchestrator."""
 
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, cast
 
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 
+from zenml.config.base_settings import BaseSettings
 from zenml.constants import ORCHESTRATOR_DOCKER_IMAGE_KEY
 from zenml.enums import StackComponentType
 from zenml.environment import Environment
 from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import (
     KubernetesOrchestratorConfig,
+    KubernetesOrchestratorSettings,
 )
 from zenml.integrations.kubernetes.orchestrators import kube_utils
 from zenml.integrations.kubernetes.orchestrators.kubernetes_orchestrator_entrypoint_configuration import (
@@ -95,6 +97,15 @@ class KubernetesOrchestrator(BaseOrchestrator):
             The configuration.
         """
         return cast(KubernetesOrchestratorConfig, self._config)
+
+    @property
+    def settings_class(self) -> Optional[Type["BaseSettings"]]:
+        """Settings class for the Kubernetes orchestrator.
+
+        Returns:
+            The settings class.
+        """
+        return KubernetesOrchestratorSettings
 
     def get_kubernetes_contexts(self) -> Tuple[List[str], str]:
         """Get list of configured Kubernetes contexts and the active context.
@@ -244,7 +255,13 @@ class KubernetesOrchestrator(BaseOrchestrator):
                 "orchestrator."
             )
 
+        settings = None
         for step in deployment.steps.values():
+            # Gets Settings from any step since they are shared.
+            settings = cast(
+                Optional[KubernetesOrchestratorSettings],
+                self.get_settings(step),
+            )
             if self.requires_resources_in_orchestration_environment(step):
                 logger.warning(
                     "Specifying step resources is not yet supported for "
@@ -298,6 +315,7 @@ class KubernetesOrchestrator(BaseOrchestrator):
                 command=command,
                 args=args,
                 service_account_name=service_account_name,
+                settings=settings,
             )
             self._k8s_batch_api.create_namespaced_cron_job(
                 body=cron_job_manifest,
@@ -318,6 +336,7 @@ class KubernetesOrchestrator(BaseOrchestrator):
             command=command,
             args=args,
             service_account_name=service_account_name,
+            settings=settings,
         )
         self._k8s_core_api.create_namespaced_pod(
             namespace=self.config.kubernetes_namespace,

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -284,7 +284,7 @@ class KubernetesOrchestrator(BaseOrchestrator):
 
         settings = cast(
             Optional[KubernetesOrchestratorSettings],
-            deployment.pipeline.settings.get("orchestrator.kubernetes"),
+            self.get_settings(deployment),
         )
 
         # Authorize pod to run Kubernetes commands inside the cluster.

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -255,13 +255,7 @@ class KubernetesOrchestrator(BaseOrchestrator):
                 "orchestrator."
             )
 
-        settings = None
         for step in deployment.steps.values():
-            # Gets Settings from any step since they are shared.
-            settings = cast(
-                Optional[KubernetesOrchestratorSettings],
-                self.get_settings(step),
-            )
             if self.requires_resources_in_orchestration_environment(step):
                 logger.warning(
                     "Specifying step resources is not yet supported for "
@@ -286,6 +280,11 @@ class KubernetesOrchestrator(BaseOrchestrator):
             run_name=run_name,
             image_name=image_name,
             kubernetes_namespace=self.config.kubernetes_namespace,
+        )
+
+        settings = cast(
+            Optional[KubernetesOrchestratorSettings],
+            deployment.pipeline.settings.get("orchestrator.kubernetes"),
         )
 
         # Authorize pod to run Kubernetes commands inside the cluster.

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -99,7 +99,9 @@ def main() -> None:
 
     settings = cast(
         Optional[KubernetesOrchestratorSettings],
-        deployment_config.pipeline.settings.get("orchestrator.kubernetes"),
+        KubernetesOrchestratorSettings.parse_obj(
+            deployment_config.pipeline.settings.get("orchestrator.kubernetes")
+        ),
     )
 
     pipeline_dag = {}

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -41,7 +41,7 @@ def build_pod_manifest(
         service_account_name: Optional name of a service account.
             Can be used to assign certain roles to a pod, e.g., to allow it to
             run Kubernetes commands from within the cluster.
-        settings: KubernetesOrchestratorSettings object
+        settings: `KubernetesOrchestratorSettings` object
 
     Returns:
         Pod manifest.
@@ -84,52 +84,25 @@ def build_pod_manifest(
     return manifest
 
 
-def add_pod_settings(settings):
+def add_pod_settings(
+    settings: KubernetesOrchestratorSettings,
+) -> Dict[str, Any]:
+    """Updates `spec` fields in pod if passed in orchestrator settings.
+
+    Args:
+        settings: `KubernetesOrchestratorSettings` object
+
+    Returns:
+        Dictionary with additional fields for the pod
+    """
     spec = {}
-    if settings.node_affinity:
-        spec["affinity"] = add_pod_affinity(settings.node_affinity)
+    if settings.affinity:
+        spec["affinity"] = settings.affinity
 
     if settings.tolerations:
-        spec["tolerations"] = add_pod_tolerations(settings.tolerations)
+        spec["tolerations"] = settings.tolerations
 
     return spec
-
-
-def add_pod_tolerations(toleration_settings):
-    tolerations = []
-    for toleration_values in toleration_settings:
-        tolerations.append(
-            dict(
-                key=toleration_values.get("key"),
-                operator=toleration_values.get("operator"),
-                value=""
-                if toleration_values.get("operator") == "Exists"
-                else toleration_values.get("value"),
-                effect=toleration_values.get("effect"),
-            )
-        )
-    return tolerations
-
-
-def add_pod_affinity(affinity_settings):
-    match_expressions = []
-    for affinity_values in affinity_settings:
-        match_expressions.append(
-            dict(
-                key=affinity_values.get("key"),
-                operator=affinity_values.get("operator"),
-                values=affinity_values.get("values"),
-            )
-        )
-
-    affinity = {
-        "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [{"matchExpressions": match_expressions}]
-            }
-        }
-    }
-    return affinity
 
 
 def build_cron_job_manifest(

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Utility functions for building manifests for k8s pods."""
 
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from zenml.constants import ENV_ZENML_ENABLE_REPO_INIT_WARNINGS
 from zenml.integrations.kubernetes.flavors import KubernetesOrchestratorSettings
@@ -86,7 +86,7 @@ def build_pod_manifest(
 
 def add_pod_settings(
     settings: KubernetesOrchestratorSettings,
-) -> Dict[str, Any]:
+) -> Dict[str, Union[Any, List]]:
     """Updates `spec` fields in pod if passed in orchestrator settings.
 
     Args:
@@ -129,7 +129,7 @@ def build_cron_job_manifest(
         service_account_name: Optional name of a service account.
             Can be used to assign certain roles to a pod, e.g., to allow it to
             run Kubernetes commands from within the cluster.
-        settings: KubernetesOrchestratorSettings object
+        settings: `KubernetesOrchestratorSettings` object
 
     Returns:
         CRON job manifest.


### PR DESCRIPTION
## Describe changes
I implemented a `KubernetesOrchestratorSettings` to allow pods to use Node Affinity and Tolerations in order to choose the right nodes to run on.

> However, the `settings` will only be available for the first `step`. It won't update the manifest on subsequent `steps`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

