### PR TITLE
Fixing broken links in docs

### DIFF
--- a/docs/book/advanced-guide/pipelines/containerization.md
+++ b/docs/book/advanced-guide/pipelines/containerization.md
@@ -7,8 +7,8 @@ use the `BaseSettings` concept to configure ZenML in various ways. In this guide
 one particular sub-class of `BaseSettings` which is of particular important: `DockerSettings`. Here is why it is important.
 
 When running locally, ZenML will execute the steps of your pipeline in the
-active Python environment. When using remote [orchestrators](../../mlops-stacks/orchestrators/orchestrators.md)
-or [step operators](../../mlops-stacks/step-operators/step-operators.md) instead,
+active Python environment. When using remote [orchestrators](../../component-gallery/orchestrators/orchestrators.md)
+or [step operators](../../component-gallery/step-operators/step-operators.md) instead,
 ZenML builds [Docker](https://www.docker.com/) images to transport and
 run your pipeline code in an isolated and well-defined environment.
 For this purpose, a [Dockerfile](https://docs.docker.com/engine/reference/builder/) is dynamically generated and used
@@ -18,7 +18,7 @@ the following steps:
 * Starts from a parent image which needs to have ZenML installed. By default, this will use the [official ZenML image](https://hub.docker.com/r/zenmldocker/zenml/) for the Python and ZenML version that you're using in the active Python environment. If you want to use a different image as the base for the following steps, check out [this guide](#using-a-custom-parent-image).
 * **Installs additional pip dependencies**. ZenML will automatically detect which integrations are used in your stack and install the required dependencies.
 If your pipeline needs any additional requirements, check out our [guide on including custom dependencies](#how-to-install-additional-pip-dependencies).
-* **Copies your global configuration**. This is needed so that ZenML can connect to your [deployed ZenML instance](../deploying-zenml/deployment.md) to fetch the active stack and other required information.
+* **Copies your global configuration**. This is needed so that ZenML can connect to your [deployed ZenML instance](../../getting-started/deploying-zenml/deploying-zenml.md) to fetch the active stack and other required information.
 * **Copies your source files**. These files need to be included in the Docker image so ZenML can execute your step code. Check out [this section](#which-files-get-included) for more information on which files get included by default and how to exclude files.
 * **Sets user-defined environment variables.**
 
@@ -51,7 +51,7 @@ from zenml.config import DockerSettings
 
 ZenML will try to determine the root directory of your source files in the following order:
 * If you've created a 
-[ZenML repository](../stacks-repositories/repository.md)
+[ZenML repository](../../starter-guide/stacks/stacks.md)
 for your project, the repository directory will be used.
 * Otherwise, the parent directory of the python file you're executing will be the source root.
 For example, running `python /path/to/file.py`, the source root would be `/path/to`.
@@ -138,7 +138,7 @@ package manager to get a list of your local packages):
     def my_pipeline(...):
         ...
     ```
-* Specify a list of [ZenML integrations](../../mlops-stacks/integrations.md) that you're using in your pipeline:
+* Specify a list of [ZenML integrations](../../component-gallery/integrations.md) that you're using in your pipeline:
     ```python
     from zenml.integrations.constants import PYTORCH, EVIDENTLY
 
@@ -166,8 +166,8 @@ package manager to get a list of your local packages):
     ```
 
 You can even combine these methods, but do make sure that your
-list of pip requirements [doesn't overlap](../../resources/best-practices.md#do-not-overlap-requiredintegrations-and-requirements)
-with the ones specified by your required integrations.
+list of pip requirements doesn't overlap with the ones specified by your required integrations.
+See our recommended [best practices](../../guidelines/best-practices.md) for more tips.
 
 Depending on all the options specified in your Docker settings, ZenML will install the requirements
 in the following order (each step optional):

--- a/docs/book/advanced-guide/pipelines/materializers.md
+++ b/docs/book/advanced-guide/pipelines/materializers.md
@@ -20,7 +20,7 @@ then deserialized and read in the next step.
 
 For most data types, ZenML already includes built-in materializers that
 automatically handle artifacts of those data types. For instance, all of the 
-examples from the [Steps and Pipelines](../steps-pipelines/steps-and-pipelines.md)
+examples from the [Steps and Pipelines](./pipelines.md)
 section were using built-in materializers under the hood to store and load 
 artifacts correctly.
 
@@ -158,7 +158,7 @@ downstream steps will use the same materializer by default.
 ### Configuring Materializers at Runtime
 
 As briefly outlined in the
-[Runtime Configuration](../steps-pipelines/settings.md#defining-materializer-source-codes)
+[Runtime Configuration](./settings.md#defining-materializer-source-codes)
 section, which materializer to use for the output of what step can also be
 configured within YAML config files.
 

--- a/docs/book/advanced-guide/practical/deploying-models.md
+++ b/docs/book/advanced-guide/practical/deploying-models.md
@@ -137,5 +137,5 @@ And with the ZenML CLI we can interact with list of served models, start, stop o
 
 {% hint style="info" %}
 To read a more detailed guide about how Model Deployers function in ZenML,
-[click here](../../component-gallery/model-deployers/).
+[click here](../../component-gallery/model-deployers/model-deployers.md).
 {% endhint %}

--- a/docs/book/advanced-guide/practical/practical-mlops.md
+++ b/docs/book/advanced-guide/practical/practical-mlops.md
@@ -19,9 +19,9 @@ into the details of the various components of a production MLOps workflow.
 
 | Practical MLOps Chapter | Corresponding ZenBytes Lesson |
 | ----------------------- | ----------------------------- |
-| [Stack Recipes](./advanced-guide/practical/stack-recipes.md) | [MLOps Stacks Repository](https://github.com/zenml-io/mlops-stacks) |
-| [Switching orchestration](./advanced-guide/practical/switching-orchestration.md) | N/A |
-|  [Secrets Management](./advanced-guide/practical/secrets-management.md) | N/A |
-| [Tracking experiments](./advanced-guide/practical/tracking-experiments.md) | [2.1 Experiment Tracking](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-1_Experiment_Tracking.ipynb) |
-| [Validating data](./advanced-guide/practical/validating-data.md) | [3.1 Data Skew](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/3-1_Data_Skew.ipynb) |
-| [Deploying models and batch inference](./advanced-guide/practical/deploying-models.md) | [2.2 Local Deployment](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-2_Local_Deployment.ipynb), [2.3 Inference Pipelines](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-3_Inference_Pipelines.ipynb) |
+| [Stack Recipes](./stack-recipes.md) | [MLOps Stacks Repository](https://github.com/zenml-io/mlops-stacks) |
+| [Switching orchestration](./switching-orchestration.md) | N/A |
+|  [Secrets Management](./secrets-management.md) | N/A |
+| [Tracking experiments](./tracking-experiments.md) | [2.1 Experiment Tracking](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-1_Experiment_Tracking.ipynb) |
+| [Validating data](./validating-data.md) | [3.1 Data Skew](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/3-1_Data_Skew.ipynb) |
+| [Deploying models and batch inference](./deploying-models.md) | [2.2 Local Deployment](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-2_Local_Deployment.ipynb), [2.3 Inference Pipelines](https://colab.research.google.com/github/zenml-io/zenbytes/blob/main/2-3_Inference_Pipelines.ipynb) |

--- a/docs/book/advanced-guide/practical/secrets-management.md
+++ b/docs/book/advanced-guide/practical/secrets-management.md
@@ -25,7 +25,7 @@ zenml annotator register label_studio_annotator \
 ## Register missing secrets for your stack
 
 When using components with secret references in your stack, you need to make sure
-that the stack contains a [secrets manager](../../mlops-stacks/secrets-managers/secrets-managers.md)
+that the stack contains a [secrets manager](../../component-gallery/secrets-managers/secrets-managers.md)
 and all the referenced secrets exist in this secrets manager. To make this process easier, you can
 use the following CLI command to interactively register all secrets for a stack:
 

--- a/docs/book/advanced-guide/practical/tracking-experiments.md
+++ b/docs/book/advanced-guide/practical/tracking-experiments.md
@@ -78,5 +78,5 @@ example](https://github.com/zenml-io/zenml/tree/main/examples/wandb_tracking).
 
 {% hint style="info" %}
 To read a more detailed guide about how Experiment Trackers function in ZenML,
-[click here](../../component-gallery/experiment-trackers).
+[click here](../../component-gallery/experiment-trackers/experiment-trackers.md).
 {% endhint %}

--- a/docs/book/advanced-guide/practical/validating-data.md
+++ b/docs/book/advanced-guide/practical/validating-data.md
@@ -80,6 +80,6 @@ be used for.
 
 {% hint style="info" %}
 To read a more detailed guide about how Data Validators function in ZenML,
-[click here](../../component-gallery/data-validators).
+[click here](../../component-gallery/data-validators/data-validators.md).
 {% endhint %}
 

--- a/docs/book/component-gallery/model-deployers/seldon.md
+++ b/docs/book/component-gallery/model-deployers/seldon.md
@@ -61,10 +61,10 @@ command line argument. This Kubernetes context needs to point to the Kubernetes
 cluster where Seldon Core model servers will be deployed. If the context is not
 explicitly supplied to the example, it defaults to using the locally active
 context. You can find more information about setup and usage of the Kubernetes
-cluster in the [ZenML Cloud Guide](../../stack-deployment-guide/overview.md)
+cluster in the [ZenML Cloud Guide](../../popular-stack-guides/overview.md).
 
 2. Seldon Core needs to be preinstalled and running in the target Kubernetes
-cluster. Check out the [official Seldon Core installation instructions](https://github.com/SeldonIO/seldon-core/tree/master/examples/auth#demo-setup)).
+cluster. Check out the [official Seldon Core installation instructions](https://github.com/SeldonIO/seldon-core/tree/master/examples/auth#demo-setup).
 
 3. models deployed with Seldon Core need to be stored in some form of
 persistent shared storage that is accessible from the Kubernetes cluster where

--- a/docs/book/getting-started/core-concepts.md
+++ b/docs/book/getting-started/core-concepts.md
@@ -104,7 +104,7 @@ The **ZenML Dashboard** also communicates with the ZenML Server to visualize you
 
 ![ZenML Dashboard](../assets/pipelines_dashboard.png)
 
-When you start working with ZenML, you'll start with a local ZenML setup, and when you want to transition you will need to [deploy ZenML](../getting-started/deploying-zenml/). Don't worry though, there is a one-click way how to do it which we'll learn about [later](../starter-guide/collaborate/).
+When you start working with ZenML, you'll start with a local ZenML setup, and when you want to transition you will need to [deploy ZenML](./deploying-zenml/deploying-zenml.md). Don't worry though, there is a one-click way how to do it which we'll learn about [later](../starter-guide/collaborate/collaborate.md).
 
 ## Other Bits and Pieces
 

--- a/docs/book/getting-started/installation/installation.md
+++ b/docs/book/getting-started/installation/installation.md
@@ -15,7 +15,7 @@ Please note that ZenML currently only supports Python 3.7, 3.8, and 3.9.
 Please adjust your Python environment accordingly.
 {% endhint %}
 
-ZenML comes bundled with a React-based dashboard that lives inside a [sister repository](https://github.com/zenml-io/zenml-dashboard). In order to get access to the dashboard locally, you need to launch the [ZenML Server and Dashboard locally](deploying-zenml/deploying-zenml.md). For this, you need to install the optional dependencies for the ZenML Server:
+ZenML comes bundled with a React-based dashboard that lives inside a [sister repository](https://github.com/zenml-io/zenml-dashboard). In order to get access to the dashboard locally, you need to launch the [ZenML Server and Dashboard locally](../deploying-zenml/deploying-zenml.md). For this, you need to install the optional dependencies for the ZenML Server:
 
 ```shell
 pip install "zenml[server]"
@@ -107,13 +107,13 @@ pip install git+https://github.com/zenml-io/zenml.git@develop --upgrade
 
 ### Using develop with Remote Orchestrators
 
-Remote orchestrators like [Kubeflow](../mlops-stacks/orchestrators/kubeflow.md)
-require [Docker Images](../developer-guide/advanced-usage/docker.md) to set up the
+Remote orchestrators like [Kubeflow](../../component-gallery/orchestrators/kubeflow.md)
+require [Docker Images](../../getting-started/deploying-zenml/docker.md) to set up the
 environments of each step. By default, they use the official ZenML docker image
 that we provide with each release. However, if you install from develop, this
 image will be outdated, so you need to build a custom image instead, and
 specify it in the configuration of your orchestrator accordingly (see the 
-[MLOps Stacks Orchestrator](../mlops-stacks/orchestrators/orchestrators.md) 
+[MLOps Stacks Orchestrator](../../component-gallery/orchestrators/orchestrators.md) 
 page of your specific orchestrator flavor for more details on how this can be 
 done).
 

--- a/docs/book/reference/cheat-sheet.md
+++ b/docs/book/reference/cheat-sheet.md
@@ -2,6 +2,6 @@
 description: Cheat sheet for ZenML CLI commands.
 ---
 
-[Download as PDF](../assets/zenml_cheat_sheet.pdf)
+[Download as PDF](https://docs.google.com/viewer?url=https://github.com/zenml-io/zenml/raw/main/docs/book/assets/zenml_cheat_sheet.pdf)
 
 ![ZenML CLI Cheat Sheet](../assets/zenml_cheat_sheet.png)

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -16,7 +16,7 @@ a high chance someone else might have already answered it on Slack!
 
 ## YouTube Channel: Video tutorials 
 
-Our [YouTube Channel](https://www.youtube.com/channel/UCi79n61eV2sVyYxJOqk\_bMw) 
+Our [YouTube Channel](https://www.youtube.com/c/ZenML)
 features a growing set of videos that take you through the entire framework. 
 Go here if you are a visual learner, and follow along with some tutorials.
 

--- a/docs/book/starter-guide/pipelines/iterating.md
+++ b/docs/book/starter-guide/pipelines/iterating.md
@@ -78,7 +78,7 @@ when you [fetch pipeline runs](./fetching-pipelines.md), to compare various runs
 When you tweaked the `gamma` variable above, you must have noticed that the 
 `digits_data_loader` step does not re-execute for each subsequent run.  This is because ZenML 
 understands that nothing has changed between subsequent runs, so it re-uses the output of the last 
-run (the outputs are persisted in the [artifact store](../../component-gallery/artifact-stores/)). 
+run (the outputs are persisted in the [artifact store](../../component-gallery/artifact-stores/artifact-stores.md). 
 This behavior is known as **caching**.
 
 Prototyping is often a fast and iterative process that

--- a/docs/book/starter-guide/pipelines/pipelines.md
+++ b/docs/book/starter-guide/pipelines/pipelines.md
@@ -45,7 +45,7 @@ def digits_data_loader() -> Output(
 As this step has multiple outputs, we need to use the
 `zenml.steps.step_output.Output` class to indicate the names of each output. 
 These names can be used to directly access the outputs of steps after running
-a pipeline, as we will see [in a later chapter](./inspecting-pipeline-runs.md).
+a pipeline, as we will see [in a later chapter](./fetching-pipelines.md).
 
 Let's come up with a second step that consumes the output of our first step and
 performs some sort of transformation on it. In this case, let's train a support

--- a/docs/book/starter-guide/stacks/stacks.md
+++ b/docs/book/starter-guide/stacks/stacks.md
@@ -14,9 +14,9 @@ At **ZenML**, we believe that this is one of the most important and challenging 
 Taking this into consideration, ZenML provides additional abstractions that
 help you simplify infrastructure configuration and management:
 
-- [Stacks](./stack.md): A combination of various MLOps *stack components*.
-- [Stack Components](./registering-stacks.md): Configuration of MLOps tools, which come in different *categories* and *flavors*.
-- [Flavors](./registering-stacks.md): Represent a concrete implementation of a stack component.
+- [Stacks](./stacks.md#stack): A combination of various MLOps *stack components*.
+- [Stack Components](./stacks.md#stack-components): Configuration of MLOps tools, which come in different *categories* and *flavors*.
+- [Flavors](./stacks.md#stack-component-flavors): Represent a concrete implementation of a stack component.
 
 Let's discuss each in further detail:
 
@@ -27,7 +27,6 @@ and infrastructure. For instance, you might want to:
 
 - Orchestrate your ML workflows with [Kubeflow](../../component-gallery/orchestrators/kubeflow.md),
 - Save ML artifacts in an [Amazon S3](../../component-gallery/artifact-stores/amazon-s3.md) bucket,
-- Track ML metadata in a managed [MySQL](../../component-gallery/metadata-stores/mysql.md) database,
 - Track your experiments with [Weights & Biases](../../component-gallery/experiment-trackers/wandb.md),
 - Deploy models on Kubernetes with [Seldon](../../component-gallery/model-deployers/seldon.md) or [KServe](../../component-gallery/model-deployers/kserve.md),
 
@@ -88,7 +87,7 @@ place in your local file system, but we could also configure ZenML to store
 this data in a cloud bucket like [Amazon S3](../../component-gallery/artifact-stores/amazon-s3.md) 
 or any other place instead.
 
-You can see all supported stack component types in a single table view [here](../component-gallery/categories.md)
+You can see all supported stack component types in a single table view [here](../../component-gallery/categories.md)
 
 {% hint style="info" %}
 Every stack can usually contain one stack component category of each type, e.g.,


### PR DESCRIPTION
## Describe changes
This PR -
1. Fixes all dead links in the docs page (except for API docs related links).
2. Fix the link to your YouTube channel.
3. Lets the user open the cheat sheet in the browser instead of directing it to the GitHub repo.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

