### PR TITLE
Fixes GCP docs typo

### DIFF
--- a/docs/book/component-gallery/container-registries/gcp.md
+++ b/docs/book/component-gallery/container-registries/gcp.md
@@ -92,7 +92,7 @@ repository yet, take a look at the [deployment section](#how-to-deploy-it).
 
 ## How to use it
 
-To use the Azure container registry, we need:
+To use the GCP container registry, we need:
 * [Docker](https://www.docker.com) installed and running.
 * The [GCP CLI](https://cloud.google.com/sdk/docs/install) installed and 
 authenticated.


### PR DESCRIPTION
Replaces mistaken `Azure` reference with `GCP` in GCP container registry documentation

## Describe changes
Fixed a mistake in the documentation

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [X] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

