### PR TITLE
Relax pydantic dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ python-dateutil = "^2.8.1"
 gitpython = "^3.1.18"
 click = "^8.0.1"
 click-params = "^0.3.0"
-pydantic = "~1.9.0"
+pydantic = "<1.11, >=1.9.0"
 analytics-python = "^1.4.0"
 distro = "^1.6.0"
 rich = {extras = ["jupyter"], version = "^12.0.0"}


### PR DESCRIPTION
Relaxing pydantic constrain to try installing `zenml` with `pydantic` 1.10 (first version of pydantic with full python 3.10 support)

## Describe changes
I modified the constrains in pyproject,tml to test most recent version of pydantic

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

