### PR TITLE
Support pydantic subclasses in BaseParameter attributes

### DIFF
--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -55,6 +55,7 @@ from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.materializers.default_materializer_registry import (
     default_materializer_registry,
 )
+from zenml.steps.base_parameters import BaseParameters
 from zenml.steps.step_context import StepContext
 from zenml.steps.utils import (
     INSTANCE_CONFIGURATION,
@@ -80,7 +81,6 @@ if TYPE_CHECKING:
     from tfx.dsl.component.experimental.decorators import _SimpleComponent
 
     from zenml.config.base_settings import SettingsOrDict
-    from zenml.steps.base_parameters import BaseParameters
 
     ParametersOrDict = Union["BaseParameters", Dict[str, Any]]
     ArtifactClassOrStr = Union[str, Type["BaseArtifact"]]
@@ -840,6 +840,9 @@ class BaseStep(metaclass=BaseStepMeta):
 
                 source = _resolve_if_necessary(artifact)
                 outputs[output_name]["artifact_source"] = source
+
+        if isinstance(parameters, BaseParameters):
+            parameters = parameters.dict()
 
         values = dict_utils.remove_none_values(
             {


### PR DESCRIPTION
## Describe changes

@felixthebeard found an issue with inherited models in attributes of our `BaseParameters` which this PR fixes.
```python
class MyConfig(BaseModel):
    field: str = "foo"


class DatasetConfig(BaseModel):
    samples: int = 100
    config: MyConfig

    class Config:
        arbitrary_types_allowed = True


class MyDatasetConfig(DatasetConfig):
    config: MyConfig = MyConfig(field="bar")


class DataQueryConfig(BaseParameters):
    datasets: List[DatasetConfig]
    limit_samples: Optional[int] = None

    class Config:
        arbitrary_types_allowed = True

# This works
data_query_config = DataQueryConfig(
    datasets=[MyDatasetConfig(samples=100, config=MyConfig(field="foobar"))],
    limit_samples=100,
)


# This not
data_query_config = DataQueryConfig(
    datasets=[MyDatasetConfig(samples=100)],
    limit_samples=100,
)
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

