### PR TITLE
Prevent running with local ZenStore and remote code execution

### DIFF
--- a/docs/book/component-gallery/orchestrators/airflow.md
+++ b/docs/book/component-gallery/orchestrators/airflow.md
@@ -105,7 +105,7 @@ In the remote case, the Airflow orchestrator works differently than other ZenML 
 Executing a python file which runs a pipeline by calling `pipeline.run()` will not actually run
 the pipeline, but instead will create a `.zip` file containing an Airflow representation of your
 ZenML pipeline. In one additional step, you need to make sure this zip file ends up in the
-[DAGs directoy](https://airflow.apache.org/docs/apache-airflow/stable/concepts/overview.html#architecture-overview) of your Airflow deployment.
+[DAGs directory](https://airflow.apache.org/docs/apache-airflow/stable/concepts/overview.html#architecture-overview) of your Airflow deployment.
 
 {% endtab %}
 {% endtabs %}

--- a/examples/airflow_orchestration/README.md
+++ b/examples/airflow_orchestration/README.md
@@ -137,7 +137,7 @@ In the remote case, the Airflow orchestrator works different than other ZenML or
 Calling `python run.py` will not actually run the pipeline, but instead will create a
 `.zip` file containing an Airflow representation of your ZenML pipeline.
 In one additional step, you need to make sure this zip file ends up in the
-[DAGs directoy](https://airflow.apache.org/docs/apache-airflow/stable/concepts/overview.html#architecture-overview)
+[DAGs directory](https://airflow.apache.org/docs/apache-airflow/stable/concepts/overview.html#architecture-overview)
 of your Airflow deployment.
 
 # 📜 Learn more

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -680,7 +680,8 @@ class Stack:
 
         if self.requires_remote_server and Client().zen_store.is_local_store():
             raise RuntimeError(
-                "Remote orchestrators and step operators require a remote "
+                "Stacks with remote components such as remote orchestrators "
+                "and step operators require a remote "
                 "ZenML server. To run a pipeline with this stack you need to "
                 "connect to a remote ZenML server first. Check out "
                 "https://docs.zenml.io/getting-started/deploying-zenml for "

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -663,6 +663,8 @@ class Stack:
 
         Raises:
             StackValidationError: If the stack component is not running.
+            RuntimeError: If trying to deploy a pipeline that requires a remote
+                ZenML server with a local one.
         """
         self.validate(fail_if_secrets_missing=True)
 

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -542,7 +542,8 @@ class Stack:
             If the stack requires a remote ZenServer to run.
         """
         return self.orchestrator.config.is_remote or (
-            self.step_operator and self.step_operator.config.is_remote
+            self.step_operator is not None
+            and self.step_operator.config.is_remote
         )
 
     def _validate_secrets(self, raise_exception: bool) -> None:

--- a/tests/unit/stack/conftest.py
+++ b/tests/unit/stack/conftest.py
@@ -41,6 +41,7 @@ def stack_with_mock_components(mocker):
     )
     orchestrator.config.required_secrets = set()
     orchestrator.settings_class = None
+    orchestrator.config.is_remote = False
 
     artifact_store.config.required_secrets = set()
     artifact_store.settings_class = None

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -396,3 +396,83 @@ def test_stack_provisioning_fails_if_stack_component_validation_fails(
 
     with pytest.raises(StackValidationError):
         stack_with_mock_components.provision()
+
+
+def test_requires_remote_server(stack_with_mock_components, mocker):
+    """Tests that the stack requires a remote server if either the orchestrator
+    or the step operator are remote."""
+    from zenml.step_operators import BaseStepOperator
+
+    step_operator = mocker.Mock(
+        spec=BaseStepOperator,
+        type=StackComponentType.STEP_OPERATOR,
+        flavor="mock",
+        name="mock_step_operator",
+    )
+    stack_with_mock_components._step_operator = step_operator
+
+    stack_with_mock_components.orchestrator.config.is_remote = False
+    stack_with_mock_components.step_operator.config.is_remote = False
+    assert stack_with_mock_components.requires_remote_server is False
+
+    stack_with_mock_components.orchestrator.config.is_remote = True
+    stack_with_mock_components.step_operator.config.is_remote = False
+    assert stack_with_mock_components.requires_remote_server is True
+
+    stack_with_mock_components.orchestrator.config.is_remote = False
+    stack_with_mock_components.step_operator.config.is_remote = True
+    assert stack_with_mock_components.requires_remote_server is True
+
+
+def test_deployment_server_validation(mocker, stack_with_mock_components):
+    """Tests that the deployment validation fails when the stack requires a
+    remote server but the store is local."""
+    deployment = PipelineDeployment(
+        run_name="",
+        stack_id=uuid4(),
+        pipeline={"name": "", "enable_cache": True},
+        proto_pipeline="",
+    )
+
+    ######### Remote server #########
+    mocker.patch(
+        "zenml.zen_stores.base_zen_store.BaseZenStore.is_local_store",
+        return_value=False,
+    )
+    mocker.patch(
+        "zenml.stack.Stack.requires_remote_server",
+        return_value=False,
+        new_callable=mocker.PropertyMock,
+    )
+    with does_not_raise():
+        stack_with_mock_components.prepare_pipeline_deployment(deployment)
+
+    mocker.patch(
+        "zenml.stack.Stack.requires_remote_server",
+        return_value=True,
+        new_callable=mocker.PropertyMock,
+    )
+    with does_not_raise():
+        stack_with_mock_components.prepare_pipeline_deployment(deployment)
+
+    ######### Local server #########
+    mocker.patch(
+        "zenml.zen_stores.base_zen_store.BaseZenStore.is_local_store",
+        return_value=True,
+    )
+
+    mocker.patch(
+        "zenml.stack.Stack.requires_remote_server",
+        return_value=False,
+        new_callable=mocker.PropertyMock,
+    )
+    with does_not_raise():
+        stack_with_mock_components.prepare_pipeline_deployment(deployment)
+
+    mocker.patch(
+        "zenml.stack.Stack.requires_remote_server",
+        return_value=True,
+        new_callable=mocker.PropertyMock,
+    )
+    with pytest.raises(RuntimeError):
+        stack_with_mock_components.prepare_pipeline_deployment(deployment)


### PR DESCRIPTION
## Describe changes
This PR adds an error if trying to run with a remote orchestrator or step operator in combination with a local ZenStore.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

