### PR TITLE
[CI Fix] Pin Llama Index Version

### DIFF
--- a/src/zenml/integrations/llama_index/__init__.py
+++ b/src/zenml/integrations/llama_index/__init__.py
@@ -25,7 +25,7 @@ class LlamaIndexIntegration(Integration):
     """Definition of Llama Index integration for ZenML."""
 
     NAME = LLAMA_INDEX
-    REQUIREMENTS = ["llama_index>=0.4.28"]
+    REQUIREMENTS = ["llama_index>=0.4.28,<0.6.0"]
 
     @classmethod
     def activate(cls) -> None:


### PR DESCRIPTION
## Describe changes
Llama Index 0.6.0 was released this week which no longer contains some of the components that we wrote materializers for and is breaking the CI because of it. Ideally, we would like to update our llama index examples / ... to use the newest version, but for now I just pinned the llama index integration version so we can get the CI to pass again.


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

