### PR TITLE
Fix GCP Artifact Store listdir empty path

### DIFF
--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -179,6 +179,9 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         return [
             _extract_basename(dict_)
             for dict_ in self.filesystem.listdir(path=path)
+            # gcsfs.listdir also returns the root directory, so we filter
+            # it out here
+            if _extract_basename(dict_)
         ]
 
     def makedirs(self, path: PathType) -> None:


### PR DESCRIPTION
## Describe changes
GCP listdir function returns an empty path, which causes an infinite loop! this fix adds a condition to the process to ignore that.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

