### PR TITLE
Bugfix/eng 1485 fix api docs build

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -53,8 +53,8 @@ jobs:
       # label_studio are currently the ones known to be very restrictive in
       # terms of what versions of dependencies they require
       # 3. Install bentoml because of its attrs version
-      # 4. Install airflow because of its attrs version>=2.1.0
-      # 5. install the rest of the integrations
+      # 4. Install airflow because of its attrs version>=22.1.0
+      # 5. install the rest of the integrations (where aws depends on attrs==20.3.0)
       # 6. as the last step, install zenml again (step 1. repeated)
       # 7. Reinstall jinja in the correct version as the contexthandler is
       # deprecated in 3.1.0 but mkdocstring depends on this method

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -52,15 +52,22 @@ jobs:
       # 2. install more restrictive integrations first: feast, seldon and
       # label_studio are currently the ones known to be very restrictive in
       # terms of what versions of dependencies they require
-      # 3. install the rest of the integrations
-      # 4. as the last step, install zenml again (step 1. repeated)
+      # 3. Install bentoml because of its attrs version
+      # 4. Install airflow because of its attrs version>=2.1.0
+      # 5. install the rest of the integrations
+      # 6. as the last step, install zenml again (step 1. repeated)
+      # 7. Reinstall jinja in the correct version as the contexthandler is
+      # deprecated in 3.1.0 but mkdocstring depends on this method
       - name: Install Dependencies
         run: |
           source $VENV
           zenml integration install -y feast
           zenml integration install -y label_studio seldon
-          zenml integration install -y --ignore-integration feast --ignore-integration label_studio --ignore-integration seldon
+          zenml integration install -y bentoml
+          zenml integration install -y airflow
+          zenml integration install -y --ignore-integration feast --ignore-integration label_studio --ignore-integration seldon --ignore-integration airflow --ignore-integration bentoml
           poetry install --extras server
+          pip install jinja2==3.0.3
 
       - name: Setup git user
         run: |

--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -110,6 +110,7 @@ BentoMLDeploymentService
 BentoMLModelDeployer
 BentoMlDeploymentConfig
 Bentos
+behaviour
 Bing
 Bitbucket
 BluePill
@@ -591,6 +592,7 @@ SecretSchemas
 SecretsManager
 SecretsManagerReadWrite
 SecretsManagerScope
+selectable
 Seldon
 SeldonClient
 SeldonClientError


### PR DESCRIPTION
## Describe changes
The API Docs build was failing because of sagemaker, airflow and bentoml having conflicting pins on their attrs version. On top of that, the neweset version on jinja2 deprecated the contexthandler which is used by mkdocstrings.

 
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

