### PR TITLE
Change zenml init --template to optionally prompt and track email

### DIFF
--- a/docs/book/getting-started/deploying-zenml/docker.md
+++ b/docs/book/getting-started/deploying-zenml/docker.md
@@ -305,8 +305,8 @@ services:
       - "8080:8080"
     environment:
       - ZENML_STORE_URL=mysql://root:password@host.docker.internal/zenml
-      - ZENML_DEFAULT_USERNAME=admin
-      - ZENML_DEFAULT_PASSWORD=zenml
+      - ZENML_DEFAULT_USER_NAME=admin
+      - ZENML_DEFAULT_USER_PASSWORD=zenml
     links:
       - mysql
     depends_on:
@@ -322,7 +322,7 @@ Note the following:
 to instruct the server to connect to the database over the Docker network.
 - The `extra_hosts` section is needed on Linux to make the `host.docker.internal`
 hostname resolvable from the ZenML server container.
-- This example also uses the `ZENML_DEFAULT_USERNAME` and `ZENML_DEFAULT_PASSWORD`
+- This example also uses the `ZENML_DEFAULT_USER_NAME` and `ZENML_DEFAULT_USER_PASSWORD`
 environment variables to customize the default account credentials.
 
 To start the containers, run the following command from the directory where

--- a/docs/book/getting-started/deploying-zenml/helm.md
+++ b/docs/book/getting-started/deploying-zenml/helm.md
@@ -232,7 +232,7 @@ Once deployed, you have to use port-forwarding to access the ZenML server and
 to connect to it from your local machine:
 
 ```bash
-kubectl -n zenml-server port-forward svc/zenml-server 8080:80
+kubectl -n zenml-server port-forward svc/zenml-server 8080:8080
 zenml connect --url=http://localhost:8080 --username=default --password password
 ```
 

--- a/docs/book/getting-started/installation/installation.md
+++ b/docs/book/getting-started/installation/installation.md
@@ -69,7 +69,7 @@ docker run -it zenmldocker/zenml /bin/bash
 If you would like to run the ZenML server with Docker:
 
 ```shell
-docker run -it -d -p 8080:80 zenmldocker/zenml-server
+docker run -it -d -p 8080:8080 zenmldocker/zenml-server
 ```
 
 ## Installing Develop

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -384,6 +384,9 @@ def go() -> None:
 def _prompt_email(event_source: AnalyticsEventSource) -> bool:
     """Ask the user to give their email address.
 
+    Args:
+        event_source: The source of the event to use for analytics.
+
     Returns:
         bool: True if the user gave an email address, False otherwise.
     """

--- a/src/zenml/cli/text_utils.py
+++ b/src/zenml/cli/text_utils.py
@@ -17,13 +17,13 @@ from typing import List
 
 from rich.markdown import Markdown
 
-zenml_go_welcome_message = Markdown(
+zenml_cli_welcome_message = Markdown(
     """
 # ⛩  Welcome to ZenML!
 """
 )
 
-zenml_go_email_prompt = Markdown(
+zenml_cli_email_prompt = Markdown(
     """
 Here at ZenML we are working hard to produce the best
 possible MLOps framework. In order to solve real-world problems
@@ -35,7 +35,7 @@ user interview and to better understand usage.
 """
 )
 
-zenml_go_privacy_message = Markdown(
+zenml_cli_privacy_message = Markdown(
     """
 ## 🔒 Privacy Policy at ZenML!
 
@@ -52,7 +52,7 @@ zenml analytics opt-out
 """
 )
 
-zenml_go_thank_you_message = Markdown(
+zenml_cli_thank_you_message = Markdown(
     """
 🙏  Thank you!
 """

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -141,6 +141,7 @@ class AnalyticsEventSource(StrEnum):
     """Enum to identify analytics events source."""
 
     ZENML_GO = "zenml go"
+    ZENML_INIT = "zenml init"
     ZENML_SERVER = "zenml server"
 
 

--- a/src/zenml/utils/analytics_utils.py
+++ b/src/zenml/utils/analytics_utils.py
@@ -47,6 +47,9 @@ class AnalyticsEvent(str, Enum):
     UPDATE_REPOSITORY = "Repository updated"
     DELETE_REPOSITORY = "Repository deleted"
 
+    # Template
+    GENERATE_TEMPLATE = "Template generated"
+
     # Zen store
     INITIALIZED_STORE = "Store initialized"
 


### PR DESCRIPTION
## Describe changes
Add a `--starter` flag to `zenml init` to generate the starter template without prompting for user input (use default param values).
Both `zenml init --starter` and `zenml init --template` ask for a user email the first time they are used, which is tracked.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

