### PR TITLE
Add example to docs for passing stack component specific settings

### DIFF
--- a/docs/book/advanced-guide/pipelines/settings.md
+++ b/docs/book/advanced-guide/pipelines/settings.md
@@ -38,7 +38,7 @@ Settings are categorized into two types:
 - **General settings** that can be used on all ZenML pipelines. Examples of these are:
   - [`DockerSettings`](../../starter-guide/production-fundamentals/containerization.md) to specify docker settings.
   - [`ResourceSettings`](./step-resources.md) to specify resource settings.
-- **Stack component specific settings**: These can be used to supply runtime configurations to certain stack components (key= <COMPONENT_CATEGORY>.<COMPONENT_FLAVOR>). Settings for components not in the active stack will be ignored. Examples of these are:
+- **Stack component specific settings**: These can be used to supply runtime configurations to certain stack components `(key= <COMPONENT_CATEGORY>.<COMPONENT_FLAVOR>)`. Settings for components not in the active stack will be ignored. Examples of these are:
   - [`KubeflowOrchestratorSettings`](../../component-gallery/orchestrators/kubeflow.md) to specify Kubeflow settings.
   - [`MLflowExperimentTrackerSettings`](../../component-gallery/experiment-trackers/mlflow.md) to specify MLflow settings.
   - [`WandbExperimentTrackerSettings`](../../component-gallery/experiment-trackers/wandb.md) to specify W&B settings.
@@ -70,6 +70,14 @@ Or like this:
 
 ```python
 settings={'docker': {'requirements': ['pandas']}}
+```
+
+#### Using stack component specific settings
+Settings for stack components must be passed with the key having a specific format being `(key= <COMPONENT_CATEGORY>.<COMPONENT_FLAVOR>)`. For example, an instance of [`SagemakerStepOperatorSettings`](https://apidocs.zenml.io/0.38.0/integration_code_docs/integrations-aws/#zenml.integrations.aws.flavors.sagemaker_step_operator_flavor.SagemakerStepOperatorSettings) for the [SageMaker Step Operator](../../component-gallery/step-operators/sagemaker.md) can be passed in as follows:
+
+```python
+from zenml.integrations.aws.flavors.sagemaker_step_operator_flavor import SagemakerStepOperatorSettings
+settings = { 'step_operator.sagemaker': SagemakerStepOperatorSettings(estimator_args={}) }
 ```
 
 ### How to use settings

--- a/docs/book/advanced-guide/pipelines/settings.md
+++ b/docs/book/advanced-guide/pipelines/settings.md
@@ -73,7 +73,7 @@ settings={'docker': {'requirements': ['pandas']}}
 ```
 
 #### Using stack component specific settings
-Settings for stack components must be passed with the key having a specific format being `(key= <COMPONENT_CATEGORY>.<COMPONENT_FLAVOR>)`. For example, an instance of [`SagemakerStepOperatorSettings`](https://apidocs.zenml.io/0.38.0/integration_code_docs/integrations-aws/#zenml.integrations.aws.flavors.sagemaker_step_operator_flavor.SagemakerStepOperatorSettings) for the [SageMaker Step Operator](../../component-gallery/step-operators/sagemaker.md) can be passed in as follows:
+Settings for stack components must be passed with the key having a specific format: `<COMPONENT_CATEGORY>.<COMPONENT_FLAVOR>`. For example, an instance of [`SagemakerStepOperatorSettings`](https://apidocs.zenml.io/latest/integration_code_docs/integrations-aws/#zenml.integrations.aws.flavors.sagemaker_step_operator_flavor.SagemakerStepOperatorSettings) for the [SageMaker Step Operator](../../component-gallery/step-operators/sagemaker.md) can be passed in as follows:
 
 ```python
 from zenml.integrations.aws.flavors.sagemaker_step_operator_flavor import SagemakerStepOperatorSettings


### PR DESCRIPTION
## Describe changes
This PR adds an example of stack component specific settings to the following page: https://docs.zenml.io/advanced-guide/pipelines/settings. When setting up the SageMaker Step Operator I needed this but was confused about what the pattern looked like; an example could have helped. This PR adds that example.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

