### PR TITLE
zenml <stack-component> logs defaults to active stack without name_or_id

### DIFF
--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -832,15 +832,16 @@ def generate_stack_component_logs_command(
         client = Client()
 
         if not name_or_id:
-            component_model = client.active_stack_model.components.get(
+            component_models = client.active_stack_model.components.get(
                 component_type, []
             )
-            if len(component_model) == 0:
+            if len(component_models) == 0:
                 cli_utils.error(
                     f"Cannot describe any {component_type} since the active "
                     f"stack has no {component_type} and no name or id was "
                     f"provided."
                 )
+            component_model = component_models[0]
         else:
             try:
                 component_model = (


### PR DESCRIPTION
## Describe changes
https://github.com/zenml-io/zenml/issues/1088 - this issue was caused by improper handling of a optional `name_or_íd` parameter for the logs command of stack-components. 

The new logic will check the active stack for the stack component if no name_or_id is supplied. If neither name_or_id are supplied and no active stack component of the type exists, then it will fail.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

