### PR TITLE
Adding component conditions to experiment tracker examples and adding to the environmental variable docs

### DIFF
--- a/docs/book/guidelines/system-environmental-variables.md
+++ b/docs/book/guidelines/system-environmental-variables.md
@@ -27,7 +27,8 @@ Setting to `true` switches to developer mode:
 ZENML_DEBUG=false
 ```
 
-Setting to a specific UUID will make the corresponding stack the active stack:
+Setting the `ZENML_ACTIVE_STACK_ID` to a specific UUID will make the 
+corresponding stack the active stack:
 ```bash
 ZENML_ACTIVE_STACK_ID=<UUID-OF-YOUR-STACK>
 ```

--- a/docs/book/guidelines/system-environmental-variables.md
+++ b/docs/book/guidelines/system-environmental-variables.md
@@ -27,6 +27,11 @@ Setting to `true` switches to developer mode:
 ZENML_DEBUG=false
 ```
 
+Setting to a specific UUID will make the corresponding stack the active stack:
+```bash
+ZENML_ACTIVE_STACK_ID=<UUID-OF-YOUR-STACK>
+```
+
 When `true`, this prevents a pipeline from executing:
 ```bash
 ZENML_PREVENT_PIPELINE_EXECUTION=false

--- a/examples/mlflow_deployment/steps/tf_evaluator/tf_evaluator_step.py
+++ b/examples/mlflow_deployment/steps/tf_evaluator/tf_evaluator_step.py
@@ -16,9 +16,20 @@ import numpy as np  # type: ignore [import]
 import tensorflow as tf  # type: ignore [import]
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 @step(experiment_tracker=experiment_tracker.name)

--- a/examples/mlflow_deployment/steps/tf_trainer/tf_trainer_step.py
+++ b/examples/mlflow_deployment/steps/tf_trainer/tf_trainer_step.py
@@ -16,9 +16,20 @@ import numpy as np  # type: ignore [import]
 import tensorflow as tf  # type: ignore [import]
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import BaseParameters, step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 class TrainerParameters(BaseParameters):

--- a/examples/mlflow_tracking/steps/evaluator/evaluator_step.py
+++ b/examples/mlflow_tracking/steps/evaluator/evaluator_step.py
@@ -16,9 +16,20 @@ import numpy as np
 import tensorflow as tf
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 @step(experiment_tracker=experiment_tracker.name)

--- a/examples/mlflow_tracking/steps/trainer/trainer_step.py
+++ b/examples/mlflow_tracking/steps/trainer/trainer_step.py
@@ -16,9 +16,20 @@ import numpy as np
 import tensorflow as tf
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import BaseParameters, step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 class TrainerParameters(BaseParameters):

--- a/examples/neptune_tracking/steps/evaluator/evaluator_step.py
+++ b/examples/neptune_tracking/steps/evaluator/evaluator_step.py
@@ -16,13 +16,26 @@ import numpy as np
 import tensorflow as tf
 
 from zenml.client import Client
+from zenml.integrations.neptune.experiment_trackers import (
+    NeptuneExperimentTracker,
+)
 from zenml.integrations.neptune.experiment_trackers.run_state import (
     get_neptune_run,
 )
 from zenml.steps import step
 
+experiment_tracker = Client().active_stack.experiment_tracker
 
-@step(experiment_tracker=Client().active_stack.experiment_tracker.name)
+if not experiment_tracker or not isinstance(
+    experiment_tracker, NeptuneExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a Neptune experiment tracker for "
+        "this example to work."
+    )
+
+
+@step(experiment_tracker=experiment_tracker.name)
 def tf_evaluator(
     x_test: np.ndarray,
     y_test: np.ndarray,

--- a/examples/neptune_tracking/steps/trainer/trainer_step.py
+++ b/examples/neptune_tracking/steps/trainer/trainer_step.py
@@ -17,6 +17,9 @@ import tensorflow as tf
 from neptune.new.integrations.tensorflow_keras import NeptuneCallback
 
 from zenml.client import Client
+from zenml.integrations.neptune.experiment_trackers import (
+    NeptuneExperimentTracker,
+)
 from zenml.integrations.neptune.experiment_trackers.run_state import (
     get_neptune_run,
 )
@@ -25,6 +28,16 @@ from zenml.integrations.tensorflow.materializers.keras_materializer import (
     KerasMaterializer,
 )
 from zenml.steps import BaseParameters, step
+
+experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, NeptuneExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a Neptune experiment tracker for "
+        "this example to work."
+    )
 
 
 class TrainerParameters(BaseParameters):
@@ -39,7 +52,7 @@ settings = NeptuneExperimentTrackerSettings(tags={"keras", "mnist"})
 
 @step(
     enable_cache=False,
-    experiment_tracker=Client().active_stack.experiment_tracker.name,
+    experiment_tracker=experiment_tracker.name,
     output_materializers=KerasMaterializer,
     settings={"experiment_tracker.neptune": settings},
 )

--- a/examples/quickstart/steps/trainers.py
+++ b/examples/quickstart/steps/trainers.py
@@ -18,9 +18,20 @@ from sklearn.base import ClassifierMixin
 from sklearn.svm import SVC
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 @step(enable_cache=False, experiment_tracker=experiment_tracker.name)

--- a/examples/slack_alert/steps/trainer.py
+++ b/examples/slack_alert/steps/trainer.py
@@ -18,9 +18,20 @@ from sklearn.base import ClassifierMixin
 from sklearn.svm import SVC
 
 from zenml.client import Client
+from zenml.integrations.mlflow.experiment_trackers import (
+    MLFlowExperimentTracker,
+)
 from zenml.steps import step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, MLFlowExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a MLFlow experiment tracker for "
+        "this example to work."
+    )
 
 
 @step

--- a/examples/wandb_tracking/steps/evaluator/evaluator_step.py
+++ b/examples/wandb_tracking/steps/evaluator/evaluator_step.py
@@ -16,9 +16,18 @@ import tensorflow as tf
 import wandb
 
 from zenml.client import Client
+from zenml.integrations.wandb.experiment_trackers import WandbExperimentTracker
 from zenml.steps import step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, WandbExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a WandB experiment tracker for "
+        "this example to work."
+    )
 
 
 @step(experiment_tracker=experiment_tracker.name)

--- a/examples/wandb_tracking/steps/trainer/trainer_step.py
+++ b/examples/wandb_tracking/steps/trainer/trainer_step.py
@@ -16,9 +16,18 @@ import tensorflow as tf
 from wandb.integration.keras import WandbCallback
 
 from zenml.client import Client
+from zenml.integrations.wandb.experiment_trackers import WandbExperimentTracker
 from zenml.steps import BaseParameters, step
 
 experiment_tracker = Client().active_stack.experiment_tracker
+
+if not experiment_tracker or not isinstance(
+    experiment_tracker, WandbExperimentTracker
+):
+    raise RuntimeError(
+        "Your active stack needs to contain a WandB experiment tracker for "
+        "this example to work."
+    )
 
 
 class TrainerParameters(BaseParameters):


### PR DESCRIPTION
## Describe changes
- I have added a condition to some of our examples to include a specific type of experiment tracker. This way we can avoid the `NoneType has no attribute 'name'` error. 
- All the examples with step operators which mirror this problem were already taken care of.
- I have also added one-liner to the list of environmental variables on our docs.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

