### PR TITLE
Fix MLflow tracking example bug for Macs

### DIFF
--- a/examples/mlflow_tracking/run.py
+++ b/examples/mlflow_tracking/run.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 
     print(
         "Now run \n "
-        f"    mlflow ui --backend-store-uri {get_tracking_uri()}\n"
+        f"    mlflow ui --backend-store-uri '{get_tracking_uri()}'\n"
         "To inspect your experiment runs within the mlflow UI.\n"
         "You can find your runs tracked within the `mlflow_example_pipeline`"
         "experiment. Here you'll also be able to compare the two runs.)"


### PR DESCRIPTION
When you run this example on a mac, the URL that it puts out is unparseable because Macs have a directory called 'Application Support' that needs escaping. A simple fix that doesn't require changing code is just to update the example adding quotes around the URI.

Currently, if you run this example on a Mac, the command you're told to run doesn't actually work because of this error.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

