### PR TITLE
[ANALYTICS] Allow server to override client's analytics opt-in

### DIFF
--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -130,6 +130,8 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
         user_email: Email address associated with this client.
         user_email_opt_in: Whether the user has opted in to email communication.
         analytics_opt_in: If a user agreed to sending analytics or not.
+        override_client_analytics_opt_in: Whether the server should override
+            the client's analytics opt-in setting using this value.
         version: Version of ZenML that was last used to create or update the
             global config.
         store: Store configuration.
@@ -145,6 +147,7 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
     user_email: Optional[str] = None
     user_email_opt_in: Optional[bool] = None
     analytics_opt_in: bool = True
+    override_client_analytics_opt_in: Optional[bool] = None
     version: Optional[str]
     store: Optional[StoreConfiguration]
     active_stack_id: Optional[uuid.UUID]

--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -45,7 +45,6 @@ from zenml.utils.analytics_utils import (
     identify_user,
     track_event,
 )
-from zenml.zen_stores.rest_zen_store import RestZenStore
 
 if TYPE_CHECKING:
     from zenml.models import ProjectResponseModel, StackResponseModel
@@ -397,7 +396,7 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
         )
 
         # if it is a REST store, override the value for analytics opt-in
-        if isinstance(store, RestZenStore):
+        if store.TYPE == StoreType.REST:
             self.analytics_opt_in = store.config.analytics_opt_in
 
         if self.store != store.config or not self._zen_store:

--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -45,6 +45,7 @@ from zenml.utils.analytics_utils import (
     identify_user,
     track_event,
 )
+from zenml.zen_stores.rest_zen_store import RestZenStore
 
 if TYPE_CHECKING:
     from zenml.models import ProjectResponseModel, StackResponseModel
@@ -391,6 +392,11 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
         store = BaseZenStore.create_store(
             config, skip_default_registrations, **kwargs
         )
+
+        # if it is a REST store, override the value for analytics opt-in
+        if isinstance(store, RestZenStore):
+            self.analytics_opt_in = store.config.analytics_opt_in
+
         if self.store != store.config or not self._zen_store:
             logger.debug(f"Configuring the global store to {store.config}")
             self.store = store.config

--- a/src/zenml/models/server_models.py
+++ b/src/zenml/models/server_models.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Model definitions for ZenML servers."""
 
+from typing import Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
@@ -56,6 +57,10 @@ class ServerModel(BaseModel):
     database_type: ServerDatabaseType = Field(
         ServerDatabaseType.OTHER,
         title="The database type that the server is using.",
+    )
+    analytics_opt_in: Optional[bool] = Field(
+        False,
+        title="Whether the server is opted in to analytics collection.",
     )
 
     def is_local(self) -> bool:

--- a/src/zenml/models/server_models.py
+++ b/src/zenml/models/server_models.py
@@ -58,7 +58,7 @@ class ServerModel(BaseModel):
         ServerDatabaseType.OTHER,
         title="The database type that the server is using.",
     )
-    analytics_opt_in: Optional[bool] = Field(
+    analytics_opt_in: bool = Field(
         False,
         title="Whether the server is opted in to analytics collection.",
     )

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -147,6 +147,7 @@ class RestZenStoreConfiguration(StoreConfiguration):
     Attributes:
         username: The username to use to connect to the Zen server.
         password: The password to use to connect to the Zen server.
+        analytics_opt_in: Whether to opt in to analytics.
         verify_ssl: Either a boolean, in which case it controls whether we
             verify the server's TLS certificate, or a string, in which case it
             must be a path to a CA bundle to use or the CA bundle value itself.
@@ -157,6 +158,7 @@ class RestZenStoreConfiguration(StoreConfiguration):
     username: Optional[str] = None
     password: Optional[str] = None
     api_token: Optional[str] = None
+    analytics_opt_in: Optional[bool] = None
     verify_ssl: Union[bool, str] = True
     http_timeout: int = DEFAULT_HTTP_TIMEOUT
 
@@ -338,8 +340,12 @@ class RestZenStore(BaseZenStore):
 
     def _initialize(self) -> None:
         """Initialize the REST store."""
+        store_info = self.get_store_info()
         client_version = zenml.__version__
-        server_version = self.get_store_info().version
+        server_version = store_info.version
+
+        # add analytics opt-in status to config
+        self.config.analytics_opt_in = store_info.analytics_opt_in
 
         if not DISABLE_CLIENT_SERVER_MISMATCH_WARNING and (
             server_version != client_version

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -753,7 +753,7 @@ class SqlZenStore(BaseZenStore):
             model.id = identity.id
 
         # get the analytics opt-in status from global config
-        model.analytics_opt_in = GlobalConfiguration().analytics_opt_in
+        model.analytics_opt_in = GlobalConfiguration().override_client_analytics_opt_in
         return model
 
     # ------

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -752,10 +752,11 @@ class SqlZenStore(BaseZenStore):
                 )
             model.id = identity.id
 
-        # get the analytics opt-in status from global config
-        model.analytics_opt_in = (
-            GlobalConfiguration().override_client_analytics_opt_in
-        )
+        # get the analytics opt-in status from global config if it is not None
+        if GlobalConfiguration().override_client_analytics_opt_in is not None:
+            model.analytics_opt_in = (
+                GlobalConfiguration().override_client_analytics_opt_in
+            )
         return model
 
     # ------

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -751,6 +751,9 @@ class SqlZenStore(BaseZenStore):
                     "The deployment ID could not be loaded from the database."
                 )
             model.id = identity.id
+
+        # get the analytics opt-in status from global config
+        model.analytics_opt_in = GlobalConfiguration().analytics_opt_in
         return model
 
     # ------

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -753,7 +753,9 @@ class SqlZenStore(BaseZenStore):
             model.id = identity.id
 
         # get the analytics opt-in status from global config
-        model.analytics_opt_in = GlobalConfiguration().override_client_analytics_opt_in
+        model.analytics_opt_in = (
+            GlobalConfiguration().override_client_analytics_opt_in
+        )
         return model
 
     # ------


### PR DESCRIPTION
## Describe changes

We want the client analytics opt in to be overridden by the value from the server. This would allow more control over the analytics in the case of managed ZenML servers, both by ZenML and any other organization that creates and hosts them.

### Scope
One way of ensuring this use case is:
- as soon as a server is connected, we call the /info endpoint on the server and get the value for the analytics opt-in and update the client's global config.


### Challenges
- What happens if we change the value in the server after the client is connected?
**Solution:** Should we hit the /info endpoint periodically to check if the value has changed?
or can we ignore that case now, since the only use of this feature is in our managed servers and we will not be changing the value of the analytics opt in in the server, once it is set.

- The client can simply override the value in its global config again
**Solution:** One way of solving this would be to check the `gc.store.config.analytics_opt_in` value (if it is set) instead of the value in gc, everytime an analytics call gets made. This can be done in the `__init__` function of the `AnalyticsContext` class.


### Questions

- Should I be overriding the `get_store_info()` function on the `SQLZenStore` to return an analytics variable or should I enable this extra variable for all server types.
- Adding the this would mean more complexity as the user might expect the analytics opt-in value in the server to always reflect in the global config which in its current scope, it won't.
- Is the `RestZenStoreConfig` a good place to add the analytics opt in variable?




## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

