### PR TITLE
Made explicit `is not None` calls to allow for empty pwd again

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -51,7 +51,6 @@ from zenml.exceptions import (
 from zenml.io import fileio
 from zenml.logger import get_logger
 from zenml.models import (
-    ArtifactRequestModel,
     ComponentRequestModel,
     ComponentResponseModel,
     ComponentUpdateModel,

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1464,7 +1464,10 @@ class RestZenStore(BaseZenStore):
             if self.config.api_token:
                 self._api_token = self.config.api_token
             # Check if the username and password are provided in the config
-            elif self.config.username and self.config.password:
+            elif (
+                self.config.username is not None
+                and self.config.password is not None
+            ):
                 response = self._handle_response(
                     requests.post(
                         self.url + API + VERSION_1 + LOGIN,


### PR DESCRIPTION
## Describe changes
ZenML up did not work on develop for default user with empty password

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

