### PR TITLE
Add warning about MacOS not being supported

### DIFF
--- a/examples/kserve_deployment/README.md
+++ b/examples/kserve_deployment/README.md
@@ -90,7 +90,11 @@ online predictions on the running KServe inference service.
 
 You don't need to set up any infrastructure to run your pipelines with KServe, locally. However, you need the following tools installed:
   * Docker must be installed on your local machine.
-  * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+  * Install k3d by running `curl -s
+    https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
+
+You also need to be running Linux or Windows. MacOS is currently not supported
+for these local deployments.
 
 ## Create a local KServe Stack
 

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -72,6 +72,9 @@ You don't need to set up any infrastructure to run your pipelines with Seldon, l
   * Docker must be installed on your local machine.
   * Install k3d by running `curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash`.
 
+You also need to be running Linux or Windows. MacOS is currently not supported
+for these local deployments.
+
 ## Create a local Seldon Stack
 
 To get a stack with Seldon Core and potential other components, you can make use of ZenML's Stack Recipes that are a set of terraform based modules that take care of setting up a cluster with Seldon among other things.


### PR DESCRIPTION
MacOS is currently not working for the kserve or seldon modular deployments. I added a small note in the prerequisites section for the two examples to reflect this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

