### PR TITLE
Fix the pipeline run sync on sqlite and the --blocking zenml server deployment

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1202,6 +1202,7 @@ mobilenetv
 modelFormat
 modelUri
 msi
+mutex
 mvq
 mybucket
 mypy

--- a/src/zenml/zen_server/deploy/local/local_zen_server.py
+++ b/src/zenml/zen_server/deploy/local/local_zen_server.py
@@ -199,10 +199,12 @@ class LocalZenServer(LocalDaemonService):
             super().start(timeout)
         else:
             self._copy_global_configuration()
+            local_stores_path = GlobalConfiguration().local_stores_path
             GlobalConfiguration._reset_instance()
             Client._reset_instance()
             config_path = os.environ.get(ENV_ZENML_CONFIG_PATH)
             os.environ[ENV_ZENML_CONFIG_PATH] = self._global_config_path
+            os.environ[ENV_ZENML_LOCAL_STORES_PATH] = local_stores_path
             try:
                 self.run()
             finally:
@@ -210,6 +212,7 @@ class LocalZenServer(LocalDaemonService):
                     os.environ[ENV_ZENML_CONFIG_PATH] = config_path
                 else:
                     del os.environ[ENV_ZENML_CONFIG_PATH]
+                del os.environ[ENV_ZENML_LOCAL_STORES_PATH]
                 GlobalConfiguration._reset_instance()
                 Client._reset_instance()
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -63,6 +63,8 @@ def initialize_zen_store() -> None:
         ValueError: If the ZenML Store is using a REST back-end.
     """
     global _zen_store
+
+    logger.debug("Initializing ZenML Store for FastAPI...")
     _zen_store = GlobalConfiguration().zen_store
 
     # We override track_analytics=False because we do not

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -18,6 +18,7 @@ import os
 import re
 from datetime import datetime, timedelta
 from pathlib import Path, PurePath
+from threading import Lock
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -528,6 +529,8 @@ class SqlZenStore(BaseZenStore):
         CONFIG_TYPE: The type of the store configuration.
         _engine: The SQLAlchemy engine.
         _metadata_store: The metadata store.
+        _lock: A thread mutex used to ensure thread safety during the pipeline
+            run synchronization.
     """
 
     config: SqlZenStoreConfiguration
@@ -539,6 +542,7 @@ class SqlZenStore(BaseZenStore):
     _metadata_store: Optional["MetadataStore"] = None
     _highest_synced_run_mlmd_id: int = 0
     _alembic: Optional[Alembic] = None
+    _sync_lock: Optional[Lock] = None
 
     @property
     def engine(self) -> Engine:
@@ -593,6 +597,20 @@ class SqlZenStore(BaseZenStore):
             raise ValueError("Store not initialized")
         return self._alembic
 
+    @property
+    def sync_lock(self) -> Lock:
+        """The mutex used to synchronize pipeline runs.
+
+        Returns:
+            The mutex used to synchronize pipeline runs.
+
+        Raises:
+            ValueError: If the store is not initialized.
+        """
+        if not self._sync_lock:
+            raise ValueError("Store not initialized")
+        return self._sync_lock
+
     # ====================================
     # ZenML Store interface implementation
     # ====================================
@@ -620,6 +638,8 @@ class SqlZenStore(BaseZenStore):
             and ENV_ZENML_DISABLE_DATABASE_MIGRATION not in os.environ
         ):
             self.migrate_database()
+
+        self._sync_lock = Lock()
 
     def migrate_database(self) -> None:
         """Migrate the database to the head as defined by the current python package."""
@@ -3568,16 +3588,30 @@ class SqlZenStore(BaseZenStore):
         from zenml.zen_stores.migrations.alembic import AlembicVersion
 
         try:
-            with Session(self.engine) as session:
-                # We use the alembic version table as a shared resource that we
-                # can lock to prevent multiple processes from syncing runs at
-                # the same time.
-                logger.debug("Syncing pipeline runs...")
-                session.query(AlembicVersion).with_for_update().all()
-                self._sync_runs_with_lock(session)
-                logger.debug("Pipeline runs sync complete")
+            # This is to synchronize the locally running threads so that only
+            # one thread attempts to sync the runs at any given time. The
+            # timeout is to ensure that we don't block the threads for too long.
+            if self.sync_lock.acquire(timeout=30):
+                with Session(self.engine) as session:
+                    logger.debug("Syncing pipeline runs...")
+                    if self.config.driver != SQLDatabaseDriver.SQLITE:
+                        # This is to synchronize all server processes trying to
+                        # sync the pipeline runs at the same time. We use the
+                        # alembic version table as a shared resource that we can
+                        # lock to prevent multiple processes from syncing runs
+                        # at the same time.
+                        session.query(AlembicVersion).with_for_update().all()
+                    self._sync_runs_with_lock(session)
+                    logger.debug("Pipeline runs sync complete")
+            else:
+                logger.warning(
+                    "Failed to acquire pipeline run sync lock. Skipping the "
+                    "sync this time around."
+                )
         except Exception:
             logger.exception("Failed to sync pipeline runs.")
+        finally:
+            self.sync_lock.release()
 
     def _sync_runs_with_lock(self, session: Session) -> None:
         """Sync runs from MLMD into the database while the DB is locked.


### PR DESCRIPTION
## Describe changes
This PR fixes two issues:

- the recently introduced mechanism that uses database locking ("select for update") to synchronize pipeline runs was not applicable to SQLite databases
- the `zenml up --blocking` command did not use the local database and instead ended up creating a new one

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

