### PR TITLE
Add warning and docs update for `label_studio` installation issue

### DIFF
--- a/docs/book/component-gallery/annotators/label-studio.md
+++ b/docs/book/component-gallery/annotators/label-studio.md
@@ -48,6 +48,14 @@ and add it to your stack:
 zenml integration install label_studio
 ```
 
+{% hint style="warning" %}
+There is a known issue with Label Studio installations via `zenml integration
+install...`. You might find that the Label Studio installation breaks the ZenML
+CLI. In this case, please run `pip install 'pydantic==1.10.4'` to fix the issue
+or [message us on Slack](https://zenml.io/slack-invite) if you need more help with
+this. We are working on a more definitive fix.
+{% endhint %}
+
 The following instructions below offer a general guide to the parts that need
 attention when deploying / using the Label Studio stack component and
 integration. The [`label_studio_annotation`

--- a/docs/book/component-gallery/annotators/label-studio.md
+++ b/docs/book/component-gallery/annotators/label-studio.md
@@ -51,7 +51,7 @@ zenml integration install label_studio
 {% hint style="warning" %}
 There is a known issue with Label Studio installations via `zenml integration
 install...`. You might find that the Label Studio installation breaks the ZenML
-CLI. In this case, please run `pip install 'pydantic==1.10.4'` to fix the issue
+CLI. In this case, please run `pip install 'pydantic<1.11,>=1.9.0'` to fix the issue
 or [message us on Slack](https://zenml.io/slack-invite) if you need more help with
 this. We are working on a more definitive fix.
 {% endhint %}

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -253,6 +253,10 @@ def install(
     ):
         with console.status("Installing integrations..."):
             install_packages(requirements)
+            if "label_studio" in integrations:
+                warning(
+                    "There is a known issue with Label Studio installations via zenml. You might find that the Label Studio installation breaks the ZenML CLI. In this case, please run `pip install 'pydantic==1.10.4'` to fix the issue or message us on Slack if you need help with this. We are working on a more definitive fix."
+                )
 
         for integration_name in integrations_to_install:
             track_event(

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -255,7 +255,7 @@ def install(
             install_packages(requirements)
             if "label_studio" in integrations:
                 warning(
-                    "There is a known issue with Label Studio installations via zenml. You might find that the Label Studio installation breaks the ZenML CLI. In this case, please run `pip install 'pydantic==1.10.4'` to fix the issue or message us on Slack if you need help with this. We are working on a more definitive fix."
+                    "There is a known issue with Label Studio installations via zenml. You might find that the Label Studio installation breaks the ZenML CLI. In this case, please run `pip install 'pydantic<1.11,>=1.9.0'` to fix the issue or message us on Slack if you need help with this. We are working on a more definitive fix."
                 )
 
         for integration_name in integrations_to_install:


### PR DESCRIPTION
Added a warning post-install, and a docs update that reflects the same message. These are interim fixes until we figure out the right version combination that works without breaking ZenML's Pydantic version.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

