### PR TITLE
Switch FastAPI response class to orjson so `NaN` values don't break the server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ types-psutil = { version = "^5.8.13", optional = true }
 docker-compose = { version = "^1.28", optional = true }
 
 [tool.poetry.extras]
-server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "fastapi-utils"]
+server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "fastapi-utils", "orjson"]
 templates = ["copier", "jinja2-time", "black", "ruff"]
 secrets-aws = ["boto3"]
 secrets-gcp = ["google-cloud-secret-manager"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ uvicorn = { extras = ["standard"], version = "~0.17.5",  optional = true}
 python-multipart = { version = "~0.0.5", optional = true}
 python-jose = { extras = ["cryptography"], version = "~3.3.0", optional = true}
 fastapi-utils = { version = "~0.2.1", optional = true}
+orjson = { version = "~3.8.3", optional = true}
 
 # optional dependencies for stack recipes
 

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -17,6 +17,7 @@ from asyncio.log import logger
 from typing import Any, List
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import ORJSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from genericpath import isfile
@@ -68,6 +69,7 @@ app = FastAPI(
     title="ZenML",
     version=zenml.__version__,
     root_path=ROOT_URL_PATH,
+    default_response_class=ORJSONResponse,
 )
 
 app.add_middleware(


### PR DESCRIPTION
Saving any `NaN` values in our DB currently breaks the server since FastAPI does not know how to serialize it, see https://github.com/zenml-io/zenml/issues/1391

To fix this, I switched the default response class to `orjson` as suggested here: https://github.com/tiangolo/fastapi/issues/459

This also introduces [orjson](https://github.com/ijl/orjson) as new server dependency.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

