### PR TITLE
Fixed broken link returned form pipeline runs

### DIFF
--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -46,7 +46,7 @@ def get_run_url(
     runs = client.depaginate(partial(client.list_runs, name=run_name))
 
     if pipeline_id:
-        url += f"/pipelines/{str(pipeline_id)}/runs"
+        url += f"/projects/{client.active_project.name}/pipelines/{str(pipeline_id)}/runs"
     elif runs:
         url += "/runs"
     else:


### PR DESCRIPTION
## Describe changes
At the end of every pipeline run, the URL in the UI is printed. This link broke in our latest release, as part of the route has changed in the dashboard. This has been fixed within this PR.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

