### PR TITLE
Add Kubernetes Orchestrator Settings

### DIFF
--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -64,6 +64,11 @@ class KubernetesOrchestratorConfig(  # type: ignore[misc] # https://github.com/p
             local stack components that store data in the local filesystem
             (i.e. it will mount the local stores directory into the pipeline
             containers).
+        incluster: If `True`, the orchestrator will be run inside the cluster
+            in which it is started. This requires the client to run in a
+            Kubernetes pod itself. If set, the `kubernetes_context` attribute
+            will be ignored.
+
         skip_local_validations: If `True`, the local validations will be
             skipped.
     """
@@ -71,6 +76,7 @@ class KubernetesOrchestratorConfig(  # type: ignore[misc] # https://github.com/p
     kubernetes_context: str  # TODO: Potential setting
     kubernetes_namespace: str = "zenml"
     local: bool = False
+    incluster: bool = False
     skip_local_validations: bool = False
 
     @root_validator(pre=True)

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -80,7 +80,6 @@ class KubernetesOrchestratorConfig(  # type: ignore[misc] # https://github.com/p
     kubernetes_context: str
     kubernetes_namespace: str = "zenml"
     local: bool = False
-    incluster: bool = False
     skip_local_validations: bool = False
 
     @root_validator(pre=True)

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -34,6 +34,12 @@ class KubernetesOrchestratorSettings(BaseSettings):
     Attributes:
         synchronous: If `True`, running a pipeline using this orchestrator will
             block until all steps finished running on Kubernetes.
+        incluster: If `True`, the orchestrator will be run inside the cluster
+            in which it is started. This requires the client to run in a
+            Kubernetes pod itself. If set, the `kubernetes_context` config
+            option and setting will both be ignored.
+        kubernetes_context: Name of a Kubernetes context to run pipelines in.
+            If set, overrides the `kubernetes_context` config option.
         timeout: How many seconds to wait for synchronous runs. `0` means
             to wait for an unlimited duration.
         service_account_name: Name of the service account to use for the
@@ -43,8 +49,9 @@ class KubernetesOrchestratorSettings(BaseSettings):
     """
 
     synchronous: bool = False
+    incluster: bool = False
+    kubernetes_context: Optional[str] = None
     timeout: int = 0
-
     service_account_name: Optional[str] = None
     pod_settings: Optional[KubernetesPodSettings] = None
 
@@ -55,7 +62,9 @@ class KubernetesOrchestratorConfig(  # type: ignore[misc] # https://github.com/p
     """Configuration for the Kubernetes orchestrator.
 
     Attributes:
-        kubernetes_context: Name of a Kubernetes context to run pipelines in.
+        kubernetes_context: Name of a default Kubernetes context to run
+            pipelines in. Can be overridden at run time using the
+            `kubernetes_context` setting.
         kubernetes_namespace: Name of the Kubernetes namespace to be used.
             If not provided, `zenml` namespace will be used.
         local: If `True`, the orchestrator will assume it is connected to a
@@ -64,16 +73,11 @@ class KubernetesOrchestratorConfig(  # type: ignore[misc] # https://github.com/p
             local stack components that store data in the local filesystem
             (i.e. it will mount the local stores directory into the pipeline
             containers).
-        incluster: If `True`, the orchestrator will be run inside the cluster
-            in which it is started. This requires the client to run in a
-            Kubernetes pod itself. If set, the `kubernetes_context` attribute
-            will be ignored.
-
         skip_local_validations: If `True`, the local validations will be
             skipped.
     """
 
-    kubernetes_context: str  # TODO: Potential setting
+    kubernetes_context: str
     kubernetes_namespace: str = "zenml"
     local: bool = False
     incluster: bool = False

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -86,7 +86,10 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
 
     def _initialize_k8s_clients(self) -> None:
         """Initialize the Kubernetes clients."""
-        kube_utils.load_kube_config(context=self.config.kubernetes_context)
+        kube_utils.load_kube_config(
+            incluster=self.config.incluster,
+            context=self.config.kubernetes_context,
+        )
         self._k8s_core_api = k8s_client.CoreV1Api()
         self._k8s_batch_api = k8s_client.BatchV1beta1Api()
         self._k8s_rbac_api = k8s_client.RbacAuthorizationV1Api()

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -193,6 +193,10 @@ def add_pod_settings(
     if settings.tolerations:
         pod_spec.tolerations = settings.tolerations
 
+    for container in pod_spec.containers:
+        assert isinstance(container, k8s_client.V1Container)
+        container._resources = settings.resources
+
 
 def build_cron_job_manifest(
     cron_expression: str,

--- a/tests/unit/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
+++ b/tests/unit/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
@@ -191,7 +191,7 @@ def test_kubernetes_orchestrator_uses_service_account_from_settings(mocker):
 def test_kubernetes_orchestrator_uses_k8s_config_from_settings(
     mocker, incluster, kubernetes_context
 ):
-
+    """Test that the k8s config can be set from the settings."""
     _patch_k8s_clients(mocker)
     orchestrator = _get_kubernetes_orchestrator(local=True)
     settings = KubernetesOrchestratorSettings(

--- a/tests/unit/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
+++ b/tests/unit/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
@@ -54,14 +54,32 @@ def _get_kubernetes_orchestrator(
 
 def _patch_k8s_clients(mocker):
     """Helper function to patch k8s clients."""
+
+    mock_context = {"name": K8S_CONTEXT}
+
+    def mock_load_kube_config(context: str) -> None:
+        mock_context["name"] = context
+
+    def mock_load_incluster_config() -> None:
+        mock_context["name"] = "incluster"
+
     mocker.patch(
-        "zenml.integrations.kubernetes.orchestrators.kubernetes_orchestrator.KubernetesOrchestrator._initialize_k8s_clients",
-        return_value=(None),
+        "kubernetes.config.load_kube_config",
+        side_effect=mock_load_kube_config,
     )
     mocker.patch(
-        "zenml.integrations.kubernetes.orchestrators.kubernetes_orchestrator.KubernetesOrchestrator.get_kubernetes_contexts",
-        return_value=([K8S_CONTEXT], K8S_CONTEXT),
+        "kubernetes.config.load_incluster_config",
+        side_effect=mock_load_incluster_config,
     )
+
+    mocker.patch(
+        "kubernetes.config.list_kube_config_contexts",
+        return_value=([mock_context], mock_context),
+    )
+
+    mocker.patch("kubernetes.client.CoreV1Api")
+    mocker.patch("kubernetes.client.BatchV1beta1Api")
+    mocker.patch("kubernetes.client.RbacAuthorizationV1Api")
 
 
 def test_kubernetes_orchestrator_remote_stack(
@@ -163,4 +181,32 @@ def test_kubernetes_orchestrator_uses_service_account_from_settings(mocker):
     assert (
         orchestrator._get_service_account_name(settings)
         == service_account_name
+    )
+
+
+@pytest.mark.parametrize("incluster", [True, False])
+@pytest.mark.parametrize(
+    "kubernetes_context", [None, "aria-kubernetes-context"]
+)
+def test_kubernetes_orchestrator_uses_k8s_config_from_settings(
+    mocker, incluster, kubernetes_context
+):
+
+    _patch_k8s_clients(mocker)
+    orchestrator = _get_kubernetes_orchestrator(local=True)
+    settings = KubernetesOrchestratorSettings(
+        kubernetes_context=kubernetes_context, incluster=incluster
+    )
+    orchestrator._initialize_k8s_clients(
+        incluster=settings.incluster, context=settings.kubernetes_context
+    )
+
+    expected_context = K8S_CONTEXT
+    if incluster:
+        expected_context = "incluster"
+    elif kubernetes_context:
+        expected_context = kubernetes_context
+    assert orchestrator.get_kubernetes_contexts() == (
+        [expected_context],
+        expected_context,
     )


### PR DESCRIPTION
## Describe changes
I fixed/added the following Kubernetes orchestrator settings:
- (fixed) `pod_settings.resources` is now correctly applied to all containers of the pod
- (new) `incluster` can be set when trying to run the orchestrator from another k8s pod in the same cluster
- (new) `kubernetes_context` can be used to override `config.kubernetes_context` so you can set the cluster programmatically.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [x] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

