### PR TITLE
Delay user instruction in dockerfile generation

### DIFF
--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -138,10 +138,9 @@ class DockerSettings(BaseSettings):
             image. If this is set to `False`, ZenML will not copy this
             configuration and you're responsible for making sure ZenML can
             access the ZenStore in the Docker image.
-        user: If not `None`, will use the USER instruction to set the username and
-            run the commands of the dockerfile as `user` instead of root.
-            Specifically,  the specified user is used for RUN instructions
-            and at runtime, runs the relevant ENTRYPOINT and CMD commands.
+        user: If not `None`, will set the user, make it owner of the `/app`
+            directory which contains all the user code and run the container
+            entrypoint as this user.
     """
 
     LEVEL = ConfigurationLevel.PIPELINE

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -224,7 +224,9 @@ def disable_logging(log_level: int) -> Iterator[None]:
         logging.disable(old_level)
 
 
-def get_apidocs_link(docs_section: str, caller_path: str, core: bool = True) -> str:
+def get_apidocs_link(
+    docs_section: str, caller_path: str, core: bool = True
+) -> str:
     """Get link to api_docs of the caller.
 
     Args:

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -444,9 +444,6 @@ class PipelineDockerImageBuilder:
         """
         lines = [f"FROM {parent_image}", f"WORKDIR {DOCKER_IMAGE_WORKDIR}"]
 
-        if docker_settings.user:
-            lines.append(f"USER {docker_settings.user}")
-
         if docker_settings.copy_global_config:
             lines.append(
                 f"ENV {ENV_ZENML_CONFIG_PATH}={DOCKER_IMAGE_ZENML_CONFIG_PATH}"
@@ -473,6 +470,10 @@ class PipelineDockerImageBuilder:
             lines.append(f"COPY {DOCKER_IMAGE_ZENML_CONFIG_DIR} .")
 
         lines.append("RUN chmod -R a+rw .")
+
+        if docker_settings.user:
+            lines.append(f"USER {docker_settings.user}")
+            lines.append(f"RUN chown -R {docker_settings.user} .")
 
         if entrypoint:
             lines.append(f"ENTRYPOINT {entrypoint}")


### PR DESCRIPTION
## Describe changes
This PR delays the `USER` instructions when generating dockerfiles and makes sure the specified user is the owner of the directory.

Adding the `USER` instruction early leads to some permission issues when installing pip packages on a system level. 
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

