### PR TITLE
Don't use docker client when building images remotely

### DIFF
--- a/src/zenml/image_builders/base_image_builder.py
+++ b/src/zenml/image_builders/base_image_builder.py
@@ -64,6 +64,15 @@ class BaseImageBuilder(StackComponent, ABC):
 
         return BuildContext
 
+    @property
+    @abstractmethod
+    def is_building_locally(self) -> bool:
+        """Whether the image builder builds the images on the client machine.
+
+        Returns:
+            True if the image builder builds locally, False otherwise.
+        """
+
     @abstractmethod
     def build(
         self,

--- a/src/zenml/image_builders/local_image_builder.py
+++ b/src/zenml/image_builders/local_image_builder.py
@@ -47,6 +47,15 @@ class LocalImageBuilder(BaseImageBuilder):
         """
         return cast(LocalImageBuilderConfig, self._config)
 
+    @property
+    def is_building_locally(self) -> bool:
+        """Whether the image builder builds the images on the client machine.
+
+        Returns:
+            True if the image builder builds locally, False otherwise.
+        """
+        return True
+
     @staticmethod
     def _check_prerequisites() -> None:
         """Checks that all prerequisites are installed.

--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -49,6 +49,15 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
         return cast(GCPImageBuilderConfig, self._config)
 
     @property
+    def is_building_locally(self) -> bool:
+        """Whether the image builder builds the images on the client machine.
+
+        Returns:
+            True if the image builder builds locally, False otherwise.
+        """
+        return False
+
+    @property
     def validator(self) -> Optional["StackValidator"]:
         """Validates the stack for the GCP Image Builder.
 

--- a/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
+++ b/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
@@ -52,6 +52,15 @@ class KanikoImageBuilder(BaseImageBuilder):
         return cast(KanikoImageBuilderConfig, self._config)
 
     @property
+    def is_building_locally(self) -> bool:
+        """Whether the image builder builds the images on the client machine.
+
+        Returns:
+            True if the image builder builds locally, False otherwise.
+        """
+        return False
+
+    @property
     def validator(self) -> Optional[StackValidator]:
         """Validates that the stack contains a container registry.
 

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -143,7 +143,8 @@ class PipelineDockerImageBuilder:
                 )
 
             push = (
-                not image_builder.config.is_local or not requires_zenml_build
+                not image_builder.is_building_locally
+                or not requires_zenml_build
             )
 
             if requires_zenml_build:
@@ -235,6 +236,9 @@ class PipelineDockerImageBuilder:
                 # We built a custom parent image and there was no container
                 # registry in the stack to push to, this is a local image
                 pull_parent_image = False
+            elif not image_builder.is_building_locally:
+                # Remote image builders always need to pull the image
+                pull_parent_image = True
             else:
                 # If the image is local, we don't need to pull it. Otherwise
                 # we play it safe and always pull in case the user pushed a new


### PR DESCRIPTION
## Describe changes
This PR fixes an accidental call to the local Docker client while using a remote image builder.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

