### PR TITLE
Persist the server ID in the database

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -869,6 +869,7 @@ bento
 bentoctl
 bentoml
 bff
+bigquery
 bigrams
 blogpost
 bool

--- a/docs/book/getting-started/deploying-zenml/docker.md
+++ b/docs/book/getting-started/deploying-zenml/docker.md
@@ -105,17 +105,6 @@ useful in certain scenarios that require mirroring the same ZenML server
 configuration across multiple container instances (e.g. a Kubernetes
 deployment with multiple replicas):
 
-- **ZENML_USER_ID**:
-    This is a UUID value that is used to uniquely identify the server's
-    identity (e.g. in analytics). If not explicitly set, it is generated
-    automatically by the server and stored in the server's global configuration.
-    This should be set to a random UUID value, e.g.:
-
-     ```python
-     from uuid import uuid4
-     print(uuid4())
-     ```
-
 - **ZENML_JWT_SECRET_KEY**:
     This is a secret key used to sign JWT tokens used for authentication. If
     not explicitly set, a random key is generated automatically by the server

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 set -x
+set -o pipefail
 
 SRC=${1:-"src/zenml tests examples"}
 SRC_NO_TESTS=${1:-"src/zenml tests/harness"}
@@ -8,7 +9,7 @@ SRC_NO_TESTS=${1:-"src/zenml tests/harness"}
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false
 flake8 $SRC
-autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place $SRC --exclude=__init__.py --check
+autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place $SRC --exclude=__init__.py --check | ( grep -v "No issues detected" || true )
 isort $SRC scripts --check-only
 black $SRC  --check
 

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -484,9 +484,6 @@ def deploy(
         metadata = {
             "server_deployment": str(server.config.provider),
         }
-        from zenml.zen_server.deploy.terraform.terraform_zen_server import (
-            TerraformServerDeploymentConfig,
-        )
 
         analytics_handler.metadata = metadata
 
@@ -527,10 +524,6 @@ def destroy() -> None:
         metadata = {
             "server_deployment": str(server.config.provider),
         }
-
-        from zenml.zen_server.deploy.terraform.terraform_zen_server import (
-            TerraformServerDeploymentConfig,
-        )
 
         analytics_handler.metadata = metadata
 

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -488,11 +488,6 @@ def deploy(
             TerraformServerDeploymentConfig,
         )
 
-        if isinstance(server.config, TerraformServerDeploymentConfig):
-            # TODO: maybe move the server ID into the ServerDeploymentConfig
-            #   class
-            metadata["server_id"] = str(server.config.server_id)
-
         analytics_handler.metadata = metadata
 
         if server.status and server.status.url:
@@ -536,9 +531,6 @@ def destroy() -> None:
         from zenml.zen_server.deploy.terraform.terraform_zen_server import (
             TerraformServerDeploymentConfig,
         )
-
-        if isinstance(server.config, TerraformServerDeploymentConfig):
-            metadata["server_id"] = str(server.config.server_id)
 
         analytics_handler.metadata = metadata
 

--- a/src/zenml/zen_server/deploy/helm/templates/server-secret.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-secret.yaml
@@ -7,12 +7,6 @@ metadata:
     {{- include "zenml.labels" . | nindent 4 }}
 data:
   ZENML_DEFAULT_USER_PASSWORD: {{ .Values.zenml.defaultPassword | b64enc | quote }}
-  {{- if not .Release.IsInstall }}
-  {{-   $deprecatedServerID := (lookup "v1" "Secret" .Release.Namespace (include "zenml.fullname" .)).data.ZENML_USER_ID | default '' -}}
-  {{-   if ne $deprecatedServerID '' }}
-  ZENML_USER_ID: {{ $deprecatedServerID | b64enc | quote) }}
-  {{-   end }}
-  {{- end }}
   {{- if .Values.zenml.jwtSecretKey }}
   ZENML_JWT_SECRET_KEY: {{ .Values.zenml.jwtSecretKey | b64enc | quote }}
   {{- else if .Release.IsInstall }}

--- a/src/zenml/zen_server/deploy/helm/templates/server-secret.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-secret.yaml
@@ -7,12 +7,11 @@ metadata:
     {{- include "zenml.labels" . | nindent 4 }}
 data:
   ZENML_DEFAULT_USER_PASSWORD: {{ .Values.zenml.defaultPassword | b64enc | quote }}
-  {{- if .Values.zenml.serverId }}
-  ZENML_USER_ID: {{ .Values.zenml.serverId | b64enc | quote }}
-  {{- else if .Release.IsInstall }}
-  ZENML_USER_ID: {{ uuidv4 | b64enc | quote }}
-  {{- else }}
-  ZENML_USER_ID: {{ (lookup "v1" "Secret" .Release.Namespace (include "zenml.fullname" .)).data.ZENML_USER_ID | default (uuidv4 | b64enc | quote)  }}
+  {{- if not .Release.IsInstall }}
+  {{-   $deprecatedServerID := (lookup "v1" "Secret" .Release.Namespace (include "zenml.fullname" .)).data.ZENML_USER_ID | default '' -}}
+  {{-   if ne $deprecatedServerID '' }}
+  ZENML_USER_ID: {{ $deprecatedServerID | b64enc | quote) }}
+  {{-   end }}
   {{- end }}
   {{- if .Values.zenml.jwtSecretKey }}
   ZENML_JWT_SECRET_KEY: {{ .Values.zenml.jwtSecretKey | b64enc | quote }}

--- a/src/zenml/zen_server/deploy/helm/values.yaml
+++ b/src/zenml/zen_server/deploy/helm/values.yaml
@@ -28,11 +28,6 @@ zenml:
   # Example values are "local", "kubernetes", "aws", "gcp", "azure".
   deploymentType:
 
-  # Unique server UUID. Used to uniquely identify the server in the
-  # telemetry events. If not set, a random UUID will be generated when the helm
-  # chart is installed and reused for all subsequent upgrades.
-  serverId:
-
   # The ZenML authentication scheme. Use one of:
   # 
   # NO_AUTH - No authentication

--- a/src/zenml/zen_server/deploy/terraform/providers/terraform_provider.py
+++ b/src/zenml/zen_server/deploy/terraform/providers/terraform_provider.py
@@ -188,7 +188,6 @@ class TerraformServerProvider(BaseServerProvider):
         assert isinstance(service, TerraformZenServer)
 
         # preserve the server ID across updates
-        new_config.server.server_id = service.config.server.server_id
         service.config = new_config
         service.start(timeout=timeout)
 

--- a/src/zenml/zen_server/deploy/terraform/recipes/aws/variables.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/aws/variables.tf
@@ -1,7 +1,3 @@
-variable "server_id" {
-  description = "Unique server ID"
-  type        = string
-}
 
 variable "username" {
   description = "Username for the default ZenML server account"

--- a/src/zenml/zen_server/deploy/terraform/recipes/aws/zen_server.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/aws/zen_server.tf
@@ -32,10 +32,6 @@ resource "helm_release" "zen-server" {
     name  = "zenml.deploymentType"
     value = "aws"
   }
-  set {
-    name  = "zenml.serverId"
-    value = var.server_id
-  }
   
   # set up the right path for ZenML
   set {

--- a/src/zenml/zen_server/deploy/terraform/recipes/azure/variables.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/azure/variables.tf
@@ -1,8 +1,3 @@
-variable "server_id" {
-  description = "Unique server ID"
-  type        = string
-}
-
 variable "username" {
   description = "Username for the default ZenML server account"
   default     = "default"

--- a/src/zenml/zen_server/deploy/terraform/recipes/azure/zen_server.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/azure/zen_server.tf
@@ -31,10 +31,6 @@ resource "helm_release" "zen-server" {
     name  = "zenml.deploymentType"
     value = "azure"
   }
-  set {
-    name  = "zenml.serverId"
-    value = var.server_id
-  }
   
   # set up the right path for ZenML
   set {

--- a/src/zenml/zen_server/deploy/terraform/recipes/gcp/variables.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/gcp/variables.tf
@@ -1,8 +1,3 @@
-variable "server_id" {
-  description = "Unique server ID"
-  type        = string
-}
-
 variable "username" {
   description = "Username for the default ZenML server account"
   default     = "default"

--- a/src/zenml/zen_server/deploy/terraform/recipes/gcp/zen_server.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/gcp/zen_server.tf
@@ -31,10 +31,6 @@ resource "helm_release" "zen-server" {
     name  = "zenml.deploymentType"
     value = "gcp"
   }
-  set {
-    name  = "zenml.serverId"
-    value = var.server_id
-  }
   
   # set up the right path for ZenML
   set {

--- a/src/zenml/zen_server/deploy/terraform/terraform_zen_server.py
+++ b/src/zenml/zen_server/deploy/terraform/terraform_zen_server.py
@@ -17,9 +17,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional, cast
-from uuid import UUID, uuid4
-
-from pydantic import Field
+from uuid import UUID
 
 from zenml.logger import get_logger
 from zenml.services import ServiceType, TerraformService, TerraformServiceConfig
@@ -115,7 +113,6 @@ class TerraformServerDeploymentConfig(ServerDeploymentConfig):
 
     log_level: str = "ERROR"
 
-    server_id: UUID = Field(default_factory=uuid4)
     username: str
     password: str
     helm_chart: str = get_helm_chart_path()

--- a/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
+++ b/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
@@ -1,7 +1,7 @@
 """Add identity table [7e4a481d17f7].
 
 Revision ID: 7e4a481d17f7
-Revises: 7834208cc3f6
+Revises: 0.30.0
 Create Date: 2022-12-08 16:27:48.909015
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7e4a481d17f7"
-down_revision = "7834208cc3f6"
+down_revision = "0.30.0"
 branch_labels = None
 depends_on = None
 

--- a/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
+++ b/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
@@ -1,0 +1,52 @@
+"""Add identity table [7e4a481d17f7].
+
+Revision ID: 7e4a481d17f7
+Revises: 7834208cc3f6
+Create Date: 2022-12-08 16:27:48.909015
+
+"""
+import sqlmodel
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7e4a481d17f7"
+down_revision = "7834208cc3f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    from zenml.config.global_config import GlobalConfiguration
+
+    op.create_table(
+        "identity",
+        sa.Column("id", sqlmodel.sql.sqltypes.GUID(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # get metadata from current connection
+    meta = sa.MetaData(bind=op.get_bind())
+
+    # pass in tuple with tables we want to reflect, otherwise whole database
+    #  will get reflected
+    meta.reflect(only=("identity",))
+    # Prefill the identity table with a single row that contains the deployment
+    # id extracted from the global configuration
+    op.bulk_insert(
+        sa.Table(
+            "identity",
+            meta,
+        ),
+        [
+            {
+                "id": str(GlobalConfiguration().user_id).replace("-", ""),
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    op.drop_table("server_info")

--- a/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
+++ b/src/zenml/zen_stores/migrations/versions/7e4a481d17f7_add_identity_table.py
@@ -5,10 +5,9 @@ Revises: 7834208cc3f6
 Create Date: 2022-12-08 16:27:48.909015
 
 """
+import sqlalchemy as sa
 import sqlmodel
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision = "7e4a481d17f7"
@@ -49,4 +48,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade database schema and/or data back to the previous revision."""
-    op.drop_table("server_info")
+    op.drop_table("identity")

--- a/src/zenml/zen_stores/schemas/__init__.py
+++ b/src/zenml/zen_stores/schemas/__init__.py
@@ -17,6 +17,9 @@ from zenml.zen_stores.schemas.artifact_schemas import ArtifactSchema
 from zenml.zen_stores.schemas.base_schemas import BaseSchema, NamedSchema
 from zenml.zen_stores.schemas.component_schemas import StackComponentSchema
 from zenml.zen_stores.schemas.flavor_schemas import FlavorSchema
+from zenml.zen_stores.schemas.identity_schemas import (
+    IdentitySchema,
+)
 from zenml.zen_stores.schemas.pipeline_run_schemas import PipelineRunSchema
 from zenml.zen_stores.schemas.pipeline_schemas import PipelineSchema
 from zenml.zen_stores.schemas.project_schemas import ProjectSchema
@@ -47,6 +50,7 @@ __all__ = [
     "BaseSchema",
     "NamedSchema",
     "FlavorSchema",
+    "IdentitySchema",
     "PipelineRunSchema",
     "PipelineSchema",
     "ProjectSchema",

--- a/src/zenml/zen_stores/schemas/__init__.py
+++ b/src/zenml/zen_stores/schemas/__init__.py
@@ -17,9 +17,7 @@ from zenml.zen_stores.schemas.artifact_schemas import ArtifactSchema
 from zenml.zen_stores.schemas.base_schemas import BaseSchema, NamedSchema
 from zenml.zen_stores.schemas.component_schemas import StackComponentSchema
 from zenml.zen_stores.schemas.flavor_schemas import FlavorSchema
-from zenml.zen_stores.schemas.identity_schemas import (
-    IdentitySchema,
-)
+from zenml.zen_stores.schemas.identity_schemas import IdentitySchema
 from zenml.zen_stores.schemas.pipeline_run_schemas import PipelineRunSchema
 from zenml.zen_stores.schemas.pipeline_schemas import PipelineSchema
 from zenml.zen_stores.schemas.project_schemas import ProjectSchema

--- a/src/zenml/zen_stores/schemas/identity_schemas.py
+++ b/src/zenml/zen_stores/schemas/identity_schemas.py
@@ -1,0 +1,27 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""SQLModel implementation for the server information table."""
+
+
+from uuid import UUID
+
+from sqlmodel import Field, SQLModel
+
+
+class IdentitySchema(SQLModel, table=True):
+    """SQL Model for the client/server identity."""
+
+    __tablename__ = "identity"
+
+    id: UUID = Field(primary_key=True)

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -119,6 +119,7 @@ from zenml.zen_stores.migrations.alembic import (
 from zenml.zen_stores.schemas import (
     ArtifactSchema,
     FlavorSchema,
+    IdentitySchema,
     NamedSchema,
     PipelineRunSchema,
     PipelineSchema,
@@ -726,10 +727,25 @@ class SqlZenStore(BaseZenStore):
 
         Returns:
             Information about the store.
+
+        Raises:
+            KeyError: If the deployment ID could not be loaded from the
+                database.
         """
         model = super().get_store_info()
         sql_url = make_url(self.config.url)
         model.database_type = ServerDatabaseType(sql_url.drivername)
+
+        # Fetch the deployment ID from the database and use it to replace the one
+        # fetched from the global configuration
+        with Session(self.engine) as session:
+            identity = session.exec(select(IdentitySchema)).first()
+
+            if identity is None:
+                raise KeyError(
+                    "The deployment ID could not be loaded from the database."
+                )
+            model.id = identity.id
         return model
 
     # ------


### PR DESCRIPTION
## Describe changes
The global configuration `user_id` attribute is now persisted as a row in a new `identity` table in the database, either when the database is initialized or when it is upgraded from a previous version. This identity field is then used to identify any and all servers that connect to the same database.

This change allows us to have a more consistent view into the lifecycle of various ZenML server instances, independent of whether they are re-installed from scratch or not.

UPDATE: additional testing also revealed that the previous way of setting the `user_id` global configuration attribute through the use of `ZENML_USER_ID` environment variable and the `serverId` helm chart configuration field **did not work** because this field is immutable in the global configuration pydatic class. This in turn caused the analytics to report a new server ID for every different zenml server instance, even when connected to the same database. This is also corrected by this PR, the `ZENML_USER_ID` environment variable mentions are removed from the docs and the `serverId` variable is removed from the helm chart.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

