### PR TITLE
Use API docs for `docs_url` instead of main docs

### DIFF
--- a/src/zenml/artifact_stores/local_artifact_store.py
+++ b/src/zenml/artifact_stores/local_artifact_store.py
@@ -156,7 +156,11 @@ class LocalArtifactStoreFlavor(BaseArtifactStoreFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/container_registries/azure_container_registry.py
+++ b/src/zenml/container_registries/azure_container_registry.py
@@ -39,7 +39,11 @@ class AzureContainerRegistryFlavor(BaseContainerRegistryFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        component_type = self.type.plural
+        base = f"https://apidocs.zenml.io/{__version__}"
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/container_registries/default_container_registry.py
+++ b/src/zenml/container_registries/default_container_registry.py
@@ -39,7 +39,11 @@ class DefaultContainerRegistryFlavor(BaseContainerRegistryFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/container_registries/dockerhub_container_registry.py
+++ b/src/zenml/container_registries/dockerhub_container_registry.py
@@ -39,7 +39,11 @@ class DockerHubContainerRegistryFlavor(BaseContainerRegistryFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/container_registries/gcp_container_registry.py
+++ b/src/zenml/container_registries/gcp_container_registry.py
@@ -39,7 +39,11 @@ class GCPContainerRegistryFlavor(BaseContainerRegistryFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/container_registries/github_container_registry.py
+++ b/src/zenml/container_registries/github_container_registry.py
@@ -53,7 +53,11 @@ class GitHubContainerRegistryFlavor(BaseContainerRegistryFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/image_builders/local_image_builder.py
+++ b/src/zenml/image_builders/local_image_builder.py
@@ -131,7 +131,11 @@ class LocalImageBuilderFlavor(BaseImageBuilderFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/orchestrators/local/local_orchestrator.py
+++ b/src/zenml/orchestrators/local/local_orchestrator.py
@@ -143,7 +143,11 @@ class LocalOrchestratorFlavor(BaseOrchestratorFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -266,7 +266,11 @@ class LocalDockerOrchestratorFlavor(BaseOrchestratorFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/secrets_managers/local/local_secrets_manager.py
+++ b/src/zenml/secrets_managers/local/local_secrets_manager.py
@@ -268,7 +268,11 @@ class LocalSecretsManagerFlavor(BaseSecretsManagerFlavor):
         Returns:
             A flavor docs url.
         """
-        return self.generate_default_docs_url()
+        from zenml import __version__
+
+        base = f"https://apidocs.zenml.io/{__version__}"
+        component_type = self.type.plural
+        return f"{base}/core_code_docs/core-{component_type}/#zenml.{component_type}.{self.name}_{self.type}"
 
     @property
     def logo_url(self) -> str:

--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -150,9 +150,5 @@ class Flavor:
         """
         from zenml import __version__
 
-        component_type = self.type.plural.replace("_", "-")
-        name = self.name.replace("_", "-")
-        base = f"https://docs.zenml.io/v/{__version__}"
-        url = f"{base}/component-gallery/{component_type}/{name}"
-
-        return url
+        base = f"https://apidocs.zenml.io/{__version__}"
+        return f"{base}/integration_code_docs/integrations-{self.name}"

--- a/tests/unit/stack/test_flavor.py
+++ b/tests/unit/stack/test_flavor.py
@@ -1,0 +1,27 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from tests.unit.test_flavor import AriaOrchestratorFlavor
+
+
+def test_docs_url_works(stub_component):
+    """Tests that the docs url works."""
+    from zenml import __version__
+
+    aria_flavor = AriaOrchestratorFlavor()
+    assert aria_flavor.docs_url is not None
+    assert (
+        aria_flavor.docs_url
+        == f"https://apidocs.zenml.io/{__version__}/integration_code_docs/integrations-{aria_flavor.name}"
+    )

--- a/tests/unit/test_flavor.py
+++ b/tests/unit/test_flavor.py
@@ -37,3 +37,7 @@ class AriaOrchestratorFlavor(BaseOrchestratorFlavor):
     @property
     def implementation_class(self) -> Type["LocalOrchestrator"]:
         return LocalOrchestrator
+
+    @property
+    def docs_url(self) -> str:
+        return self.generate_default_docs_url()


### PR DESCRIPTION
I updated the default for our way of generating `docs_url`s and added in custom ways for built-ins / non-integrations.

Not quite sure if this is the optimum way of doing this, esp w/r/t what might break down the line.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

