### PR TITLE
Add social media heading on docs page

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -15,3 +15,4 @@ internal:
   - '@ayush714'
   - '@safoinme'
   - '@fa9r'
+  - '@dnth'

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -19,7 +19,8 @@ a high chance someone else might have already answered it on Slack!
 We are active on [LinkedIn](https://www.linkedin.com/company/zenml) and 
 [Twitter](https://twitter.com/zenml_io) where we post bite-sized updates on releases, 
 events, and MLOps in general. Follow us to interact and stay up to date!
-We would appreciate it if you could comment and share our posts so more people can benefit from our work at ZenML!
+We would appreciate it if you could comment on and share our posts 
+so more people can benefit from our work at ZenML!
 
 ## YouTube Channel: Video tutorials, workshops, and more
 

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -62,5 +62,5 @@ Every week, we pop in a session for 30 minutes to interact directly with the
 community. Sometimes we'll be presenting a feature, other times just taking 
 questions and having fun. Join us if you are curious about ZenML or just want 
 to talk shop about MLOps. The session is free and open to everyone, 
-[join us](https://zenml.io/meet) now.
+[sign up](https://zenml.io/meet) now.
 

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -19,7 +19,7 @@ a high chance someone else might have already answered it on Slack!
 We are active on [LinkedIn](https://www.linkedin.com/company/zenml) and 
 [Twitter](https://twitter.com/zenml_io) where we post bite-sized updates on releases, 
 events, and MLOps in general. Follow us to interact and stay up to date!
-We appreciate it if you could comment and share our posts so more people can benefit from our work at ZenML!
+We would appreciate it if you could comment and share our posts so more people can benefit from our work at ZenML!
 
 ## YouTube Channel: Video tutorials, workshops, and more
 

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -4,17 +4,24 @@ description: All possible ways for our community to get in touch with ZenML.
 
 The ZenML team and community have put together a list of references
 that can be used to get in touch with the development team of ZenML and 
-develop a deeper understanding about the framework.
+develop a deeper understanding of the framework.
 
 ## Slack Channel: Get help from the community 
 
 The ZenML [Slack Channel](https://zenml.io/slack-invite) is the main gathering 
 point for the community. Not only is it the best place to get in touch with the 
-core team of ZenML, it is also a great way to discuss new ideas and share 
-your own ZenML projects with the community. If you have a question, there is 
+core team of ZenML, but it is also a great way to discuss new ideas and share 
+your ZenML projects with the community. If you have a question, there is 
 a high chance someone else might have already answered it on Slack!
 
-## YouTube Channel: Video tutorials 
+## Social Media: Bite-sized updates
+
+We are active on [LinkedIn](https://www.linkedin.com/company/zenml) and 
+[Twitter](https://twitter.com/zenml_io) where we post bite-sized updates on releases, 
+events, and MLOps in general. Follow us to interact and stay up to date!
+We appreciate it if you could comment and share our posts so more people can benefit from our work at ZenML!
+
+## YouTube Channel: Video tutorials, workshops, and more
 
 Our [YouTube Channel](https://www.youtube.com/c/ZenML)
 features a growing set of videos that take you through the entire framework. 
@@ -25,19 +32,19 @@ Go here if you are a visual learner, and follow along with some tutorials.
 The feedback from our community plays a significant role in the development
 of ZenML. That's why we have a [Public Roadmap](https://zenml.hellonext.co/roadmap) 
 that serves as a bridge between our users and our development team. If you 
-have any new ideas regarding any new features or want to prioritize on above 
-the other, feel free to share you thoughts here or vote on existing ideas.
+have ideas regarding any new features or want to prioritize one over 
+the other, feel free to share your thoughts here or vote on existing ideas.
 
 ## Blog
 
-In our [Blog](https://blog.zenml.io/) page, you can find various articles written by our team. We use 
+On our [Blog](https://blog.zenml.io/) page, you can find various articles written by our team. We use 
 it as a platform to share our thoughts and explain the implementation process 
-of our tool, its new features and the thought process behind them.
+of our tool, its new features, and the thought process behind them.
 
 ## Podcast
 
-We also have a [Podcast](https://podcast.zenml.io/) series brings you 
-interviews and discussion with industry leaders, top technology professionals 
+We also have a [Podcast](https://podcast.zenml.io/) series that brings you 
+interviews and discussions with industry leaders, top technology professionals 
 and others. We discuss the latest developments in machine learning, deep 
 learning, artificial intelligence, with a particular focus on MLOps, or how 
 trained models are used in production.
@@ -49,10 +56,11 @@ we share what we learn as we develop open-source tooling for production
 machine learning. You will also get all the exciting news about ZenML in 
 general.
 
-## Community Event
+## Community Meetup
 
-Every week, as a [ZenML community event](https://www.eventbrite.de/e/zenml-meet-the-community-tickets-354426688767), 
-our core team pops in a session for 30 minutes to interact directly with the 
+Every week, we pop in a session for 30 minutes to interact directly with the 
 community. Sometimes we'll be presenting a feature, other times just taking 
 questions and having fun. Join us if you are curious about ZenML or just want 
-to talk shop about MLOps.
+to talk shop about MLOps. The session is free and open to everyone, 
+[join us](https://zenml.io/meet) now.
+


### PR DESCRIPTION
## Describe changes
This PR adds a section heading to include LinkedIn and Twitter pages.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

