### PR TITLE
remove modules from the list output for stack recipes

### DIFF
--- a/src/zenml/cli/stack_recipes.py
+++ b/src/zenml/cli/stack_recipes.py
@@ -312,6 +312,7 @@ class GitStackRecipesHandler(object):
                 and not name == "LICENSE"
                 and not name.endswith(".md")
                 and not name.endswith(".sh")
+                and not name == "modules"
             )
         ]
 


### PR DESCRIPTION
## Describe changes
I removed "modules" from the output of the stack recipe list command.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

