### PR TITLE
Fix two steps race condition

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -40,7 +40,12 @@ import pymysql
 from pydantic import root_validator, validator
 from sqlalchemy import asc, desc, func, text
 from sqlalchemy.engine import URL, Engine, make_url
-from sqlalchemy.exc import ArgumentError, NoResultFound, OperationalError
+from sqlalchemy.exc import (
+    ArgumentError,
+    IntegrityError,
+    NoResultFound,
+    OperationalError,
+)
 from sqlalchemy.orm import noload
 from sqlmodel import Session, create_engine, or_, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
@@ -3235,10 +3240,10 @@ class SqlZenStore(BaseZenStore):
         # it first will reduce concurrency issues.
         try:
             return self.create_run(pipeline_run), True
-        except EntityExistsError:
-            # Currently, an `EntityExistsError` is raised if either the run ID
-            # or the run name already exists. Therefore, we need to have another
-            # try block since getting the run by ID might still fail.
+        except (EntityExistsError, IntegrityError):
+            # Catch both `EntityExistsError`` and `IntegrityError`` exceptions
+            # since either one can be raised by the database when trying
+            # to create a new pipeline run with duplicate ID or name.
             try:
                 return self.get_run(pipeline_run.id), False
             except KeyError:


### PR DESCRIPTION
## Describe changes
This is just an initial fix on how to avoid the race condition since we already catching `EntityExistsError` which should raise if the pipeline run we try to add to the DB exists, adding `IntegrityError` can also catch the error causing the race condition since it tries to create new raw with a run id that already exists which breaks the unique constraints. 

##Question for reviewers :
Adding an exception for `IntegrityError` may not be the best approach, since it could be raised for other broken constraints should it be also verified that it matches `IntegrityError: UNIQUE constraint failed: pipeline_run.id` or we want different approach were we have some pre-verification than try-catch 


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

