### PR TITLE
Add Kubeflow Pipeline UI Port to deprecated config

### DIFF
--- a/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
@@ -200,6 +200,7 @@ class KubeflowOrchestratorConfig(  # type: ignore[misc] # https://github.com/pyd
         provisioning_attrs = [
             "skip_cluster_provisioning",
             "skip_ui_daemon_provisioning",
+            "kubeflow_pipelines_ui_port",
         ]
 
         provisioning_attrs_used = [


### PR DESCRIPTION
## Describe changes
We had this deleted after the kubeflow update and moving to k3D, but for the old configuration this was causing an error if it was already set, to solve that we add this back to the deprecated attrs

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

