### PR TITLE
Fix label studio `dataset delete` command

### DIFF
--- a/examples/label_studio_annotation/README.md
+++ b/examples/label_studio_annotation/README.md
@@ -86,7 +86,7 @@ zenml stack update <ANNOTATION_STACK_NAME> -x <YOUR_SECRETS_MANAGER>
 
 zenml secrets-manager secret register <YOUR_AZURE_AUTH_SECRET_NAME> --schema=azure --account_name="<YOUR_AZURE_ACCOUNT_NAME>" --account_key="<YOUR_AZURE_ACCOUNT_KEY>"
 
-zenml artifact-store register azure_artifact_store -f=azure --path="az://<NAME_OF_ARTIFACT_STORE_OR_BLOB_IN_AZURE>" --authentication_secret="<YOUR_AZURE_AUTH_SECRET_NAME>"
+zenml artifact-store register azure_artifact_store -f azure --path="az://<NAME_OF_ARTIFACT_STORE_OR_BLOB_IN_AZURE>" --authentication_secret="<YOUR_AZURE_AUTH_SECRET_NAME>"
 
 zenml stack update <ANNOTATION_STACK_NAME> -a <YOUR_CLOUD_ARTIFACT_STORE>
 
@@ -144,7 +144,7 @@ zenml stack update <YOUR_ANNOTATION_STACK_NAME> -x <YOUR_SECRETS_MANAGER>
 
 zenml secrets-manager secret register <YOUR_GCP_AUTH_SECRETS_NAME> --schema=gcp --token="@PATH/TO/JSON/FILE/CREATED/ABOVE"
 
-zenml artifact-store register gcp_artifact_store -f=gcp --path="gs://<YOUR_BUCKET_NAME>" --authentication_secret="<YOUR_GCP_AUTH_SECRETS_NAME>"
+zenml artifact-store register gcp_artifact_store -f gcp --path="gs://<YOUR_BUCKET_NAME>" --authentication_secret="<YOUR_GCP_AUTH_SECRETS_NAME>"
 
 zenml stack update <YOUR_ANNOTATION_STACK_NAME> -a <YOUR_CLOUD_ARTIFACT_STORE>
 

--- a/src/zenml/cli/annotator.py
+++ b/src/zenml/cli/annotator.py
@@ -69,8 +69,12 @@ def register_annotator_subcommands() -> None:
         Args:
             annotator: The annotator stack component.
         """
+        dataset_names = annotator.get_dataset_names()
+        if not dataset_names:
+            cli_utils.warning("No datasets found.")
+            return
         cli_utils.print_list_items(
-            list_items=annotator.get_dataset_names(),
+            list_items=dataset_names,
             column_title="DATASETS",
         )
 
@@ -109,7 +113,7 @@ def register_annotator_subcommands() -> None:
     @click.option(
         "--all",
         "-a",
-        "all",
+        "all_",
         is_flag=True,
         help="Use this flag to delete all datasets.",
         type=click.BOOL,

--- a/src/zenml/integrations/label_studio/__init__.py
+++ b/src/zenml/integrations/label_studio/__init__.py
@@ -26,7 +26,7 @@ class LabelStudioIntegration(Integration):
     """Definition of Label Studio integration for ZenML."""
 
     NAME = LABEL_STUDIO
-    REQUIREMENTS = ["label-studio==1.6.0", "label-studio-sdk==0.0.15"]
+    REQUIREMENTS = ["label-studio==1.6.0", "label-studio-sdk>=0.0.17"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/label_studio/annotators/label_studio_annotator.py
+++ b/src/zenml/integrations/label_studio/annotators/label_studio_annotator.py
@@ -240,21 +240,20 @@ class LabelStudioAnnotator(BaseAnnotator, AuthenticationMixin):
                 client.
 
         Raises:
-            NotImplementedError: If the deletion of a dataset is not supported.
+            ValueError: If the dataset name is not provided or if the dataset
+                does not exist.
         """
-        raise NotImplementedError("Awaiting Label Studio release.")
-        # TODO: Awaiting a new Label Studio version to be released with this method
-        # ls = self._get_client()
-        # dataset_name = kwargs.get("dataset_name")
-        # if not dataset_name:
-        #     raise ValueError("`dataset_name` keyword argument is required.")
+        ls = self._get_client()
+        dataset_name = kwargs.get("dataset_name")
+        if not dataset_name:
+            raise ValueError("`dataset_name` keyword argument is required.")
 
-        # dataset_id = self.get_id_from_name(dataset_name)
-        # if not dataset_id:
-        #     raise ValueError(
-        #         f"Dataset name '{dataset_name}' has no corresponding `dataset_id` in Label Studio."
-        #     )
-        # ls.delete_project(dataset_id)
+        dataset_id = self.get_id_from_name(dataset_name)
+        if not dataset_id:
+            raise ValueError(
+                f"Dataset name '{dataset_name}' has no corresponding `dataset_id` in Label Studio."
+            )
+        ls.delete_project(dataset_id)
 
     def get_dataset(self, **kwargs: Any) -> Any:
         """Gets the dataset with the given name.


### PR DESCRIPTION
- updated README which had some wrong commands
- implemented the `zenml annotator dataset delete` command which was waiting for an update to the label_studio sdk package
- bumped our version of the label_studio sdk package accordingly

(Tested this manually to ensure it works.)

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

