### PR TITLE
Add support for modular recipes to the recipe CLI

### DIFF
--- a/examples/kserve_deployment/README.md
+++ b/examples/kserve_deployment/README.md
@@ -84,6 +84,35 @@ deployment server so that the new model is being served instead of the old one.
 The inference pipeline loads the image from the local filesystem and performs 
 online predictions on the running KServe inference service.
 
+# 🏠 Local Stack
+
+## 📄 Infrastructure Requirements (Pre-requisites)
+
+You don't need to set up any infrastructure to run your pipelines with KServe, locally. However, you need the following tools installed:
+  * Docker must be installed on your local machine.
+  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+
+## Create a local KServe Stack
+
+To get a stack with KServe and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with Seldon among other things.
+
+Run the following command to deploy the local KServe stack:
+
+```bash
+zenml stack recipe deploy k3d-modular --install kserve
+```
+
+>**Note**:
+> This recipe comes with MLflow, Kubeflow and Minio enabled by default. If you want any other components like Seldon or Tekton, you can specify that using the `--install/-i` flag.
+
+This will deploy a local Kubernetes cluster with KServe installed. 
+It will also generate a stack YAML file that you can import as a ZenML stack by running 
+
+```bash
+zenml stack import -f <path-to-stack-yaml>
+```
+Once the stack is set, you can then simply proceed to running your pipelines.
+
 # ☁️ Cloud Stack
 
 ### 📄 Prerequisites 

--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -106,39 +106,31 @@ python run.py --stop-tensorboard
 
 ## 🏃️ Run the same pipeline on a local Kubeflow Pipelines deployment
 
-### 🥞 Create a local Kubeflow Pipelines Stack
+## 📄 Infrastructure Requirements (Pre-requisites)
 
-Now with all the installation and initialization out of the way, all that's left
-to do is configuring our ZenML [stack](https://docs.zenml.io/getting-started/core-concepts). For
-this example, the stack we create consists of the following four parts:
-* The **local artifact store** stores step outputs on your hard disk.
-* The docker images that are created to run your pipeline are stored in a local
-docker **container registry**.
-* The **Kubeflow orchestrator** is responsible for running your ZenML pipeline
-in Kubeflow Pipelines.
+You don't need to set up any infrastructure to run your pipelines with Kubeflow, locally. However, you need the following tools installed:
+  * Docker must be installed on your local machine.
+  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
 
-```bash
-# Make sure to create the local registry on port 5000 for it to work 
-zenml container-registry register local_registry --flavor=default --uri=localhost:5000 
-zenml orchestrator register local_kubeflow_orchestrator --flavor=kubeflow
-zenml stack register local_kubeflow_stack \
-    -a default \
-    -o local_kubeflow_orchestrator \
-    -c local_registry \
-    --set
-```
+## Create a local Kubeflow Stack
 
-### 🏁 Start up Kubeflow Pipelines locally
+To get a stack with Kubeflow and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with Kubeflow among other things.
 
-ZenML takes care of setting up and configuring the local Kubeflow Pipelines
-deployment. All we need to do is run:
+Run the following command to deploy the local Kubeflow Pipelines stack:
 
 ```bash
-zenml stack up
+zenml stack recipe deploy k3d-modular
 ```
+>**Note**:
+> This recipe comes with MLflow, Kubeflow and Minio enabled by default. If you want any other components like KServe, Seldon or Tekton, you can specify that using the `--install/-i` flag.
 
-When the setup is finished, you should see a local URL which you can access in
-your browser and take a look at the Kubeflow Pipelines UI.
+This will deploy a local Kubernetes cluster with Kubeflow installed. 
+It also generate a stack YAML file that you can import as a ZenML stack by running 
+
+```bash
+zenml stack import -f <path-to-stack-yaml>
+```
+Once the stack is set, you can then simply proceed to running your pipelines.
 
 ### ▶️ Run the pipeline
 We can now run the pipeline by simply executing the python script:

--- a/examples/mlflow_tracking/README.md
+++ b/examples/mlflow_tracking/README.md
@@ -155,6 +155,36 @@ Alternatively, if you want to run based on the config.yaml you can run with:
 zenml pipeline run pipelines/training_pipeline/training_pipeline.py -c config.yaml
 ```
 
+## Running on a local Kubernetes cluster
+
+
+## 📄 Infrastructure Requirements (Pre-requisites)
+
+You don't need to set up any infrastructure to run your pipelines with MLflow on a Kubernetes cluster, locally. However, you need the following tools installed:
+  * Docker must be installed on your local machine.
+  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+
+## Create a local MLflow Stack
+
+To get a stack with MLflow installed with authentication and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with MLflow among other things.
+
+Run the following command to deploy the local MLflow stack:
+
+```bash
+zenml stack recipe deploy k3d-modular
+```
+
+>**Note**:
+> This recipe comes with MLflow, Kubeflow and Minio enabled by default. If you want any other components like KServe, Seldon or Tekton, you can specify that using the `--install/-i` flag.
+
+This will deploy a local Kubernetes cluster with MLflow installed. 
+It will also generate a stack YAML file that you can import as a ZenML stack by running 
+
+```bash
+zenml stack import -f <path-to-stack-yaml>
+```
+Once the stack is set, you can then simply proceed to running your pipelines.
+
 ### 🔮 See results
 Now we just need to start the mlflow UI to have a look at our two pipeline runs.
 To do this we need to run:

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -64,6 +64,35 @@ The inference pipeline simulates loading data from a dynamic external source,
 then uses that data to perform online predictions using the running Seldon
 Core prediction server.
 
+# 🏠 Local Stack
+
+## 📄 Infrastructure Requirements (Pre-requisites)
+
+You don't need to set up any infrastructure to run your pipelines with Seldon, locally. However, you need the following tools installed:
+  * Docker must be installed on your local machine.
+  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+
+## Create a local Seldon Stack
+
+To get a stack with Seldon Core and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with Seldon among other things.
+
+Run the following command to deploy the local Seldon stack:
+
+```bash
+zenml stack recipe deploy k3d-modular --install seldon
+```
+
+>**Note**:
+> This recipe comes with MLflow, Kubeflow and Minio enabled by default. If you want any other components like KServe or Tekton, you can specify that using the `--install/-i` flag.
+
+This will deploy a local Kubernetes cluster with Seldon installed. 
+It will also generate a stack YAML file that you can import as a ZenML stack by running 
+
+```bash
+zenml stack import -f <path-to-stack-yaml>
+```
+Once the stack is set, you can then simply proceed to running your pipelines.
+
 # ☁️ Cloud Stack
 
 ### 📄 Prerequisites 

--- a/examples/tekton_pipelines_orchestration/README.md
+++ b/examples/tekton_pipelines_orchestration/README.md
@@ -59,6 +59,35 @@ python run.py --lr=0.02
 python run.py --epochs=10
 ```
 
+## Run the same pipeline on a local Tekton Pipelines deployment
+
+### 📄 Infrastructure Requirements (Pre-requisites)
+
+You don't need to set up any infrastructure to run the pipeline locally. However, you need the following tools installed:
+  * Docker must be installed on your local machine.
+  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+
+## Create a local Tekton Pipelines Stack
+
+To get a stack with Tekton Pipelines and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with Tekton among other things.
+
+Run the following command to deploy the local Tekton Pipelines stack:
+
+```bash
+zenml stack recipe deploy k3d-modular --install tekton
+```
+
+>**Note**:
+> This recipe comes with MLflow, Kubeflow and Minio enabled by default. If you want any other components like KServe, or Seldon, you can specify that using the `--install/-i` flag.
+
+This will deploy a local Kubernetes cluster with Tekton Pipelines installed. You can verify this by running `kubectl get pods` and checking if the Tekton Pipelines pods are running.
+It will also generate a stack YAML file that you can import as a ZenML stack by running 
+
+```bash
+zenml stack import -f <path-to-stack-yaml>
+```
+Once the stack is set, you can then simply proceed to running your pipelines.
+
 ## 🏃️ Run the same pipeline on a cloud-based Tekton Pipelines deployment
 
 ### 📄 Infrastructure Requirements (Pre-requisites)

--- a/src/zenml/cli/stack_recipes.py
+++ b/src/zenml/cli/stack_recipes.py
@@ -688,6 +688,16 @@ def pull(
                     f"in the file: {os.path.join(destination_dir, 'locals.tf')} "
                     "before you run the deploy command."
                 )
+        # also copy the modules folder from the repo (if it exists)
+        # this is a temporary fix until we have a proper module registry
+        modules_dir = os.path.join(
+            git_stack_recipes_handler.stack_recipes_dir, "modules"
+        )
+        if os.path.exists(modules_dir):
+            cli_utils.declare("Copying modules folder...")
+            io_utils.copy_dir(
+                modules_dir, os.path.join(stack_recipes_dir, "modules"), True
+            )
 
 
 @stack_recipe.command(

--- a/src/zenml/cli/stack_recipes.py
+++ b/src/zenml/cli/stack_recipes.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import click
 from rich.text import Text
@@ -763,6 +763,12 @@ def pull(
     "if you have a local copy of your recipe already. Use the `--path` or `-p` flag to "
     "specify the directory that hosts your recipe(s).",
 )
+@click.option(
+    "--install",
+    "-i",
+    "enabled_services",
+    multiple=True,
+)
 @pass_git_stack_recipes_handler
 @click.pass_context
 def deploy(
@@ -777,6 +783,7 @@ def deploy(
     no_server: bool,
     skip_pull: bool,
     stack_name: Optional[str],
+    enabled_services: Tuple[str],
 ) -> None:
     """Run the stack_recipe at the specified relative path.
 
@@ -802,6 +809,8 @@ def deploy(
             deployment.
         skip_pull: Skip the pull of the stack recipe before deploying. This
             should be used if you have a local copy of your recipe already.
+        enabled_services: A list of services to install. Choose from mlflow, seldon, 
+            kserve, kubeflow, tekton.
     """
     with event_handler(
         event=AnalyticsEvent.RUN_STACK_RECIPE,
@@ -914,7 +923,8 @@ def deploy(
                         )
                     else:
                         stack_recipe_service = StackRecipeService(
-                            config=terraform_config
+                            config=terraform_config,
+                            enabled_services=enabled_services,
                         )
 
                     # start the service (the init and apply operation)

--- a/src/zenml/recipes/stack_recipe_service.py
+++ b/src/zenml/recipes/stack_recipe_service.py
@@ -52,7 +52,8 @@ class StackRecipeService(TerraformService):
         "stack_recipes",
     )
 
-    create_zen_server: bool = False
+    # list of all enabled stack components
+    enabled_services: list = []
 
     def check_installation(self) -> None:
         """Checks if necessary tools are installed on the host system.
@@ -188,6 +189,11 @@ class StackRecipeService(TerraformService):
             derived from the tfvars.json file.
         """
         vars = super().get_vars()
+
+        # enable services
+        for service in self.enabled_services:
+            vars[f'enable_{service}'] = True
+            
         # update zenml version to current version
         vars[ZENML_VERSION_VARIABLE] = zenml.__version__
         return vars


### PR DESCRIPTION
## Describe changes
I implemented support for modular recipes for the `zenml stack recipe` CLI commands.
Also included are additions to the example READMEs specifying how users can set up local stacks with components like MLflow, Kubeflow, Seldon, KServe and Tekton.

## User flow

In addition to making the existing recipe CLI commands work with the new modular architecture, the user can now specify what components to install using flags in the CLI too.

For example, if a user wishes to deploy a local stack with Seldon installed, they can simply run:
```
zenml stack recipe deploy k3d-modular --install seldon
```

and so on.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

