### PR TITLE
Bugfix/bump evidently version

### DIFF
--- a/src/zenml/integrations/evidently/__init__.py
+++ b/src/zenml/integrations/evidently/__init__.py
@@ -36,7 +36,7 @@ class EvidentlyIntegration(Integration):
     """[Evidently](https://github.com/evidentlyai/evidently) integration for ZenML."""
 
     NAME = EVIDENTLY
-    REQUIREMENTS = ["evidently==0.1.52dev0"]
+    REQUIREMENTS = ["evidently==0.1.54dev0"]
 
     @staticmethod
     def activate() -> None:


### PR DESCRIPTION
## Describe changes
Numpy 1.24 lead to failing tests with the old evidently version due to np.bool being deprecated. 

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

