### PR TITLE
Fix Source Resolving in Colab

### DIFF
--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -249,6 +249,9 @@ class Environment(metaclass=SingletonMetaClass):
             `True` if the current Python process is running in a notebook,
             `False` otherwise.
         """
+        if Environment.in_google_colab():
+            return True
+
         if find_spec("IPython") is not None:
             from IPython import get_ipython  # type: ignore
 

--- a/src/zenml/post_execution/artifact.py
+++ b/src/zenml/post_execution/artifact.py
@@ -68,7 +68,7 @@ class ArtifactView(BaseView):
         from zenml.environment import Environment
         from zenml.utils.artifact_utils import load_artifact_visualization
 
-        if not Environment.in_notebook() and not Environment.in_google_colab():
+        if not Environment.in_notebook():
             raise RuntimeError(
                 "The `output.visualize()` method is only available in Jupyter "
                 "notebooks. In all other runtime environments, please open "


### PR DESCRIPTION
## Describe changes
Running pipelines in Colab was broken because `Environment.in_notebook()` would be `False` in Colab, so the following source resolution code would raise an exception (`source_utils.py` L. 428):

```python
        if module.__name__ == "__main__" and not Environment.in_notebook():
            raise RuntimeError(
                f"Unable to resolve module `{module}` because it was "
                "not loaded from a file."
            )
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

