### PR TITLE
Kubernetes Orchestrator Improvements

### DIFF
--- a/src/zenml/integrations/kubeflow/utils.py
+++ b/src/zenml/integrations/kubeflow/utils.py
@@ -61,3 +61,7 @@ def apply_pod_settings(
     resource_limits = settings.resources.get("limits") or {}
     for name, value in resource_limits.items():
         container_op.add_resource_limit(name, value)
+
+    annotations = settings.annotations or {}
+    for name, value in annotations.items():
+        container_op.add_pod_annotation(name, value)

--- a/src/zenml/integrations/kubeflow/utils.py
+++ b/src/zenml/integrations/kubeflow/utils.py
@@ -62,6 +62,5 @@ def apply_pod_settings(
     for name, value in resource_limits.items():
         container_op.add_resource_limit(name, value)
 
-    annotations = settings.annotations or {}
-    for name, value in annotations.items():
+    for name, value in settings.annotations.items():
         container_op.add_pod_annotation(name, value)

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -36,12 +36,16 @@ class KubernetesOrchestratorSettings(BaseSettings):
             block until all steps finished running on Kubernetes.
         timeout: How many seconds to wait for synchronous runs. `0` means
             to wait for an unlimited duration.
+        service_account_name: Name of the service account to use for the
+            orchestrator pod. If not provided, a new service account with "edit"
+            permissions will be created.
         pod_settings: Pod settings to apply.
     """
 
     synchronous: bool = False
     timeout: int = 0
 
+    service_account_name: Optional[str] = None
     pod_settings: Optional[KubernetesPodSettings] = None
 
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -78,20 +78,19 @@ def is_inside_kubernetes() -> bool:
         return False
 
 
-def load_kube_config(context: Optional[str] = None) -> None:
+def load_kube_config(
+    incluster: bool = False, context: Optional[str] = None
+) -> None:
     """Load the Kubernetes client config.
 
-    Depending on the environment (whether it is inside the running Kubernetes
-    cluster or remote host), different location will be searched for the config
-    file.
-
     Args:
+        incluster: Whether to load the in-cluster config.
         context: Name of the Kubernetes context. If not provided, uses the
-            currently active context.
+            currently active context. Will be ignored if `incluster` is True.
     """
-    try:
+    if incluster:
         k8s_config.load_incluster_config()
-    except k8s_config.ConfigException:
+    else:
         k8s_config.load_kube_config(context=context)
 
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -410,6 +410,9 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
 
         Args:
             settings: The orchestrator settings.
+
+        Returns:
+            The service account name.
         """
         if settings.service_account_name:
             return settings.service_account_name

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -327,13 +327,16 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
         )
 
         # Authorize pod to run Kubernetes commands inside the cluster.
-        service_account_name = "zenml-service-account"
-        kube_utils.create_edit_service_account(
-            core_api=self._k8s_core_api,
-            rbac_api=self._k8s_rbac_api,
-            service_account_name=service_account_name,
-            namespace=self.config.kubernetes_namespace,
-        )
+        if settings.service_account_name:
+            service_account_name = settings.service_account_name
+        else:
+            service_account_name = "zenml-service-account"
+            kube_utils.create_edit_service_account(
+                core_api=self._k8s_core_api,
+                rbac_api=self._k8s_rbac_api,
+                service_account_name=service_account_name,
+                namespace=self.config.kubernetes_namespace,
+            )
 
         # Schedule as CRON job if CRON schedule is given.
         if deployment.schedule:

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -327,16 +327,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
         )
 
         # Authorize pod to run Kubernetes commands inside the cluster.
-        if settings.service_account_name:
-            service_account_name = settings.service_account_name
-        else:
-            service_account_name = "zenml-service-account"
-            kube_utils.create_edit_service_account(
-                core_api=self._k8s_core_api,
-                rbac_api=self._k8s_rbac_api,
-                service_account_name=service_account_name,
-                namespace=self.config.kubernetes_namespace,
-            )
+        service_account_name = self._get_service_account_name(settings)
 
         # Schedule as CRON job if CRON schedule is given.
         if deployment.schedule:
@@ -408,6 +399,29 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 f"Run the following command to inspect the logs: "
                 f"`kubectl logs {pod_name} -n {self.config.kubernetes_namespace}`."
             )
+
+    def _get_service_account_name(
+        self, settings: KubernetesOrchestratorSettings
+    ) -> str:
+        """Returns the service account name to use for the orchestrator pod.
+
+        If the user has not specified a service account name in the settings,
+        we create a new service account with the required permissions.
+
+        Args:
+            settings: The orchestrator settings.
+        """
+        if settings.service_account_name:
+            return settings.service_account_name
+        else:
+            service_account_name = "zenml-service-account"
+            kube_utils.create_edit_service_account(
+                core_api=self._k8s_core_api,
+                rbac_api=self._k8s_rbac_api,
+                service_account_name=service_account_name,
+                namespace=self.config.kubernetes_namespace,
+            )
+            return service_account_name
 
     def get_orchestrator_run_id(self) -> str:
         """Returns the active orchestrator run id.

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -62,7 +62,7 @@ def main() -> None:
     args = parse_args()
 
     # Get Kubernetes Core API for running kubectl commands later.
-    kube_utils.load_kube_config()
+    kube_utils.load_kube_config(incluster=True)
     core_api = k8s_client.CoreV1Api()
 
     orchestrator_run_id = socket.gethostname()

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -158,6 +158,9 @@ def build_pod_manifest(
         },
     )
 
+    if settings.pod_settings and settings.pod_settings.annotations:
+        pod_metadata.annotations = settings.pod_settings.annotations
+
     pod_manifest = k8s_client.V1Pod(
         kind="Pod",
         api_version="v1",

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -36,12 +36,14 @@ class KubernetesPodSettings(BaseSettings):
         affinity: Affinity to apply to the pod.
         tolerations: Tolerations to apply to the pod.
         resources: Resource requests and limits for the pod.
+        annotations: Annotations to apply to the pod metadata.
     """
 
     node_selectors: Dict[str, str] = {}
     affinity: Dict[str, Any] = {}
     tolerations: List[Dict[str, Any]] = []
     resources: Dict[str, Dict[str, str]] = {}
+    annotations: Dict[str, str] = {}
 
     @validator("affinity", pre=True)
     def _convert_affinity(

--- a/tests/unit/integrations/kubeflow/test_utils.py
+++ b/tests/unit/integrations/kubeflow/test_utils.py
@@ -1,0 +1,32 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for utils.py."""
+
+from kfp.dsl import ContainerOp
+
+from zenml.integrations.kubeflow.utils import apply_pod_settings
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+
+
+def test_apply_pod_settings():
+    """Unit test for `apply_pod_settings`."""
+    container_op = ContainerOp(
+        name="test",
+        image="test",
+    )
+    pod_settings = KubernetesPodSettings(
+        annotations={"blupus_loves": "strawberries"},
+    )
+    apply_pod_settings(container_op, pod_settings)
+    assert container_op.pod_annotations["blupus_loves"] == "strawberries"

--- a/tests/unit/integrations/kubernetes/orchestrators/test_manifest_utils.py
+++ b/tests/unit/integrations/kubernetes/orchestrators/test_manifest_utils.py
@@ -1,0 +1,49 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for manifest_utils.py."""
+
+from kubernetes.client import V1ObjectMeta, V1Pod
+
+from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import (
+    KubernetesOrchestratorSettings,
+)
+from zenml.integrations.kubernetes.orchestrators.manifest_utils import (
+    build_pod_manifest,
+)
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+
+
+def test_build_pod_manifest_metadata():
+    """Test that the metadata is correctly set in the manifest."""
+    manifest: V1Pod = build_pod_manifest(
+        pod_name="test_name",
+        run_name="test_run",
+        pipeline_name="test_pipeline",
+        image_name="test_image",
+        command=["test", "command"],
+        args=["test", "args"],
+        settings=KubernetesOrchestratorSettings(
+            pod_settings=KubernetesPodSettings(
+                annotations={"blupus_loves": "strawberries"},
+            )
+        ),
+    )
+    assert isinstance(manifest, V1Pod)
+
+    metadata = manifest.metadata
+    assert isinstance(metadata, V1ObjectMeta)
+    assert metadata.name == "test_name"
+    assert metadata.labels["run"] == "test_run"
+    assert metadata.labels["pipeline"] == "test_pipeline"
+    assert metadata.annotations["blupus_loves"] == "strawberries"


### PR DESCRIPTION
## Describe changes
Various minor improvements to the k8s orchestrator:
- `service_account_name` can now be specified as a setting
- The orchestrator can now be started from within other k8s pods
- [Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) can now be assigned to pods using `KubernetesPodSettings.annotations`

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

