### PR TITLE
Add docs on upgrading and troubleshooting zenml server

### DIFF
--- a/docs/book/getting-started/deploying-zenml/cli.md
+++ b/docs/book/getting-started/deploying-zenml/cli.md
@@ -262,3 +262,20 @@ To disconnect from the current ZenML server and revert to using the local defaul
 ```bash
 zenml disconnect
 ```
+
+## Upgrading your ZenML server
+
+To upgrade your ZenML server (that was deployed with the `zenml deploy` command) to a newer version, you can follow the steps below.
+
+- In the config file, set `zenmlserver_image_tag` to the version that you want your ZenML server to be running.
+- Run the deploy command again with this config file:
+    
+    ```bash
+    zenml deploy --config=/PATH/TO/FILE
+    ```
+    
+
+Any database schema updates are automatically handled by ZenML and unless mentioned otherwise, all of your data is migrated to the new version, intact.
+
+>**Warning**
+> If you wish to downgrade a server, make sure that the version of ZenML that you’re moving to has the same database schema. This is because reverse migration of the schema is not supported.

--- a/docs/book/getting-started/deploying-zenml/docker.md
+++ b/docs/book/getting-started/deploying-zenml/docker.md
@@ -389,3 +389,33 @@ server, you can check the logs with the command:
 ```shell
 docker compose -p zenml logs -f
 ```
+
+## Upgrading your ZenML server
+
+To upgrade to a new version with docker, you would have to delete the existing container and then execute the docker run command again with the version of the `zenml-server` image that you want to use.
+
+- Delete the existing ZenML container:
+    
+  ```bash
+  # find your container ID
+  docker ps
+  ```
+  
+  ```bash
+  # stop the container
+  docker stop <CONTAINER_ID>
+  
+  # remove the container
+  docker rm <CONTAINER_ID>
+  ```
+    
+- Deploy the version of the `zenml-server` image that you want to use. Find all versions [here](https://hub.docker.com/r/zenmldocker/zenml-server/tags).
+
+  ```bash
+  docker run -it -d -p 8080:80 --name <CONTAINER_NAME> zenmldocker/zenml-server:<VERSION>
+  ```
+
+If you wish to keep your data after the upgrade, you should choose to deploy the container either with a persistent storage or with an external MySQL instance. In all other cases, your data will be lost once the container is deleted and a new one is spun up.
+
+>**Warning**
+> If you wish to downgrade a server, make sure that the version of ZenML that you’re moving to has the same database schema. This is because reverse migration of the schema is not supported.

--- a/docs/book/getting-started/deploying-zenml/helm.md
+++ b/docs/book/getting-started/deploying-zenml/helm.md
@@ -100,3 +100,30 @@ To disconnect from the current ZenML server and revert to using the local defaul
 ```bash
 zenml disconnect
 ```
+
+## Upgrading your ZenML server
+
+To upgrade your ZenML server Helm release to a new version, follow the steps below: 
+
+- Modify your `values.yaml` file that you used for the initial deployment to include the new image tag. The path to the tag is `zenml.image.tag`.
+- If you don’t have the previous `values.yaml` file handy, you can create a new one with your existing values using the following command:
+
+    ```bash
+    helm get values <ZENML_RELEASE> > values.yaml
+    ```
+
+- Upgrade the release using your modified values file. Make sure you are in the directory that hosts the helm chart:
+
+    ```bash
+    helm upgrade -n <NAMESPACE> <ZENML_RELEASE> . -f values.yaml
+    ```
+
+If you only want to change a few variables (like the image tag), you can also bypass using the values file and just use the `--set` flag to set the desired value.
+
+```bash
+helm upgrade -n <NAMESPACE> <ZENML_RELEASE> . --set zenml.image.tag=<VERSION>
+```
+
+
+> **Warning**
+> If you wish to downgrade a server, make sure that the version of ZenML that you’re moving to has the same database schema. This is because reverse migration of the schema is not supported.

--- a/docs/book/getting-started/deploying-zenml/troubleshooting.md
+++ b/docs/book/getting-started/deploying-zenml/troubleshooting.md
@@ -1,0 +1,102 @@
+---
+description: Troubleshooting tips for your ZenML deployment
+---
+
+In this document, we will go over some common issues that you might face when deploying ZenML and how to solve them.
+
+## Viewing logs
+
+Analyzing logs is a great way to debug issues. Depending on whether you have a Kubernetes (using Helm or `zenml deploy`) or a Docker deployment, you can view the logs in different ways.
+
+{% tabs %}
+{% tab title="Kubernetes" %}
+If you are using Kubernetes, you can view the logs of the ZenML server using the following method:
+
+- Check all pods that are running your ZenML deployment.
+
+```bash
+kubectl -n <KUBERNETES_NAMESPACE> get pods
+```
+
+- If you see that the pods aren't running, you can use the command below to get the logs for all pods at once.
+
+```bash
+kubectl -n <KUBERNETES_NAMESPACE> logs -l app.kubernetes.io/name=zenml
+```
+
+Note that the error can either be from the `zenml-db-init` container that connects to the MySQL database or from the `zenml` container that runs the server code. If the get pods command show that the pod is failing in the `Init` state then use `zenml-db-init` as the container name, otherwise use `zenml`.
+
+
+```bash
+kubectl -n <KUBERNETES_NAMESPACE> logs -l app.kubernetes.io/name=zenml -c <CONTAINER_NAME>
+```
+
+{% hint style="info" %}
+You can also use the `--tail` flag to limit the number of lines to show or the `--follow` flag to follow the logs in real time.
+{% endhint %}
+{% endtab %}
+
+{% tab title="Docker" %}
+If you are using Docker, you can view the logs of the ZenML server using the following method:
+
+- If you used the `zenml up --docker` CLI command to deploy the Docker ZenML server, you can check the logs with the command:
+
+    ```shell
+    zenml logs -f
+    ```
+
+- If you used the `docker run` command to manually deploy the Docker ZenML server, you can check the logs with the command:
+
+    ```shell
+    docker logs zenml -f
+    ```
+
+- If you used the `docker compose` command to manually deploy the Docker ZenML
+server, you can check the logs with the command:
+
+    ```shell
+    docker compose -p zenml logs -f
+    ```
+
+
+## Fixing database connection problems
+
+If you are using a MySQL database, you might face issues connecting to it. The logs from the `zenml-db-init` container should give you a good idea of what the problem is. Here are some common issues and how to fix them:
+
+- If you see an error like `ERROR 1045 (28000): Access denied for user <USER> using password YES`, it means that the username or password is incorrect. Make sure that the username and password are correctly set for whatever deployment method you are using.
+
+- If you see an error like `ERROR 2003 (HY000): Can't connect to MySQL server on <HOST> (<IP>)`, it means that the host is incorrect. Make sure that the host is correctly set for whatever deployment method you are using.
+
+You can test the connection and the credentials by running the following command from your machine:
+
+```bash
+mysql -h <HOST> -u <USER> -p
+```
+
+{% hint style="info" %}
+If you are using a Kubernetes deployment, you can use the `kubectl port-forward` command to forward the MySQL port to your local machine. This will allow you to connect to the database from your machine.
+{% endhint %}
+
+## Fixing database initialization problems
+
+If you’ve migrated from a newer ZenML version to an older version and see errors like `Revision not found` in your `zenml-db-init` logs, one way out is to drop the database and create a new one with the same name.
+
+- Log in to your MySQL instance.
+    
+    ```bash
+    mysql -h <HOST> -u <NAME> -p
+    ```
+    
+- Drop the database for the server.
+
+    ```sql
+    drop database <NAME>;
+    ```
+    
+- Create the database with the same name.
+    
+    ```sql
+    create database <NAME>;
+    ```
+
+- Restart the Kubernetes pods or the docker container running your server to trigger the database initialization again.

--- a/docs/book/getting-started/deploying-zenml/troubleshooting.md
+++ b/docs/book/getting-started/deploying-zenml/troubleshooting.md
@@ -57,7 +57,8 @@ server, you can check the logs with the command:
     ```shell
     docker compose -p zenml logs -f
     ```
-
+{% endtab %}
+{% endtabs %}
 
 ## Fixing database connection problems
 

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -10,6 +10,7 @@
   * [One Click Deployment using CLI](./getting-started/deploying-zenml/cli.md)
   * [Deploying with Docker](./getting-started/deploying-zenml/docker.md)
   * [Deploying with Helm](./getting-started/deploying-zenml/helm.md)
+  * [Troubleshooting your server](./getting-started/deploying-zenml/troubleshooting.md)
 * [Architecture Diagrams](getting-started/architecture-diagrams.md)
 * [Examples](./getting-started/examples.md)
 


### PR DESCRIPTION
## Describe changes
I added docs on how a user can upgrade their zenml servers for all deployment scenarios. This is now available as a new section in each of the three deployment methods.

There's also a new page on troubleshooting some common problems with the zenml server deployment and the MySQL database.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

