### PR TITLE
ZenML Hub CLI Improvements

### DIFF
--- a/src/zenml/_hub/utils.py
+++ b/src/zenml/_hub/utils.py
@@ -61,12 +61,12 @@ def parse_plugin_name(
 
 
 def plugin_display_name(
-    plugin_name: str, version: Optional[str], author: Optional[str]
+    name: str, version: Optional[str], author: Optional[str]
 ) -> str:
     """Helper function to get the display name of a plugin.
 
     Args:
-        plugin_name: Name of the plugin.
+        name: Name of the plugin.
         version: Version of the plugin.
         author: Username of the plugin author.
 
@@ -77,4 +77,4 @@ def plugin_display_name(
     if author and author != ZENML_HUB_ADMIN_USERNAME:
         author_prefix = f"{author}/"
     version_suffix = f":{version}" if version else ":latest"
-    return f"{author_prefix}{plugin_name}{version_suffix}"
+    return f"{author_prefix}{name}{version_suffix}"

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -1507,7 +1507,7 @@ zenml hub clone
 This is useful, e.g., for extending an existing plugin or for getting the 
 examples of a plugin.
 
-Submitting/contributing a plugin to the Hub (requires login, see below):
+- Submitting/contributing a plugin to the Hub (requires login, see below):
 ```bash
 zenml hub submit
 ```

--- a/src/zenml/utils/git_utils.py
+++ b/src/zenml/utils/git_utils.py
@@ -1,0 +1,63 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Utility function to clone a Git repository."""
+
+import os
+from typing import Optional
+
+from git.repo import Repo
+
+
+def clone_git_repository(
+    url: str,
+    to_path: str,
+    branch: Optional[str] = None,
+    commit: Optional[str] = None,
+) -> Repo:
+    """Clone a repository and get the hash of the latest commit.
+
+    Args:
+        url: URL of the repository to clone.
+        to_path: Path to clone the repository to.
+        branch: Branch to clone. Defaults to "main".
+        commit: Commit to checkout. If specified, the branch argument is
+            ignored.
+
+    Returns:
+        The cloned repository.
+
+    Raises:
+        RuntimeError: If the repository could not be cloned.
+    """
+    from git import GitCommandError
+    from git.repo import Repo
+
+    os.makedirs(os.path.basename(to_path), exist_ok=True)
+    try:
+        if commit:
+            repo = Repo.clone_from(
+                url=url,
+                to_path=to_path,
+                no_checkout=True,
+            )
+            repo.git.checkout(commit)
+        else:
+            repo = Repo.clone_from(
+                url=url,
+                to_path=to_path,
+                branch=branch or "main",
+            )
+        return repo
+    except GitCommandError as e:
+        raise RuntimeError from e


### PR DESCRIPTION
## Describe changes
Misc `zenml hub ...` CLI command improvements:
- Added `zenml hub submit-batch` that can be used to batch submit/update multiple plugins at once
- Adjusted `zenml hub list` to sort plugins by author > name > version
- Fixed `zenml hub logs` (calling `error` before would cause the execution to end and not show the stacktrace)
- Moved `_clone_repo()` util function to `zenml.utils.git_utils.clone_git_repository()`

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

