### PR TITLE
Remove excess help text for `zenml connect` command

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -583,7 +583,7 @@ def status() -> None:
 @cli.command(
     "connect",
     help=(
-        """Configure your client to connect to a remote ZenML server.
+        """Connect to a remote ZenML server.
 
     Examples:
 


### PR DESCRIPTION
The `zenml connect` command help text currently spans more than 1 line (see image below). We prefer not to do that on the CLI, so this fix removes some excess text.

![ScreenShot 2023-02-06 at 16 17 52](https://user-images.githubusercontent.com/3348134/217010523-4bb5ef51-383a-490b-a068-e24f0191353d.png)
