### PR TITLE
Fix project scoping for artifact list through ZenServer

### DIFF
--- a/src/zenml/zen_server/routers/artifacts_endpoints.py
+++ b/src/zenml/zen_server/routers/artifacts_endpoints.py
@@ -69,6 +69,7 @@ def list_artifacts(
             "update your ZenML client to match the server version."
         )
     return zen_store().list_artifacts(
+        project_name_or_id=project_name_or_id,
         artifact_uri=artifact_uri,
         artifact_store_id=artifact_store_id,
         only_unused=only_unused,


### PR DESCRIPTION
## Describe changes
A kwarg of the artifact list endpoint was not passed down. This should fix the failing CI tests under `docker-server` environment.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

