### PR TITLE
Prevent deletion/update of default entities

### DIFF
--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -28,7 +28,7 @@ from zenml.client import Client
 from zenml.config.global_config import GlobalConfiguration
 from zenml.console import console
 from zenml.enums import CliCategories, StackComponentType
-from zenml.exceptions import ProvisioningError
+from zenml.exceptions import IllegalOperationError, ProvisioningError
 from zenml.utils.analytics_utils import AnalyticsEvent, track_event
 from zenml.utils.yaml_utils import read_yaml, write_yaml
 
@@ -427,7 +427,10 @@ def update_stack(
 
         stack_to_update.components = stack_components
 
-        client.update_stack(stack_to_update)
+        try:
+            client.update_stack(stack_to_update)
+        except IllegalOperationError as err:
+            cli_utils.error(str(err))
         cli_utils.declare(
             f"Stack `{stack_to_update.name}` successfully " f"updated!"
         )
@@ -483,8 +486,10 @@ def share_stack(
         with console.status(f"Sharing stack `{stack_to_share.name}` ...\n"):
 
             stack_to_share.is_shared = True
-
-            client.update_stack(stack_to_share)
+            try:
+                client.update_stack(stack_to_share)
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
             cli_utils.declare(
                 f"Stack `{stack_to_share.name}` successfully shared!"
             )
@@ -655,7 +660,10 @@ def remove_stack_component(
                 StackComponentType.DATA_VALIDATOR, None
             )
 
-        client.update_stack(stack_to_update)
+        try:
+            client.update_stack(stack_to_update)
+        except IllegalOperationError as err:
+            cli_utils.error(str(err))
         cli_utils.declare(f"Stack `{stack_name_or_id}` successfully updated!")
 
 
@@ -696,7 +704,10 @@ def rename_stack(
             pass
 
         stack_to_rename.name = new_stack_name
-        client.update_stack(stack_to_rename)
+        try:
+            client.update_stack(stack_to_rename)
+        except IllegalOperationError as err:
+            cli_utils.error(str(err))
         cli_utils.declare(
             f"Stack `{current_stack_name_or_id}` successfully renamed to `"
             f"{new_stack_name}`!"
@@ -812,8 +823,10 @@ def delete_stack(
                 f"active. Please choose a different active stack first by "
                 f"running 'zenml stack set STACK'."
             )
-
-    Client().deregister_stack(stack_to_delete)
+    try:
+        Client().deregister_stack(stack_to_delete)
+    except IllegalOperationError as err:
+        cli_utils.error(str(err))
     cli_utils.declare(f"Deleted stack '{stack_to_delete.name}'.")
 
 

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -30,6 +30,7 @@ from zenml.cli.utils import _component_display_name
 from zenml.client import Client
 from zenml.console import console
 from zenml.enums import CliCategories, StackComponentType
+from zenml.exceptions import IllegalOperationError
 from zenml.io import fileio
 from zenml.utils.analytics_utils import AnalyticsEvent, track_event
 
@@ -318,12 +319,15 @@ def generate_stack_component_update_command(
                 **parsed_args,
             }
 
-            # Update the component
-            client.update_stack_component(
-                component=existing_component.copy(
-                    update={"configuration": updated_attributes}
+            try:
+                # Update the component
+                client.update_stack_component(
+                    component=existing_component.copy(
+                        update={"configuration": updated_attributes}
+                    )
                 )
-            )
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
 
             cli_utils.declare(
                 f"Successfully updated {display_name} `{name_or_id}`."
@@ -373,8 +377,11 @@ def generate_stack_component_share_command(
 
             existing_component.is_shared = True
 
-            # Update the component
-            client.update_stack_component(component=existing_component)
+            try:
+                # Update the component
+                client.update_stack_component(component=existing_component)
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
 
             cli_utils.declare(
                 f"Successfully shared {display_name} " f"`{name_or_id}`."
@@ -439,8 +446,11 @@ def generate_stack_component_remove_attribute_command(
                         f"."
                     )
 
-            # Update the stack component
-            client.update_stack_component(component=existing_comp)
+            try:
+                # Update the stack component
+                client.update_stack_component(component=existing_comp)
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
 
             cli_utils.declare(
                 f"Successfully updated {display_name} `{name_or_id}`."
@@ -493,10 +503,15 @@ def generate_stack_component_rename_command(
                 )
             )
 
-            # Rename and update the existing component
-            client.update_stack_component(
-                component=existing_component.copy(update={"name": new_name}),
-            )
+            try:
+                # Rename and update the existing component
+                client.update_stack_component(
+                    component=existing_component.copy(
+                        update={"name": new_name}
+                    ),
+                )
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
 
             cli_utils.declare(
                 f"Successfully renamed {display_name} `{name_or_id}` to"
@@ -538,8 +553,12 @@ def generate_stack_component_delete_command(
                 id_or_name_or_prefix=name_or_id,
             )
 
-            # Delete the component
-            client.deregister_stack_component(existing_comp)
+            try:
+                # Delete the component
+                client.deregister_stack_component(existing_comp)
+            except IllegalOperationError as err:
+                cli_utils.error(str(err))
+
             cli_utils.declare(f"Deleted {display_name}: {name_or_id}")
 
     return delete_stack_component_command

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -404,7 +404,7 @@ def update_project(
         project.name = name or project.name
         project.description = description or project.description
         Client().zen_store.update_project(project)
-    except (EntityExistsError, KeyError) as err:
+    except (EntityExistsError, KeyError, IllegalOperationError) as err:
         cli_utils.error(str(err))
     cli_utils.declare(f"Updated project '{project_name}'.")
 

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -588,7 +588,7 @@ def update_role(
 
         role.name = name or role.name
         Client().zen_store.update_role(role)
-    except (EntityExistsError, KeyError) as err:
+    except (EntityExistsError, KeyError, IllegalOperationError) as err:
         cli_utils.error(str(err))
     cli_utils.declare(f"Updated role '{role_name}'.")
 
@@ -606,7 +606,7 @@ def delete_role(role_name_or_id: str) -> None:
         Client().zen_store.delete_role(
             role_name_or_id=parse_name_or_uuid(role_name_or_id)
         )
-    except KeyError as err:
+    except (KeyError, IllegalOperationError) as err:
         cli_utils.error(str(err))
     cli_utils.declare(f"Deleted role '{role_name_or_id}'.")
 

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -1442,17 +1442,8 @@ class Client(metaclass=ClientMetaClass):
 
         Args:
             user_name_or_id: The name or ID of the user to delete.
-
-        Raises:
-            IllegalOperationError: If the user to delete is the active user.
         """
-        user = self.zen_store.get_user(user_name_or_id)
-        if self.zen_store.active_user_name == user.name:
-            raise IllegalOperationError(
-                "You cannot delete yourself. If you wish to delete your active "
-                "user account, please contact your ZenML administrator."
-            )
-        Client().zen_store.delete_user(user_name_or_id=user.name)
+        Client().zen_store.delete_user(user_name_or_id=user_name_or_id)
 
     def delete_project(self, project_name_or_id: str) -> None:
         """Delete a project.

--- a/src/zenml/zen_server/routers/users_endpoints.py
+++ b/src/zenml/zen_server/routers/users_endpoints.py
@@ -260,8 +260,10 @@ def delete_user(
 
     if auth_context.user.name == user.name:
         raise IllegalOperationError(
-            "You cannot delete yourself. If you wish to delete your active "
-            "user account, please contact your ZenML administrator."
+            "You cannot delete the user account currently used to authenticate "
+            "to the ZenML server. If you wish to delete this account, "
+            "please authenticate with another account or contact your ZenML "
+            "administrator."
         )
     zen_store().delete_user(user_name_or_id=user_name_or_id)
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -120,7 +120,7 @@ def forbidden(error: Exception) -> HTTPException:
         error: Exception to convert.
 
     Returns:
-        HTTPException with status code 404.
+        HTTPException with status code 403.
     """
     return HTTPException(status_code=403, detail=error_detail(error))
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -25,6 +25,7 @@ from zenml.constants import ENV_ZENML_SERVER_ROOT_URL_PATH
 from zenml.enums import StoreType
 from zenml.exceptions import (
     EntityExistsError,
+    IllegalOperationError,
     NotAuthorizedError,
     StackComponentExistsError,
     StackExistsError,
@@ -112,6 +113,18 @@ def not_authorized(error: Exception) -> HTTPException:
     return HTTPException(status_code=401, detail=error_detail(error))
 
 
+def forbidden(error: Exception) -> HTTPException:
+    """Convert an Exception to a HTTP 403 response.
+
+    Args:
+        error: Exception to convert.
+
+    Returns:
+        HTTPException with status code 404.
+    """
+    return HTTPException(status_code=403, detail=error_detail(error))
+
+
 def not_found(error: Exception) -> HTTPException:
     """Convert an Exception to a HTTP 404 response.
 
@@ -178,6 +191,9 @@ def handle_exceptions(func: F) -> F:
         ) as error:
             logger.exception("Entity already exists")
             raise conflict(error) from error
+        except IllegalOperationError as error:
+            logger.exception("Illegal operation")
+            raise forbidden(error) from error
         except ValueError as error:
             logger.exception("Validation error")
             raise unprocessable(error) from error

--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -59,6 +59,7 @@ DEFAULT_USERNAME = "default"
 DEFAULT_PASSWORD = ""
 DEFAULT_PROJECT_NAME = "default"
 DEFAULT_STACK_NAME = "default"
+DEFAULT_STACK_COMPONENT_NAME = "default"
 ADMIN_ROLE = "admin"
 GUEST_ROLE = "guest"
 
@@ -428,7 +429,7 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
             component=ComponentModel(
                 user=user.id,
                 project=project.id,
-                name="default",
+                name=DEFAULT_STACK_COMPONENT_NAME,
                 type=StackComponentType.ORCHESTRATOR,
                 flavor="local",
                 configuration={},
@@ -440,7 +441,7 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
             component=ComponentModel(
                 user=user.id,
                 project=project.id,
-                name="default",
+                name=DEFAULT_STACK_COMPONENT_NAME,
                 type=StackComponentType.ARTIFACT_STORE,
                 flavor="local",
                 configuration={},
@@ -450,7 +451,7 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
         components = {c.type: [c.id] for c in [orchestrator, artifact_store]}
         # Register the default stack
         stack = StackModel(
-            name="default",
+            name=DEFAULT_STACK_NAME,
             components=components,
             is_shared=False,
             project=project.id,
@@ -661,6 +662,15 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
     # --------
 
     @property
+    def _default_project_name(self) -> str:
+        """Get the default project name.
+
+        Returns:
+            The default project name.
+        """
+        return os.getenv(ENV_ZENML_DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_NAME)
+
+    @property
     def _default_project(self) -> ProjectModel:
         """Get the default project.
 
@@ -670,9 +680,7 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
         Raises:
             KeyError: if the default project doesn't exist.
         """
-        project_name = os.getenv(
-            ENV_ZENML_DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_NAME
-        )
+        project_name = self._default_project_name
         try:
             return self.get_project(project_name)
         except KeyError:
@@ -687,9 +695,7 @@ class BaseZenStore(BaseModel, ZenStoreInterface, AnalyticsTrackerMixin):
         Returns:
             The default project.
         """
-        project_name = os.getenv(
-            ENV_ZENML_DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_NAME
-        )
+        project_name = self._default_project_name
         logger.info(f"Creating default project '{project_name}' ...")
         return self.create_project(ProjectModel(name=project_name))
 

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -60,6 +60,7 @@ from zenml.exceptions import (
     AuthorizationException,
     DoesNotExistException,
     EntityExistsError,
+    IllegalOperationError,
     StackComponentExistsError,
     StackExistsError,
 )
@@ -1571,6 +1572,8 @@ class RestZenStore(BaseZenStore):
                 entity already exists.
             AuthorizationException: If the response indicates that the request
                 is not authorized.
+            IllegalOperationError: If the response indicates that the requested
+                operation is forbidden.
             KeyError: If the response indicates that the requested entity
                 does not exist.
             RuntimeError: If the response indicates that the requested entity
@@ -1595,6 +1598,10 @@ class RestZenStore(BaseZenStore):
             raise AuthorizationException(
                 f"{response.status_code} Client Error: Unauthorized request to "
                 f"URL {response.url}: {response.json().get('detail')}"
+            )
+        elif response.status_code == 403:
+            raise IllegalOperationError(
+                response.json().get("detail", (response.text,))[1]
             )
         elif response.status_code == 404:
             if "KeyError" in response.text:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2066,6 +2066,7 @@ class SqlZenStore(BaseZenStore):
 
         Raises:
             KeyError: if the role does not exist.
+            IllegalOperationError: if the role is a system role.
         """
         with Session(self.engine) as session:
             existing_role = session.exec(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1234,7 +1234,7 @@ class SqlZenStore(BaseZenStore):
 
         Raises:
             KeyError: if the stack component doesn't exist.
-            IllegalOperationError: if the stack component a default stack
+            IllegalOperationError: if the stack component is a default stack
                 component.
         """
         with Session(self.engine) as session:

--- a/tests/unit/cli/test_stack_components.py
+++ b/tests/unit/cli/test_stack_components.py
@@ -402,6 +402,23 @@ def test_renaming_non_core_component_succeeds(clean_client) -> None:
 
 def test_renaming_core_component_succeeds(clean_client) -> None:
     """Test renaming a core stack component succeeds."""
+
+    new_component_name = "arias_orchestrator"
+    register_orchestrator_command = cli.commands["orchestrator"].commands[
+        "register"
+    ]
+
+    runner = CliRunner()
+    register_result = runner.invoke(
+        register_orchestrator_command,
+        [
+            "some_orchestrator",
+            "--flavor",
+            "local",
+        ],
+    )
+    assert register_result.exit_code == 0
+
     new_component_name = "arias_orchestrator"
 
     rename_orchestrator_command = cli.commands["orchestrator"].commands[
@@ -410,18 +427,92 @@ def test_renaming_core_component_succeeds(clean_client) -> None:
     runner = CliRunner()
     result = runner.invoke(
         rename_orchestrator_command,
-        ["default", new_component_name],
+        ["some_orchestrator", new_component_name],
     )
     assert result.exit_code == 0
     with pytest.raises(KeyError):
         cli_utils.get_component_by_id_or_name_or_prefix(
             client=clean_client,
             component_type=StackComponentType.ORCHESTRATOR,
-            id_or_name_or_prefix="default",
+            id_or_name_or_prefix="some_orchestrator",
         )
     with does_not_raise():
         cli_utils.get_component_by_id_or_name_or_prefix(
             client=clean_client,
             component_type=StackComponentType.ORCHESTRATOR,
             id_or_name_or_prefix=new_component_name,
+        )
+
+
+def test_renaming_default_component_fails(clean_client) -> None:
+    """Test renaming a default stack component fails."""
+    new_component_name = "aria"
+
+    runner = CliRunner()
+    rename_command = cli.commands["orchestrator"].commands["rename"]
+    result = runner.invoke(
+        rename_command,
+        ["default", new_component_name],
+    )
+    assert result.exit_code == 1
+    with does_not_raise():
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ORCHESTRATOR,
+            id_or_name_or_prefix="default",
+        )
+    with pytest.raises(KeyError):
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ORCHESTRATOR,
+            id_or_name_or_prefix=new_component_name,
+        )
+
+    rename_command = cli.commands["artifact-store"].commands["rename"]
+    result = runner.invoke(
+        rename_command,
+        ["default", new_component_name],
+    )
+    assert result.exit_code == 1
+    with does_not_raise():
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ARTIFACT_STORE,
+            id_or_name_or_prefix="default",
+        )
+    with pytest.raises(KeyError):
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ARTIFACT_STORE,
+            id_or_name_or_prefix=new_component_name,
+        )
+
+
+def test_delete_default_component_fails(clean_client) -> None:
+    """Test deleting a default stack component fails."""
+    runner = CliRunner()
+    delete_command = cli.commands["orchestrator"].commands["delete"]
+    result = runner.invoke(
+        delete_command,
+        ["default"],
+    )
+    assert result.exit_code == 1
+    with does_not_raise():
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ORCHESTRATOR,
+            id_or_name_or_prefix="default",
+        )
+
+    delete_command = cli.commands["artifact-store"].commands["delete"]
+    result = runner.invoke(
+        delete_command,
+        ["default"],
+    )
+    assert result.exit_code == 1
+    with does_not_raise():
+        cli_utils.get_component_by_id_or_name_or_prefix(
+            client=clean_client,
+            component_type=StackComponentType.ARTIFACT_STORE,
+            id_or_name_or_prefix="default",
         )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -319,16 +319,27 @@ def test_registering_a_new_stack_with_already_registered_components(
 def test_updating_a_stack_with_new_components(clean_client):
     """Tests that updating a new stack with already registered components
     updates the stack with the new or altered components passed in."""
-    current_stack = clean_client.active_stack
-    old_orchestrator = current_stack.orchestrator
+    stack = _create_local_stack(
+        repo=clean_client, stack_name="some_new_stack_name"
+    )
+    stack_model = stack.to_model(
+        user=clean_client.active_user.id,
+        project=clean_client.active_project.id,
+    )
+    clean_client.register_stack_component(stack.orchestrator.to_model())
+    clean_client.register_stack_component(stack.artifact_store.to_model())
+    clean_client.register_stack(stack_model)
+    clean_client.activate_stack(stack_model)
+
+    old_orchestrator = stack.orchestrator
     new_orchestrator = _create_local_stack(
         clean_client, "", orchestrator_name="new_orchestrator"
     ).orchestrator
     updated_stack = Stack(
-        id=current_stack.id,
-        name=current_stack.name,
+        id=stack.id,
+        name=stack.name,
         orchestrator=new_orchestrator,
-        artifact_store=current_stack.artifact_store,
+        artifact_store=stack.artifact_store,
     )
 
     with does_not_raise():
@@ -348,13 +359,24 @@ def test_updating_a_stack_with_new_components(clean_client):
 
 def test_renaming_stack_with_update_method_succeeds(clean_client):
     """Tests that renaming a stack with the update method succeeds."""
-    current_stack = clean_client.active_stack
+    stack = _create_local_stack(
+        repo=clean_client, stack_name="some_new_stack_name"
+    )
+    stack_model = stack.to_model(
+        user=clean_client.active_user.id,
+        project=clean_client.active_project.id,
+    )
+    clean_client.register_stack_component(stack.orchestrator.to_model())
+    clean_client.register_stack_component(stack.artifact_store.to_model())
+    clean_client.register_stack(stack_model)
+    clean_client.activate_stack(stack_model)
+
     new_stack_name = "new_stack_name"
     updated_stack = Stack(
-        id=current_stack.id,
+        id=stack.id,
         name=new_stack_name,
-        orchestrator=current_stack.orchestrator,
-        artifact_store=current_stack.artifact_store,
+        orchestrator=stack.orchestrator,
+        artifact_store=stack.artifact_store,
     )
 
     with does_not_raise():

--- a/tests/unit/zen_stores/test_sql_zen_store.py
+++ b/tests/unit/zen_stores/test_sql_zen_store.py
@@ -22,6 +22,7 @@ from zenml.config.pipeline_configurations import PipelineSpec
 from zenml.enums import ExecutionStatus, PermissionType, StackComponentType
 from zenml.exceptions import (
     EntityExistsError,
+    IllegalOperationError,
     StackComponentExistsError,
     StackExistsError,
 )
@@ -72,13 +73,30 @@ def test_getting_nonexistent_project_raises_error(
         sql_store["store"].get_project("blupus_project")
 
 
-def test_updating_project(sql_store: BaseZenStore):
-    """Tests updating a project."""
+def test_updating_default_project_fails(sql_store: BaseZenStore):
+    """Tests updating the default project."""
     default_project = sql_store["default_project"]
     assert default_project.name == DEFAULT_NAME
     default_project.name = "aria"
-    sql_store["store"].update_project(default_project)
-    assert sql_store["store"].list_projects()[0].name == "aria"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_project(default_project)
+
+
+def test_updating_project(sql_store: BaseZenStore):
+    """Tests updating a project."""
+    new_project = ProjectModel(name="arias_project")
+    new_project = sql_store["store"].create_project(new_project)
+    with does_not_raise():
+        updated_project = sql_store["store"].get_project(
+            project_name_or_id="arias_project"
+        )
+    updated_project.name = "axls_project"
+    with does_not_raise():
+        sql_store["store"].update_project(updated_project)
+    with does_not_raise():
+        updated_project = sql_store["store"].get_project(
+            project_name_or_id="axls_project"
+        )
 
 
 def test_updating_nonexisting_project_raises_error(
@@ -92,8 +110,17 @@ def test_updating_nonexisting_project_raises_error(
 
 def test_deleting_project_succeeds(sql_store: BaseZenStore):
     """Tests deleting a project."""
-    sql_store["store"].delete_project(DEFAULT_NAME)
-    assert len(sql_store["store"].list_projects()) == 0
+    new_project = ProjectModel(name="axls_project")
+    new_project = sql_store["store"].create_project(new_project)
+    with does_not_raise():
+        sql_store["store"].delete_project("axls_project")
+    assert len(sql_store["store"].list_projects()) == 1
+
+
+def test_deleting_default_project_fails(sql_store: BaseZenStore):
+    """Tests deleting the default project."""
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_project(DEFAULT_NAME)
 
 
 def test_deleting_nonexistent_project_raises_error(
@@ -334,6 +361,14 @@ def test_updating_user_succeeds(sql_store: BaseZenStore):
         sql_store["store"].get_user("aria")
 
 
+def test_updating_default_user_fails(sql_store: BaseZenStore):
+    """Tests that updating the default user is prohibited."""
+    default_user = sql_store["store"].get_user("default")
+    default_user.name = "axl"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_user(default_user)
+
+
 def test_updating_nonexistent_user_fails(sql_store: BaseZenStore):
     """Tests updating a nonexistent user fails."""
     new_user = UserModel(name="demonic_aria")
@@ -349,6 +384,12 @@ def test_deleting_user_succeeds(sql_store: BaseZenStore):
     assert len(sql_store["store"].users) == 2
     sql_store["store"].delete_user(new_user_id)
     assert len(sql_store["store"].users) == 1
+
+
+def test_deleting_default_user_fails(sql_store: BaseZenStore):
+    """Tests that deleting the default user is prohibited."""
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_user("default")
 
 
 #  .------.
@@ -715,17 +756,31 @@ def test_updating_stack_succeeds(
     sql_store: BaseZenStore,
 ):
     """Tests updating stack."""
-    current_stack_id = sql_store["default_stack"].id
     new_stack = StackModel(
-        id=current_stack_id,
         name="arias_stack",
         components={},
         project=sql_store["default_project"].id,
         user=sql_store["active_user"].id,
     )
+    new_stack = sql_store["store"].create_stack(
+        stack=new_stack,
+    )
+
+    new_stack.name = "axls_stack"
     sql_store["store"].update_stack(new_stack)
-    assert sql_store["store"].get_stack(current_stack_id) is not None
-    assert sql_store["store"].get_stack(current_stack_id).name == "arias_stack"
+    assert sql_store["store"].get_stack(new_stack.id) is not None
+    assert sql_store["store"].get_stack(new_stack.id).name == "axls_stack"
+
+
+def test_updating_default_stack_fails(
+    sql_store: BaseZenStore,
+):
+    """Tests that updating the default stack is prohibited."""
+    default_stack_id = sql_store["default_stack"].id
+    default_stack = sql_store["store"].get_stack(default_stack_id)
+    default_stack.name = "axl"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_stack(default_stack)
 
 
 def test_updating_nonexistent_stack_fails(
@@ -746,14 +801,31 @@ def test_updating_nonexistent_stack_fails(
     assert sql_store["store"].get_stack(current_stack_id).name != "arias_stack"
 
 
-def test_deleting_default_stack_succeeds(
+def test_deleting_stack_succeeds(
     sql_store: BaseZenStore,
 ):
     """Tests deleting stack."""
-    current_stack_id = sql_store["default_stack"].id
-    sql_store["store"].delete_stack(current_stack_id)
+    new_stack = StackModel(
+        name="arias_stack",
+        components={},
+        project=sql_store["default_project"].id,
+        user=sql_store["active_user"].id,
+    )
+    new_stack = sql_store["store"].create_stack(
+        stack=new_stack,
+    )
+    sql_store["store"].delete_stack(new_stack.id)
     with pytest.raises(KeyError):
-        sql_store["store"].get_stack(current_stack_id)
+        sql_store["store"].get_stack(new_stack.id)
+
+
+def test_deleting_default_stack_fails(
+    sql_store: BaseZenStore,
+):
+    """Tests that deleting the default stack is prohibited."""
+    default_stack_id = sql_store["default_stack"].id
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_stack(default_stack_id)
 
 
 def test_deleting_nonexistent_stack_fails(
@@ -1279,11 +1351,21 @@ def test_update_stack_component_succeeds(
     sql_store: BaseZenStore,
 ):
     """Tests updating stack component."""
-    updated_orchestrator_name = "blupus"
-    orchestrator = sql_store["store"].list_stack_components(
-        project_name_or_id=sql_store["default_project"].name,
+    stack_component_name = "aria"
+    stack_component = ComponentModel(
+        name=stack_component_name,
         type=StackComponentType.ORCHESTRATOR,
-    )[0]
+        flavor="default",
+        configuration={},
+        project=sql_store["default_project"].id,
+        user=sql_store["active_user"].id,
+    )
+    with does_not_raise():
+        orchestrator = sql_store["store"].create_stack_component(
+            component=stack_component
+        )
+
+    updated_orchestrator_name = "axl"
     orchestrator.name = updated_orchestrator_name
     with does_not_raise():
         sql_store["store"].update_stack_component(component=orchestrator)
@@ -1291,6 +1373,35 @@ def test_update_stack_component_succeeds(
             component_id=orchestrator.id
         )
         assert updated_stack_component.name == updated_orchestrator_name
+
+
+def test_update_default_stack_component_fails(
+    sql_store: BaseZenStore,
+):
+    """Tests that updating default stack components fails."""
+    default_artifact_store = sql_store["store"].list_stack_components(
+        project_name_or_id=sql_store["default_project"].name,
+        type=StackComponentType.ARTIFACT_STORE,
+        name="default",
+    )[0]
+
+    default_orchestrator = sql_store["store"].list_stack_components(
+        project_name_or_id=sql_store["default_project"].name,
+        type=StackComponentType.ORCHESTRATOR,
+        name="default",
+    )[0]
+
+    default_artifact_store.name = "aria"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_stack_component(
+            component=default_artifact_store
+        )
+
+    default_orchestrator.name = "axl"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_stack_component(
+            component=default_orchestrator
+        )
 
 
 def test_update_stack_component_fails_when_component_does_not_exist(
@@ -1346,6 +1457,29 @@ def test_delete_stack_component_succeeds(
         assert sql_store["store"].get_stack_component(
             component_id=stack_component.id
         )
+
+
+def test_delete_default_stack_component_fails(
+    sql_store: BaseZenStore,
+):
+    """Tests that deleting default stack components is prohibited."""
+    default_artifact_store = sql_store["store"].list_stack_components(
+        project_name_or_id=sql_store["default_project"].name,
+        type=StackComponentType.ARTIFACT_STORE,
+        name="default",
+    )[0]
+
+    default_orchestrator = sql_store["store"].list_stack_components(
+        project_name_or_id=sql_store["default_project"].name,
+        type=StackComponentType.ORCHESTRATOR,
+        name="default",
+    )[0]
+
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_stack_component(default_artifact_store.id)
+
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_stack_component(default_orchestrator.id)
 
 
 def test_delete_stack_component_fails_when_component_does_not_exist(

--- a/tests/unit/zen_stores/test_sql_zen_store.py
+++ b/tests/unit/zen_stores/test_sql_zen_store.py
@@ -513,6 +513,28 @@ def test_deleting_nonexistent_role_fails(sql_store: BaseZenStore):
         sql_store["store"].delete_role(uuid.uuid4())
 
 
+def test_deleting_builtin_role_fails(sql_store: BaseZenStore):
+    """Tests deleting a built-in role fails."""
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_role("admin")
+
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].delete_role("guest")
+
+
+def test_updating_builtin_role_fails(sql_store: BaseZenStore):
+    """Tests updating a built-in role fails."""
+    role = sql_store["store"].get_role("admin")
+    role.name = "new_name"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_role(role)
+
+    role = sql_store["store"].get_role("guest")
+    role.name = "new_name"
+    with pytest.raises(IllegalOperationError):
+        sql_store["store"].update_role(role)
+
+
 #  .----------------
 # | ROLE ASSIGNMENTS
 # '-----------------


### PR DESCRIPTION
## Describe changes
Prevent deletion/update of default entities:

* default user
* default project
* default stack
* default stack components
* default roles

This PR also solves a related issue with IllegalOperationErrors not being properly propagated to the client when connected to a server (e.g. when deleting a component that is still part of a stack).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

