### PR TITLE
Integration tests for post execution functions

### DIFF
--- a/src/zenml/post_execution/pipeline_run.py
+++ b/src/zenml/post_execution/pipeline_run.py
@@ -51,7 +51,7 @@ def get_run(name: str) -> "PipelineRunView":
     # TODO: [server] this error handling could be improved
     if not runs:
         raise KeyError(f"No run with name '{name}' exists.")
-    elif runs.total:
+    elif runs.total > 1:
         raise RuntimeError(
             f"Multiple runs have been found for name  '{name}'.", runs
         )
@@ -59,7 +59,7 @@ def get_run(name: str) -> "PipelineRunView":
 
 
 def get_unlisted_runs() -> List["PipelineRunView"]:
-    """Fetches post-execution views the most recent 50 unlisted runs.
+    """Fetches the post-execution views of the 50 most recent unlisted runs.
 
     Unlisted runs are runs that are not associated with any pipeline.
 

--- a/tests/integration/functional/post_execution/test_pipeline.py
+++ b/tests/integration/functional/post_execution/test_pipeline.py
@@ -1,0 +1,89 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Integration tests for pipeline post-execution functionality."""
+
+import pytest
+
+from tests.integration.functional.conftest import (
+    constant_int_output_test_step,
+    int_plus_one_test_step,
+)
+from zenml.post_execution.pipeline import (
+    PipelineView,
+    get_pipeline,
+    get_pipelines,
+)
+
+
+def test_get_pipelines(clean_client, connected_two_step_pipeline):
+    """Integration test for the `get_pipelines` function."""
+    pipeline_instance = connected_two_step_pipeline(
+        step_1=constant_int_output_test_step(),
+        step_2=int_plus_one_test_step(),
+    )
+    assert len(get_pipelines()) == 0
+    pipeline_instance.run()
+    pipelines = get_pipelines()
+    assert len(pipelines) == 1
+    assert pipelines[0].name == "connected_two_step_pipeline"
+
+
+def test_get_pipeline(clean_client, connected_two_step_pipeline):
+    """Integration test for the `get_pipeline` function."""
+    pipeline_instance = connected_two_step_pipeline(
+        step_1=constant_int_output_test_step(),
+        step_2=int_plus_one_test_step(),
+    )
+
+    # Test getting non-existent pipeline returns None
+    assert get_pipeline("connected_two_step_pipeline") is None
+    assert get_pipeline(connected_two_step_pipeline) is None
+    assert get_pipeline(pipeline_instance) is None
+
+    pipeline_instance.run()
+
+    # Test getting existing pipeline by name
+    pipeline1 = get_pipeline("connected_two_step_pipeline")
+    assert isinstance(pipeline1, PipelineView)
+    assert pipeline1.name == "connected_two_step_pipeline"
+
+    # Test getting existing pipeline by class
+    pipeline2 = get_pipeline(connected_two_step_pipeline)
+    assert pipeline2 == pipeline1
+
+    # Test getting existing pipeline by instance
+    pipeline3 = get_pipeline(pipeline_instance)
+    assert pipeline3 == pipeline1
+
+
+class NotAPipeline:
+    """This is not a pipeline and cannot be used as arg of `get_pipeline()`."""
+
+
+@pytest.mark.parametrize(
+    "wrong_pipeline_type",
+    [
+        3,
+        True,
+        3.14,
+        ["list_of_pipelines"],
+        {"dict_of_pipelines": "yes"},
+        NotAPipeline,
+        NotAPipeline(),
+    ],
+)
+def test_get_pipeline_fails_for_wrong_type(clean_client, wrong_pipeline_type):
+    """Test that `get_pipeline` fails for wrong input types."""
+    with pytest.raises(RuntimeError):
+        get_pipeline(wrong_pipeline_type)

--- a/tests/integration/functional/post_execution/test_pipeline_run.py
+++ b/tests/integration/functional/post_execution/test_pipeline_run.py
@@ -13,13 +13,45 @@
 #  permissions and limitations under the License.
 """Integration tests for pipeline run post-execution functionality."""
 
+import pytest
+
 from tests.integration.functional.conftest import (
     constant_int_output_test_step,
     int_plus_one_test_step,
 )
 from zenml.config.schedule import Schedule
 from zenml.environment import get_run_environment_dict
-from zenml.post_execution import get_pipeline
+from zenml.post_execution import get_pipeline, get_run, get_unlisted_runs
+
+
+def test_get_run(clean_client, connected_two_step_pipeline):
+    """Test that `get_run()` returns the correct run."""
+    pipeline_instance = connected_two_step_pipeline(
+        step_1=constant_int_output_test_step(),
+        step_2=int_plus_one_test_step(),
+    )
+    pipeline_instance.run()
+    run_ = get_pipeline("connected_two_step_pipeline").runs[-1]
+    assert get_run(run_.name) == run_
+
+
+def test_get_run_fails_for_non_existent_run():
+    """Test that `get_run()` raises a `KeyError` for non-existent runs."""
+    with pytest.raises(KeyError):
+        get_run("non_existent_run")
+
+
+def test_get_unlisted_runs(clean_client, connected_two_step_pipeline):
+    """Test that `get_unlisted_runs()` only returns unlisted runs."""
+    assert len(get_unlisted_runs()) == 0
+    pipeline_instance = connected_two_step_pipeline(
+        step_1=constant_int_output_test_step(),
+        step_2=int_plus_one_test_step(),
+    )
+    pipeline_instance.run()
+    assert len(get_unlisted_runs()) == 0
+    pipeline_instance.run(unlisted=True)
+    assert len(get_unlisted_runs()) == 1
 
 
 def test_pipeline_run_has_client_and_orchestrator_environment(


### PR DESCRIPTION
## Describe changes
I added integration tests for `post_execution.get_pipeline()` / `get_pipelines()` / `get_run()` / `get_unlisted_runs()`.

Also included the fix from #1263.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

