### PR TITLE
Use `ruff` instead of `flake8`

### DIFF
--- a/examples/huggingface/steps/training/token_training_step.py
+++ b/examples/huggingface/steps/training/token_training_step.py
@@ -42,8 +42,12 @@ def token_trainer(
     )
 
     # Update label2id lookup
-    model.config.label2id = {l: i for i, l in enumerate(label_list)}
-    model.config.id2label = {i: l for i, l in enumerate(label_list)}
+    model.config.label2id = {
+        list_label: list_id for list_id, list_label in enumerate(label_list)
+    }
+    model.config.id2label = {
+        list_id: list_label for list_id, list_label in enumerate(label_list)
+    }
 
     # Prepare optimizer
     num_train_steps = (

--- a/examples/spark_distributed_programming/steps/__init__.py
+++ b/examples/spark_distributed_programming/steps/__init__.py
@@ -19,18 +19,20 @@ from zenml.integrations.spark.step_operators.spark_step_operator import (
     SparkStepOperator,
 )
 
+from .importer_step.importer_step import ImporterParameters, importer_step
+from .split_step.split_step import SplitParameters, split_step
+from .statistics_step.statistics_step import statistics_step
+from .trainer_step.trainer_step import trainer_step
+from .transformer_step.transformer_step import transformer_step
+
 step_operator = Client().active_stack.step_operator
+
 if not step_operator or not isinstance(step_operator, SparkStepOperator):
     raise RuntimeError(
         "Your active stack needs to contain a Spark step operator for this "
         "example to work."
     )
 
-from .importer_step.importer_step import ImporterParameters, importer_step
-from .split_step.split_step import SplitParameters, split_step
-from .statistics_step.statistics_step import statistics_step
-from .trainer_step.trainer_step import trainer_step
-from .transformer_step.transformer_step import transformer_step
 
 __all__ = [
     "importer_step",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,9 +206,9 @@ exclude = [
     "venv",
 ]
 per-file-ignores = {}
-# Never enforce `E501` (line length violations).
 ignore = ["E501", "F401"]
 src = ["src", "test"]
+# use Python 3.7 as the minimum version for autofixing
 target-version = "py37"
 ignore-init-module-imports = true
 # Disable autofix for unused imports (`F401`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "fastapi-util
 black = "^22.3.0"
 pytest = "^6.2.4"
 mypy = "^0.991"
-flake8 = "^3.9.2"
+ruff = "^0.0.206"
 interrogate = "^1.4.0"
 coverage = { extras = ["toml"], version = "^5.5" }
 isort = "^5.9.3"
@@ -180,6 +180,50 @@ exclude_lines = [
     'if __name__ == "__main__":',
     "if TYPE_CHECKING:",
 ]
+
+[tool.ruff]
+line-length = 80
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+per-file-ignores = {}
+# Never enforce `E501` (line length violations).
+ignore = ["E501", "F401"]
+src = ["src", "test"]
+target-version = "py37"
+ignore-init-module-imports = true
+# Disable autofix for unused imports (`F401`).
+unfixable = ["F401"]
+
+[tool.ruff.flake8-import-conventions.aliases]
+altair = "alt"
+"matplotlib.pyplot" = "plt"
+numpy = "np"
+pandas = "pd"
+seaborn = "sns"
+
+[tool.ruff.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
 
 [tool.isort]
 profile = "black"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,7 +8,7 @@ SRC_NO_TESTS=${1:-"src/zenml tests/harness"}
 
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false
-flake8 $SRC
+ruff $SRC
 autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place $SRC --exclude=__init__.py --check | ( grep -v "No issues detected" || true )
 isort $SRC scripts --check-only
 black $SRC  --check

--- a/src/zenml/integrations/gcp/secrets_manager/gcp_secrets_manager.py
+++ b/src/zenml/integrations/gcp/secrets_manager/gcp_secrets_manager.py
@@ -172,7 +172,7 @@ class GCPSecretsManager(BaseSecretsManager):
                 return f"labels.{ZENML_GROUP_KEY}:*"
 
         metadata = self._get_secret_scope_metadata(secret_name)
-        filters = [f"labels.{l}={v}" for (l, v) in metadata.items()]
+        filters = [f"labels.{label}={v}" for (label, v) in metadata.items()]
         if secret_name:
             filters.append(f"name:{secret_name}")
 

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -41,8 +41,8 @@ def test_get_human_readable_filesize_formats_correctly() -> None:
 
 def test_random_str_is_random() -> None:
     """Test that random_str returns a random string."""
-    l: List[str] = []
-    for i in range(10000):
+    lst: List[str] = []
+    for _ in range(10000):
         new_str = string_utils.random_str(16)
-        assert new_str not in l
-        l.append(new_str)
+        assert new_str not in lst
+        lst.append(new_str)


### PR DESCRIPTION
As originally suggested by @schustmi, I tested out [`ruff`](https://github.com/charliermarsh/ruff) as an alternative to `flake8`. It indeed runs **much** faster.

This PR doesn't do too deep a surgery, but potentially we can also remove:

- `pydocstyle`
- `isort`
- `autoflake`

...since their functionality is covered by `ruff`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

