### PR TITLE
Update examples to mention stack component deploy CLI command

### DIFF
--- a/examples/custom_code_deployment/README.md
+++ b/examples/custom_code_deployment/README.md
@@ -188,6 +188,15 @@ zenml artifact-store register gcs_store -f gcp \
     --authentication_secret=gcp_secret
 ```
 
+Note that you can deploy your GCS Store using the ZenML CLI as well, using the
+`zenml artifact-store deploy` command. This is how you would do it:
+
+```shell
+zenml artifact-store deploy gcs_store --flavor=gcs --project_id=my_project ...
+```
+
+For more information on this `deploy` subcommand, please refer to the 
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 
 ## 📦 KServe Custom Code Deployment
 
@@ -273,6 +282,11 @@ zenml stack register local_gcp_kserve_stack -a gcp_artifact_store -o default -d 
 > zenml artifact-store register gcp_artifact_store --flavor=gcp --path gs://my-bucket \
 >   --authentication_secret=gcp_secret
 > ```
+
+Note that the KServe model deployer, the GCP artifact store and the GCP
+container registry can be deployed using the ZenML CLI as well, using the
+`zenml <STACK_COMPONENT> deploy` command. For more information on this `deploy` subcommand, please refer to the 
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 
 ### 🔦 Run The pipelines
 
@@ -460,6 +474,11 @@ zenml stack register local_gcp_seldon_stack -a gcp_artifact_store -o default -d 
 >   --authentication_secret=gcp_secret
 > ```
 
+Note that the Seldon model deployer, the GCP artifact store and the GCP
+container registry can be deployed using the ZenML CLI as well, using the
+`zenml <STACK_COMPONENT> deploy` command. For more information on this `deploy` subcommand, please refer to the 
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 ### 🔦 Run The pipelines
 
 The Training/Deployment pipeline consists of the following steps:
@@ -644,7 +663,16 @@ To stop any prediction servers running in the background, use the
 zenml model-deployer models delete eaa6fc48-cda7-4c4e-8785-dc5b85cf0a31
 ```
 
-Then delete the remaining ZenML references.
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
+```
+
+Then delete the remaining ZenML references:
 
 ```shell
 rm -rf zenml_examples

--- a/examples/custom_code_deployment/README.md
+++ b/examples/custom_code_deployment/README.md
@@ -192,7 +192,7 @@ Note that you can deploy your GCS Store using the ZenML CLI as well, using the
 `zenml artifact-store deploy` command. This is how you would do it:
 
 ```shell
-zenml artifact-store deploy gcs_store --flavor=gcs --project_id=my_project ...
+zenml artifact-store deploy gcs_store --flavor=gcp --project_id=my_project ...
 ```
 
 For more information on this `deploy` subcommand, please refer to the 

--- a/examples/kserve_deployment/README.md
+++ b/examples/kserve_deployment/README.md
@@ -342,8 +342,7 @@ prerequisites are met.
 
 #### Deploying Individual Stack Components using the CLI
 
-The KServe model deployer and the GCP artifact store (i.e. as individual stack
-components) can be deployed using the ZenML CLI as well, using the `zenml
+The KServe model deployer and the GCP artifact store can be deployed using the ZenML CLI as well, using the `zenml
 <STACK_COMPONENT> deploy` command. For more information on this `deploy`
 subcommand, please refer to the
 [documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).

--- a/examples/kserve_deployment/README.md
+++ b/examples/kserve_deployment/README.md
@@ -340,6 +340,14 @@ components are described in this document, but similar stacks may be set up
 using different backends and used to run the example as long as the basic Stack
 prerequisites are met.
 
+#### Deploying Individual Stack Components using the CLI
+
+The KServe model deployer and the GCP artifact store (i.e. as individual stack
+components) can be deployed using the ZenML CLI as well, using the `zenml
+<STACK_COMPONENT> deploy` command. For more information on this `deploy`
+subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 #### Local and remote authentication
 
 The ZenML Stacks featured in this example are based on managed GCP services like
@@ -840,7 +848,16 @@ and `zenml model-server delete <uuid>` CLI commands.:
 zenml model-deployer models delete 62aac6aa-88fd-4eb7-a753-b46f1658775c
 ```
 
-Then delete the remaining ZenML references.
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
+```
+
+Then delete the remaining ZenML references:
 
 ```shell
 rm -rf zenml_examples

--- a/examples/kubeflow_pipelines_orchestration/README.md
+++ b/examples/kubeflow_pipelines_orchestration/README.md
@@ -175,6 +175,20 @@ kubectl get ingress -A  -o jsonpath='{.items[*].spec.rules[*].host}'
 kubeflow.<EXTERNAL-IP>.nip.io mlflow.<EXTERNAL-IP>.nip.io minio-console.<EXTERNAL-IP>.nip.io
 ```
 
+#### ⛽️ Deploy individual stack components using ZenML CLI
+
+As an alternative to deploying the entire stack, you can also deploy individual
+components using the `zenml <STACK_COMPONENT> deploy` command. As an
+illustration, the Kubeflow orchestrator could be deployed in the following way:
+
+```shell
+zenml orchestrator deploy kubeflow --flavor kubeflow ...
+```
+
+For more information on this `deploy`
+subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 ### ▶️ Run the pipeline
 We can now run the pipeline by simply executing the python script:
 
@@ -373,6 +387,15 @@ If you have created the GCP Kubeflow stack using the recipe, you can delete it u
 
 ```bash
 zenml stack recipe destroy gcp_kubeflow_stack
+```
+
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
 ```
 
 # ⚠️ Important note for multi-tenant Kubeflow deployments

--- a/examples/kubernetes_orchestration/README.md
+++ b/examples/kubernetes_orchestration/README.md
@@ -67,6 +67,11 @@ to have the following additional software installed on your local machine:
 * [kubectl](https://kubernetes.io/docs/tasks/tools/)
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
+Note that the Kubernetes orchestrator, the ECR container registry and the S3
+artifact store can be deployed using the ZenML CLI as well (i.e. as an
+alternative to the instructions below), using the `zenml <STACK_COMPONENT> deploy` command. For more information on this `deploy` subcommand, please refer to the 
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 #### Setup and Register Kubernetes Orchestrator
 
 After spinning up your Kubernetes cluster in the cloud, you will first need

--- a/examples/kubernetes_orchestration/README.md
+++ b/examples/kubernetes_orchestration/README.md
@@ -68,7 +68,7 @@ to have the following additional software installed on your local machine:
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
 Note that the Kubernetes orchestrator, the ECR container registry and the S3
-artifact store can be deployed using the ZenML CLI as well (i.e. as an
+artifact store can be deployed using the ZenML CLI as well (in other words, as an
 alternative to the instructions below), using the `zenml <STACK_COMPONENT> deploy` command. For more information on this `deploy` subcommand, please refer to the 
 [documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 

--- a/examples/sagemaker_orchestration/README.md
+++ b/examples/sagemaker_orchestration/README.md
@@ -95,7 +95,7 @@ zenml stack register sagemaker_stack -a aws_artifact_store -o sagemaker_orchestr
 
 Note that if you want an easy way to deploy the required cloud resources for
 this example via the ZenML CLI, you can do so using the `zenml <STACK_COMPONENT>
-deploy` sub-command. For example, to deploy the S3 artifact store, you can
+deploy` command. For example, to deploy the S3 artifact store, you can
 run:
 
 ```shell

--- a/examples/sagemaker_orchestration/README.md
+++ b/examples/sagemaker_orchestration/README.md
@@ -93,6 +93,20 @@ zenml image-builder register local_builder --flavor=local
 zenml stack register sagemaker_stack -a aws_artifact_store -o sagemaker_orchestrator -c aws_registry -i local_builder --set
 ```
 
+Note that if you want an easy way to deploy the required cloud resources for
+this example via the ZenML CLI, you can do so using the `zenml <STACK_COMPONENT>
+deploy` sub-command. For example, to deploy the S3 artifact store, you can
+run:
+
+```shell
+zenml artifact-store deploy aws_artifact_store --flavor=s3
+```
+
+You could also deploy the Sagemaker orchestrator itself as well as the ECR
+container registry. For more information on this `deploy` subcommand, please
+refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 ### ▶️ Run the pipeline
 
 Once your stack is fully set up, you should be good to go. 
@@ -144,6 +158,15 @@ rm -rf zenml_examples
 
 Additionally, you might have to clean up your cloud resources to avoid running 
 costs for storage of artifacts or containers.
+
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
+```
 
 # 📜 Learn more
 

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -233,6 +233,13 @@ components are described in this document, but similar stacks may be set up
 using different backends and used to run the example as long as the basic Stack
 prerequisites are met.
 
+#### Deploying Individual Stack Components using the CLI
+
+The Seldon model deployer and the AWS S3 artifact store (i.e. as individual stack
+components) can be deployed using the ZenML CLI as well, using the `zenml
+<STACK_COMPONENT> deploy` command. For more information on this `deploy`
+subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 
 #### Local and remote authentication
 
@@ -609,7 +616,16 @@ and `zenml model-server delete <uuid>` CLI commands.:
 zenml model-deployer models delete 8cbe671b-9fce-4394-a051-68e001f92765
 ```
 
-Then delete the remaining ZenML references.
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
+```
+
+Then delete the remaining ZenML references:
 
 ```shell
 rm -rf zenml_examples

--- a/examples/seldon_deployment/README.md
+++ b/examples/seldon_deployment/README.md
@@ -235,8 +235,7 @@ prerequisites are met.
 
 #### Deploying Individual Stack Components using the CLI
 
-The Seldon model deployer and the AWS S3 artifact store (i.e. as individual stack
-components) can be deployed using the ZenML CLI as well, using the `zenml
+The Seldon model deployer and the AWS S3 artifact store can be deployed using the ZenML CLI as well, using the `zenml
 <STACK_COMPONENT> deploy` command. For more information on this `deploy`
 subcommand, please refer to the
 [documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).

--- a/examples/spark_distributed_programming/README.md
+++ b/examples/spark_distributed_programming/README.md
@@ -221,8 +221,7 @@ KUBERNETES_SERVICE_ACCOUNT=spark-service-account
 Now that we have all the necessary resources, we can connect to the server and
 then set up the stack and stack components.
 
-Note that the AWS S3 artifact store and the ECR container registry (i.e. as
-individual stack components) can be deployed using the ZenML CLI as well, using
+Note that the AWS S3 artifact store and the ECR container registry can be deployed using the ZenML CLI as well, using
 the `zenml <STACK_COMPONENT> deploy` command. For more information on this
 `deploy` subcommand, please refer to the
 [documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).

--- a/examples/spark_distributed_programming/README.md
+++ b/examples/spark_distributed_programming/README.md
@@ -219,7 +219,13 @@ KUBERNETES_SERVICE_ACCOUNT=spark-service-account
 # Connect to the Server and Setting up the stack 
 
 Now that we have all the necessary resources, we can connect to the server and
-then set up the stack and stack components. 
+then set up the stack and stack components.
+
+Note that the AWS S3 artifact store and the ECR container registry (i.e. as
+individual stack components) can be deployed using the ZenML CLI as well, using
+the `zenml <STACK_COMPONENT> deploy` command. For more information on this
+`deploy` subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 
 ```bash
 # Connect to the server

--- a/examples/step_operator_remote_training/README.md
+++ b/examples/step_operator_remote_training/README.md
@@ -70,6 +70,12 @@ The stack will consist of:
 * An **Image Builder** which will be used to build the Docker image that will
   be used to run the training step.
 
+Note that the S3 artifact store and the Sagemaker step operator can both (i.e.
+as individual stack components) be deployed using the ZenML CLI as well, using
+the `zenml <STACK_COMPONENT> deploy` command. For more information on this
+`deploy` subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
+
 To configure resources for the step operators, please
 follow [this guide](https://docs.zenml.io/component-gallery/step-operators/amazon-sagemaker)
 and then proceed with the following steps:
@@ -211,7 +217,16 @@ python run.py
 
 ### 🧽 Clean up
 
-In order to clean up, delete the remaining ZenML references.
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy s3_artifact_store
+```
+
+Then delete the remaining ZenML references:
 
 ```shell
 rm -rf zenml_examples

--- a/examples/tekton_pipelines_orchestration/README.md
+++ b/examples/tekton_pipelines_orchestration/README.md
@@ -108,7 +108,7 @@ to access the GCP container registry.
 * Kubectl can [access](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl) your GCP 
 Kubernetes cluster.
 
-Note that you can deploy (i.e. as individual stack components) the GCP container
+Note that you can deploy the GCP container
 registry, the artifact store and the Tekton orchestrator using the ZenML CLI as
 well, using the `zenml <STACK_COMPONENT> deploy` command. For more information
 on this `deploy` subcommand, please refer to the

--- a/examples/tekton_pipelines_orchestration/README.md
+++ b/examples/tekton_pipelines_orchestration/README.md
@@ -108,6 +108,11 @@ to access the GCP container registry.
 * Kubectl can [access](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl) your GCP 
 Kubernetes cluster.
 
+Note that you can deploy (i.e. as individual stack components) the GCP container
+registry, the artifact store and the Tekton orchestrator using the ZenML CLI as
+well, using the `zenml <STACK_COMPONENT> deploy` command. For more information
+on this `deploy` subcommand, please refer to the
+[documentation](https://docs.zenml.io/advanced-guide/practical-mlops/stack-recipes#deploying-stack-components-directly).
 
 ### 🥞 Create a Tekton Pipelines Stack
 
@@ -200,6 +205,15 @@ Once you're done experimenting, you can delete the example files by calling:
 
 ```bash
 rm -rf zenml_examples
+```
+
+To destroy any resources deployed using the ZenML `deploy` subcommand, use the
+`destroy` subcommand to delete each individual stack component, as in the
+following example:
+
+```shell
+# replace with the name of the component you want to destroy
+zenml artifact-store destroy gcp_artifact_store
 ```
 
 # 📜 Learn more


### PR DESCRIPTION
Updated all examples to include references to the new `zenml <STACK_COMPONENT> deploy...` subcommand.

This will need to be merged onto the main PR / implementation branch #1328.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

