### PR TITLE
Fix CI (Deepchecks integration tests)

### DIFF
--- a/src/zenml/integrations/deepchecks/__init__.py
+++ b/src/zenml/integrations/deepchecks/__init__.py
@@ -36,7 +36,11 @@ class DeepchecksIntegration(Integration):
     """Definition of [Deepchecks](https://github.com/deepchecks/deepchecks) integration for ZenML."""
 
     NAME = DEEPCHECKS
-    REQUIREMENTS = ["deepchecks[vision]==0.8.0", "torchvision==0.14.0"]
+    REQUIREMENTS = [
+        "deepchecks[vision]==0.8.0",
+        "torchvision==0.14.0",
+        "pandas<1.3.0",
+    ]
     APT_PACKAGES = ["ffmpeg", "libsm6", "libxext6"]
 
     @staticmethod

--- a/src/zenml/integrations/deepchecks/__init__.py
+++ b/src/zenml/integrations/deepchecks/__init__.py
@@ -39,7 +39,7 @@ class DeepchecksIntegration(Integration):
     REQUIREMENTS = [
         "deepchecks[vision]==0.8.0",
         "torchvision==0.14.0",
-        "pandas<1.3.0",
+        "pandas<2.0.0",
     ]
     APT_PACKAGES = ["ffmpeg", "libsm6", "libxext6"]
 


### PR DESCRIPTION
## Describe changes
Currently integration tests for Python>=3.8 are failing on all new PRs.

Looking into the error, it seems that the issue is that our Deepchecks version is so old that it no longer works with the latest Pandas. Until we properly update/rework Deepchecks, I added `"pandas<2.0.0"` as a requirement for the Deepchecks integration.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

