### PR TITLE
Fix `SO_REUSEPORT` issue

### DIFF
--- a/src/zenml/utils/networking_utils.py
+++ b/src/zenml/utils/networking_utils.py
@@ -14,7 +14,6 @@
 """Utility functions for networking."""
 
 import socket
-import sys
 from typing import Optional, cast
 from urllib.parse import urlparse
 
@@ -40,7 +39,7 @@ def port_available(port: int, address: str = "127.0.0.1") -> bool:
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            if sys.platform != "win32":
+            if hasattr(socket, "SO_REUSEPORT"):
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             else:
                 # The SO_REUSEPORT socket option is not supported on Windows.


### PR DESCRIPTION
## Describe changes
Apparently `SO_REUSEPORT` can also be missing under other operating systems than Windows in certain circumstances. Using an explicit `hasattr` check should be a more general fix than the platform check we did before.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

