### PR TITLE
Minor fixes in Migration to 0.20.0 documentation

### DIFF
--- a/docs/book/guidelines/migration-zero-twenty.md
+++ b/docs/book/guidelines/migration-zero-twenty.md
@@ -593,7 +593,7 @@ The Post-execution workflow has changed as follows:
 
 - The `get_pipelines` and `get_pipeline` methods have been moved out of the `Repository` (i.e. the new `Client` ) class and lie directly in the post_execution module now. To use the user has to do:
 
-```bash
+```python
 from zenml.post_execution import get_pipelines, get_pipeline
 ```
 

--- a/docs/book/guidelines/migration-zero-twenty.md
+++ b/docs/book/guidelines/migration-zero-twenty.md
@@ -499,10 +499,10 @@ With the above changes, we are deprecating the much-loved `enable_xxx` decorator
 
 ```python
 @step(
-    experiment_tracker="mlflow_stack_comp_name"  # name of registered component
+    experiment_tracker="mlflow_stack_comp_name",  # name of registered component
     settings={  # settings of registered component
         "experiment_tracker.mlflow": {  # this is `category`.`flavor`, so another example is `step_operator.spark`
-            "experiment_name": "name"
+            "experiment_name": "name",
             "nested": False
         }
     }


### PR DESCRIPTION
## Describe changes

While I was going through the documentation for migrating from `zenml` 0.13.0 to 0.20.0 at https://docs.zenml.io/guidelines/migration-zero-twenty, I found that commas were missing in the code in **Deprecating the `enable_xxx` decorators** section, so I've included those so that anyone can just copy-paste that code and make it work without having to manually add the missing commas. Also, the syntax highlighting has been checked and updated when applicable, from `bash` to `python` when the code was written in Python.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above) -> Documentation update

