### PR TITLE
expose run time in step context

### DIFF
--- a/src/zenml/steps/step_context.py
+++ b/src/zenml/steps/step_context.py
@@ -56,10 +56,10 @@ class StepContext:
     """
 
     def __init__(
-        self,
-        step_name: str,
-        output_materializers: Dict[str, Type["BaseMaterializer"]],
-        output_artifact_uris: Dict[str, str],
+            self,
+            step_name: str,
+            output_materializers: Dict[str, Type["BaseMaterializer"]],
+            output_artifact_uris: Dict[str, str],
     ):
         """Initializes a StepContext instance.
 
@@ -92,7 +92,7 @@ class StepContext:
         self._stack = Client().active_stack
 
     def _get_output(
-        self, output_name: Optional[str] = None
+            self, output_name: Optional[str] = None
     ) -> StepContextOutput:
         """Returns the materializer and artifact URI for a given step output.
 
@@ -145,9 +145,9 @@ class StepContext:
         return self._stack
 
     def get_output_materializer(
-        self,
-        output_name: Optional[str] = None,
-        custom_materializer_class: Optional[Type["BaseMaterializer"]] = None,
+            self,
+            output_name: Optional[str] = None,
+            custom_materializer_class: Optional[Type["BaseMaterializer"]] = None,
     ) -> "BaseMaterializer":
         """Returns a materializer for a given step output.
 
@@ -184,3 +184,22 @@ class StepContext:
             Artifact URI for the given output.
         """
         return self._get_output(output_name).artifact_uri
+
+    @staticmethod
+    def _get_context_run_time() -> PipelineRunResponseModel:
+        """
+        Returns: PipelineRunResponseModel
+        """
+
+        pipeline_run_id = Environment().step_environment.pipeline_run_id
+        pipeline_run = Client().get_pipeline_run(pipeline_run_id)
+        return pipeline_run
+
+    def get_context_run_time(self) -> datetime.datetime:
+        """Returns the context run time for a given run.
+
+        Returns:
+            the context run time for a given run.
+        """
+
+        return self._get_context_run_time().start_time


### PR DESCRIPTION
## Describe changes
What is the request?

to have something similar to Airflow {{ ds }} : https://airflow.apache.org/docs/apache-airflow/2.0.0/macros-ref.html
a run date based on the scheduled time.

where it's needed? 
in a sensor ( first step of a pipeline) and second step of a pipeline
usually, have something like 
select * from source_tabe where date=='{{ ds }}', and then the pipeline starts.

the impl here is a result of a talk with @schustmi and @hamzamaiot regarding this feature.


I implemented a call to PipelineRunResponseModel in StepContext class in order to expose the context start time in a given run.




## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

