### PR TITLE
Fix step and pipeline run metadata in LineageGraph

### DIFF
--- a/src/zenml/post_execution/lineage/lineage_graph.py
+++ b/src/zenml/post_execution/lineage/lineage_graph.py
@@ -70,7 +70,7 @@ class LineageGraph(BaseModel):
                     outputs={k: v.uri for k, v in step.outputs.items()},
                     metadata=[
                         (m.key, str(m.value), str(m.type))
-                        for m in step.metadata
+                        for m in step.metadata.values()
                     ],
                 ),
             )
@@ -123,7 +123,7 @@ class LineageGraph(BaseModel):
             run: The PipelineRunView to generate the lineage graph for.
         """
         self.run_metadata = [
-            (m.key, str(m.value), str(m.type)) for m in run.metadata
+            (m.key, str(m.value), str(m.type)) for m in run.metadata.values()
         ]
         for step in run.steps:
             self.generate_step_nodes_and_edges(step)

--- a/tests/integration/functional/post_execution/lineage/test_lineage_graph.py
+++ b/tests/integration/functional/post_execution/lineage/test_lineage_graph.py
@@ -17,6 +17,7 @@ from tests.integration.functional.conftest import (
     constant_int_output_test_step,
     int_plus_one_test_step,
 )
+from zenml.metadata.metadata_types import MetadataTypeEnum, Uri
 from zenml.post_execution import get_pipeline
 from zenml.post_execution.lineage.lineage_graph import (
     ARTIFACT_PREFIX,
@@ -28,13 +29,48 @@ from zenml.post_execution.lineage.lineage_graph import (
 def test_generate_run_nodes_and_edges(
     clean_client, connected_two_step_pipeline
 ):
-    """Tests that the created lineage graph has the right nodes and edges."""
+    """Tests that the created lineage graph has the right nodes and edges.
+
+    We also write some mock metadata for both pipeline runs and steps runs here
+    to test that they are correctly added to the lineage graph.
+    """
+    active_stack_model = clean_client.active_stack_model
+    orchestrator_id = active_stack_model.components["orchestrator"][0].id
+
     # Create and retrieve a pipeline run
     pipeline_instance = connected_two_step_pipeline(
         step_1=constant_int_output_test_step(),
         step_2=int_plus_one_test_step(),
     )
     pipeline_instance.run()
+    pipeline_run = get_pipeline("connected_two_step_pipeline").runs[-1]
+
+    # Write some metadata for the pipeline run
+    clean_client.create_run_metadata(
+        metadata={"orchestrator_url": Uri("https://www.ariaflow.org")},
+        pipeline_run_id=pipeline_run.id,
+        stack_component_id=orchestrator_id,
+    )
+
+    # Write some metadata for all steps
+    steps = pipeline_run.steps
+    for step_ in steps:
+        clean_client.create_run_metadata(
+            metadata={
+                "experiment_tracker_url": Uri("https://www.aria_and_blupus.ai")
+            },
+            step_run_id=step_.id,
+            stack_component_id=orchestrator_id,  # just link something
+        )
+
+        # Write some metadata for all artifacts
+        for output_artifact in step_.outputs.values():
+            clean_client.create_run_metadata(
+                metadata={"aria_loves_alex": True},
+                artifact_id=output_artifact.id,
+            )
+
+    # Get the run again so all the metadata is loaded
     pipeline_run = get_pipeline("connected_two_step_pipeline").runs[-1]
 
     # Generate a lineage graph for the pipeline run
@@ -76,3 +112,28 @@ def test_generate_run_nodes_and_edges(
             edge = edge_id_to_model_mapping[edge_id]
             assert edge.source == artifact_id
             assert edge.target == step_id
+
+    # Check that the run, all steps, and all artifacts have metadata
+    # Here we only check the last element in case we run this test with stack
+    # components that add their own metadata in the future
+    assert len(graph.run_metadata) > 0
+    assert graph.run_metadata[-1] == (
+        "orchestrator_url",
+        "https://www.ariaflow.org",
+        MetadataTypeEnum.URI,
+    )
+    for node in graph.nodes:
+        node_metadata = node.data.metadata
+        assert len(node_metadata) > 0
+        if node.type == "step":
+            assert node_metadata[-1] == (
+                "experiment_tracker_url",
+                "https://www.aria_and_blupus.ai",
+                MetadataTypeEnum.URI,
+            )
+        elif node.type == "artifact":
+            assert node_metadata[-1] == (
+                "aria_loves_alex",
+                "True",
+                MetadataTypeEnum.BOOL,
+            )


### PR DESCRIPTION
## Describe changes
I missed updating the lineage graph after turning the `.metadata` fields into dicts which would cause all graphs with step/pipeline run metadata to raise exceptions. I fixed that and also modified the lineage graph test from #1253 to ensure this won't happen again.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

