### PR TITLE
Fix bug when running non-local annotator instance.

### DIFF
--- a/src/zenml/integrations/label_studio/annotators/label_studio_annotator.py
+++ b/src/zenml/integrations/label_studio/annotators/label_studio_annotator.py
@@ -27,6 +27,7 @@ from zenml.exceptions import ProvisioningError
 from zenml.integrations.azure import AZURE_ARTIFACT_STORE_FLAVOR
 from zenml.integrations.gcp import GCP_ARTIFACT_STORE_FLAVOR
 from zenml.integrations.label_studio.flavors.label_studio_annotator_flavor import (
+    DEFAULT_LOCAL_INSTANCE_URL,
     LabelStudioAnnotatorConfig,
 )
 from zenml.integrations.label_studio.steps.label_studio_standard_steps import (
@@ -644,6 +645,15 @@ class LabelStudioAnnotator(BaseAnnotator, AuthenticationMixin):
 
         return True
 
+    @property
+    def is_local_instance(self) -> bool:
+        """Determines if the Label Studio instance is running locally.
+
+        Returns:
+            True if the component is running locally, False otherwise.
+        """
+        return self.config.instance_url == DEFAULT_LOCAL_INSTANCE_URL
+
     def provision(self) -> None:
         """Spins up the annotation server backend."""
         fileio.makedirs(self.root_directory)
@@ -659,7 +669,8 @@ class LabelStudioAnnotator(BaseAnnotator, AuthenticationMixin):
             logger.info("Local kubeflow pipelines deployment already running.")
             return
 
-        self.start_annotator_daemon()
+        if self.is_local_instance:
+            self.start_annotator_daemon()
 
     def suspend(self) -> None:
         """Suspends the annotation interface."""
@@ -667,7 +678,8 @@ class LabelStudioAnnotator(BaseAnnotator, AuthenticationMixin):
             logger.info("Local annotation server is not running.")
             return
 
-        self.stop_annotator_daemon()
+        if self.is_local_instance:
+            self.stop_annotator_daemon()
 
     def start_annotator_daemon(self) -> None:
         """Starts the annotation server backend.


### PR DESCRIPTION
## Describe changes
`zenml stack up` attempts to start a local Label Studio instance even though the annotator is configured to use a non-local instance. I fixed it by checking if the instance URL is the same as `DEFAULT_LOCAL_INSTANCE_URL` before starting/stopping local annotator daemon.


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

