### PR TITLE
Define `@pipeline` and `@step` decorators as public API

### DIFF
--- a/src/zenml/__init__.py
+++ b/src/zenml/__init__.py
@@ -34,5 +34,7 @@ __path__ = extend_path(__path__, __name__)
 
 # Define public Python API
 from zenml.api import show
+from zenml.new.pipelines.pipeline_decorator import pipeline
+from zenml.new.steps.step_decorator import step
 
-__all__ = ["show"]
+__all__ = ["show", "pipeline", "step"]

--- a/src/zenml/new/pipelines/pipeline_decorator.py
+++ b/src/zenml/new/pipelines/pipeline_decorator.py
@@ -24,18 +24,16 @@ from typing import (
     overload,
 )
 
-from zenml.new.pipelines.pipeline import Pipeline
-
 if TYPE_CHECKING:
     from zenml.config.base_settings import SettingsOrDict
+    from zenml.new.pipelines.pipeline import Pipeline
 
     HookSpecification = Union[str, FunctionType]
-
-F = TypeVar("F", bound=Callable[..., None])
+    F = TypeVar("F", bound=Callable[..., None])
 
 
 @overload
-def pipeline(_func: F) -> Pipeline:
+def pipeline(_func: "F") -> "Pipeline":
     ...
 
 
@@ -47,12 +45,12 @@ def pipeline(
     enable_artifact_metadata: Optional[bool] = None,
     settings: Optional[Dict[str, "SettingsOrDict"]] = None,
     extra: Optional[Dict[str, Any]] = None,
-) -> Callable[[F], Pipeline]:
+) -> Callable[["F"], "Pipeline"]:
     ...
 
 
 def pipeline(
-    _func: Optional[F] = None,
+    _func: Optional["F"] = None,
     *,
     name: Optional[str] = None,
     enable_cache: Optional[bool] = None,
@@ -61,7 +59,7 @@ def pipeline(
     extra: Optional[Dict[str, Any]] = None,
     on_failure: Optional["HookSpecification"] = None,
     on_success: Optional["HookSpecification"] = None,
-) -> Union[Pipeline, Callable[[F], Pipeline]]:
+) -> Union["Pipeline", Callable[["F"], "Pipeline"]]:
     """Decorator to create a pipeline.
 
     Args:
@@ -86,7 +84,9 @@ def pipeline(
         A pipeline instance.
     """
 
-    def inner_decorator(func: F) -> Pipeline:
+    def inner_decorator(func: F) -> "Pipeline":
+        from zenml.new.pipelines.pipeline import Pipeline
+
         p = Pipeline(
             name=name or func.__name__,
             enable_cache=enable_cache,

--- a/src/zenml/new/steps/decorated_step.py
+++ b/src/zenml/new/steps/decorated_step.py
@@ -1,0 +1,37 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from typing import Any
+
+from zenml.config.source import Source
+from zenml.steps import BaseStep
+
+
+class _DecoratedStep(BaseStep):
+    @property
+    def source_object(self) -> Any:
+        """The source object of this step.
+        Returns:
+            The source object of this step.
+        """
+        return self.entrypoint
+
+    def resolve(self) -> "Source":
+        """Resolves the step.
+        Returns:
+            The step source.
+        """
+        from zenml.utils import source_utils
+
+        return source_utils.resolve(self.entrypoint, skip_validation=True)


### PR DESCRIPTION
## Describe changes

The pipeline and step decorators are now part of the public API and can be imported via `zenml.pipeline` and `zenml.step` directly.

### Detailed Changes
- moved both decorator definitions to a new `zenml.api` package
- adjusted `zenml.__init__.py` to import the decorators
- optimized imports so we don't need to import anything except for `typing` to load the decorators
- ~~adjusted all examples/... imports to use `from zenml import pipeline, step` syntax instead (thus all the file changes)~~


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

