### PR TITLE
Made role assignment/revokation possible through zen_server

### DIFF
--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -140,9 +140,7 @@ def create_user(
     except EntityExistsError:
         # As the role assignment of the user might already have happened in the
         #  zen_serve_api.
-        cli_utils.declare(
-            f"Created user '{user_name}'."
-        )
+        cli_utils.declare(f"Created user '{user_name}'.")
 
     if not user.active and user.activation_token is not None:
         cli_utils.declare(

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -49,7 +49,7 @@ def list_users() -> None:
 
     cli_utils.print_pydantic_models(
         users,
-        exclude_columns=["id", "created", "updated", "email", "email_opted_in"],
+        exclude_columns=["created", "updated", "email", "email_opted_in"],
         is_active=lambda u: u.name == Client().zen_store.active_user_name,
     )
 
@@ -131,12 +131,19 @@ def create_user(
             user_or_team_name_or_id=user.id,
             is_user=True,
         )
+
+        cli_utils.declare(
+            f"Created user '{user_name}' with role " f"'{initial_role}'."
+        )
     except KeyError as err:
         cli_utils.error(str(err))
+    except EntityExistsError:
+        # As the role assignment of the user might already have happened in the
+        #  zen_serve_api.
+        cli_utils.declare(
+            f"Created user '{user_name}'."
+        )
 
-    cli_utils.declare(
-        f"Created user '{user_name}' with role " f"'{initial_role}'."
-    )
     if not user.active and user.activation_token is not None:
         cli_utils.declare(
             f"The created user account is currently inactive. You can activate "
@@ -479,7 +486,7 @@ def list_roles() -> None:
         return
     cli_utils.print_pydantic_models(
         roles,
-        exclude_columns=["id", "created", "updated"],
+        exclude_columns=["created", "updated"],
     )
 
 
@@ -771,11 +778,17 @@ def list_role_assignments(
             for.
     """
     cli_utils.print_active_config()
-    role_assignments = Client().zen_store.list_role_assignments(
-        user_name_or_id=user_name_or_id,
-        team_name_or_id=team_name_or_id,
-        project_name_or_id=project_name_or_id,
-    )
+    # Hacky workaround while role assignments are scoped to the user endpoint
+    role_assignments = []
+    for user in Client().zen_store.users:
+        role_assignments.extend(
+            Client().zen_store.list_role_assignments(
+                user_name_or_id=user.id,
+                role_name_or_id=role_name_or_id,
+                team_name_or_id=team_name_or_id,
+                project_name_or_id=project_name_or_id,
+            )
+        )
     if not role_assignments:
         cli_utils.declare("No roles assigned.")
         return

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -101,7 +101,6 @@ def token(
     role_assignments = zen_store().list_role_assignments(
         user_name_or_id=auth_context.user.id, project_name_or_id=None
     )
-    print(role_assignments)
     permissions = set().union(
         *[zen_store().get_role(ra.role).permissions for ra in role_assignments]
     )

--- a/src/zenml/zen_server/routers/users_endpoints.py
+++ b/src/zenml/zen_server/routers/users_endpoints.py
@@ -314,6 +314,7 @@ def email_opt_in_response(
 def get_role_assignments_for_user(
     user_name_or_id: Union[str, UUID],
     project_name_or_id: Optional[Union[str, UUID]] = None,
+    role_name_or_id: Optional[Union[str, UUID]] = None,
 ) -> List[RoleAssignmentModel]:
     """Returns a list of all roles that are assigned to a user.
 
@@ -321,6 +322,8 @@ def get_role_assignments_for_user(
         user_name_or_id: Name or ID of the user.
         project_name_or_id: If provided, only list roles that are limited to
             the given project.
+        role_name_or_id: If provided, only list assignments of the given
+            role
 
     Returns:
         A list of all roles that are assigned to a user.
@@ -328,6 +331,7 @@ def get_role_assignments_for_user(
     return zen_store().list_role_assignments(
         user_name_or_id=user_name_or_id,
         project_name_or_id=project_name_or_id,
+        role_name_or_id=role_name_or_id,
     )
 
 

--- a/src/zenml/zen_server/routers/users_endpoints.py
+++ b/src/zenml/zen_server/routers/users_endpoints.py
@@ -367,7 +367,7 @@ def assign_role(
 def unassign_role(
     user_name_or_id: Union[str, UUID],
     role_name_or_id: Union[str, UUID],
-    project_name_or_id: Optional[Union[str, UUID]],
+    project_name_or_id: Optional[Union[str, UUID]] = None,
     _: AuthContext = Security(authorize, scopes=["write"]),
 ) -> None:
     """Remove a users role within a project or globally.

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -936,6 +936,9 @@ class RestZenStore(BaseZenStore):
 
         Args:
             team_name_or_id: The name or ID of the team for which to get users.
+
+        Raises:
+            NotImplementedError: This method is not implemented
         """
         raise NotImplementedError("Not Implemented")
 
@@ -947,6 +950,9 @@ class RestZenStore(BaseZenStore):
         Args:
             user_name_or_id: The name or ID of the user for which to get all
                 teams.
+
+        Raises:
+            NotImplementedError: This method is not implemented
         """
         raise NotImplementedError("Not Implemented")
 
@@ -960,6 +966,9 @@ class RestZenStore(BaseZenStore):
         Args:
             user_name_or_id: Name or ID of the user to add to the team.
             team_name_or_id: Name or ID of the team to which to add the user to.
+
+        Raises:
+            NotImplementedError: This method is not implemented
         """
         raise NotImplementedError("Not Implemented")
 
@@ -972,7 +981,11 @@ class RestZenStore(BaseZenStore):
 
         Args:
             user_name_or_id: Name or ID of the user to remove from the team.
-            team_name_or_id: Name or ID of the team from which to remove the user.
+            team_name_or_id: Name or ID of the team from which to remove the
+                user.
+
+        Raises:
+            NotImplementedError: This method is not implemented
         """
         raise NotImplementedError("Not Implemented")
 

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1118,8 +1118,10 @@ class RestZenStore(BaseZenStore):
                 assign the role. If this is not provided, the role will be
                 assigned globally.
         """
-        path = f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}" \
-               f"?role_name_or_id={role_name_or_id}"
+        path = (
+            f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}"
+            f"?role_name_or_id={role_name_or_id}"
+        )
         logger.debug(f"Sending POST request to {path}...")
         self._request(
             "POST",
@@ -1145,8 +1147,10 @@ class RestZenStore(BaseZenStore):
                 the role. If this is not provided, the role will be revoked
                 globally.
         """
-        path = f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}" \
-               f"/{str(role_name_or_id)}"
+        path = (
+            f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}"
+            f"/{str(role_name_or_id)}"
+        )
         logger.debug(f"Sending POST request to {path}...")
         self._request(
             "DELETE",

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -12,7 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """REST Zen Store implementation."""
-
+import json
 import os
 import re
 from pathlib import Path, PurePath
@@ -937,6 +937,7 @@ class RestZenStore(BaseZenStore):
         Args:
             team_name_or_id: The name or ID of the team for which to get users.
         """
+        raise NotImplementedError("Not Implemented")
 
     def get_teams_for_user(
         self, user_name_or_id: Union[str, UUID]
@@ -947,6 +948,7 @@ class RestZenStore(BaseZenStore):
             user_name_or_id: The name or ID of the user for which to get all
                 teams.
         """
+        raise NotImplementedError("Not Implemented")
 
     def add_user_to_team(
         self,
@@ -959,6 +961,7 @@ class RestZenStore(BaseZenStore):
             user_name_or_id: Name or ID of the user to add to the team.
             team_name_or_id: Name or ID of the team to which to add the user to.
         """
+        raise NotImplementedError("Not Implemented")
 
     def remove_user_from_team(
         self,
@@ -971,6 +974,7 @@ class RestZenStore(BaseZenStore):
             user_name_or_id: Name or ID of the user to remove from the team.
             team_name_or_id: Name or ID of the team from which to remove the user.
         """
+        raise NotImplementedError("Not Implemented")
 
     # -----
     # Roles
@@ -1058,6 +1062,7 @@ class RestZenStore(BaseZenStore):
     def list_role_assignments(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,
+        role_name_or_id: Optional[Union[str, UUID]] = None,
         team_name_or_id: Optional[Union[str, UUID]] = None,
         user_name_or_id: Optional[Union[str, UUID]] = None,
     ) -> List[RoleAssignmentModel]:
@@ -1066,6 +1071,8 @@ class RestZenStore(BaseZenStore):
         Args:
             project_name_or_id: If provided, only list assignments for the given
                 project
+            role_name_or_id: If provided, only list assignments of the given
+                role
             team_name_or_id: If provided, only list assignments for the given
                 team
             user_name_or_id: If provided, only list assignments for the given
@@ -1111,6 +1118,14 @@ class RestZenStore(BaseZenStore):
                 assign the role. If this is not provided, the role will be
                 assigned globally.
         """
+        path = f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}" \
+               f"?role_name_or_id={role_name_or_id}"
+        logger.debug(f"Sending POST request to {path}...")
+        self._request(
+            "POST",
+            self.url + API + VERSION_1 + path,
+            data=json.dumps({}),
+        )
 
     def revoke_role(
         self,
@@ -1130,6 +1145,14 @@ class RestZenStore(BaseZenStore):
                 the role. If this is not provided, the role will be revoked
                 globally.
         """
+        path = f"{USERS}/{str(user_or_team_name_or_id)}{ROLES}" \
+               f"/{str(role_name_or_id)}"
+        logger.debug(f"Sending POST request to {path}...")
+        self._request(
+            "DELETE",
+            self.url + API + VERSION_1 + path,
+            data=json.dumps({}),
+        )
 
     # --------
     # Projects

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2226,6 +2226,7 @@ class SqlZenStore(BaseZenStore):
     def list_role_assignments(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,
+        role_name_or_id: Optional[Union[str, UUID]] = None,
         team_name_or_id: Optional[Union[str, UUID]] = None,
         user_name_or_id: Optional[Union[str, UUID]] = None,
     ) -> List[RoleAssignmentModel]:
@@ -2234,6 +2235,8 @@ class SqlZenStore(BaseZenStore):
         Args:
             project_name_or_id: If provided, only return role assignments for
                 this project.
+            role_name_or_id: If provided, only list assignments of the given
+                role
             team_name_or_id: If provided, only list assignments for this team.
             user_name_or_id: If provided, only list assignments for this user.
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2166,6 +2166,7 @@ class SqlZenStore(BaseZenStore):
     def _list_user_role_assignments(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,
+        role_name_or_id: Optional[Union[str, UUID]] = None,
         user_name_or_id: Optional[Union[str, UUID]] = None,
     ) -> List[RoleAssignmentModel]:
         """List all user role assignments.
@@ -2174,6 +2175,8 @@ class SqlZenStore(BaseZenStore):
             project_name_or_id: If provided, only return role assignments for
                 this project.
             user_name_or_id: If provided, only list assignments for this user.
+            role_name_or_id: If provided, only list assignments of the given
+                role
 
         Returns:
             A list of user role assignments.
@@ -2187,6 +2190,9 @@ class SqlZenStore(BaseZenStore):
                 query = query.where(
                     UserRoleAssignmentSchema.project_id == project.id
                 )
+            if role_name_or_id is not None:
+                role = self._get_role_schema(role_name_or_id, session=session)
+                query = query.where(UserRoleAssignmentSchema.role_id == role.id)
             if user_name_or_id is not None:
                 user = self._get_user_schema(user_name_or_id, session=session)
                 query = query.where(UserRoleAssignmentSchema.user_id == user.id)
@@ -2197,6 +2203,7 @@ class SqlZenStore(BaseZenStore):
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,
         team_name_or_id: Optional[Union[str, UUID]] = None,
+        role_name_or_id: Optional[Union[str, UUID]] = None,
     ) -> List[RoleAssignmentModel]:
         """List all team role assignments.
 
@@ -2204,6 +2211,8 @@ class SqlZenStore(BaseZenStore):
             project_name_or_id: If provided, only return role assignments for
                 this project.
             team_name_or_id: If provided, only list assignments for this team.
+            role_name_or_id: If provided, only list assignments of the given
+                role
 
         Returns:
             A list of team role assignments.
@@ -2217,6 +2226,9 @@ class SqlZenStore(BaseZenStore):
                 query = query.where(
                     TeamRoleAssignmentSchema.project_id == project.id
                 )
+            if role_name_or_id is not None:
+                role = self._get_role_schema(role_name_or_id, session=session)
+                query = query.where(TeamRoleAssignmentSchema.role_id == role.id)
             if team_name_or_id is not None:
                 team = self._get_team_schema(team_name_or_id, session=session)
                 query = query.where(TeamRoleAssignmentSchema.team_id == team.id)
@@ -2246,10 +2258,12 @@ class SqlZenStore(BaseZenStore):
         user_role_assignments = self._list_user_role_assignments(
             project_name_or_id=project_name_or_id,
             user_name_or_id=user_name_or_id,
+            role_name_or_id=role_name_or_id,
         )
         team_role_assignments = self._list_team_role_assignments(
             project_name_or_id=project_name_or_id,
             team_name_or_id=team_name_or_id,
+            role_name_or_id=role_name_or_id,
         )
         return user_role_assignments + team_role_assignments
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -740,6 +740,7 @@ class ZenStoreInterface(ABC):
     def list_role_assignments(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,
+        role_name_or_id: Optional[Union[str, UUID]] = None,
         team_name_or_id: Optional[Union[str, UUID]] = None,
         user_name_or_id: Optional[Union[str, UUID]] = None,
     ) -> List[RoleAssignmentModel]:
@@ -748,6 +749,8 @@ class ZenStoreInterface(ABC):
         Args:
             project_name_or_id: If provided, only list assignments for the given
                 project
+            role_name_or_id: If provided, only list assignments of the given
+                role
             team_name_or_id: If provided, only list assignments for the given
                 team
             user_name_or_id: If provided, only list assignments for the given


### PR DESCRIPTION
## Describe changes
The following commands will now work through the rest_zen_server
`zenml role assign admin --user stefan`
`zenml role revoke admin --user stefan`

The following command has been temporarily fixed (this [ticket](https://zenml.atlassian.net/jira/software/projects/ENG/boards/5/backlog?selectedIssue=ENG-1466) tracks the long term solution) 
`zenml role assignment list`

Verified to work with the following commands:
```
zenml status
zenml user list
zenml role list
zenml role assignment list
zenml user create stefan --password stefan
zenml role assignment list
zenml role revoke admin --user stefan
zenml role assignment list
zenml role assign guest --user stefan
zenml role assignment list
zenml user delete stefan
zenml up
zenml user list
zenml role list
zenml role assignment list
zenml user create steefan --password steefan
zenml role assignment list
zenml role revoke admin --user steefan
zenml role assignment list
zenml role assign guest --user steefan
zenml role assignment list
zenml down
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

