### PR TITLE
Remove local orchestrator restriction from step operator docs

### DIFF
--- a/docs/book/component-gallery/step-operators/amazon-sagemaker.md
+++ b/docs/book/component-gallery/step-operators/amazon-sagemaker.md
@@ -40,11 +40,9 @@ your stack. This is needed so that both your orchestration environment
 and SageMaker can read and write step artifacts. Check out the documentation 
 page of the artifact store you want to use for more information on how to set 
 that up and configure authentication for it.
-* A [local orchestrator](../orchestrators/local.md) as part of your stack. 
-This is a current limitation of the SageMaker step operator which will be 
-resolved in an upcoming release.
-* The `aws` cli set up and authenticated. Make sure you have the permissions to 
-create and manage SageMaker runs.
+* If using a [local orchestrator](../orchestrators/local.md): The `aws` cli set up and authenticated. Make sure you have the permissions to create and manage SageMaker runs.
+* If using a remote orchestrator: The environment in which the orchestrator runs its containers needs to be able
+to assume the IAM role specified when registering the SageMaker step operator.
 * An instance type that we want to execute our steps on.
 See [here](https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html)
 for a list of available instance types.

--- a/docs/book/component-gallery/step-operators/gcloud-vertexai.md
+++ b/docs/book/component-gallery/step-operators/gcloud-vertexai.md
@@ -43,9 +43,6 @@ your stack. This is needed so that both your orchestration environment and
 VertexAI can read and write step artifacts. Check out the documentation page 
 of the artifact store you want to use for more information on how to set that up
 and configure authentication for it.
-* A [local orchestrator](../orchestrators/local.md) as part of your stack. 
-This is a current limitation of the Vertex step operator which will be 
-resolved in an upcoming release.
 
 We can then register the step operator and use it in our active stack:
 ```shell


### PR DESCRIPTION
## Describe changes

I remember doing this before, but it seems my change didn't survive some merge. The SageMaker and Vertex step
operator don't require a local orchestrator anymore since we updated them to build Docker images before the pipeline
is running.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

