### PR TITLE
Remove all `zenml.cli` imports outside of `zenml.cli`

### DIFF
--- a/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
+++ b/src/zenml/integrations/dash/visualizers/pipeline_run_lineage_visualizer.py
@@ -21,7 +21,6 @@ import dash_cytoscape as cyto
 from dash import dcc, html
 from dash.dependencies import Input, Output
 
-from zenml.cli import utils as cli_utils
 from zenml.enums import ExecutionStatus
 from zenml.environment import Environment
 from zenml.logger import get_logger
@@ -149,7 +148,7 @@ class PipelineRunLineageVisualizer(BaseVisualizer):
                 )
                 mode = "inline"
             else:
-                cli_utils.warning(
+                logger.warning(
                     "Cannot set magic flag in non-notebook environments."
                 )
         else:

--- a/src/zenml/recipes/stack_recipe_service.py
+++ b/src/zenml/recipes/stack_recipe_service.py
@@ -20,13 +20,15 @@ from typing import Any, ClassVar, Dict, List, Optional, cast
 import yaml
 
 import zenml
-from zenml.cli.stack_recipes import logger
+from zenml.logger import get_logger
 from zenml.services import ServiceType
 from zenml.services.terraform.terraform_service import (
     SERVICE_CONFIG_FILE_NAME,
     TerraformService,
 )
 from zenml.utils import io_utils, yaml_utils
+
+logger = get_logger(__name__)
 
 STACK_FILE_NAME_OUTPUT = "stack-yaml-path"
 DATABASE_HOST_OUTPUT = "metadata-db-host"

--- a/src/zenml/secrets_managers/local/local_secrets_manager.py
+++ b/src/zenml/secrets_managers/local/local_secrets_manager.py
@@ -17,7 +17,6 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Type, cast
 
-from zenml.cli.utils import error
 from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import LOCAL_SECRETS_FILENAME
 from zenml.exceptions import SecretExistsError
@@ -240,8 +239,8 @@ class LocalSecretsManager(BaseSecretsManager):
         try:
             secrets_store_items.pop(secret_name)
             yaml_utils.write_yaml(self.secrets_file, secrets_store_items)
-        except KeyError:
-            error(f"Secret {secret_name} does not exist.")
+        except KeyError as e:
+            raise KeyError(f"Secret {secret_name} does not exist.") from e
 
     def delete_all_secrets(self) -> None:
         """Delete all existing secrets."""


### PR DESCRIPTION
## Describe changes
Three places in our code imported functionality from `zenml.cli` from outside that package. This is problematic because `zenml/cli/__init__.py` imports the entire CLI code, leading to huge overhead. It also caused the GH actions of one of my PRs to fail with a cryptic error. IMO none of these imports was even necessary so I removed/replaced them.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

