### PR TITLE
Fix post execution `get_pipeline()` and `pipeline.get_runs()`

### DIFF
--- a/docs/book/guidelines/best-practices.md
+++ b/docs/book/guidelines/best-practices.md
@@ -126,7 +126,6 @@ second_pipeline.run()
 first_pipeline.run()
 
 get_pipelines()
->>> [PipelineView('first_pipeline'), PipelineView('second_pipeline')]
 
 # This is the recommended explicit way to retrieve your specific pipeline 
 # using the pipeline class if you have it at hand

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -14,6 +14,7 @@
 """Implementation of the SageMaker orchestrator."""
 
 import os
+import re
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type, cast
 from uuid import UUID
 
@@ -151,9 +152,14 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                 "and the pipeline will be run immediately."
             )
 
-        orchestrator_run_name = get_orchestrator_run_name(
+        # sagemaker requires pipelineName to use alphanum and hyphens only
+        unsanitized_orchestrator_run_name = get_orchestrator_run_name(
             pipeline_name=deployment.pipeline_configuration.name
-        ).replace("_", "-")
+        )
+        # replace all non-alphanum and non-hyphens with hyphens
+        orchestrator_run_name = re.sub(
+            r"[^a-zA-Z0-9\-]", "-", unsanitized_orchestrator_run_name
+        )
 
         session = sagemaker.Session(default_bucket=self.config.bucket)
 

--- a/src/zenml/integrations/plotly/visualizers/pipeline_lineage_visualizer.py
+++ b/src/zenml/integrations/plotly/visualizers/pipeline_lineage_visualizer.py
@@ -21,7 +21,7 @@ import plotly.express as px
 from plotly.graph_objs import Figure
 
 from zenml.logger import get_logger
-from zenml.post_execution import PipelineView
+from zenml.post_execution import PipelineVersionView
 from zenml.visualizers import BaseVisualizer
 
 logger = get_logger(__name__)
@@ -35,7 +35,7 @@ class PipelineLineageVisualizer(BaseVisualizer):
 
     @abstractmethod
     def visualize(
-        self, object: PipelineView, *args: Any, **kwargs: Any
+        self, object: PipelineVersionView, *args: Any, **kwargs: Any
     ) -> Figure:
         """Creates a pipeline lineage diagram using plotly.
 

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -177,8 +177,8 @@ class GetRunsDescriptor:
         if pipeline_view:
             return lambda: pipeline_view.runs
         raise RuntimeError(
-            "The pipeline view for this pipeline was not found. Are you sure "
-            "this pipeline has been run already?"
+            "The pipeline view for this pipeline was not found. Please check "
+            "that the pipeline has been run already."
         )
 
 

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -85,7 +85,11 @@ from zenml.utils.analytics_utils import AnalyticsEvent, event_handler
 if TYPE_CHECKING:
     from zenml.config.base_settings import SettingsOrDict
     from zenml.config.source import Source
-    from zenml.post_execution import PipelineRunView, PipelineView
+    from zenml.post_execution import (
+        PipelineRunView,
+        PipelineVersionView,
+        PipelineView,
+    )
 
     StepConfigurationUpdateOrDict = Union[
         Dict[str, Any], StepConfigurationUpdate
@@ -168,7 +172,7 @@ class GetRunsDescriptor:
         """
         from zenml.post_execution import get_pipeline
 
-        pipeline_view: PipelineView
+        pipeline_view: Union["PipelineVersionView", "PipelineView"]
         if instance is None:
             pipeline_view = get_pipeline(cls)
         else:

--- a/src/zenml/post_execution/__init__.py
+++ b/src/zenml/post_execution/__init__.py
@@ -30,6 +30,7 @@ from zenml.post_execution.lineage import (
     StepNodeDetails,
 )
 from zenml.post_execution.pipeline import (
+    PipelineVersionView,
     PipelineView,
     get_pipeline,
     get_pipelines,
@@ -42,6 +43,7 @@ from zenml.post_execution.pipeline_run import (
 from zenml.post_execution.step import StepView
 
 __all__ = [
+    "PipelineVersionView",
     "PipelineView",
     "PipelineRunView",
     "StepView",

--- a/src/zenml/post_execution/pipeline.py
+++ b/src/zenml/post_execution/pipeline.py
@@ -16,7 +16,7 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Type, Union, cast
 
 from zenml.client import Client
-from zenml.logger import get_apidocs_link, get_logger
+from zenml.logger import get_logger
 from zenml.models import PipelineResponseModel, PipelineRunFilterModel
 from zenml.models.base_models import BaseResponseModel
 from zenml.post_execution.base_view import BaseView
@@ -36,7 +36,6 @@ def get_pipelines() -> List["PipelineView"]:
     Returns:
         A list of post-execution pipeline views.
     """
-    # TODO: [server] handle the active stack correctly
     client = Client()
     pipelines = client.list_pipelines(
         workspace_id=client.active_workspace.id,
@@ -47,12 +46,9 @@ def get_pipelines() -> List["PipelineView"]:
 
 @track(event=AnalyticsEvent.GET_PIPELINE)
 def get_pipeline(
-    pipeline: Optional[
-        Union["BasePipeline", Type["BasePipeline"], str]
-    ] = None,
+    pipeline: Union["BasePipeline", Type["BasePipeline"], str],
     version: Optional[str] = None,
-    **kwargs: Any,
-) -> Optional["PipelineView"]:
+) -> Optional[Union["PipelineClassView", "PipelineView"]]:
     """Fetches a post-execution pipeline view.
 
     Use it in one of these ways:
@@ -74,56 +70,51 @@ def get_pipeline(
 
     Args:
         pipeline: Name, class or instance of the pipeline.
-        version: Optional version of the pipeline. If not given, the latest
-            version will be returned.
-        **kwargs: The deprecated `pipeline_name` is caught as a kwarg to
-            specify the pipeline instead of using the `pipeline` argument.
+        version: Optional pipeline version. Behavior depends on `pipeline`:
+            - If `pipeline` is a pipeline instance, this argument is ignored.
+            - If `pipeline` is a pipeline class or name, then this argument
+            specifies the version of the pipeline to return. If not given, a
+            `PipelineClassView` will be returned that contains all versions and
+            all runs of this pipeline name/class.
 
     Returns:
-        A post-execution pipeline view for the given pipeline or `None` if
-        it doesn't exist.
+        A post-execution view for the given pipeline name, class, or instance
+        or `None` if it doesn't exist.
 
     Raises:
         RuntimeError: If the pipeline was not specified correctly.
     """
     from zenml.pipelines.base_pipeline import BasePipeline
 
-    if isinstance(pipeline, str):
-        pipeline_name = pipeline
-    elif isinstance(pipeline, BasePipeline):
+    # Pipeline instance: find the corresponding pipeline version in the DB.
+    if isinstance(pipeline, BasePipeline):
         pipeline_model = pipeline._get_registered_model()
         if pipeline_model:
             return PipelineView(model=pipeline_model)
         else:
             return None
+
+    # Otherwise, for pipeline name or class, determine the name first.
+    if isinstance(pipeline, str):
+        pipeline_name = pipeline
+
     elif isinstance(pipeline, type) and issubclass(pipeline, BasePipeline):
         pipeline_name = pipeline.__name__
-    elif "pipeline_name" in kwargs and isinstance(
-        kwargs.get("pipeline_name"), str
-    ):
-        logger.warning(
-            "Using 'pipeline_name' to get a pipeline from "
-            "'get_pipeline()' is deprecated and "
-            "will be removed in the future. Instead please "
-            "use 'pipeline' to access a pipeline in your Repository based "
-            "on the name of the pipeline or even the class or instance "
-            "of the pipeline. Learn more in our API docs: %s",
-            get_apidocs_link(
-                "core-repository", "zenml.post_execution.pipeline.get_pipeline"
-            ),
-        )
-
-        pipeline_name = kwargs.pop("pipeline_name")
     else:
         raise RuntimeError(
-            "No pipeline specified. Please set a `pipeline` "
-            "within the `get_pipeline()` method. Learn more "
-            "in our API docs: %s",
-            get_apidocs_link(
-                "core-repository", "zenml.post_execution.pipeline.get_pipeline"
-            ),
+            f"Pipeline must be specified as a name (string), a class or an "
+            f"instance of a class. Got type `{type(pipeline)}` instead. "
         )
 
+    # If no version is given, return a `PipelineClassView` that contains all
+    # versions and all runs of this pipeline name/class.
+    if version is None:
+        class_view = PipelineClassView(name=pipeline_name)
+        if class_view.runs:
+            return class_view
+        return None
+
+    # Otherwise, find the corresponding pipeline version in the DB.
     client = Client()
     try:
         pipeline_model = client.get_pipeline(
@@ -134,11 +125,78 @@ def get_pipeline(
         return None
 
 
+class PipelineClassView:
+    """Post-execution class for a pipeline name/class."""
+
+    def __init__(self, name: str):
+        """Initializes a post-execution class for a pipeline name/class.
+
+        Args:
+            name: The name of the pipeline.
+        """
+        self.name = name
+
+    @property
+    def versions(self) -> List["PipelineView"]:
+        """Returns all versions/instances of this pipeline name/class.
+
+        Returns:
+            A list of all versions of this pipeline.
+        """
+        client = Client()
+        pipelines = client.list_pipelines(
+            workspace_id=client.active_workspace.id,
+            name=self.name,
+            sort_by="desc:created",
+        )
+        return [PipelineView(model) for model in pipelines.items]
+
+    @property
+    def num_runs(self) -> int:
+        """Returns the number of runs of this pipeline name/class.
+
+        This is the sum of all runs of all versions of this pipeline.
+
+        Returns:
+            The number of runs of this pipeline name/class.
+        """
+        return sum([version.num_runs for version in self.versions])
+
+    @property
+    def runs(self) -> List["PipelineRunView"]:
+        """Returns the last 50 stored runs of this pipeline name/class.
+
+        The runs are returned in reverse chronological order, so the latest
+        run will be the first element in this list.
+
+        Returns:
+            A list of all stored runs of this pipeline name/class.
+        """
+        all_runs = [run for version in self.versions for run in version.runs]
+        sorted_runs = sorted(
+            all_runs, key=lambda x: x.model.created, reverse=True
+        )
+        return sorted_runs[:50]
+
+    def __eq__(self, other: Any) -> bool:
+        """Compares this pipeline class view to another object.
+
+        Args:
+            other: The other object to compare to.
+
+        Returns:
+            Whether the other object is a pipeline class view with same name.
+        """
+        if not isinstance(other, PipelineClassView):
+            return False
+        return self.name == other.name
+
+
 class PipelineView(BaseView):
-    """Post-execution pipeline class."""
+    """Post-execution class for a specific version/instance of a pipeline."""
 
     MODEL_CLASS: Type[BaseResponseModel] = PipelineResponseModel
-    REPR_KEYS = ["id", "name"]
+    REPR_KEYS = ["id", "name", "version"]
 
     @property
     def model(self) -> PipelineResponseModel:
@@ -189,34 +247,3 @@ class PipelineView(BaseView):
         )
 
         return [PipelineRunView(run) for run in runs.items]
-
-    def get_run_for_completed_step(self, step_name: str) -> "PipelineRunView":
-        """Ascertains which pipeline run produced the cached artifact of a given step.
-
-        Args:
-            step_name: Name of step at hand
-
-        Returns:
-            None if no run is found that completed the given step,
-                else the original pipeline_run.
-
-        Raises:
-            LookupError: If no run is found that completed the given step
-        """
-        orig_pipeline_run = None
-
-        for run in reversed(self.runs):
-            try:
-                step = run.get_step(step_name)
-                if step.is_completed:
-                    orig_pipeline_run = run
-                    break
-            except KeyError:
-                pass
-        if not orig_pipeline_run:
-            raise LookupError(
-                "No Pipeline Run could be found, that has"
-                f" completed the provided step: [{step_name}]"
-            )
-
-        return orig_pipeline_run

--- a/src/zenml/post_execution/pipeline_run.py
+++ b/src/zenml/post_execution/pipeline_run.py
@@ -91,7 +91,7 @@ class PipelineRunView(BaseView):
         """Initializes a post-execution pipeline run object.
 
         In most cases `PipelineRunView` objects should not be created manually
-        but retrieved from a `PipelineView` object instead.
+        but retrieved from a `PipelineView` or `PipelineVersionView` instead.
 
         Args:
             model: The model to initialize this object from.

--- a/tests/integration/functional/conftest.py
+++ b/tests/integration/functional/conftest.py
@@ -40,6 +40,11 @@ def int_plus_one_test_step(input: int) -> int:
     return input + 1
 
 
+@step
+def int_plus_two_test_step(input: int) -> int:
+    return input + 2
+
+
 @pytest.fixture
 def clean_client_with_run(clean_client, connected_two_step_pipeline):
     """Fixture to get a clean client with an existing pipeline run in it."""

--- a/tests/integration/functional/post_execution/test_pipeline.py
+++ b/tests/integration/functional/post_execution/test_pipeline.py
@@ -24,7 +24,7 @@ from tests.integration.functional.conftest import (
 )
 from zenml.pipelines.base_pipeline import BasePipeline
 from zenml.post_execution.pipeline import (
-    PipelineClassView,
+    PipelineVersionView,
     PipelineView,
     get_pipeline,
     get_pipelines,
@@ -60,7 +60,7 @@ def test_get_pipeline(clean_client, connected_two_step_pipeline):
 
     # Test getting existing pipeline by name
     pipeline1 = get_pipeline("connected_two_step_pipeline")
-    assert isinstance(pipeline1, PipelineClassView)
+    assert isinstance(pipeline1, PipelineView)
     assert pipeline1.name == "connected_two_step_pipeline"
 
     # Test getting existing pipeline by class
@@ -69,7 +69,7 @@ def test_get_pipeline(clean_client, connected_two_step_pipeline):
 
     # Test getting existing pipeline by instance
     pipeline3 = get_pipeline(pipeline_instance)
-    assert isinstance(pipeline3, PipelineView)
+    assert isinstance(pipeline3, PipelineVersionView)
     assert pipeline3.name == "connected_two_step_pipeline"
 
 

--- a/tests/integration/functional/post_execution/test_pipeline.py
+++ b/tests/integration/functional/post_execution/test_pipeline.py
@@ -24,6 +24,7 @@ from tests.integration.functional.conftest import (
 )
 from zenml.pipelines.base_pipeline import BasePipeline
 from zenml.post_execution.pipeline import (
+    PipelineClassView,
     PipelineView,
     get_pipeline,
     get_pipelines,
@@ -59,7 +60,7 @@ def test_get_pipeline(clean_client, connected_two_step_pipeline):
 
     # Test getting existing pipeline by name
     pipeline1 = get_pipeline("connected_two_step_pipeline")
-    assert isinstance(pipeline1, PipelineView)
+    assert isinstance(pipeline1, PipelineClassView)
     assert pipeline1.name == "connected_two_step_pipeline"
 
     # Test getting existing pipeline by class
@@ -68,7 +69,8 @@ def test_get_pipeline(clean_client, connected_two_step_pipeline):
 
     # Test getting existing pipeline by instance
     pipeline3 = get_pipeline(pipeline_instance)
-    assert pipeline3 == pipeline1
+    assert isinstance(pipeline3, PipelineView)
+    assert pipeline3.name == "connected_two_step_pipeline"
 
 
 class NotAPipeline:

--- a/tests/unit/post_execution/test_pipeline.py
+++ b/tests/unit/post_execution/test_pipeline.py
@@ -19,7 +19,7 @@ import pytest
 
 from zenml.pipelines import pipeline
 from zenml.post_execution.pipeline import (
-    PipelineClassView,
+    PipelineVersionView,
     PipelineView,
     get_pipeline,
 )
@@ -96,13 +96,13 @@ def test_getting_pipeline_with_multiple_registered_versions(
     pipeline_instance_v2.run()
 
     post_execution_pipeline_v1 = get_pipeline(pipeline_instance_v1)
-    assert isinstance(post_execution_pipeline_v1, PipelineView)
+    assert isinstance(post_execution_pipeline_v1, PipelineVersionView)
     post_execution_pipeline_v2 = get_pipeline(pipeline_instance_v2)
     assert post_execution_pipeline_v1 != post_execution_pipeline_v2
-    assert isinstance(post_execution_pipeline_v2, PipelineView)
+    assert isinstance(post_execution_pipeline_v2, PipelineVersionView)
 
     post_execution_class_view = get_pipeline(one_step_pipeline.__name__)
-    assert isinstance(post_execution_class_view, PipelineClassView)
+    assert isinstance(post_execution_class_view, PipelineView)
     assert len(post_execution_class_view.versions) == 2
     assert get_pipeline(one_step_pipeline) == post_execution_class_view
 


### PR DESCRIPTION
## Describe changes
Getting the last run of a pipeline was broken because both `get_pipeline(...).runs` and `pipeline.get_runs()` would return the last run of the most recent pipeline version, but older versions might have newer runs.

This was very problematic because such basic behavior as the following was not working correctly:
```python
pipeline_instance.run()
run_view = pipeline_instance.get_runs()[0]  # was not guaranteed to be the run that was just executed
```

See the new integration test for a more detailed example.

To fix it, I changed the following behaviors:
- `pipeline_instance.get_runs()`: now returns the last 50 runs of this exact pipeline version (instead of the last 50 runs of the last version of the pipeline with the same name)
- `pipeline_class.get_runs()` / `get_pipeline(pipeline_name).runs ` / `get_pipeline(pipeline_class).runs`: now return the last 50 runs of all pipeline versions with the given pipeline name (instead of the last 50 runs of the last version only)


### Technical Details
- I introduced a new `PipelineClassView` post execution class that is just a namespace and has a list of all versions associated to that pipeline name. Calling `get_pipeline("pipeline_name")` or `get_pipeline(pipeline_class)` will now return such a `PipelineClassView` instead of the `PipelineView`.
- I reimplemented `BasePipeline.get_runs()` as a Descriptor that has different behavior based on whether the method is called on a pipeline class or a pipeline instance.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

