### PR TITLE
SageMaker step operator: expand input arguments and add support for S3 input data

### DIFF
--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -15,8 +15,6 @@
 
 from typing import TYPE_CHECKING, Optional, Type, Union, Dict, Any
 
-import sagemaker
-
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR
 from zenml.step_operators.base_step_operator import (

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Amazon SageMaker step operator flavor."""
 
-from typing import TYPE_CHECKING, Optional, Type, Union, Dict, Any
+from typing import Any, Dict, Optional, Type, TYPE_CHECKING, Union 
 
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -38,7 +38,7 @@ class SagemakerStepOperatorSettings(BaseSettings):
             to the container is configured with estimator_args.input_mode. Two possible
             input types:
                 - str: S3 location where training data is saved.
-                - dict[str, str]: (ChannelName, S3Location) which represent
+                - Dict[str, str]: (ChannelName, S3Location) which represent
                     channels (e.g. training, validation, testing) where
                     specific parts of the data are saved in S3.
         estimator_args: Arguments that are directly passed to the SageMaker

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -13,7 +13,9 @@
 #  permissions and limitations under the License.
 """Amazon SageMaker step operator flavor."""
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, Union
+
+import sagemaker
 
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR
@@ -29,17 +31,68 @@ if TYPE_CHECKING:
 class SagemakerStepOperatorSettings(BaseSettings):
     """Settings for the Sagemaker step operator.
 
-    Attributes:
-        instance_type: The type of the compute instance where jobs will run.
-            Check https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html
-            for a list of available instance types.
+    Non-Estimator attributes:
         experiment_name: The name for the experiment to which the job
             will be associated. If not provided, the job runs would be
             independent.
-    """
+        input_data_s3_uri: S3 URI where training data is located if not locally,
+            e.g. s3://my-bucket/my-data/train. How data will be made available
+            to the container is configured with input_mode. Two possible
+            input types:
+                - str: S3 location where training data is saved.
+                - dict[str, str]: (ChannelName, S3Location) which represent
+                    channels (e.g. training, validation, testing) where
+                    specific parts of the data are saved in S3.
 
+    Estimator attributes:
+        See https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Estimator
+        for a full list of attributes.
+
+    """
+    instance_count: Optional[int] = None
     instance_type: Optional[str] = None
+    keep_alive_period_in_seconds: Optional[int] = None
+    volume_size: Optional[int] = None
+    volume_kms_key: Optional[str] = None
+    max_run: Optional[int] = None
+    input_mode: Optional[str] = None
+    output_path: Optional[str] = None
+    output_kms_key: Optional[str] = None
+    base_job_name: Optional[str] = None
+    sagemaker_session: Optional[sagemaker.session.Session] = None
+    hyperparameters: Optional[dict[str, str]] = None
+    tags: Optional[list[dict[str, str]]] = None
+    subnets: Optional[list[str]] = None
+    security_group_ids: Optional[list[str]] = None
+    model_uri: Optional[str] = None
+    model_channel_name: Optional[str] = None
+    metric_definitions: Optional[list[dict[str, str]]] = None
+    encrypt_inter_container_traffic: Optional[bool] = None
+    use_spot_instances: Optional[bool] = None
+    max_wait: Optional[int] = None
+    checkpoint_s3_uri: Optional[str] = None
+    checkpoint_local_path: Optional[str] = None
+    enable_network_isolation: Optional[bool] = None
+    rules: Optional[list[sagemaker.debugger.RuleBase]] = None
+    debugger_hook_config: Optional[Union[sagemaker.debugger.DebuggerHookConfig, bool]] = None
+    tensorboard_output_config: Optional[sagemaker.debugger.TensorBoardOutputConfig] = None
+    enable_sagemaker_metrics: Optional[bool] = None
+    profiler_config: Optional[sagemaker.debugger.ProfilerConfig] = None
+    disable_profiler: Optional[bool] = None
+    environment: Optional[dict[str, str]] = None
+    max_retry_attempts: Optional[int] = None
+    source_dir: Optional[str] = None
+    git_config: Optional[dict[str, str]] = None
+    container_log_level: Optional[int] = None
+    code_location: Optional[str] = None
+    entry_point: Optional[str] = None
+    dependencies: Optional[list[str]] = None
+    instance_groups: Optional[list[sagemaker.instance_group.InstanceGroup]] = None
+    training_repository_access_mode: Optional[str] = None
+    training_repository_credentials_provider_arn: Optional[str] = None
+
     experiment_name: Optional[str] = None
+    input_data_s3_uri: Optional[Union[str, dict[str, str]]] = None
 
 
 class SagemakerStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydantic/pydantic/issues/4173

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -35,7 +35,7 @@ class SagemakerStepOperatorSettings(BaseSettings):
             independent.
         input_data_s3_uri: S3 URI where training data is located if not locally,
             e.g. s3://my-bucket/my-data/train. How data will be made available
-            to the container is configured with input_mode. Two possible
+            to the container is configured with estimator_args.input_mode. Two possible
             input types:
                 - str: S3 location where training data is saved.
                 - dict[str, str]: (ChannelName, S3Location) which represent
@@ -45,6 +45,9 @@ class SagemakerStepOperatorSettings(BaseSettings):
             Estimator. See
             https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Estimator
             for a full list of arguments.
+            For estimator_args.instance_type, check
+            https://docs.aws.amazon.com/sagemaker/latest/dg/notebooks-available-instance-types.html
+            for a list of available instance types.
 
     """
     experiment_name: Optional[str] = None

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Amazon SageMaker step operator flavor."""
 
-from typing import Any, Dict, Optional, Type, TYPE_CHECKING, Union 
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR
@@ -51,12 +51,15 @@ class SagemakerStepOperatorSettings(BaseSettings):
             for a list of available instance types.
 
     """
+
     instance_type: Optional[str] = None
     experiment_name: Optional[str] = None
     input_data_s3_uri: Optional[Union[str, Dict[str, str]]] = None
     estimator_args: Dict[str, Any] = {}
 
-    _deprecation_validator = deprecation_utils.deprecate_pydantic_attributes("instance_type")
+    _deprecation_validator = deprecation_utils.deprecate_pydantic_attributes(
+        "instance_type"
+    )
 
 
 class SagemakerStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydantic/pydantic/issues/4173

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -21,6 +21,7 @@ from zenml.step_operators.base_step_operator import (
     BaseStepOperatorConfig,
     BaseStepOperatorFlavor,
 )
+from zenml.utils import deprecation_utils
 
 if TYPE_CHECKING:
     from zenml.integrations.aws.step_operators import SagemakerStepOperator
@@ -50,9 +51,12 @@ class SagemakerStepOperatorSettings(BaseSettings):
             for a list of available instance types.
 
     """
+    instance_type: Optional[str] = None
     experiment_name: Optional[str] = None
     input_data_s3_uri: Optional[Union[str, Dict[str, str]]] = None
     estimator_args: Dict[str, Any] = {}
+
+    _deprecation_validator = deprecation_utils.deprecate_pydantic_attributes("instance_type")
 
 
 class SagemakerStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydantic/pydantic/issues/4173

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Amazon SageMaker step operator flavor."""
 
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Type, Union, Dict, Any
 
 import sagemaker
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class SagemakerStepOperatorSettings(BaseSettings):
     """Settings for the Sagemaker step operator.
 
-    Non-Estimator attributes:
+    Attributes:
         experiment_name: The name for the experiment to which the job
             will be associated. If not provided, the job runs would be
             independent.
@@ -43,56 +43,15 @@ class SagemakerStepOperatorSettings(BaseSettings):
                 - dict[str, str]: (ChannelName, S3Location) which represent
                     channels (e.g. training, validation, testing) where
                     specific parts of the data are saved in S3.
-
-    Estimator attributes:
-        See https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Estimator
-        for a full list of attributes.
+        estimator_args: Arguments that are directly passed to the SageMaker
+            Estimator. See
+            https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Estimator
+            for a full list of arguments.
 
     """
-    instance_count: Optional[int] = None
-    instance_type: Optional[str] = None
-    keep_alive_period_in_seconds: Optional[int] = None
-    volume_size: Optional[int] = None
-    volume_kms_key: Optional[str] = None
-    max_run: Optional[int] = None
-    input_mode: Optional[str] = None
-    output_path: Optional[str] = None
-    output_kms_key: Optional[str] = None
-    base_job_name: Optional[str] = None
-    sagemaker_session: Optional[sagemaker.session.Session] = None
-    hyperparameters: Optional[dict[str, str]] = None
-    tags: Optional[list[dict[str, str]]] = None
-    subnets: Optional[list[str]] = None
-    security_group_ids: Optional[list[str]] = None
-    model_uri: Optional[str] = None
-    model_channel_name: Optional[str] = None
-    metric_definitions: Optional[list[dict[str, str]]] = None
-    encrypt_inter_container_traffic: Optional[bool] = None
-    use_spot_instances: Optional[bool] = None
-    max_wait: Optional[int] = None
-    checkpoint_s3_uri: Optional[str] = None
-    checkpoint_local_path: Optional[str] = None
-    enable_network_isolation: Optional[bool] = None
-    rules: Optional[list[sagemaker.debugger.RuleBase]] = None
-    debugger_hook_config: Optional[Union[sagemaker.debugger.DebuggerHookConfig, bool]] = None
-    tensorboard_output_config: Optional[sagemaker.debugger.TensorBoardOutputConfig] = None
-    enable_sagemaker_metrics: Optional[bool] = None
-    profiler_config: Optional[sagemaker.debugger.ProfilerConfig] = None
-    disable_profiler: Optional[bool] = None
-    environment: Optional[dict[str, str]] = None
-    max_retry_attempts: Optional[int] = None
-    source_dir: Optional[str] = None
-    git_config: Optional[dict[str, str]] = None
-    container_log_level: Optional[int] = None
-    code_location: Optional[str] = None
-    entry_point: Optional[str] = None
-    dependencies: Optional[list[str]] = None
-    instance_groups: Optional[list[sagemaker.instance_group.InstanceGroup]] = None
-    training_repository_access_mode: Optional[str] = None
-    training_repository_credentials_provider_arn: Optional[str] = None
-
     experiment_name: Optional[str] = None
-    input_data_s3_uri: Optional[Union[str, dict[str, str]]] = None
+    input_data_s3_uri: Optional[Union[str, Dict[str, str]]] = None
+    estimator_args: Dict[str, Any] = {}
 
 
 class SagemakerStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydantic/pydantic/issues/4173

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -172,6 +172,7 @@ class SagemakerStepOperator(BaseStepOperator):
             environment=environment,
             instance_count=instance_count,
             instance_type=instance_type,
+            sagemaker_session=session,
             **estimator_args
         )
 

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -163,8 +163,7 @@ class SagemakerStepOperator(BaseStepOperator):
         estimator_args = settings.estimator_args
         session = sagemaker.Session(default_bucket=self.config.bucket)
 
-        if "instance_type" not in estimator_args:
-            estimator_args["instance_type"] = "ml.m5.large"
+        estimator_args.setdefault("instance_type", settings.instance_type or "ml.m5.large")
 
         estimator_args["environment"] = environment
         estimator_args["instance_count"] = 1

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -159,55 +159,20 @@ class SagemakerStepOperator(BaseStepOperator):
 
         settings = cast(SagemakerStepOperatorSettings, self.get_settings(info))
 
-        session = settings.sagemaker_session or sagemaker.Session(default_bucket=self.config.bucket)
-        instance_type = settings.instance_type or "ml.m5.large"
-        instance_count = settings.instance_count or 1
+        # Get and default fill SageMaker estimator arguments 
+        estimator_args = settings.estimator_args
+        session = estimator_args.sagemaker_session or sagemaker.Session(default_bucket=self.config.bucket)
+        instance_type = estimator_args.instance_type or "ml.m5.large"
+        instance_count = estimator_args.instance_count or 1
 
+        # Create Estimator
         estimator = sagemaker.estimator.Estimator(
             image_name,
             self.config.role,
             environment=environment,
             instance_count=instance_count,
             instance_type=instance_type,
-            keep_alive_period_in_seconds = settings.keep_alive_period_in_seconds,
-            volume_size = settings.volume_size,
-            volume_kms_key = settings.volume_kms_key,
-            max_run = settings.max_run,
-            input_mode = settings.input_mode,
-            output_path = settings.output_path,
-            output_kms_key = settings.output_kms_key,
-            base_job_name = settings.base_job_name,
-            sagemaker_session = session,
-            hyperparameters = settings.hyperparameters,
-            tags = settings.tags,
-            subnets = settings.subnets,
-            security_group_ids = settings.security_group_ids,
-            model_uri = settings.model_uri,
-            model_channel_name = settings.model_channel_name,
-            metric_definitions = settings.metric_definitions,
-            encrypt_inter_container_traffic = settings.encrypt_inter_container_traffic,
-            use_spot_instances = settings.use_spot_instances,
-            max_wait = settings.max_wait,
-            checkpoint_s3_uri = settings.checkpoint_s3_uri,
-            checkpoint_local_path = settings.checkpoint_local_path,
-            enable_network_isolation = settings.enable_network_isolation,
-            rules = settings.rules,
-            debugger_hook_config = settings.debugger_hook_config,
-            tensorboard_output_config = settings.tensorboard_output_config,
-            enable_sagemaker_metrics = settings.enable_sagemaker_metrics,
-            profiler_config = settings.profiler_config,
-            disable_profiler = settings.disable_profiler,
-            environment = settings.environment,
-            max_retry_attempts = settings.max_retry_attempts,
-            source_dir = settings.source_dir,
-            git_config = settings.git_config,
-            container_log_level = settings.container_log_level,
-            code_location = settings.code_location,
-            entry_point = settings.entry_point,
-            dependencies = settings.dependencies,
-            instance_groups = settings.instance_groups,
-            training_repository_access_mode = settings.training_repository_access_mode,
-            training_repository_credentials_provider_arn = settings.training_repository_credentials_provider_arn
+            **estimator_args
         )
 
         # Sagemaker doesn't allow any underscores in job/experiment/trial names

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -163,7 +163,9 @@ class SagemakerStepOperator(BaseStepOperator):
         estimator_args = settings.estimator_args
         session = sagemaker.Session(default_bucket=self.config.bucket)
 
-        estimator_args.setdefault("instance_type", settings.instance_type or "ml.m5.large")
+        estimator_args.setdefault(
+            "instance_type", settings.instance_type or "ml.m5.large"
+        )
 
         estimator_args["environment"] = environment
         estimator_args["instance_count"] = 1
@@ -171,9 +173,7 @@ class SagemakerStepOperator(BaseStepOperator):
 
         # Create Estimator
         estimator = sagemaker.estimator.Estimator(
-            image_name,
-            self.config.role,
-            **estimator_args
+            image_name, self.config.role, **estimator_args
         )
 
         # Sagemaker doesn't allow any underscores in job/experiment/trial names
@@ -183,11 +183,15 @@ class SagemakerStepOperator(BaseStepOperator):
         inputs = None
 
         if isinstance(settings.input_data_s3_uri, str):
-            inputs = sagemaker.inputs.TrainingInput(s3_data=settings.input_data_s3_uri)
+            inputs = sagemaker.inputs.TrainingInput(
+                s3_data=settings.input_data_s3_uri
+            )
         elif isinstance(settings.input_data_s3_uri, dict):
             inputs = {}
             for channel, s3_uri in settings.input_data_s3_uri.items():
-                inputs[channel] = sagemaker.inputs.TrainingInput(s3_data=s3_uri)
+                inputs[channel] = sagemaker.inputs.TrainingInput(
+                    s3_data=s3_uri
+                )
 
         experiment_config = {}
         if settings.experiment_name:

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -159,20 +159,21 @@ class SagemakerStepOperator(BaseStepOperator):
 
         settings = cast(SagemakerStepOperatorSettings, self.get_settings(info))
 
-        # Get and default fill SageMaker estimator arguments 
+        # Get and default fill SageMaker estimator arguments for full ZenML support
         estimator_args = settings.estimator_args
-        session = estimator_args.sagemaker_session or sagemaker.Session(default_bucket=self.config.bucket)
-        instance_type = estimator_args.instance_type or "ml.m5.large"
-        instance_count = estimator_args.instance_count or 1
+        session = sagemaker.Session(default_bucket=self.config.bucket)
+
+        if "instance_type" not in estimator_args:
+            estimator_args["instance_type"] = "ml.m5.large"
+
+        estimator_args["environment"] = environment
+        estimator_args["instance_count"] = 1
+        estimator_args["sagemaker_session"] = session
 
         # Create Estimator
         estimator = sagemaker.estimator.Estimator(
             image_name,
             self.config.role,
-            environment=environment,
-            instance_count=instance_count,
-            instance_type=instance_type,
-            sagemaker_session=session,
             **estimator_args
         )
 


### PR DESCRIPTION
## Describe changes
Hi, we are seeing great potential in ZenML to serve as the core of our MLOps strategy. However, we're also missing certain functionalities, at the moment esp. in the SageMaker step operator. We plan to actively contribute to ZenML development in order to fulfill our requirements while making them available for the broader public too.

This PR does the following:
* Expand `SagemakerStepOperatorSettings` with arguments available in `sagemaker.estimator.Estimator` to give ZenML based SageMaker training jobs more control over SageMaker behavior. It also adds `input_data_s3_uri` to the settings class, see next bullet point.
* Add support for S3-based training (or training, validation, testing) data imports into the SageMaker training container via `TrainingInput` objects (as described here - https://docs.aws.amazon.com/sagemaker/latest/dg/model-access-training-data.html). We've recently had a use case where we trained with approx. 300GB of data, which currently is unsupported with ZenML SageMaker step operator, but will be important for us in the near future.

What I am unsure about at the moment:
* There is a second class named `SagemakerStepOperatorConfig`, too, and it can be that certain arguments added in this PR belong there instead of in `SagemakerStepOperatorSettings`. Let me know the threshold for when specific things must be in Settings and in Config, and I will adapt the PR.
* There is no **test suite** for the SageMaker step operator atm; I omitted it here, too.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly. (Only changes in API docs).
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

