### PR TITLE
Prototype: Remove `block_recursion` for pipelines and runs

### DIFF
--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -31,7 +31,7 @@ from zenml.zen_stores.schemas.stack_schemas import StackSchema
 from zenml.zen_stores.schemas.user_schemas import UserSchema
 
 if TYPE_CHECKING:
-    from zenml.models import PipelineRunUpdateModel
+    from zenml.models import PipelineResponseModel, PipelineRunUpdateModel
     from zenml.zen_stores.schemas.step_run_schemas import StepRunSchema
 
 
@@ -97,56 +97,40 @@ class PipelineRunSchema(NamedSchema, table=True):
     )
 
     def to_model(
-        self, _block_recursion: bool = False
+        self,
+        pipeline: Optional["PipelineResponseModel"] = None,
     ) -> PipelineRunResponseModel:
         """Convert a `PipelineRunSchema` to a `PipelineRunResponseModel`.
+
+        Args:
+            pipeline: If provided, link `PipelineRunResponseModel.pipeline` to
+                this pipeline instead of hydrating `self.pipeline`.
 
         Returns:
             The created `PipelineRunResponseModel`.
         """
-        if _block_recursion:
-            return PipelineRunResponseModel(
-                id=self.id,
-                name=self.name,
-                stack=self.stack.to_model() if self.stack else None,
-                project=self.project.to_model(),
-                user=self.user.to_model() if self.user else None,
-                orchestrator_run_id=self.orchestrator_run_id,
-                enable_cache=self.enable_cache,
-                start_time=self.start_time,
-                end_time=self.end_time,
-                status=self.status,
-                pipeline_configuration=json.loads(self.pipeline_configuration),
-                num_steps=self.num_steps,
-                git_sha=self.git_sha,
-                zenml_version=self.zenml_version,
-                created=self.created,
-                updated=self.updated,
-            )
-        else:
-            return PipelineRunResponseModel(
-                id=self.id,
-                name=self.name,
-                stack=self.stack.to_model() if self.stack else None,
-                project=self.project.to_model(),
-                user=self.user.to_model() if self.user else None,
-                orchestrator_run_id=self.orchestrator_run_id,
-                enable_cache=self.enable_cache,
-                start_time=self.start_time,
-                end_time=self.end_time,
-                status=self.status,
-                pipeline=(
-                    self.pipeline.to_model(not _block_recursion)
-                    if self.pipeline
-                    else None
-                ),
-                pipeline_configuration=json.loads(self.pipeline_configuration),
-                num_steps=self.num_steps,
-                git_sha=self.git_sha,
-                zenml_version=self.zenml_version,
-                created=self.created,
-                updated=self.updated,
-            )
+        if not pipeline and self.pipeline:
+            pipeline = self.pipeline.to_model()
+
+        return PipelineRunResponseModel(
+            id=self.id,
+            name=self.name,
+            stack=self.stack.to_model() if self.stack else None,
+            project=self.project.to_model(),
+            user=self.user.to_model() if self.user else None,
+            orchestrator_run_id=self.orchestrator_run_id,
+            enable_cache=self.enable_cache,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            status=self.status,
+            pipeline=pipeline,
+            pipeline_configuration=json.loads(self.pipeline_configuration),
+            num_steps=self.num_steps,
+            git_sha=self.git_sha,
+            zenml_version=self.zenml_version,
+            created=self.created,
+            updated=self.updated,
+        )
 
     def update(
         self, run_update: "PipelineRunUpdateModel"

--- a/src/zenml/zen_stores/schemas/pipeline_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_schemas.py
@@ -68,13 +68,11 @@ class PipelineSchema(NamedSchema, table=True):
 
     def to_model(
         self,
-        _block_recursion: bool = False,
         last_x_runs: int = 3,
     ) -> "PipelineResponseModel":
         """Convert a `PipelineSchema` to a `PipelineModel`.
 
         Args:
-            _block_recursion: Don't recursively fill attributes
             last_x_runs: How many runs to use for the execution status
 
         Returns:
@@ -84,31 +82,19 @@ class PipelineSchema(NamedSchema, table=True):
         status_last_x_runs = []
         for run in x_runs:
             status_last_x_runs.append(run.status)
-        if _block_recursion:
-            return PipelineResponseModel(
-                id=self.id,
-                name=self.name,
-                project=self.project.to_model(),
-                user=self.user.to_model() if self.user else None,
-                docstring=self.docstring,
-                spec=PipelineSpec.parse_raw(self.spec),
-                created=self.created,
-                updated=self.updated,
-                status=status_last_x_runs,
-            )
-        else:
-            return PipelineResponseModel(
-                id=self.id,
-                name=self.name,
-                project=self.project.to_model(),
-                user=self.user.to_model() if self.user else None,
-                runs=[r.to_model(True) for r in self.runs],
-                docstring=self.docstring,
-                spec=PipelineSpec.parse_raw(self.spec),
-                created=self.created,
-                updated=self.updated,
-                status=status_last_x_runs,
-            )
+        model = PipelineResponseModel(
+            id=self.id,
+            name=self.name,
+            project=self.project.to_model(),
+            user=self.user.to_model() if self.user else None,
+            docstring=self.docstring,
+            spec=PipelineSpec.parse_raw(self.spec),
+            created=self.created,
+            updated=self.updated,
+            status=status_last_x_runs,
+        )
+        model.runs = [r.to_model(pipeline=model) for r in self.runs]
+        return model
 
     def update(
         self, pipeline_update: "PipelineUpdateModel"


### PR DESCRIPTION
## Describe changes

This is a prototype of how we could remove the `_block_recursion` arg from `PipelineSchema.to_model()` and `PipelineRunSchema.to_model()` in favor of interlinking the models.

Won't work for N-M relationships though since N-M hydration could lead to chain reactions that hydrate the entire DB.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

