### PR TITLE
Add get_or_create_run() ZenStore method

### DIFF
--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -193,6 +193,7 @@ ACTIVATE = "/activate"
 INFO = "/info"
 VERSION_1 = "/v1"
 STATUS = "/status"
+GET_OR_CREATE = "/get-or-create"
 
 # mandatory stack component attributes
 MANDATORY_COMPONENT_ATTRIBUTES = ["name", "uuid"]

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -193,7 +193,6 @@ ACTIVATE = "/activate"
 INFO = "/info"
 VERSION_1 = "/v1"
 STATUS = "/status"
-GET_OR_CREATE = "/get-or-create"
 
 # mandatory stack component attributes
 MANDATORY_COMPONENT_ATTRIBUTES = ["name", "uuid"]

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -444,30 +444,6 @@ class BaseOrchestrator(StackComponent, ABC):
 
         run_id = self.get_run_id_for_orchestrator_run_id(orchestrator_run_id)
 
-        try:
-            run_model = Client().zen_store.get_run(run_id)
-        except KeyError:
-            run_model = self._create_run(
-                run_id=run_id,
-                orchestrator_run_id=orchestrator_run_id,
-            )
-
-        return run_model
-
-    def _create_run(
-        self, run_id: UUID, orchestrator_run_id: str
-    ) -> PipelineRunModel:
-        """Creates a run in the ZenStore.
-
-        Args:
-            run_id: The id of the run to create.
-            orchestrator_run_id: The orchestrator id of the run to create.
-
-        Returns:
-            The created run.
-        """
-        assert self._active_deployment
-
         date = datetime.now().strftime("%Y_%m_%d")
         time = datetime.now().strftime("%H_%M_%S_%f")
         run_name = self._active_deployment.run_name.format(date=date, time=time)
@@ -488,7 +464,7 @@ class BaseOrchestrator(StackComponent, ABC):
             num_steps=len(self._active_deployment.steps),
         )
 
-        return client.zen_store.create_run(run_model)
+        return client.zen_store.get_or_create_run(run_model)
 
     @staticmethod
     def _publish_failed_run(run_name_or_id: Union[str, UUID]) -> None:

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -44,6 +44,7 @@ from zenml.constants import (
     EMAIL_ANALYTICS,
     ENV_ZENML_DISABLE_CLIENT_SERVER_MISMATCH_WARNING,
     FLAVORS,
+    GET_OR_CREATE,
     INFO,
     INPUTS,
     LOGIN,
@@ -1401,6 +1402,25 @@ class RestZenStore(BaseZenStore):
             resource_id=run_name_or_id,
             route=RUNS,
             resource_model=PipelineRunModel,
+        )
+
+    def get_or_create_run(
+        self, pipeline_run: PipelineRunModel
+    ) -> PipelineRunModel:
+        """Gets or creates a pipeline run.
+
+        If a run with the same ID already exists, it is returned. Otherwise, a
+        new run is created.
+
+        Args:
+            pipeline_run: The pipeline run to get or create.
+
+        Returns:
+            The pipeline run.
+        """
+        return self._create_project_scoped_resource(
+            resource=pipeline_run,
+            route=f"{RUNS}{GET_OR_CREATE}",
         )
 
     def list_runs(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1408,8 +1408,8 @@ class RestZenStore(BaseZenStore):
     ) -> PipelineRunModel:
         """Gets or creates a pipeline run.
 
-        If a run with the same ID already exists, it is returned. Otherwise, a
-        new run is created.
+        If a run with the same ID or name already exists, it is returned.
+        Otherwise, a new run is created.
 
         Args:
             pipeline_run: The pipeline run to get or create.

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -44,7 +44,6 @@ from zenml.constants import (
     EMAIL_ANALYTICS,
     ENV_ZENML_DISABLE_CLIENT_SERVER_MISMATCH_WARNING,
     FLAVORS,
-    GET_OR_CREATE,
     INFO,
     INPUTS,
     LOGIN,
@@ -1419,8 +1418,7 @@ class RestZenStore(BaseZenStore):
             The pipeline run.
         """
         return self._create_project_scoped_resource(
-            resource=pipeline_run,
-            route=f"{RUNS}{GET_OR_CREATE}",
+            resource=pipeline_run, route=RUNS, params={"get_if_exists": True}
         )
 
     def list_runs(
@@ -1901,6 +1899,7 @@ class RestZenStore(BaseZenStore):
         route: str,
         request_model: Optional[Type[CreateRequest[AnyModel]]] = None,
         response_model: Optional[Type[CreateResponse[AnyModel]]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> AnyModel:
         """Create a new resource.
 
@@ -1911,6 +1910,7 @@ class RestZenStore(BaseZenStore):
                 If not provided, the resource object itself will be used.
             response_model: Optional model to use to deserialize the response
                 body. If not provided, the resource class itself will be used.
+            params: Optional query parameters to pass to the endpoint.
 
         Returns:
             The created resource.
@@ -1918,7 +1918,7 @@ class RestZenStore(BaseZenStore):
         request: BaseModel = resource
         if request_model is not None:
             request = request_model.from_model(resource)
-        response_body = self.post(f"{route}", body=request)
+        response_body = self.post(f"{route}", body=request, params=params)
         if response_model is not None:
             response = response_model.parse_obj(response_body)
             created_resource = response.to_model()
@@ -1936,6 +1936,7 @@ class RestZenStore(BaseZenStore):
         response_model: Optional[
             Type[CreateResponse[AnyProjectScopedModel]]
         ] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> AnyProjectScopedModel:
         """Create a new project scoped resource.
 
@@ -1946,6 +1947,7 @@ class RestZenStore(BaseZenStore):
                 If not provided, the resource object itself will be used.
             response_model: Optional model to use to deserialize the response
                 body. If not provided, the resource class itself will be used.
+            params: Optional query parameters to pass to the endpoint.
 
         Returns:
             The created resource.
@@ -1955,6 +1957,7 @@ class RestZenStore(BaseZenStore):
             route=f"{PROJECTS}/{str(resource.project)}{route}",
             request_model=request_model,
             response_model=response_model,
+            params=params,
         )
 
     def _get_resource(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2898,6 +2898,25 @@ class SqlZenStore(BaseZenStore):
             self.update_run(run_model)
         return run_model
 
+    def get_or_create_run(
+        self, pipeline_run: PipelineRunModel
+    ) -> PipelineRunModel:
+        """Gets or creates a pipeline run.
+
+        If a run with the same ID already exists, it is returned. Otherwise, a
+        new run is created.
+
+        Args:
+            pipeline_run: The pipeline run to get or create.
+
+        Returns:
+            The pipeline run.
+        """
+        try:
+            return self.get_run(pipeline_run.id)
+        except KeyError:
+            return self.create_run(pipeline_run)
+
     def list_runs(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2919,7 +2919,7 @@ class SqlZenStore(BaseZenStore):
         except EntityExistsError:
             # Currently, an `EntityExistsError` is raised if either the run ID
             # or the run name already exists. Therefore, we need to have another
-            # try block since getting the run by ID might still fa
+            # try block since getting the run by ID might still fail.
             try:
                 return self.get_run(pipeline_run.id)
             except KeyError:

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -992,8 +992,8 @@ class ZenStoreInterface(ABC):
     ) -> PipelineRunModel:
         """Gets or creates a pipeline run.
 
-        If a run with the same ID already exists, it is returned. Otherwise, a
-        new run is created.
+        If a run with the same ID or name already exists, it is returned.
+        Otherwise, a new run is created.
 
         Args:
             pipeline_run: The pipeline run to get or create.

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -987,6 +987,22 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
+    def get_or_create_run(
+        self, pipeline_run: PipelineRunModel
+    ) -> PipelineRunModel:
+        """Gets or creates a pipeline run.
+
+        If a run with the same ID already exists, it is returned. Otherwise, a
+        new run is created.
+
+        Args:
+            pipeline_run: The pipeline run to get or create.
+
+        Returns:
+            The pipeline run.
+        """
+
+    @abstractmethod
     def list_runs(
         self,
         project_name_or_id: Optional[Union[str, UUID]] = None,


### PR DESCRIPTION
## Describe changes
I created a `get_or_create_run()` method in the ZenStores.

This is currently only used by the orchestrator, which calls this method at the start of each step.

The main reason for moving this logic from the orchestrator into the SQLZenStore is that the server logs are now no longer polluted with error messages.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

