### PR TITLE
Add pydantic materializer

### DIFF
--- a/src/zenml/materializers/__init__.py
+++ b/src/zenml/materializers/__init__.py
@@ -26,6 +26,7 @@ from zenml.materializers.built_in_materializer import (
 )
 from zenml.materializers.numpy_materializer import NumpyMaterializer
 from zenml.materializers.pandas_materializer import PandasMaterializer
+from zenml.materializers.pydantic_materializer import PydanticMaterializer
 from zenml.materializers.service_materializer import ServiceMaterializer
 from zenml.materializers.unmaterialized_artifact import UnmaterializedArtifact
 
@@ -35,6 +36,7 @@ __all__ = [
     "BytesMaterializer",
     "NumpyMaterializer",
     "PandasMaterializer",
+    "PydanticMaterializer",
     "ServiceMaterializer",
     "UnmaterializedArtifact",
 ]

--- a/src/zenml/materializers/built_in_materializer.py
+++ b/src/zenml/materializers/built_in_materializer.py
@@ -384,7 +384,9 @@ class BuiltInContainerMaterializer(BaseMaterializer):
             The extracted metadata as a dictionary.
         """
         base_metadata = super().extract_metadata(data)
-        container_metadata = {
-            "length": len(data),
-        }
+        container_metadata = {}
+        if hasattr(data, "__len__"):
+            container_metadata = {
+                "length": len(data),
+            }
         return {**base_metadata, **container_metadata}

--- a/src/zenml/materializers/pydantic_materializer.py
+++ b/src/zenml/materializers/pydantic_materializer.py
@@ -32,7 +32,7 @@ class PydanticMaterializer(BuiltInContainerMaterializer):
     )
 
     def load(self, data_type: Type[BaseModel]) -> Any:
-        """Reads basic primitive types from JSON.
+        """Reads BaseModel from JSON.
 
         Args:
             data_type: The type of the data to read.
@@ -44,7 +44,7 @@ class PydanticMaterializer(BuiltInContainerMaterializer):
         return data_type(**contents)
 
     def save(self, data: BaseModel) -> None:
-        """Serialize a basic type to JSON.
+        """Serialize a BaseModel to JSON.
 
         Args:
             data: The data to store.

--- a/src/zenml/materializers/pydantic_materializer.py
+++ b/src/zenml/materializers/pydantic_materializer.py
@@ -1,0 +1,52 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Implementation of ZenML's pydantic materializer."""
+
+from typing import Any, Type
+
+from pydantic import BaseModel
+
+from zenml.enums import ArtifactType
+from zenml.materializers.built_in_materializer import (
+    BuiltInContainerMaterializer,
+)
+
+
+class PydanticMaterializer(BuiltInContainerMaterializer):
+    """Handle Pydantic BaseModel objects."""
+
+    ASSOCIATED_ARTIFACT_TYPE = ArtifactType.DATA
+    ASSOCIATED_TYPES = BuiltInContainerMaterializer.ASSOCIATED_TYPES + (
+        BaseModel,
+    )
+
+    def load(self, data_type: Type[BaseModel]) -> Any:
+        """Reads basic primitive types from JSON.
+
+        Args:
+            data_type: The type of the data to read.
+
+        Returns:
+            The data read.
+        """
+        contents = super().load(dict)
+        return data_type(**contents)
+
+    def save(self, data: BaseModel) -> None:
+        """Serialize a basic type to JSON.
+
+        Args:
+            data: The data to store.
+        """
+        super().save(data.dict())

--- a/src/zenml/materializers/pydantic_materializer.py
+++ b/src/zenml/materializers/pydantic_materializer.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Implementation of ZenML's pydantic materializer."""
 
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Dict, Type
 
 from pydantic import BaseModel
 
@@ -21,6 +21,9 @@ from zenml.enums import ArtifactType
 from zenml.materializers.built_in_materializer import (
     BuiltInContainerMaterializer,
 )
+
+if TYPE_CHECKING:
+    from zenml.metadata.metadata_types import MetadataType
 
 
 class PydanticMaterializer(BuiltInContainerMaterializer):
@@ -50,3 +53,18 @@ class PydanticMaterializer(BuiltInContainerMaterializer):
             data: The data to store.
         """
         super().save(data.dict())
+
+    def extract_metadata(self, data: BaseModel) -> Dict[str, "MetadataType"]:
+        """Extract metadata from the given BaseModel object.
+
+        Args:
+            data: The BaseModel object to extract metadata from.
+
+        Returns:
+            The extracted metadata as a dictionary.
+        """
+        base_metadata = super().extract_metadata(data)
+        container_metadata = {
+            "schema": data.schema(),
+        }
+        return {**base_metadata, **container_metadata}

--- a/tests/unit/materializers/test_pydantic_materializer.py
+++ b/tests/unit/materializers/test_pydantic_materializer.py
@@ -1,0 +1,36 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from pydantic import BaseModel
+
+from tests.unit.test_general import _test_materializer
+from zenml.materializers.pydantic_materializer import PydanticMaterializer
+
+
+def test_pydantic_materializer():
+    """Test the pydantic materializer."""
+
+    class MyModel(BaseModel):
+        a: int = 1
+        b: int = 2
+
+    model = MyModel(a=2, b=3)
+
+    result = _test_materializer(
+        step_output_type=MyModel,
+        materializer_class=PydanticMaterializer,
+        step_output=model,
+    )
+    assert result.a == 2
+    assert result.b == 3


### PR DESCRIPTION
## Describe changes
I added a pydantic materializer. To check:

```
import random

from zenml.pipelines import pipeline
from zenml.steps import Output, step
from pydantic import BaseModel

class Lol(BaseModel):
    a: int = 1

@step(enable_cache=False)
def get_first_num() -> Lol:
    """Returns an integer."""

    return Lol(a=5)


@step(enable_cache=False)
def get_random_int() -> Output(random_num=int):
    """Get a random integer between 0 and 10"""
    return random.randint(0, 10)


@step
def subtract_numbers(first_num: int, lol: Lol) -> Output(result=int):
    """Subtract random_num from first_num."""
    print(lol.a)
    return first_num - lol.a


@pipeline
def hamzas_example_pipeline2(get_first_num, get_random_int, subtract_numbers):
    # Link all the steps artifacts together
    first_num = get_first_num()
    random_num = get_random_int()
    subtract_numbers(random_num, first_num )


if __name__ == "__main__":
    # Initialize a new pipeline run
    aep = hamzas_example_pipeline2(
        get_first_num=get_first_num(),
        get_random_int=get_random_int(),
        subtract_numbers=subtract_numbers(),
    )
    DAG = aep.run()
    
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

