### PR TITLE
Remove deprecated CLI options

### DIFF
--- a/src/zenml/cli/example.py
+++ b/src/zenml/cli/example.py
@@ -739,14 +739,6 @@ def info(git_examples_handler: GitExamplesHandler, example_name: str) -> None:
     "folder.",
 )
 @click.option(
-    "--force",
-    "-f",
-    "old_force",
-    is_flag=True,
-    help="DEPRECATED: Force the redownload of the examples folder to the ZenML "
-    "config folder. Use `-y/--yes` instead.",
-)
-@click.option(
     "--version",
     "-v",
     type=click.STRING,
@@ -773,7 +765,6 @@ def pull(
     git_examples_handler: GitExamplesHandler,
     example_name: str,
     force: bool,
-    old_force: bool,
     version: str,
     path: str,
     branch: Optional[str],
@@ -789,21 +780,12 @@ def pull(
         example_name: The name of the example.
         force: Force the redownload of the examples folder to the ZenML config
             folder.
-        old_force: DEPRECATED: Force the redownload of the examples folder to
-            the ZenML config folder.
         version: The version of ZenML to use for the force-redownloaded
             examples.
         path: The path at which you want to install the example(s).
         branch: The branch of the ZenML repo to use for the force-redownloaded
             examples.
     """
-    if old_force:
-        force = old_force
-        warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` or "
-            "`-y` instead."
-        )
-
     branch = branch.strip() if branch else f"release/{version}"
     git_examples_handler.pull(branch=branch, force=force)
 
@@ -866,15 +848,6 @@ def pull(
     "requirements.",
 )
 @click.option(
-    "--force",
-    "-f",
-    "old_force",
-    is_flag=True,
-    help="DEPRECATED: Force the run of the example. This deletes the .zen "
-    "folder from the example folder and force installs all necessary "
-    "integration requirements. Use `-y/--yes` instead.",
-)
-@click.option(
     "--shell-executable",
     "-x",
     type=click.Path(exists=True),
@@ -892,7 +865,6 @@ def run(
     example_name: str,
     path: str,
     force: bool,
-    old_force: bool,
     shell_executable: Optional[str],
 ) -> None:
     """Run the example at the specified relative path.
@@ -906,16 +878,9 @@ def run(
         example_name: The name of the example.
         path: The path at which you want to install the example(s).
         force: Force the run of the example.
-        old_force: DEPRECATED: Force the run of the example.
         shell_executable: Manually specify the path to the executable that
             runs .sh files.
     """
-    if old_force:
-        force = old_force
-        warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` or "
-            "`-y` instead."
-        )
     check_for_version_mismatch(git_examples_handler)
 
     # TODO [ENG-272]: - create a post_run function inside individual setup.sh

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -175,20 +175,10 @@ def export_requirements(
     help="Force the installation of the required packages. This will skip the "
     "confirmation step and reinstall existing packages as well",
 )
-@click.option(
-    "--force",
-    "-f",
-    "old_force",
-    is_flag=True,
-    help="DEPRECATED: Force the installation of the required packages. "
-    "This will skip the confirmation step and reinstall existing packages "
-    "as well. Use `-y/--yes` instead.",
-)
 def install(
     integrations: Tuple[str],
     ignore_integration: Tuple[str],
     force: bool = False,
-    old_force: bool = False,
 ) -> None:
     """Installs the required packages for a given integration.
 
@@ -200,16 +190,9 @@ def install(
             for.
         ignore_integration: List of integrations to ignore explicitly.
         force: Force the installation of the required packages.
-        old_force: DEPRECATED: Force the installation of the required packages.
     """
     from zenml.integrations.registry import integration_registry
 
-    if old_force:
-        force = old_force
-        warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` or "
-            "`-y` instead."
-        )
     if not integrations:
         # no integrations specified, use all registered integrations
         integrations = set(integration_registry.integrations.keys())
@@ -277,17 +260,7 @@ def install(
     help="Force the uninstallation of the required packages. This will skip "
     "the confirmation step",
 )
-@click.option(
-    "--force",
-    "-f",
-    "old_force",
-    is_flag=True,
-    help="DEPRECATED: Force the uninstallation of the required packages. "
-    "This will skip the confirmation step. Use `-y/--yes` instead.",
-)
-def uninstall(
-    integrations: Tuple[str], force: bool = False, old_force: bool = False
-) -> None:
+def uninstall(integrations: Tuple[str], force: bool = False) -> None:
     """Installs the required packages for a given integration.
 
     If no integration is specified all required packages for all integrations
@@ -297,17 +270,9 @@ def uninstall(
         integrations: The name of the integration to install the requirements
             for.
         force: Force the uninstallation of the required packages.
-        old_force: DEPRECATED: Force the uninstallation of the required
-            packages.
     """
     from zenml.integrations.registry import integration_registry
 
-    if old_force:
-        force = old_force
-        warning(
-            "The `--force` flag will soon be deprecated. Use `--yes` "
-            "or `-y` instead."
-        )
     if not integrations:
         # no integrations specified, use all registered integrations
         integrations = tuple(integration_registry.integrations.keys())

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -263,22 +263,12 @@ def register_model_deployer_subcommands() -> None:  # noqa: C901
         "shutdown processes and try to force the model server to stop "
         "immediately, if possible.",
     )
-    @click.option(
-        "--force",
-        "-f",
-        "old_force",
-        is_flag=True,
-        help="DEPRECATED: Force the model server to stop. This will bypass "
-        "any graceful shutdown processes and try to force the model "
-        "server to stop immediately, if possible. Use `-y/--yes` instead.",
-    )
     @click.pass_obj
     def stop_model_service(
         model_deployer: "BaseModelDeployer",
         served_model_uuid: str,
         timeout: int,
         force: bool,
-        old_force: bool,
     ) -> None:
         """Stop a specified model server.
 
@@ -287,14 +277,7 @@ def register_model_deployer_subcommands() -> None:  # noqa: C901
             served_model_uuid: The UUID of the served model.
             timeout: Time in seconds to wait for the model to stop.
             force: Force the model server to stop.
-            old_force: DEPRECATED: Force the model server to stop.
         """
-        if old_force:
-            force = old_force
-            warning(
-                "The `--force` flag will soon be deprecated. Use `--yes` or "
-                "`-y` instead."
-            )
         served_models = model_deployer.find_model_server(
             service_uuid=uuid.UUID(served_model_uuid)
         )
@@ -328,23 +311,12 @@ def register_model_deployer_subcommands() -> None:  # noqa: C901
         "graceful shutdown processes and try to force the model server to "
         "stop and delete immediately, if possible.",
     )
-    @click.option(
-        "--force",
-        "-f",
-        "old_force",
-        is_flag=True,
-        help="DEPRECATED: Force the model server to stop and delete. This will "
-        "bypass any graceful shutdown processes and try to force the model "
-        "server to stop and delete immediately, if possible. Use `-y/--yes` "
-        "instead.",
-    )
     @click.pass_obj
     def delete_model_service(
         model_deployer: "BaseModelDeployer",
         served_model_uuid: str,
         timeout: int,
         force: bool,
-        old_force: bool,
     ) -> None:
         """Delete a specified model server.
 
@@ -353,14 +325,7 @@ def register_model_deployer_subcommands() -> None:  # noqa: C901
             served_model_uuid: The UUID of the served model.
             timeout: Time in seconds to wait for the model to be deleted.
             force: Force the model server to stop and delete.
-            old_force: DEPRECATED: Force the model server to stop and delete.
         """
-        if old_force:
-            force = old_force
-            warning(
-                "The `--force` flag will soon be deprecated. Use `--yes` or "
-                "`-y` instead."
-            )
         served_models = model_deployer.find_model_server(
             service_uuid=uuid.UUID(served_model_uuid)
         )

--- a/src/zenml/cli/secret.py
+++ b/src/zenml/cli/secret.py
@@ -490,31 +490,16 @@ def register_secrets_manager_subcommands() -> None:
         help="Force the deletion of all secrets",
         type=click.BOOL,
     )
-    @click.option(
-        "--force",
-        "-f",
-        "force",
-        is_flag=True,
-        help="DEPRECATED: Force the deletion of all secrets. Use `-y/--yes` "
-        "instead.",
-        type=click.BOOL,
-    )
     @click.pass_obj
     def delete_all_secrets(
-        secrets_manager: "BaseSecretsManager", yes: bool, force: bool
+        secrets_manager: "BaseSecretsManager", yes: bool
     ) -> None:
         """Delete all secrets tracked by your Secrets Manager.
 
         Args:
             secrets_manager: The secrets manager to use.
             yes: Skip asking for confirmation.
-            force: DEPRECATED: Skip asking for confirmation.
         """
-        if force:
-            warning(
-                "The `--force` flag will soon be deprecated. Use `--yes` or "
-                "`-y` instead."
-            )
         if not yes:
             confirmation_response = confirmation(
                 "This will delete all secrets. Are you sure you want to "


### PR DESCRIPTION
I removed some deprecations that are at least 9 months old. I figured that's enough notice for people to have changed their usage by now.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

