### PR TITLE
Always instantiate a zen_store before startup.

### DIFF
--- a/.pyspelling-ignore-words
+++ b/.pyspelling-ignore-words
@@ -1608,3 +1608,9 @@ conjuncted
 StackModels
 ComponentModels
 zenprojects
+ClusterIssuer
+balancer
+defaultPassword
+generateCerts
+letsencrypt
+privateKeySecretRef

--- a/src/zenml/zen_server/deploy/deployer.py
+++ b/src/zenml/zen_server/deploy/deployer.py
@@ -105,8 +105,8 @@ class ServerDeployer(metaclass=SingletonMetaClass):
         # before the server is deployed. This is necessary because the server
         # may require access to the local store configuration or database.
         gc = GlobalConfiguration()
-        if gc.store is None:
-            _ = gc.zen_store
+
+        _ = gc.zen_store
 
         try:
             self.get_server(config.name)


### PR DESCRIPTION
## Describe changes
Two errors are solved by this:

No migration when running `zenml up` as raised [here](https://github.com/zenml-io/zenml/issues/1259)
```
pip install zenml==0.31.0
zenml stack list
zenml up
zenml down
pip install zenml==0.32.0
zenml up
```
This would fail because zenml up does not run migrations. 

No migration when running `zenml up`
```
zenml stack list
zenml up
zenml down
rm -rf ~.config/zenml/local_stores/default_zen_store/zenml.db
zenml up
```
This would fail also because zenml up does not run migrations so no db would be present.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

