### PR TITLE
Workspace/projects fix for dashboard URL output when running pipeline

### DIFF
--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -46,7 +46,7 @@ def get_run_url(
     runs = client.depaginate(partial(client.list_runs, name=run_name))
 
     if pipeline_id:
-        url += f"/projects/{client.active_workspace.name}/pipelines/{str(pipeline_id)}/runs"
+        url += f"/workspaces/{client.active_workspace.name}/pipelines/{str(pipeline_id)}/runs"
     elif runs:
         url += "/runs"
     else:


### PR DESCRIPTION
Running pipelines outputs a URL when the run is finished. That URL currently points to `/projects/` which gives you a 404 error when visiting the URL. The url should just be `/workspaces/` instead.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

