### PR TITLE
GCP Image Builder network 

### DIFF
--- a/docs/book/component-gallery/image-builders/gcp.md
+++ b/docs/book/component-gallery/image-builders/gcp.md
@@ -41,3 +41,19 @@ zenml image-builder register <IMAGE_BUILDER_NAME> \
 # Register and activate a stack with the new image builder
 zenml stack register <STACK_NAME> -i <IMAGE_BUILDER_NAME> ... --set
 ```
+
+## Caveats
+
+As described in this [Google Cloud Build documentation page](https://cloud.google.com/build/docs/build-config-file-schema#network), Google Cloud Build uses containers to execute the build steps which are automatically attached to a network called `cloudbuild` that provides some Application Default Credentials (ADC), that allows the container to be authenticated and therefore use other GCP services.
+
+By default, the GCP Image Builder is executing the build command of the ZenML Pipeline Docker image with the option `--network=cloudbuild`, so the ADC provided by the `cloudbuild` network can also be used in the build. This is useful if you want to install a private dependency from a GCP Artifact Registry, but you will also need to use a [custom base parent image](../../advanced-guide/pipelines/containerization.md#using-a-custom-parent-image) with the [`keyrings.google-artifactregistry-auth`](https://pypi.org/project/keyrings.google-artifactregistry-auth/) installed, so `pip` can connect and authenticate in the private artifact registry to download the dependency.
+
+```dockerfile
+FROM zenmldocker/zenml:latest
+
+RUN pip install keyrings.google-artifactregistry-auth
+```
+
+{% hint style="warning" %}
+The above `Dockerfile` uses `zenmldocker/zenml:latest` as base image, but is recommended to change the tag to specify the ZenML version and Python version like `0.33.0-py3.10`.
+{% endhint %}

--- a/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from zenml.integrations.gcp.image_builders import GCPImageBuilder
 
 DEFAULT_CLOUD_BUILDER_IMAGE = "gcr.io/cloud-builders/docker"
+DEFAULT_CLOUD_BUILDER_NETWORK = "cloudbuild"
 
 
 class GCPImageBuilderConfig(
@@ -35,9 +36,12 @@ class GCPImageBuilderConfig(
     Attributes:
         cloud_builder_image: The name of the Docker image to use for the build
             steps. Defaults to `gcr.io/cloud-builders/docker`.
+        network: The network name to which the build container will be
+            attached while building the Docker image. Defaults to `cloudbuild`.
     """
 
     cloud_builder_image: str = DEFAULT_CLOUD_BUILDER_IMAGE
+    network: str = DEFAULT_CLOUD_BUILDER_NETWORK
 
 
 class GCPImageBuilderFlavor(BaseImageBuilderFlavor):

--- a/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
@@ -37,7 +37,10 @@ class GCPImageBuilderConfig(
         cloud_builder_image: The name of the Docker image to use for the build
             steps. Defaults to `gcr.io/cloud-builders/docker`.
         network: The network name to which the build container will be
-            attached while building the Docker image. Defaults to `cloudbuild`.
+            attached while building the Docker image. More information about
+            this:
+            https://cloud.google.com/build/docs/build-config-file-schema#network.
+            Defaults to `cloudbuild`.
     """
 
     cloud_builder_image: str = DEFAULT_CLOUD_BUILDER_IMAGE

--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -151,9 +151,12 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
         )
 
         cloud_builder_image = self.config.cloud_builder_image
+        cloud_builder_network_option = f"--network={self.config.network}"
         logger.info(
-            "Using Cloud Builder image `%s` to run the steps in the build",
+            "Using Cloud Builder image `%s` to run the steps in the build. "
+            "Container will be attached to network using option `%s`.",
             cloud_builder_image,
+            cloud_builder_network_option,
         )
 
         return cloudbuild_v1.Build(
@@ -165,7 +168,13 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
             steps=[
                 {
                     "name": cloud_builder_image,
-                    "args": ["build", "-t", image_name, "."],
+                    "args": [
+                        "build",
+                        cloud_builder_network_option,
+                        "-t",
+                        image_name,
+                        ".",
+                    ],
                 },
                 {
                     "name": cloud_builder_image,


### PR DESCRIPTION
## Describe changes

I encountered an authentication problem while trying to build a pipeline Docker image that uses a dependency from a private GCP Artifact Registry using the GCP Image Builder.

As described in this [Google Cloud documentation page](https://cloud.google.com/build/docs/build-config-file-schema#network) about Google Cloud Build, when cloud build runs a step the container gets attached to a network called `cloudbuild` that can be used to get the Application Default Credentials.

In order to install a dependency from a private GCP Artifact Registry, the build container needs to be attached to this network using `--network=cloudbuild` option. This way, the container will be automatically authenticated and the dependency can be installed from the private GCP Artifact Registry. For it to work, you will also need to use a custom base `Dockerimage` like this one:

```dockerfile
FROM zenmldocker/zenml:0.33.0-py3.10

RUN pip install keyrings.google-artifactregistry-auth
```

This PR adds the `GCPImageBuilder.network` attribute that can be used to pass the name of the network to which the build container has to be attached. By default, I gave it the value of `cloudbuild` as it's likely that someone building a Dockerimage using the Google Cloud Build will need to install a dependency from a private GCP Artifact Registry.

Let me know if the instructions described above need to be included in the docs!

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

