### PR TITLE
Fix failing filter on stacks by component id

### DIFF
--- a/src/zenml/models/artifact_models.py
+++ b/src/zenml/models/artifact_models.py
@@ -74,6 +74,9 @@ class ArtifactResponseModel(ArtifactBaseModel, WorkspaceScopedResponseModel):
 class ArtifactFilterModel(WorkspaceScopedFilterModel):
     """Model to enable advanced filtering of all Artifacts."""
 
+    # `only_unused` refers to a property of the artifacts relationship
+    #  rather than a field in the db, hence it needs to be handled
+    #  explicitly
     FILTER_EXCLUDE_FIELDS: ClassVar[List[str]] = [
         *WorkspaceScopedFilterModel.FILTER_EXCLUDE_FIELDS,
         "only_unused",

--- a/src/zenml/models/stack_models.py
+++ b/src/zenml/models/stack_models.py
@@ -14,7 +14,7 @@
 """Models representing stacks."""
 
 import json
-from typing import Any, Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -120,6 +120,14 @@ class StackFilterModel(ShareableWorkspaceScopedFilterModel):
     `generate_filter()` method of the baseclass is overwritten to include the
     scoping.
     """
+
+    # `component_id` refers to a relationship through a link-table
+    #  rather than a field in the db, hence it needs to be handled
+    #  explicitly
+    FILTER_EXCLUDE_FIELDS: ClassVar[List[str]] = [
+        *ShareableWorkspaceScopedFilterModel.FILTER_EXCLUDE_FIELDS,
+        "component_id",  # This is a relationship, not a field
+    ]
 
     is_shared: Union[bool, str] = Field(
         default=None, description="If the stack is shared or private"

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -154,6 +154,7 @@ from zenml.zen_stores.schemas import (
     RoleSchema,
     ScheduleSchema,
     StackComponentSchema,
+    StackCompositionSchema,
     StackSchema,
     StepRunInputArtifactSchema,
     StepRunOutputArtifactSchema,
@@ -965,6 +966,13 @@ class SqlZenStore(BaseZenStore):
         """
         with Session(self.engine) as session:
             query = select(StackSchema)
+            if stack_filter_model.component_id:
+                query = query.where(
+                    StackCompositionSchema.stack_id == StackSchema.id
+                ).where(
+                    StackCompositionSchema.component_id
+                    == stack_filter_model.component_id
+                )
             return self.filter_and_paginate(
                 session=session,
                 query=query,


### PR DESCRIPTION
## Describe changes
The following request would previously fail: 
`http://127.0.0.1:8237/api/v1/stacks?sort_by=created&logical_operator=and&page=1&size=50&component_id=ecfedc9a-a5f5-4c2d-ae63-21bfe6d5cb62`

This was due to the fact that component_id is not a field on the StackSchema. I adjusted the logic for this and alos verified this same issue does not appear elsewhere.

The only models where this could have been an issue as well would have been Component, User and Team, but none of their filter models support a reference to their linked counterparts.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

