### PR TITLE
Make `/cloud` point to enterprise page

### DIFF
--- a/docs/book/getting-started/deploying-zenml/deploying-zenml.md
+++ b/docs/book/getting-started/deploying-zenml/deploying-zenml.md
@@ -14,7 +14,7 @@ to use it. This section covers the various scenarios when it comes to deploying 
 from starting locally to transitioning to the cloud.
 
 **Tip**: In order to skip deploying ZenML completely, or if you just want to get up and running
-quickly, you can use an early version of the [ZenML Cloud](https://zenml.io/cloud)
+quickly, you can use an early version of [ZenML Enterprise](https://zenml.io/pricing)
 where we'll give you a free and managed ZenML server!
 
 ## The components of a ZenML Deployment
@@ -91,10 +91,6 @@ As such, it is important that you deploy ZenML in a way that is accessible from
 your machine as well as from all stack components that need access to the server.
 > If you are looking for a quick deployment without having to worry about configuring 
 > the right access, the [`zenml deploy` CLI command ](./cli.md) is the way to go!
-
- **Tip**: In order to quickly get access to a ZenML server deployed in the cloud
-without the hassle of setting it up and maintaining it, you can get a free, early version
-of the [ZenML Cloud](https://zenml.io/cloud) by filling out this form instead!
 
 ### Scenario 3: Server and Database hosted on cloud
 

--- a/examples/spark_distributed_programming/README.md
+++ b/examples/spark_distributed_programming/README.md
@@ -59,7 +59,7 @@ In order to achieve this there are two different ways to get access to a remote
 ZenML Server.
 
 1. Deploy and manage the server manually on [your own cloud](https://docs.zenml.io/getting-started/deploying-zenml)/
-2. Sign up for [ZenML Cloud](https://zenml.io/cloud-signup) and get access to a 
+2. Sign up for [ZenML Enterprise](https://zenml.io/pricing) and get access to a 
 hosted version of the ZenML Server with no setup required.
 
 # Setting up the AWS resources


### PR DESCRIPTION
Removed / edited references in the zenml repository where we point to the cloud page.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

