### PR TITLE
Fix GitHub pip download cache key

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -59,7 +59,7 @@ runs:
         requirement_files: 'pyproject.toml'
         # The pip download cache can be updated on a weekly basis as new packages
         # don't appear that often
-        custom_cache_key_element: ${{ inputs.cache_version }}-${{steps.date.outputs.week}}
+        custom_cache_key_element: ${{ inputs.cache_version }}-${{ inputs.python-version }}-${{steps.date.outputs.week}}
 
     - name: Install ZenML
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Describe changes
The default cache key setup by `syphar/restore-pip-download-cache` doesn't include the python version. This caused some of our pip download caches to spill across python versions.
 
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

