### PR TITLE
Rename project table to workspace

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/5330ba58bf20_rename_tables_and_foreign_keys.py
+++ b/src/zenml/zen_stores/migrations/versions/5330ba58bf20_rename_tables_and_foreign_keys.py
@@ -117,7 +117,7 @@ def _get_changes() -> Tuple[
         "pipelinerunschema": "pipeline_run",
         "steprunschema": "step_run",
         "teamassignmentschema": "team_assignment",
-        "projectschema": "project",
+        "projectschema": "workspace",
         "flavorschema": "flavor",
         "userschema": "user",
         "stackcomponentschema": "stack_component",
@@ -141,7 +141,7 @@ def _get_changes() -> Tuple[
     ]
     new_fk_constraints: List[Tuple[str, str, str, str, str]] = [
         *[
-            (source, "project", "project_id", "id", "CASCADE")
+            (source, "workspace", "project_id", "id", "CASCADE")
             for source in project_user_fk_tables
         ],  # 5
         *[
@@ -177,7 +177,7 @@ def _get_changes() -> Tuple[
         ("team_role_assignment", "role", "role_id", "id", "CASCADE"),  # 25
         (
             "team_role_assignment",
-            "project",
+            "workspace",
             "project_id",
             "id",
             "CASCADE",
@@ -186,7 +186,7 @@ def _get_changes() -> Tuple[
         ("user_role_assignment", "role", "role_id", "id", "CASCADE"),  # 28
         (
             "user_role_assignment",
-            "project",
+            "workspace",
             "project_id",
             "id",
             "CASCADE",

--- a/src/zenml/zen_stores/schemas/project_schemas.py
+++ b/src/zenml/zen_stores/schemas/project_schemas.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 class ProjectSchema(SQLModel, table=True):
     """SQL Model for projects."""
 
-    __tablename__ = "project"
+    __tablename__ = "workspace"
 
     id: UUID = Field(primary_key=True)
     name: str


### PR DESCRIPTION
## Describe changes
I renamed the project table to workspace. This only changes the table name, nothing else (all foreign keys are still called `project_id`, schemas and models still have `project`, ...)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

