### PR TITLE
Removing old option command from contribution doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,6 @@ Optionally, you might want to run the following commands to ensure you have all
 integrations for `mypy` checks:
 
 ```
-zenml integration install -f
 zenml integration install -y -i feast
 pip install click~=8.0.3
 mypy --install-types


### PR DESCRIPTION
## Describe changes
Running `zenml integration install -f` command is giving below error - 

> Error: No such option: -f

This option was deprecated and now has been removed from the codebase as well.
--yes or -y can be used instead. Run `zenml integration install --help` to see the options and their descriptions.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [X] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

