### PR TITLE
Rename `step_run_artifact` table to `step_run_input_artifact`

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/5330ba58bf20_rename_tables_and_foreign_keys.py
+++ b/src/zenml/zen_stores/migrations/versions/5330ba58bf20_rename_tables_and_foreign_keys.py
@@ -109,7 +109,7 @@ def _get_changes() -> Tuple[
     # Define all the tables that should be renamed
     table_name_mapping: Dict[str, str] = {
         "roleschema": "role",
-        "stepinputartifactschema": "step_run_artifact",
+        "stepinputartifactschema": "step_run_input_artifact",
         "userroleassignmentschema": "user_role_assignment",
         "steprunorderschema": "step_run_parents",
         "teamschema": "team",
@@ -159,9 +159,15 @@ def _get_changes() -> Tuple[
         ("pipeline_run", "pipeline", "pipeline_id", "id", "SET NULL"),  # 13
         ("pipeline_run", "stack", "stack_id", "id", "SET NULL"),  # 14
         ("step_run", "pipeline_run", "pipeline_run_id", "id", "CASCADE"),  # 15
-        ("step_run_artifact", "step_run", "step_id", "id", "CASCADE"),  # 16
         (
-            "step_run_artifact",
+            "step_run_input_artifact",
+            "step_run",
+            "step_id",
+            "id",
+            "CASCADE",
+        ),  # 16
+        (
+            "step_run_input_artifact",
             "artifacts",
             "artifact_id",
             "id",

--- a/src/zenml/zen_stores/schemas/__init__.py
+++ b/src/zenml/zen_stores/schemas/__init__.py
@@ -19,7 +19,7 @@ from zenml.zen_stores.schemas.pipeline_schemas import (
     ArtifactSchema,
     PipelineRunSchema,
     PipelineSchema,
-    StepRunArtifactSchema,
+    StepRunInputArtifactSchema,
     StepRunParentsSchema,
     StepRunSchema,
 )
@@ -48,7 +48,7 @@ __all__ = [
     "UserRoleAssignmentSchema",
     "UserSchema",
     "ArtifactSchema",
-    "StepRunArtifactSchema",
+    "StepRunInputArtifactSchema",
     "StepRunParentsSchema",
     "StepRunSchema",
 ]

--- a/src/zenml/zen_stores/schemas/pipeline_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_schemas.py
@@ -464,10 +464,10 @@ class ArtifactSchema(SQLModel, table=True):
         )
 
 
-class StepRunArtifactSchema(SQLModel, table=True):
+class StepRunInputArtifactSchema(SQLModel, table=True):
     """SQL Model that defines which artifacts are inputs to which step."""
 
-    __tablename__ = "step_run_artifact"
+    __tablename__ = "step_run_input_artifact"
 
     step_id: UUID = build_foreign_key_field(
         source=__tablename__,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -103,7 +103,7 @@ from zenml.zen_stores.schemas import (
     RoleSchema,
     StackComponentSchema,
     StackSchema,
-    StepRunArtifactSchema,
+    StepRunInputArtifactSchema,
     StepRunParentsSchema,
     StepRunSchema,
     TeamAssignmentSchema,
@@ -3199,15 +3199,15 @@ class SqlZenStore(BaseZenStore):
 
             # Check if the input is already set.
             assignment = session.exec(
-                select(StepRunArtifactSchema)
-                .where(StepRunArtifactSchema.step_id == step_id)
-                .where(StepRunArtifactSchema.artifact_id == artifact_id)
+                select(StepRunInputArtifactSchema)
+                .where(StepRunInputArtifactSchema.step_id == step_id)
+                .where(StepRunInputArtifactSchema.artifact_id == artifact_id)
             ).first()
             if assignment is not None:
                 return
 
             # Save the input assignment in the database.
-            assignment = StepRunArtifactSchema(
+            assignment = StepRunInputArtifactSchema(
                 step_id=step_id, artifact_id=artifact_id, name=name
             )
             session.add(assignment)
@@ -3266,9 +3266,9 @@ class SqlZenStore(BaseZenStore):
             # Get input artifacts.
             input_artifact_list = session.exec(
                 select(
-                    StepRunArtifactSchema.artifact_id,
-                    StepRunArtifactSchema.name,
-                ).where(StepRunArtifactSchema.step_id == step.id)
+                    StepRunInputArtifactSchema.artifact_id,
+                    StepRunInputArtifactSchema.name,
+                ).where(StepRunInputArtifactSchema.step_id == step.id)
             ).all()
             input_artifacts = {
                 input_artifact[1]: input_artifact[0]
@@ -3397,9 +3397,11 @@ class SqlZenStore(BaseZenStore):
                     f"{step_id}: No step with this ID found."
                 )
             query_result = session.exec(
-                select(ArtifactSchema, StepRunArtifactSchema)
-                .where(ArtifactSchema.id == StepRunArtifactSchema.artifact_id)
-                .where(StepRunArtifactSchema.step_id == step_id)
+                select(ArtifactSchema, StepRunInputArtifactSchema)
+                .where(
+                    ArtifactSchema.id == StepRunInputArtifactSchema.artifact_id
+                )
+                .where(StepRunInputArtifactSchema.step_id == step_id)
             ).all()
             return {
                 step_input_artifact.name: artifact.to_model()


### PR DESCRIPTION
## Describe changes
I renamed the `step_run_artifact` table to `step_run_input_artifact`, and the `StepRunArtifactSchema` back to `StepRunInputArtifactSchema`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

