### PR TITLE
Upgrade dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ templates = ["copier", "jinja2-time", "black", "ruff"]
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"
 pytest = "^6.2.4"
-mypy = "^0.991"
+mypy = "^1.0.0"
 ruff = "^0.0.246"
 coverage = { extras = ["toml"], version = "^5.5" }
 pre-commit = "^2.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ templates = ["copier", "jinja2-time", "black", "ruff"]
 black = "^22.3.0"
 pytest = "^6.2.4"
 mypy = "^1.0.0"
-ruff = "^0.0.246"
+ruff = "^0.0.247"
 coverage = { extras = ["toml"], version = "^5.5" }
 pre-commit = "^2.14.0"
 pyment = "^0.3.3"
@@ -106,7 +106,6 @@ darglint = "^1.8.1"
 pytest-randomly = "^3.10.1"
 pytest-mock = "^3.6.1"
 pytest-clarity = "^1.0.1"
-pytest-xdist = "^3.0.2"
 
 # mkdocs including plugins
 mkdocs="^1.2.3"


### PR DESCRIPTION
Via [the mypy release blog](https://mypy-lang.blogspot.com/2023/02/mypy-10-released.html): "Mypy 1.0 is up to 40% faster than mypy 0.991 when type checking the Dropbox internal codebase." Can confirm, it def feels faster on my machine now esp when paired with the cache.

I also updated / upgraded ruff to the latest version and removed `pytest-xdist` which we don't use any more since our tests can't run distributed across multiple cores (on account of server conflicts).

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

