### PR TITLE
Remove stack extra from installation, enable re-running the quickstart

### DIFF
--- a/docs/book/getting-started/installation/installation.md
+++ b/docs/book/getting-started/installation/installation.md
@@ -21,12 +21,6 @@ ZenML comes bundled with a React-based dashboard that lives inside a [sister rep
 pip install "zenml[server]"
 ```
 
-If you do not have deployed infrastructure, and want to quickly spin up combinations of tools on the cloud, the [MLOps stack sister repository](https://github.com/zenml-io/mlops-stacks) contains a series of Terraform-based recipes to provision such stacks. These recipes can be used directly with ZenML:
-
-```shell
-pip install "zenml[stacks]"
-```
-
 ## Virtual Environments
 
 We highly encourage you to install ZenML in a virtual environment.

--- a/examples/quickstart/setup.sh
+++ b/examples/quickstart/setup.sh
@@ -8,7 +8,8 @@ setup_stack () {
     msg "${WARNING}Reusing preexisting model deployer ${NOFORMAT}mlflow_deployer"
   zenml experiment-tracker register mlflow_tracker  --flavor=mlflow || \
     msg "${WARNING}Reusing preexisting experiment tracker ${NOFORMAT}mlflow_tracker"
-  zenml data-validator register evidently_validator --flavor=evidently
+  zenml data-validator register evidently_validator --flavor=evidently || \
+    msg "${WARNING}Reusing preexisting data validator ${NOFORMAT}evidently_validator"
   zenml stack register quickstart_stack \
       -a default \
       -o default \


### PR DESCRIPTION
## Describe changes
- `zenml example run quickstart` failed when running it for the second time as it tried to register a stack component that already exists
- The `zenml[stacks]` extra doesn't exist anymore

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

