### PR TITLE
Allow secret values replacement in REST API PUT

### DIFF
--- a/src/zenml/models/base_models.py
+++ b/src/zenml/models/base_models.py
@@ -41,7 +41,9 @@ class BaseZenModel(AnalyticsTrackedModelMixin):
         # This is needed to allow the REST client and server to unpack SecretStr
         # values correctly.
         json_encoders = {
-            SecretStr: lambda v: v.get_secret_value() if v else None
+            SecretStr: lambda v: v.get_secret_value()
+            if v is not None
+            else None
         }
 
         # Allow extras on all models to support forwards and backwards

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2417,21 +2417,23 @@ class RestZenStore(BaseZenStore):
         resource_update: BaseModel,
         response_model: Type[AnyResponseModel],
         route: str,
+        params: Optional[Dict[str, Any]] = None,
     ) -> AnyResponseModel:
         """Update an existing resource.
 
         Args:
             resource_id: The id of the resource to update.
             resource_update: The resource update.
-            route: The resource REST API route to use.
             response_model: Optional model to use to deserialize the response
                 body. If not provided, the resource class itself will be used.
+            route: The resource REST API route to use.
+            params: Optional query parameters to pass to the endpoint.
 
         Returns:
             The updated resource.
         """
         response_body = self.put(
-            f"{route}/{str(resource_id)}", body=resource_update
+            f"{route}/{str(resource_id)}", body=resource_update, params=params
         )
 
         return response_model.parse_obj(response_body)

--- a/src/zenml/zen_stores/secrets_stores/rest_secrets_store.py
+++ b/src/zenml/zen_stores/secrets_stores/rest_secrets_store.py
@@ -243,6 +243,10 @@ class RestSecretsStore(BaseSecretsStore):
             resource_update=secret_update,
             route=SECRETS,
             response_model=SecretResponseModel,
+            # The default endpoint behavior is to replace all secret values
+            # with the values in the update. We want to merge the values
+            # instead.
+            params=dict(patch_values=True),
         )
 
     @track(AnalyticsEvent.DELETED_SECRET)

--- a/tests/integration/functional/zen_stores/test_secrets_store.py
+++ b/tests/integration/functional/zen_stores/test_secrets_store.py
@@ -85,6 +85,35 @@ def test_list_secret_excludes_values():
         assert len(all_secrets[0].values) == 0
 
 
+def test_secret_empty_values():
+    """Tests that secrets can hold empty values."""
+    client = Client()
+    store = client.zen_store
+
+    values = dict(
+        aria="space cat",
+        axl="",
+    )
+    with SecretContext(values=values) as secret:
+        saved_secret = store.get_secret(secret_id=secret.id)
+        assert saved_secret.secret_values == values
+
+        values["axl"] = "also space cat"
+        updated_secret = store.update_secret(
+            secret_id=secret.id,
+            secret_update=SecretUpdateModel(
+                values=dict(
+                    axl=values["axl"],
+                ),
+            ),
+        )
+
+        assert updated_secret.secret_values == values
+
+        saved_secret = store.get_secret(secret_id=secret.id)
+        assert saved_secret.secret_values == values
+
+
 def test_update_secret_existing_values():
     """Tests that existing values a secret can be updated."""
     client = Client()


### PR DESCRIPTION
## Describe changes
Change the default behavior of `PUT /api/v1/secrets/{secret_id}` to replace all values of an existing secret with those passed in the request body, to facilitate a simpler dashboard implementation for updating/deleting keys.

The ZenML python client is still using the previous behavior that only patches the existing secret. The differentiation is made through a `patch_values` request parameter.

This PR also fixes a bug that reported null values instead of empty string values for secret values that were set to the empty string.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

