### PR TITLE
Apply formatting fixes to `/scripts`

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 set -x
 
-SRC=${1:-"src/zenml tests examples docs/mkdocstrings_helper.py"}
+SRC=${1:-"src/zenml tests examples docs/mkdocstrings_helper.py scripts"}
 
 export ZENML_DEBUG=1
 export ZENML_ANALYTICS_OPT_IN=false

--- a/scripts/verify_flavor_url_valid.py
+++ b/scripts/verify_flavor_url_valid.py
@@ -13,20 +13,18 @@
 #  permissions and limitations under the License.
 """Verify the current flavor implementations contains valid fields."""
 import os.path
+import tempfile
 from typing import Type
 
+import click
+import requests
 from requests import Response
 from rich.console import Console
 from rich.progress import track
-import tempfile
-
-from zenml.enums import StoreType
-from zenml.stack import Flavor
-from zenml.stack.flavor_registry import FlavorRegistry
-import requests
-import click
 
 from zenml import __version__
+from zenml.stack import Flavor
+from zenml.stack.flavor_registry import FlavorRegistry
 from zenml.zen_stores.sql_zen_store import SqlZenStore
 
 
@@ -48,32 +46,33 @@ def verify() -> None:
 @verify.command(
     "docs",
     help="Verify that all flavor doc urls are valid. "
-         "Whenever new flavors are added or when the structure of the docs is "
-         "adjusted, there is potential to break the link between flavors and "
-         "their corresponding docs."
-         "\n"
-         "The `flavor_docs_url` property on flavors is built with a very "
-         "specific assumption of how this url is built. This script is "
-         "designed to validate that this assumption still holds. But there are "
-         "some manual steps involved:"
-         "\n"
-         "1) Push your code."
-         "\n"
-         "2) Use the GitBook UI to provision a Test Space with an unlisted"
-         " public url that uses your code."
-         "\n"
-         "3) Set the RootDomain of this unlisted gitbook space as "
-         "parameter for this command."
-         "\n"
-         "4) Run this command to make sure all the urls mentioned in code are "
-         "working.")
+    "Whenever new flavors are added or when the structure of the docs is "
+    "adjusted, there is potential to break the link between flavors and "
+    "their corresponding docs."
+    "\n"
+    "The `flavor_docs_url` property on flavors is built with a very "
+    "specific assumption of how this url is built. This script is "
+    "designed to validate that this assumption still holds. But there are "
+    "some manual steps involved:"
+    "\n"
+    "1) Push your code."
+    "\n"
+    "2) Use the GitBook UI to provision a Test Space with an unlisted"
+    " public url that uses your code."
+    "\n"
+    "3) Set the RootDomain of this unlisted gitbook space as "
+    "parameter for this command."
+    "\n"
+    "4) Run this command to make sure all the urls mentioned in code are "
+    "working.",
+)
 @click.option(
     "-r",
     "--root-domain",
     "root_domain",
     type=str,
     required=False,
-    default=f"https://docs.zenml.io/v/{__version__}"
+    default=f"https://docs.zenml.io/v/{__version__}",
 )
 @click.option(
     "-i",
@@ -82,12 +81,9 @@ def verify() -> None:
     help="If True, only print failing urls.",
     is_flag=True,
     type=click.BOOL,
-    default=True
+    default=True,
 )
-def docs(
-    root_domain: str,
-    ignore_passing: bool
-) -> None:
+def docs(root_domain: str, ignore_passing: bool) -> None:
     fr = FlavorRegistry()
     flavors = fr.builtin_flavors + fr.integration_flavors
 
@@ -100,16 +96,20 @@ def docs(
         r = requests.head(url)
         if r.status_code == 404:
             style = "bold red"
-            text = f"{flavor().__module__}, flavor_docs_url points at {url} " \
-                   f"which does not seem to exist."
+            text = (
+                f"{flavor().__module__}, flavor_docs_url points at {url} "
+                f"which does not seem to exist."
+            )
 
             Console().print(text, style=style)
         elif not ignore_passing:
 
             style = "green"
 
-            text = f"The url for {flavor().__module__} points to a valid " \
-                   f"location: {url}"
+            text = (
+                f"The url for {flavor().__module__} points to a valid "
+                f"location: {url}"
+            )
 
             Console().print(text, style=style)
 
@@ -119,16 +119,20 @@ def docs(
         r = requests.head(url)
         if r.status_code == 404:
             style = "bold red"
-            text = f"{flavor().__module__}, sdk_docs_url points at {url} " \
-                   f"which does not seem to exist."
+            text = (
+                f"{flavor().__module__}, sdk_docs_url points at {url} "
+                f"which does not seem to exist."
+            )
 
             Console().print(text, style=style)
         elif not ignore_passing:
 
             style = "green"
 
-            text = f"The url for {flavor().__module__} points to a valid " \
-                   f"location: {url}"
+            text = (
+                f"The url for {flavor().__module__} points to a valid "
+                f"location: {url}"
+            )
 
             Console().print(text, style=style)
 
@@ -136,13 +140,14 @@ def docs(
 @verify.command(
     "logos",
     help="Verify that all flavor logo urls are valid images. "
-         "The logos for all flavors are hosted in an s3 bucket that is "
-         "publicly accessible."
-         "\n"
-         "The `logo_urls` are defined as a property on all flavors. When "
-         "creating new flavors or when making changes to the s3 bucket"
-         "structure, it might be necessary to verify that all flavors are "
-         "still pointing at valid images.")
+    "The logos for all flavors are hosted in an s3 bucket that is "
+    "publicly accessible."
+    "\n"
+    "The `logo_urls` are defined as a property on all flavors. When "
+    "creating new flavors or when making changes to the s3 bucket"
+    "structure, it might be necessary to verify that all flavors are "
+    "still pointing at valid images.",
+)
 @click.option(
     "-i",
     "--ignore-passing",
@@ -150,11 +155,9 @@ def docs(
     help="If True, only print failing urls.",
     is_flag=True,
     type=click.BOOL,
-    default=True
+    default=True,
 )
-def logos(
-    ignore_passing: bool
-) -> None:
+def logos(ignore_passing: bool) -> None:
     fr = FlavorRegistry()
     flavors = fr.builtin_flavors + fr.integration_flavors
 
@@ -164,8 +167,10 @@ def logos(
         r = requests.get(url)
         if r.status_code == 404:
             style = "bold red"
-            text = f"{flavor().__module__}, logo_url points at {url} " \
-                   f"which does not seem to exist."
+            text = (
+                f"{flavor().__module__}, logo_url points at {url} "
+                f"which does not seem to exist."
+            )
             Console().print(text, style=style)
 
         _verify_image_not_corrupt(r, flavor)
@@ -174,8 +179,10 @@ def logos(
 
             style = "green"
 
-            text = f"The url for {flavor().__module__} points to a valid " \
-                   f"location: {url}"
+            text = (
+                f"The url for {flavor().__module__} points to a valid "
+                f"location: {url}"
+            )
 
             Console().print(text, style=style)
 
@@ -188,13 +195,15 @@ def _verify_image_not_corrupt(r: Response, flavor: Type[Flavor]):
         if not os.path.exists(type_filepath):
             os.makedirs(type_filepath)
 
-        filepath = os.path.join(type_filepath, flavor().logo_url.split('/')[-1])
-        with open(filepath, 'wb') as f:
+        filepath = os.path.join(
+            type_filepath, flavor().logo_url.split("/")[-1]
+        )
+        with open(filepath, "wb") as f:
             for chunk in r.iter_content(chunk_size=512 * 1024):
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
 
-        if not filepath.endswith('svg'):
+        if not filepath.endswith("svg"):
             assert Image.open(filepath)  # Open image without failing
         else:
             pass  # Not yet verifying valid svg
@@ -203,8 +212,9 @@ def _verify_image_not_corrupt(r: Response, flavor: Type[Flavor]):
 @flavors.command(
     "sync",
     help="During development of new flavors, this function can be used to "
-         "purge the database and sync all flavors, including the new one, "
-         "into the database.")
+    "purge the database and sync all flavors, including the new one, "
+    "into the database.",
+)
 def sync():
     from zenml.client import Client
 
@@ -213,6 +223,8 @@ def sync():
         store._sync_flavors()
     else:
         style = "bold orange"
-        text = "This command requires you to be connected to a SqlZenStore. " \
-               "Please disconnect from the RestZenStore and try again."
+        text = (
+            "This command requires you to be connected to a SqlZenStore. "
+            "Please disconnect from the RestZenStore and try again."
+        )
         Console().print(text, style=style)


### PR DESCRIPTION
If you run our `format.sh` script without passing in arguments, it ignores the `scripts/` folder, but if you run it passing in a `.` as the folder to check, it always tries to autofix this file. It often ends up accidentally in PRs, having to be removed later etc, so I've just applied the fixes now so this doesn't happen any more.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

