### PR TITLE
Fix last remaining runs index

### DIFF
--- a/tests/integration/examples/test_quickstart_py37.py
+++ b/tests/integration/examples/test_quickstart_py37.py
@@ -28,7 +28,7 @@ def test_example(request: pytest.FixtureRequest) -> None:
     ):
         from zenml.integrations.mlflow.services import MLFlowDeploymentService
 
-        training_run = get_pipeline("training_pipeline").runs[-1]
+        training_run = get_pipeline("training_pipeline").runs[0]
 
         service = training_run.get_step("model_deployer").output.read()
         assert isinstance(service, MLFlowDeploymentService)


### PR DESCRIPTION
## Describe changes
Fix the last remaining usage of incorrect "latest pipeline run" index.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

