### PR TITLE
Fix `BuiltInContainerMaterializer` for subtypes and non-built-in types

### DIFF
--- a/src/zenml/materializers/built_in_materializer.py
+++ b/src/zenml/materializers/built_in_materializer.py
@@ -306,7 +306,7 @@ class BuiltInContainerMaterializer(BaseMaterializer):
                     element = materializer.load(type_)
                     outputs.append(element)
 
-            # New format for zenml >= 0.37.1
+            # New format for zenml > 0.37.0
             elif isinstance(metadata, list):
                 for entry in metadata:
                     path_ = entry["path"]

--- a/tests/unit/materializers/test_built_in_materializer.py
+++ b/tests/unit/materializers/test_built_in_materializer.py
@@ -190,11 +190,6 @@ def test_container_materializer_for_custom_types(mocker):
 
         # Container materializer should find materializer for both elements in
         # the default materializer registry.
-        mocker.patch.object(
-            default_materializer_registry,
-            "materializer_types",
-            {CustomType: CustomTypeMaterializer},
-        )
         materializer.save(example)
 
         # When loading, the default materializer registry should no longer be

--- a/tests/unit/materializers/test_built_in_materializer.py
+++ b/tests/unit/materializers/test_built_in_materializer.py
@@ -12,8 +12,14 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import os
+from tempfile import TemporaryDirectory
+from typing import Optional, Type
 
 from tests.unit.test_general import _test_materializer
+from zenml.materializers.base_materializer import BaseMaterializer
+from zenml.materializers.built_in_materializer import (
+    BuiltInContainerMaterializer,
+)
 
 
 def test_basic_type_materialization():
@@ -128,4 +134,82 @@ def test_none_values():
         result = _test_materializer(
             step_output_type=type_, step_output=example
         )
+        assert result == example
+
+
+class CustomType:
+    """Custom type used for testing the container materializer below."""
+
+    myname = "aria"
+
+    def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, CustomType):
+            return self.myname == __value.myname
+        return False
+
+
+class CustomSubType(CustomType):
+    """Subtype of CustomType."""
+
+    myname = "axl"
+
+
+class CustomTypeMaterializer(BaseMaterializer):
+    """Mock materializer for custom types.
+
+    Does not actually save anything to disk, just initializes the type.
+    """
+
+    ASSOCIATED_TYPES = (CustomType,)
+
+    def save(self, data: CustomType) -> None:
+        """Save the data (not)."""
+        pass
+
+    def load(self, data_type: Type[CustomType]) -> Optional[CustomType]:
+        """Load the data."""
+        return data_type()
+
+
+def test_container_materializer_for_custom_types(mocker):
+    """Test container materializer for custom types.
+
+    This ensures that:
+    - The container materializer can handle custom types.
+    - Custom types are loaded as the correct type.
+    - The materializer of the subtype does not need to be registered in the
+        materializer registry when the container is loaded.
+    """
+    from zenml.materializers.default_materializer_registry import (
+        default_materializer_registry,
+    )
+
+    example = [CustomType(), CustomSubType()]
+    with TemporaryDirectory() as artifact_uri:
+        materializer = BuiltInContainerMaterializer(uri=artifact_uri)
+
+        # Container materializer should find materializer for both elements in
+        # the default materializer registry.
+        mocker.patch.object(
+            default_materializer_registry,
+            "materializer_types",
+            {CustomType: CustomTypeMaterializer},
+        )
+        materializer.save(example)
+
+        # When loading, the default materializer registry should no longer be
+        # needed because the container materializer should have saved the
+        # materializer that was used for each element.
+        mocker.patch.object(
+            default_materializer_registry,
+            "materializer_types",
+            {},
+        )
+        result = materializer.load(list)
+
+        # Check that the loaded elements are of the correct types.
+        assert isinstance(result[0], CustomType)
+        assert isinstance(result[1], CustomSubType)
+        assert result[0].myname == "aria"
+        assert result[1].myname == "axl"
         assert result == example


### PR DESCRIPTION
## Describe changes
I fixed two issues of the `BuiltInContainerMaterializer`:
- Elements would previously be loaded as the data type that the corresponding materializer is registered with. E.g., a pydantic model `MyModel(BaseModel)` would be loaded as `BaseModel` since only `BaseModel` is in the `ASSOCIATED_TYPES` of the `PydanticMaterializer`. This is obviously problematic since some functionality might get lost.
- Elements that are not handled by built-in materializers could previously sometimes not be loaded because the default materializer registry might no longer have the respective materializer in it. To fix this, we now save the path of each materializer as part of the list metadata and load the materializer class directly from source.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

