### PR TITLE
Fix Azure CLI auth problem

### DIFF
--- a/src/zenml/integrations/azure/__init__.py
+++ b/src/zenml/integrations/azure/__init__.py
@@ -40,7 +40,7 @@ class AzureIntegration(Integration):
         "adlfs==2021.10.0",
         "azure-keyvault-keys",
         "azure-keyvault-secrets",
-        "azure-identity",
+        "azure-identity==1.10.0",
         "azureml-core==1.42.0.post1",
     ]
 


### PR DESCRIPTION
## Describe changes
I pinned the version of `azure-identity` to fix a problem where the `DefaultAzureCredential` class doesn't take the `AzureCLIAuthentication` option in the chain.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

