### PR TITLE
Fix steps having class name as name when loaded from `PipelineSpec`

### DIFF
--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -881,7 +881,10 @@ class BasePipeline(metaclass=BasePipelineMeta):
                         "the output of the step was renamed."
                     )
 
-            step = BaseStep.load_from_source(step_spec.source)
+            step = BaseStep.load_from_source(
+                source=step_spec.source,
+                name=step_spec.pipeline_parameter_name,
+            )
             input_names = set(step.INPUT_SIGNATURE)
             spec_input_names = set(step_spec.inputs)
 

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -339,11 +339,15 @@ class BaseStep(metaclass=BaseStepMeta):
         )
 
     @classmethod
-    def load_from_source(cls, source: str) -> "BaseStep":
+    def load_from_source(
+        cls, source: str, name: Optional[str] = None
+    ) -> "BaseStep":
         """Loads a step from source.
 
         Args:
             source: The path to the step source.
+            name: The name parameter of the step in the pipeline. If not provided, the
+                class name of the step will be used.
 
         Returns:
             The loaded step.
@@ -351,7 +355,7 @@ class BaseStep(metaclass=BaseStepMeta):
         step_class: Type[BaseStep] = source_utils.load_and_validate_class(
             source, expected_class=BaseStep
         )
-        return step_class()
+        return step_class(name=name)
 
     @property
     def upstream_steps(self) -> Set[str]:

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -606,9 +606,9 @@ def test_loading_pipeline_from_model(clean_workspace, create_pipeline_model):
                 },
                 {
                     "source": "my_steps.s2",
-                    "upstream_steps": ["s1"],
+                    "upstream_steps": ["step_1"],
                     "inputs": {
-                        "inp": {"step_name": "s1", "output_name": "output"}
+                        "inp": {"step_name": "step_1", "output_name": "output"}
                     },
                     "pipeline_parameter_name": "step_2",
                 },


### PR DESCRIPTION
## Describe changes

When executing the command `zenml pipeline build <build_name>` with a pipeline previously registered with `zenml pipeline register <pipeline_import>` and that was using the same step class at least twice in the pipeline, I got this error:

```plain
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/bin/zenml:6 in   │
│ <module>                                                                                         │
│                                                                                                  │
│   3 from zenml.cli.cli import cli                                                                │
│   4                                                                                              │
│   5 if __name__ == '__main__':                                                                   │
│ ❱ 6 │   sys.exit(cli())                                                                          │
│   7                                                                                              │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:1130 in __call__                                                      │
│                                                                                                  │
│   1127 │                                                                                         │
│   1128 │   def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:                           │
│   1129 │   │   """Alias for :meth:`main`."""                                                     │
│ ❱ 1130 │   │   return self.main(*args, **kwargs)                                                 │
│   1131                                                                                           │
│   1132                                                                                           │
│   1133 class Command(BaseCommand):                                                               │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:1055 in main                                                          │
│                                                                                                  │
│   1052 │   │   try:                                                                              │
│   1053 │   │   │   try:                                                                          │
│   1054 │   │   │   │   with self.make_context(prog_name, args, **extra) as ctx:                  │
│ ❱ 1055 │   │   │   │   │   rv = self.invoke(ctx)                                                 │
│   1056 │   │   │   │   │   if not standalone_mode:                                               │
│   1057 │   │   │   │   │   │   return rv                                                         │
│   1058 │   │   │   │   │   # it's not safe to `ctx.exit(rv)` here!                               │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:1657 in invoke                                                        │
│                                                                                                  │
│   1654 │   │   │   │   super().invoke(ctx)                                                       │
│   1655 │   │   │   │   sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)                    │
│   1656 │   │   │   │   with sub_ctx:                                                             │
│ ❱ 1657 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx))               │
│   1658 │   │                                                                                     │
│   1659 │   │   # In chain mode we create the contexts step by step, but after the                │
│   1660 │   │   # base command has been invoked.  Because at that point we do not                 │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:1657 in invoke                                                        │
│                                                                                                  │
│   1654 │   │   │   │   super().invoke(ctx)                                                       │
│   1655 │   │   │   │   sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)                    │
│   1656 │   │   │   │   with sub_ctx:                                                             │
│ ❱ 1657 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx))               │
│   1658 │   │                                                                                     │
│   1659 │   │   # In chain mode we create the contexts step by step, but after the                │
│   1660 │   │   # base command has been invoked.  Because at that point we do not                 │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:1404 in invoke                                                        │
│                                                                                                  │
│   1401 │   │   │   echo(style(message, fg="red"), err=True)                                      │
│   1402 │   │                                                                                     │
│   1403 │   │   if self.callback is not None:                                                     │
│ ❱ 1404 │   │   │   return ctx.invoke(self.callback, **ctx.params)                                │
│   1405 │                                                                                         │
│   1406 │   def shell_complete(self, ctx: Context, incomplete: str) -> t.List["CompletionItem"]:  │
│   1407 │   │   """Return a list of completions for the incomplete value. Looks                   │
│                                                                                                  │
│ /Users/gabriel.martin/Library/Caches/pypoetry/virtualenvs/zenml-RM5jvh0o-py3.10/lib/python3.10/s │
│ ite-packages/click/core.py:760 in invoke                                                         │
│                                                                                                  │
│    757 │   │                                                                                     │
│    758 │   │   with augment_usage_errors(__self):                                                │
│    759 │   │   │   with ctx:                                                                     │
│ ❱  760 │   │   │   │   return __callback(*args, **kwargs)                                        │
│    761 │                                                                                         │
│    762 │   def forward(                                                                          │
│    763 │   │   __self, __cmd: "Command", *args: t.Any, **kwargs: t.Any  # noqa: B902             │
│                                                                                                  │
│ /Users/gabriel.martin/src/gabrielmbmb/zenml/src/zenml/cli/pipeline.py:163 in build_pipeline      │
│                                                                                                  │
│   160 │                                                                                          │
│   161 │   with cli_utils.temporary_active_stack(stack_name_or_id=stack_name_or_id):              │
│   162 │   │   pipeline_instance = BasePipeline.from_model(pipeline_model)                        │
│ ❱ 163 │   │   build = pipeline_instance.build(config_path=config_path)                           │
│   164 │                                                                                          │
│   165 │   if build:                                                                              │
│   166 │   │   cli_utils.declare(f"Created pipeline build `{build.id}`.")                         │
│                                                                                                  │
│ /Users/gabriel.martin/src/gabrielmbmb/zenml/src/zenml/pipelines/base_pipeline.py:369 in build    │
│                                                                                                  │
│    366 │   │   Returns:                                                                          │
│    367 │   │   │   The build output.                                                             │
│    368 │   │   """                                                                               │
│ ❱  369 │   │   deployment, pipeline_spec, _, _ = self._compile(                                  │
│    370 │   │   │   config_path=config_path,                                                      │
│    371 │   │   │   steps=step_configurations,                                                    │
│    372 │   │   │   settings=settings,                                                            │
│                                                                                                  │
│ /Users/gabriel.martin/src/gabrielmbmb/zenml/src/zenml/pipelines/base_pipeline.py:961 in _compile │
│                                                                                                  │
│    958 │   │   # Update with the values in code so they take precedence                          │
│    959 │   │   run_config = pydantic_utils.update_model(run_config, update=update)               │
│    960 │   │                                                                                     │
│ ❱  961 │   │   deployment, pipeline_spec = Compiler().compile(                                   │
│    962 │   │   │   pipeline=self,                                                                │
│    963 │   │   │   stack=Client().active_stack,                                                  │
│    964 │   │   │   run_configuration=run_config,                                                 │
│                                                                                                  │
│ /Users/gabriel.martin/src/gabrielmbmb/zenml/src/zenml/config/compiler.py:72 in compile           │
│                                                                                                  │
│    69 │   │   │   pipeline=pipeline, config=run_configuration                                    │
│    70 │   │   )                                                                                  │
│    71 │   │   self._apply_stack_default_settings(pipeline=pipeline, stack=stack)                 │
│ ❱  72 │   │   self._verify_distinct_step_names(pipeline=pipeline)                                │
│    73 │   │   if run_configuration.run_name:                                                     │
│    74 │   │   │   self._verify_run_name(run_configuration.run_name)                              │
│    75                                                                                            │
│                                                                                                  │
│ /Users/gabriel.martin/src/gabrielmbmb/zenml/src/zenml/config/compiler.py:261 in                  │
│ _verify_distinct_step_names                                                                      │
│                                                                                                  │
│   258 │   │   for step_argument_name, step in pipeline.steps.items():                            │
│   259 │   │   │   previous_argument_name = step_names.get(step.name, None)                       │
│   260 │   │   │   if previous_argument_name:                                                     │
│ ❱ 261 │   │   │   │   raise PipelineInterfaceError(                                              │
│   262 │   │   │   │   │   f"Found multiple step objects with the same name "                     │
│   263 │   │   │   │   │   f"`{step.name}` for arguments '{previous_argument_name}' "             │
│   264 │   │   │   │   │   f"and '{step_argument_name}' in pipeline "                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
PipelineInterfaceError: Found multiple step objects with the same name `MyStep` for arguments 'my_step' and 'my_step_2' in pipeline 'my_pipeline'. All steps of a ZenML pipeline need to have distinct 
names. To solve this issue, assign a new name to one of the steps by calling `my_step_instance.configure(name='some_distinct_name')`
```

I've discovered that this was happening because when creating the step from the `PipelineSpec`, the attribute `pipeline_parameter_name` previously registered was not being used, causing the step to have its class name as name, and therefore raising an error in the method `_verify_distinct_step_names`.

To reproduce the error:

```python
"""Dummy pipeline for testing purposes."""

from zenml.config import DockerSettings
from zenml.pipelines import pipeline
from zenml.steps import BaseParameters, BaseStep


class MyStepParams(BaseParameters):
    """Class to hold parameters for MyStep."""

    number: int = 5


class MyStep(BaseStep):
    """Dummy step for testing purposes."""

    def entrypoint(self, params: MyStepParams) -> int:
        return params.number


@pipeline(
    settings={
        "docker": DockerSettings(
            requirements="requirements.txt", dockerfile="Dockerfile"
        ),
    }
)
def my_pipeline(my_step, my_step_2) -> int:
    """Dummy pipeline for testing purposes."""
    my_step()
    my_step_2()


pipeline = my_pipeline(
    my_step=MyStep(
        params=MyStepParams(),
    ).configure(name="my_step_1"),
    my_step_2=MyStep(
        params=MyStepParams(),
    ).configure(name="my_step_2"),
)
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

