### PR TITLE
Add option to get deployment outputs

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -505,6 +505,32 @@ def deploy(
                 )
 
 
+# get outputs
+@cli.command(
+    "get-deploy-outputs",
+    help="Get the outputs of a ZenML server deployment.",
+)
+@click.argument(
+    "name",
+    required=True,
+    type=click.STRING,
+)
+@click.option(
+    "--output",
+    help="The name of the output to get.",
+    required=False,
+)
+def get_outputs(name: str, output: Optional[str] = None) -> Dict[str, str]:
+    """Get the outputs of the ZenML server deployment."""
+    from zenml.zen_server.deploy.deployer import ServerDeployer
+
+    deployer = ServerDeployer()
+    outputs = deployer.get_deployment_outputs(name, output)
+
+    cli_utils.declare("Outputs:")
+    cli_utils.declare(outputs)
+
+
 @cli.command(
     "destroy", help="Tear down and clean up the cloud ZenML deployment."
 )

--- a/src/zenml/services/terraform/terraform_service.py
+++ b/src/zenml/services/terraform/terraform_service.py
@@ -356,6 +356,25 @@ class TerraformService(BaseService):
             "This method is not available for Terraform services."
         )
 
+    def get_outputs(self, output: Optional[str] = None) -> Dict[str, Any]:
+        """Get outputs from the terraform state.
+
+        Returns:
+            A dictionary of outputs from the terraform state.
+        """
+        if output:
+            # if output is specified, then full_outputs is just a string
+            full_outputs = self.terraform_client.output(
+                output, full_value=True
+            )
+            return {output: full_outputs}
+        else:
+            # get value of the "value" key in the value of full_outputs
+            # and assign it to the key in the output dict
+            full_outputs = self.terraform_client.output(full_value=True)
+            outputs = {k: v["value"] for k, v in full_outputs.items()}
+            return outputs
+
     def check_installation(self) -> None:
         """Checks if necessary tools are installed on the host system.
 

--- a/src/zenml/zen_server/deploy/base_provider.py
+++ b/src/zenml/zen_server/deploy/base_provider.py
@@ -14,7 +14,7 @@
 """Base ZenML server provider class."""
 
 from abc import ABC, abstractmethod
-from typing import ClassVar, Generator, List, Optional, Tuple, Type
+from typing import ClassVar, Dict, Generator, List, Optional, Tuple, Type
 
 from pydantic import ValidationError
 
@@ -258,6 +258,24 @@ class BaseServerProvider(ABC):
             )
 
         return service.get_logs(follow=follow, tail=tail)
+
+    def get_deployment_outputs(
+        self,
+        config: ServerDeploymentConfig,
+        output_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Get the outputs of a ZenML server deployment.
+
+        This method only returns an empty dict and can be overridden by
+        subclasses to return outputs.
+
+        Args:
+            config: The generic server deployment configuration.
+
+        Returns:
+            The outputs of the server deployment.
+        """
+        return {"server": f"{config.name}"}
 
     def _get_deployment_status(
         self, service: BaseService

--- a/src/zenml/zen_server/deploy/deployer.py
+++ b/src/zenml/zen_server/deploy/deployer.py
@@ -418,3 +418,34 @@ class ServerDeployer(metaclass=SingletonMetaClass):
         return provider.get_server_logs(
             server.config, follow=follow, tail=tail
         )
+
+    def get_deployment_outputs(
+        self,
+        server_name: str,
+        output_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Get the outputs of a ZenML server deployment.
+
+        Args:
+            server_name: The server deployment name.
+
+        Returns:
+            The outputs of the server deployment.
+        """
+        # this will also raise ServerDeploymentNotFoundError if the server
+        # does not exist
+        server = self.get_server(server_name)
+
+        provider_name = server.config.provider.value
+        provider = self.get_provider(server.config.provider)
+
+        # if the provider does not implement this method, we return an empty
+        # dict
+        if not hasattr(provider, "get_deployment_outputs"):
+            return {}
+
+        logger.info(
+            f"Fetching outputs from the '{server_name}' {provider_name} ZenML "
+            f"server..."
+        )
+        return provider.get_deployment_outputs(server.config, output_name)

--- a/src/zenml/zen_server/deploy/terraform/providers/terraform_provider.py
+++ b/src/zenml/zen_server/deploy/terraform/providers/terraform_provider.py
@@ -14,7 +14,7 @@
 """Zen Server terraform deployer implementation."""
 
 import os
-from typing import ClassVar, List, Optional, Tuple, Type, cast
+from typing import ClassVar, Dict, List, Optional, Tuple, Type, cast
 
 from zenml.config.global_config import GlobalConfiguration
 from zenml.logger import get_logger
@@ -330,3 +330,16 @@ class TerraformServerProvider(BaseServerProvider):
             connected=connected,
             ca_crt=ca_crt,
         )
+
+    def get_deployment_outputs(
+        self,
+        config: ServerDeploymentConfig,
+        output_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        outputs = super().get_deployment_outputs(config)
+
+        # add the terraform outputs
+        service = self._get_service(config.name)
+        outputs.update(service.get_outputs(output=output_name))
+
+        return outputs

--- a/src/zenml/zen_server/deploy/terraform/recipes/aws/outputs.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/aws/outputs.tf
@@ -12,3 +12,11 @@ output "ca_crt" {
   value = base64decode(data.kubernetes_secret.certificates.binary_data["ca.crt"])
   sensitive = true
 }
+
+output "database_username" {
+  value = module.metadata_store[0].db_instance_username
+}
+output "database_password" {
+  value = module.metadata_store[0].db_instance_password
+  sensitive = true
+}

--- a/src/zenml/zen_server/deploy/terraform/recipes/azure/outputs.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/azure/outputs.tf
@@ -12,3 +12,11 @@ output "ca_crt" {
   value = base64decode(data.kubernetes_secret.certificates.binary_data["ca.crt"])
   sensitive = true
 }
+
+output "database_username" {
+  value = var.database_username
+}
+output "database_password" {
+  value = azurerm_mysql_flexible_server.mysql[0].administrator_password
+  sensitive = true
+}

--- a/src/zenml/zen_server/deploy/terraform/recipes/gcp/outputs.tf
+++ b/src/zenml/zen_server/deploy/terraform/recipes/gcp/outputs.tf
@@ -12,3 +12,11 @@ output "ca_crt" {
   value = base64decode(data.kubernetes_secret.certificates.binary_data["ca.crt"])
   sensitive = true
 }
+
+output "database_username" {
+  value = var.database_username
+}
+output "database_password" {
+  value = module.metadata_store[0].generated_user_password
+  sensitive = true
+}


### PR DESCRIPTION
## Describe changes
I implemented a new function for the server deployer to get outputs related to Zen Server deployments.
Also included is the implementation for the Terraform provider.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

