### PR TITLE
Fix alembic migration for sqlite<3.25

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/7834208cc3f6_artifact_project_scoping.py
+++ b/src/zenml/zen_stores/migrations/versions/7834208cc3f6_artifact_project_scoping.py
@@ -89,7 +89,7 @@ def upgrade() -> None:
         producer_step_run = conn.execute(
             select([step_runs])
             .where(step_runs.c.status == "completed")
-            .where(step_runs.c.id == step_run_output_artifacts.c.step_run_id)
+            .where(step_runs.c.id == step_run_output_artifacts.c.step_id)
             .where(step_run_output_artifacts.c.artifact_id == artifact.id)
         ).first()
         if producer_step_run is not None:

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -225,10 +225,10 @@ class StepRunInputArtifactSchema(SQLModel, table=True):
 
     __tablename__ = "step_run_input_artifact"
 
-    step_run_id: UUID = build_foreign_key_field(
+    step_id: UUID = build_foreign_key_field(
         source=__tablename__,
         target=StepRunSchema.__tablename__,
-        source_column="step_run_id",
+        source_column="step_id",
         target_column="id",
         ondelete="CASCADE",
         nullable=False,
@@ -251,10 +251,10 @@ class StepRunOutputArtifactSchema(SQLModel, table=True):
 
     __tablename__ = "step_run_output_artifact"
 
-    step_run_id: UUID = build_foreign_key_field(
+    step_id: UUID = build_foreign_key_field(
         source=__tablename__,
         target=StepRunSchema.__tablename__,
-        source_column="step_run_id",
+        source_column="step_id",
         target_column="id",
         ondelete="CASCADE",
         nullable=False,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -3022,7 +3022,7 @@ class SqlZenStore(BaseZenStore):
         # Check if the input is already set.
         assignment = session.exec(
             select(StepRunInputArtifactSchema)
-            .where(StepRunInputArtifactSchema.step_run_id == run_step_id)
+            .where(StepRunInputArtifactSchema.step_id == run_step_id)
             .where(StepRunInputArtifactSchema.artifact_id == artifact_id)
         ).first()
         if assignment is not None:
@@ -3030,7 +3030,7 @@ class SqlZenStore(BaseZenStore):
 
         # Save the input assignment in the database.
         assignment = StepRunInputArtifactSchema(
-            step_run_id=run_step_id, artifact_id=artifact_id, name=name
+            step_id=run_step_id, artifact_id=artifact_id, name=name
         )
         session.add(assignment)
 
@@ -3075,7 +3075,7 @@ class SqlZenStore(BaseZenStore):
         # Check if the output is already set.
         assignment = session.exec(
             select(StepRunOutputArtifactSchema)
-            .where(StepRunOutputArtifactSchema.step_run_id == step_run_id)
+            .where(StepRunOutputArtifactSchema.step_id == step_run_id)
             .where(StepRunOutputArtifactSchema.artifact_id == artifact_id)
         ).first()
         if assignment is not None:
@@ -3083,7 +3083,7 @@ class SqlZenStore(BaseZenStore):
 
         # Save the output assignment in the database.
         assignment = StepRunOutputArtifactSchema(
-            step_run_id=step_run_id,
+            step_id=step_run_id,
             artifact_id=artifact_id,
             name=name,
         )
@@ -3141,7 +3141,7 @@ class SqlZenStore(BaseZenStore):
                 .where(
                     ArtifactSchema.id == StepRunInputArtifactSchema.artifact_id
                 )
-                .where(StepRunInputArtifactSchema.step_run_id == step_run.id)
+                .where(StepRunInputArtifactSchema.step_id == step_run.id)
             ).all()
             input_artifacts = {
                 input_name: self._artifact_schema_to_model(artifact)
@@ -3157,7 +3157,7 @@ class SqlZenStore(BaseZenStore):
                 .where(
                     ArtifactSchema.id == StepRunOutputArtifactSchema.artifact_id
                 )
-                .where(StepRunOutputArtifactSchema.step_run_id == step_run.id)
+                .where(StepRunOutputArtifactSchema.step_id == step_run.id)
             ).all()
             output_artifacts = {
                 output_name: self._artifact_schema_to_model(artifact)
@@ -3289,14 +3289,12 @@ class SqlZenStore(BaseZenStore):
         # Find the producer step run ID.
         with Session(self.engine) as session:
             producer_step_run_id = session.exec(
-                select(StepRunOutputArtifactSchema.step_run_id)
+                select(StepRunOutputArtifactSchema.step_id)
                 .where(
                     StepRunOutputArtifactSchema.artifact_id
                     == artifact_schema.id
                 )
-                .where(
-                    StepRunOutputArtifactSchema.step_run_id == StepRunSchema.id
-                )
+                .where(StepRunOutputArtifactSchema.step_id == StepRunSchema.id)
                 .where(StepRunSchema.status != ExecutionStatus.CACHED)
             ).first()
 


### PR DESCRIPTION
## Describe changes
I fixed the 0.30.0 migrations for users with sqlite<3.25 (e.g., anyone on Ubuntu 16.04 or Ubuntu 18.04).

The main change is that this renames `step_run_input_artifact.step_run_id` and `step_run_output_artifact.step_run_id` back to `step_id`.

This will break the DB for anyone who executed the 0.30.0 migrations prior to this change. As a result, anyone who installed RC versions of 0.30.0 needs to wipe his database before upgrading to non-RC versions.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

