### PR TITLE
Bug: local ZenML server ignores ip-address CLI argument

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -195,7 +195,10 @@ def up(
             config_attrs["image"] = image
         if port is not None:
             config_attrs["port"] = port
-        if ip_address is not None and provider == ServerProviderType.DOCKER:
+        if ip_address is not None and provider in [
+            ServerProviderType.LOCAL,
+            ServerProviderType.DOCKER,
+        ]:
             config_attrs["ip_address"] = ip_address
 
         from zenml.zen_server.deploy.deployment import ServerDeploymentConfig
@@ -225,7 +228,6 @@ def up(
                 and gc.store.type == StoreType.REST
                 and not connect
             ):
-
                 try:
                     if gc.zen_store.is_local_store():
                         connect = True
@@ -716,7 +718,6 @@ def connect(
     verify_ssl = ssl_ca_cert if ssl_ca_cert is not None else not no_verify_ssl
 
     if config:
-
         if os.path.isfile(config):
             store_dict = yaml_utils.read_yaml(config)
         else:


### PR DESCRIPTION
## Describe changes
Allow `--ip-address` to be properly used with local zenml server deployments.

Fixes: #1281

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

