### PR TITLE
Remove  source pins and ignore source pins during step spec comparisons

### DIFF
--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
 from zenml.config.base_settings import BaseSettings, SettingsOrDict
 from zenml.config.constants import RESOURCE_SETTINGS_KEY
 from zenml.config.strict_base_model import StrictBaseModel
+from zenml.utils import source_utils
 
 if TYPE_CHECKING:
     from zenml.config import ResourceSettings
@@ -127,13 +128,20 @@ class StepSpec(StrictBaseModel):
             if self.upstream_steps != other.upstream_steps:
                 return False
 
-            if self.source == other.source:
+            # Remove internal version pin from older sources for backwards
+            # compatability
+            source = source_utils.remove_internal_version_pin(self.source)
+            other_source = source_utils.remove_internal_version_pin(
+                other.source
+            )
+
+            if source == other_source:
                 return True
 
-            if self.source.endswith(other.source):
+            if source.endswith(other_source):
                 return True
 
-            if other.source.endswith(self.source):
+            if other_source.endswith(source):
                 return True
 
             return False

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -129,7 +129,7 @@ class StepSpec(StrictBaseModel):
                 return False
 
             # Remove internal version pin from older sources for backwards
-            # compatability
+            # compatibility
             source = source_utils.remove_internal_version_pin(self.source)
             other_source = source_utils.remove_internal_version_pin(
                 other.source

--- a/tests/unit/config/test_step_configurations.py
+++ b/tests/unit/config/test_step_configurations.py
@@ -1,0 +1,34 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+from zenml.config.step_configurations import StepSpec
+
+
+def test_step_spec_equality():
+    """Tests the step spec equality operator."""
+    assert StepSpec(
+        source="zenml.integrations.airflow.AirflowIntegration",
+        upstream_steps=[],
+    ) == StepSpec(
+        source="zenml.integrations.airflow.AirflowIntegration@zenml_1.0.0",
+        upstream_steps=[],
+    )
+    assert StepSpec(
+        source="zenml.integrations.airflow.AirflowIntegration",
+        upstream_steps=[],
+    ) != StepSpec(
+        source="zenml.integrations.airflow.NotAirflowIntegration",
+        upstream_steps=[],
+    )

--- a/tests/unit/utils/test_source_utils.py
+++ b/tests/unit/utils/test_source_utils.py
@@ -246,3 +246,17 @@ def test_class_importing_by_path():
 
     with pytest.raises(AttributeError):
         source_utils.import_class_by_path("zenml.client.NotAClass")
+
+
+def test_internal_pin_removal():
+    """Tests that removing the internal pin removal works."""
+    assert (
+        source_utils.remove_internal_version_pin(
+            "zenml.client.Client@zenml_0.21.0"
+        )
+        == "zenml.client.Client"
+    )
+    assert (
+        source_utils.remove_internal_version_pin("zenml.client.Client")
+        == "zenml.client.Client"
+    )


### PR DESCRIPTION
## Describe changes
This PR removes our version pins and updates the step spec comparison to ignore them if added during legacy runs.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

