### PR TITLE
Fix Client flavor-related methods

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -51,9 +51,12 @@ from zenml.exceptions import (
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.models import (
+    ArtifactRequestModel,
     ComponentRequestModel,
+    ComponentResponseModel,
     ComponentUpdateModel,
     FlavorRequestModel,
+    FlavorResponseModel,
     PipelineRequestModel,
     PipelineResponseModel,
     PipelineRunRequestModel,
@@ -73,20 +76,18 @@ from zenml.models import (
     StepRunResponseModel,
     TeamRequestModel,
     TeamResponseModel,
+    TeamUpdateModel,
     UserRequestModel,
     UserResponseModel,
     UserUpdateModel,
 )
-from zenml.models.artifact_models import ArtifactRequestModel
 from zenml.models.base_models import BaseResponseModel
-from zenml.models.team_models import TeamUpdateModel
 from zenml.utils import io_utils
 from zenml.utils.analytics_utils import AnalyticsEvent, track
 from zenml.utils.filesync_model import FileSyncModel
 
 if TYPE_CHECKING:
     from zenml.config.pipeline_configurations import PipelineSpec
-    from zenml.models import ComponentResponseModel, FlavorResponseModel
     from zenml.stack import Stack, StackComponentConfig
     from zenml.zen_stores.base_zen_store import BaseZenStore
 


### PR DESCRIPTION
## Describe changes
The `FlavorResponseModel` was only imported for type checking and the commands related to it were failing.
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

