### PR TITLE
Include latest (not oldest) three runs in HydratedPipelineModel

### DIFF
--- a/src/zenml/zen_server/models/pipeline_models.py
+++ b/src/zenml/zen_server/models/pipeline_models.py
@@ -96,7 +96,7 @@ class HydratedPipelineModel(PipelineModel):
         project = zen_store.get_project(pipeline_model.project)
         user = zen_store.get_user(pipeline_model.user)
         runs = zen_store.list_runs(pipeline_id=pipeline_model.id)
-        last_x_runs = runs[:num_runs]
+        last_x_runs = runs[-num_runs:]
         status_last_x_runs = []
         for run in last_x_runs:
             status_last_x_runs.append(

--- a/tests/unit/zen_server/models/__init__.py
+++ b/tests/unit/zen_server/models/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/zen_server/models/test_pipeline_models.py
+++ b/tests/unit/zen_server/models/test_pipeline_models.py
@@ -1,0 +1,81 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from uuid import UUID
+
+from zenml.config.pipeline_configurations import PipelineSpec
+from zenml.enums import ExecutionStatus
+from zenml.models import PipelineRunModel, ProjectModel, UserModel
+from zenml.zen_server.models.pipeline_models import (
+    HydratedPipelineModel,
+    PipelineModel,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+def _create_run_model(
+    name: str, user_id: UUID, project_id: UUID
+) -> PipelineRunModel:
+    """Creates a pipeline run model with the given attributes."""
+    return PipelineRunModel(
+        user=user_id,
+        project=project_id,
+        name=name,
+        num_steps=1,
+        pipeline_configuration={},
+        status=ExecutionStatus.COMPLETED,
+    )
+
+
+def test_pipeline_model_hydration(mocker):
+    """Tests that pipeline model hydration works as expected."""
+
+    user = UserModel()
+    project = ProjectModel(name="my_project")
+    runs = [
+        _create_run_model(name="run_0", user_id=user.id, project_id=project.id),
+        _create_run_model(name="run_1", user_id=user.id, project_id=project.id),
+        _create_run_model(name="run_2", user_id=user.id, project_id=project.id),
+        _create_run_model(name="run_3", user_id=user.id, project_id=project.id),
+    ]
+
+    mocker.patch.object(
+        SqlZenStore,
+        "get_user",
+        return_value=user,
+    )
+    mocker.patch.object(
+        SqlZenStore,
+        "get_project",
+        return_value=project,
+    )
+    mocker.patch.object(
+        SqlZenStore,
+        "list_runs",
+        return_value=runs,
+    )
+    mocker.patch.object(
+        SqlZenStore,
+        "get_run",
+        return_value=runs[0],
+    )
+    model = PipelineModel(
+        user=user.id,
+        project=project.id,
+        name="my_pipeline",
+        spec=PipelineSpec(steps=[]),
+    )
+
+    hydrated_model = HydratedPipelineModel.from_model(model)
+    assert hydrated_model.runs == runs[-3:]


### PR DESCRIPTION
## Describe changes

This PR fixes a bug that leads to the UI displaying the oldest runs in the pipeline overview UI instead of the latest ones.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

