### PR TITLE
Add `build_timeout` attribute to `GCPImageBuilderConfig`

### DIFF
--- a/docs/book/component-gallery/image-builders/gcp.md
+++ b/docs/book/component-gallery/image-builders/gcp.md
@@ -9,6 +9,7 @@ to build container images.
 ## When to use it
 
 You should use the Google Cloud image builder if:
+
 * you're **unable** to install or use [Docker](https://www.docker.com) on your client machine.
 * you're already using GCP.
 * your stack is mainly composed of other Google Cloud components such as the [GCS Artifact Store](../artifact-stores/gcloud-gcs.md) or the [Vertex Orchestrator](../orchestrators/gcloud-vertexai.md).
@@ -22,21 +23,29 @@ In order to use the ZenML Google Cloud image builder you need to enable Google C
 To use the Google Cloud image builder, we need:
 
 * The ZenML `gcp` integration installed. If you haven't done so, run:
+
     ```shell
     zenml integration install gcp
     ```
+
 * A [GCP Artifact Store](../artifact-stores/gcloud-gcs.md) where the build context will be uploaded, so Google Cloud Build can access it.
-* A [remote container registry](../container-registries/container-registries.md) where the built image will be pushed.
+* A [GCP container registry](../container-registries/gcp.md) where the built image will be pushed.
 * Optionally, the GCP project ID in which you want to run the build and a service account with the needed permissions to run the build. If not provided, then the project ID and credentials will be inferred from the environment.
-* Optionally, you can change the Docker image used by Google Cloud Build to execute the steps to build and push the Docker image. By default, the builder image will be `'gcr.io/cloud-builders/docker'`.
+* Optionally, you can change:
+  * the Docker image used by Google Cloud Build to execute the steps to build and push the Docker image. By default, the builder image will be `'gcr.io/cloud-builders/docker'`.
+  * The network to which the container used to build the ZenML pipeline docker image will be attached. More information: [Cloud build network](https://cloud.google.com/build/docs/build-config-file-schema#network).
+  * The build timeout for the build, and for the blocking operation waiting for the build to finish. More information: [Build Timeout](https://cloud.google.com/build/docs/build-config-file-schema#timeout_2).
 
 We can register the image builder and use it in our active stack:
+
 ```shell
 zenml image-builder register <IMAGE_BUILDER_NAME> \
     --flavor=gcp \
     --project=<PROJECT_ID> \
     --service_account_path=<SERVICE_ACCOUNT_PATH> \
-    --cloud_builder_image=<BUILDER_IMAGE_NAME>
+    --cloud_builder_image=<BUILDER_IMAGE_NAME> \
+    --network=<DOCKER_NETWORK> \
+    --build_timeout=<BUILD_TIMEOUT_IN_SECONDS>
 
 # Register and activate a stack with the new image builder
 zenml stack register <STACK_NAME> -i <IMAGE_BUILDER_NAME> ... --set

--- a/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
@@ -15,6 +15,8 @@
 
 from typing import TYPE_CHECKING, Optional, Type
 
+from pydantic import PositiveInt
+
 from zenml.image_builders import BaseImageBuilderConfig, BaseImageBuilderFlavor
 from zenml.integrations.gcp import GCP_IMAGE_BUILDER_FLAVOR
 from zenml.integrations.gcp.google_credentials_mixin import (
@@ -26,6 +28,7 @@ if TYPE_CHECKING:
 
 DEFAULT_CLOUD_BUILDER_IMAGE = "gcr.io/cloud-builders/docker"
 DEFAULT_CLOUD_BUILDER_NETWORK = "cloudbuild"
+DEFAULT_CLOUD_BUILD_TIMEOUT = 3600
 
 
 class GCPImageBuilderConfig(
@@ -41,10 +44,15 @@ class GCPImageBuilderConfig(
             this:
             https://cloud.google.com/build/docs/build-config-file-schema#network.
             Defaults to `cloudbuild`.
+        build_timeout: The timeout of the build in seconds. More information
+            about this parameter:
+            https://cloud.google.com/build/docs/build-config-file-schema#timeout_2
+            Defaults to `3600`.
     """
 
     cloud_builder_image: str = DEFAULT_CLOUD_BUILDER_IMAGE
     network: str = DEFAULT_CLOUD_BUILDER_NETWORK
+    build_timeout: PositiveInt = DEFAULT_CLOUD_BUILD_TIMEOUT
 
 
 class GCPImageBuilderFlavor(BaseImageBuilderFlavor):

--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -191,6 +191,7 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
                 },
             ],
             images=[image_name],
+            timeout=f"{self.config.build_timeout}s",
         )
 
     def _run_cloud_build(self, build: cloudbuild_v1.Build) -> str:
@@ -215,7 +216,7 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
             log_url,
         )
 
-        result = operation.result()
+        result = operation.result(timeout=self.config.build_timeout)
 
         if result.status != cloudbuild_v1.Build.Status.SUCCESS:
             raise RuntimeError(


### PR DESCRIPTION
## Describe changes
I've added the `build_timeout` attribute to the `GCPImageBuilderConfig`, so a build timeout can be specified. [By default, it's 3600 seconds](https://cloud.google.com/build/docs/build-config-file-schema#timeout_2).

I haven't exceeded the default Google Cloud build timeout yet with any ZenML pipeline, but I have with the blocking operation that it's waiting the build to finish (it has a default value of 15 minutes): https://github.com/zenml-io/zenml/blob/cb1bcbda58df06e057fd0a152b4ba3facf9c2d59/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py#L209

Having that said, I think it's a good idea to use this new `build_timeout` attribute to specify a timeout for the build and also a timeout for the blocking operation that waits for the build to finish.
## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

