### PR TITLE
Fix `PyTorchDataLoaderMaterializer` for older torch versions

### DIFF
--- a/src/zenml/integrations/pytorch/__init__.py
+++ b/src/zenml/integrations/pytorch/__init__.py
@@ -22,7 +22,7 @@ class PytorchIntegration(Integration):
     """Definition of PyTorch integration for ZenML."""
 
     NAME = PYTORCH
-    REQUIREMENTS = ["torch"]
+    REQUIREMENTS = ["torch>=1.7"]
 
     @classmethod
     def activate(cls) -> None:

--- a/src/zenml/integrations/pytorch/__init__.py
+++ b/src/zenml/integrations/pytorch/__init__.py
@@ -22,7 +22,7 @@ class PytorchIntegration(Integration):
     """Definition of PyTorch integration for ZenML."""
 
     NAME = PYTORCH
-    REQUIREMENTS = ["torch>=1.7"]
+    REQUIREMENTS = ["torch"]
 
     @classmethod
     def activate(cls) -> None:

--- a/src/zenml/integrations/pytorch/materializers/pytorch_dataloader_materializer.py
+++ b/src/zenml/integrations/pytorch/materializers/pytorch_dataloader_materializer.py
@@ -14,7 +14,7 @@
 """Implementation of the PyTorch DataLoader materializer."""
 
 import os
-from typing import Any, Type, cast
+from typing import Any, Type
 
 import torch
 from torch.utils.data.dataloader import DataLoader
@@ -33,7 +33,7 @@ class PyTorchDataLoaderMaterializer(BaseMaterializer):
     ASSOCIATED_TYPES = (DataLoader,)
     ASSOCIATED_ARTIFACT_TYPES = (DataArtifact,)
 
-    def handle_input(self, data_type: Type[Any]) -> DataLoader[Any]:
+    def handle_input(self, data_type: Type[Any]) -> Any:
         """Reads and returns a PyTorch dataloader.
 
         Args:
@@ -46,9 +46,9 @@ class PyTorchDataLoaderMaterializer(BaseMaterializer):
         with fileio.open(
             os.path.join(self.artifact.uri, DEFAULT_FILENAME), "rb"
         ) as f:
-            return cast(DataLoader[Any], torch.load(f))
+            return torch.load(f)
 
-    def handle_return(self, dataloader: DataLoader[Any]) -> None:
+    def handle_return(self, dataloader: Any) -> None:
         """Writes a PyTorch dataloader.
 
         Args:


### PR DESCRIPTION
## Describe changes

I relaxed the typing of the `PyTorchDataLoaderMaterializer` to use `Any` instead of `DataLoader[Any]` since `DataLoader` is not subscriptable under `torch<1.7`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

