### PR TITLE
Skip kubeflow UI daemon provisioning if a hostname is configured

### DIFF
--- a/tests/unit/integrations/kubeflow/orchestrators/test_kubeflow_orchestrator.py
+++ b/tests/unit/integrations/kubeflow/orchestrators/test_kubeflow_orchestrator.py
@@ -76,23 +76,23 @@ def test_kubeflow_orchestrator_stack_validation(
         ).validate()
 
 
-def test_skip_ui_daemon_provisioning():
+@pytest.mark.parametrize(
+    "config,skip_ui_daemon_provisioning",
+    [
+        (KubeflowOrchestratorConfig(), False),
+        (
+            KubeflowOrchestratorConfig(
+                kubeflow_hostname="https://arias-kubeflow.com/pipeline"
+            ),
+            True,
+        ),
+        (KubeflowOrchestratorConfig(skip_ui_daemon_provisioning=True), True),
+    ],
+)
+def test_skip_ui_daemon_provisioning(config, skip_ui_daemon_provisioning):
     """Tests that the UI daemon provisioning is skipped if either set explicitly
     or when a hostname is specified."""
-    empty_config = KubeflowOrchestratorConfig()
     assert (
-        _get_kubeflow_orchestrator(empty_config).skip_ui_daemon_provisioning
-        is False
-    )
-
-    config = KubeflowOrchestratorConfig(
-        kubeflow_hostname="https://arias-kubeflow.com/pipeline"
-    )
-    assert (
-        _get_kubeflow_orchestrator(config).skip_ui_daemon_provisioning is True
-    )
-
-    config = KubeflowOrchestratorConfig(skip_ui_daemon_provisioning=True)
-    assert (
-        _get_kubeflow_orchestrator(config).skip_ui_daemon_provisioning is True
+        _get_kubeflow_orchestrator(config).skip_ui_daemon_provisioning
+        is skip_ui_daemon_provisioning
     )


### PR DESCRIPTION
## Describe changes
When a hostname is configured for the KubeflowOrchestrator, the UI is already accessible and we don't need to run the local port-forwarding daemon.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

