### PR TITLE
Add executing custom command for getting requirements

### DIFF
--- a/docs/book/advanced-guide/pipelines/containerization.md
+++ b/docs/book/advanced-guide/pipelines/containerization.md
@@ -122,6 +122,22 @@ package manager to get a list of your local packages):
     def my_pipeline(...):
         ...
     ```
+
+    If required, a custom command can be provided. This command has to output a list of requirements
+    following the format of the [requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/):
+
+    ```python
+    docker_settings = DockerSettings(replicate_local_python_environment=[
+        "poetry",
+        "export",
+        "--extras=train",
+        "--format=requirements.txt"
+    ])
+
+    @pipeline(settings={"docker": docker_settings})
+    def my_pipeline(...):
+        ...
+    ```
 * Specify a list of pip requirements in code:
     ```python
     docker_settings = DockerSettings(requirements=["torch==1.12.0", "torchvision"])

--- a/docs/book/legacy/developer-guide/advanced-usage/docker.md
+++ b/docs/book/legacy/developer-guide/advanced-usage/docker.md
@@ -114,6 +114,21 @@ package manager to get a list of your local packages):
     def my_pipeline(...):
         ...
     ```
+    If required, a custom command can be provided. This command has to output a list of requirements
+    following the format of the [requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/):
+
+    ```python
+    docker_settings = DockerSettings(replicate_local_python_environment=[
+        "poetry",
+        "export",
+        "--extras=train",
+        "--format=requirements.txt"
+    ])
+
+    @pipeline(settings={"docker": docker_settings})
+    def my_pipeline(...):
+        ...
+    ```
 * Specify a list of pip requirements in code:
     ```python
     docker_config = DockerConfiguration(requirements=["torch==1.12.0", "torchvision"])

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -154,7 +154,7 @@ class DockerSettings(BaseSettings):
     target_repository: str = "zenml"
 
     replicate_local_python_environment: Optional[
-        PythonEnvironmentExportMethod
+        Union[List[str], PythonEnvironmentExportMethod]
     ] = None
     requirements: Union[None, str, List[str]] = None
     required_integrations: List[str] = []

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -361,7 +361,9 @@ class PipelineDockerImageBuilder:
                     docker_settings.replicate_local_python_environment.command
                 )
             else:
-                command = " ".join(docker_settings.replicate_local_python_environment)
+                command = " ".join(
+                    docker_settings.replicate_local_python_environment
+                )
 
             try:
                 local_requirements = subprocess.check_output(

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -353,7 +353,6 @@ class PipelineDockerImageBuilder:
 
         # Generate requirements file for the local environment if configured
         if docker_settings.replicate_local_python_environment:
-            command: List[str]
             if isinstance(
                 docker_settings.replicate_local_python_environment,
                 PythonEnvironmentExportMethod,

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence, Tuple
 
 import zenml
 from zenml.config import DockerSettings
+from zenml.config.docker_settings import PythonEnvironmentExportMethod
 from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import (
     DOCKER_IMAGE_DEPLOYMENT_CONFIG_FILE,
@@ -352,10 +353,20 @@ class PipelineDockerImageBuilder:
 
         # Generate requirements file for the local environment if configured
         if docker_settings.replicate_local_python_environment:
+            command: List[str]
+            if isinstance(
+                docker_settings.replicate_local_python_environment,
+                PythonEnvironmentExportMethod,
+            ):
+                command = (
+                    docker_settings.replicate_local_python_environment.command
+                )
+            else:
+                command = " ".join(docker_settings.replicate_local_python_environment)
+
             try:
                 local_requirements = subprocess.check_output(
-                    docker_settings.replicate_local_python_environment.command,
-                    shell=True,
+                    command, shell=True
                 ).decode()
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(


### PR DESCRIPTION
## Describe changes
I have modified `DockerSettings.replicate_local_python_environment`, so a custom command can be provided too (e.g. `["poetry", "export", "--extras=train", "--format=requirements.txt"]`) as discussed with @schustmi in Slack channel.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

