### PR TITLE
Improve CLI help text for `zenml integration install -i ...`

### DIFF
--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -190,6 +190,14 @@ zenml integration install INTEGRATION_NAME
 Note that if you don't specify a specific integration to be installed, the
 ZenML CLI will install **all** available integrations.
 
+If you want to install all integrations apart from one or multiple integrations,
+use the following syntax, for example, which will install all integrations
+except `feast` and `aws`:
+
+```shell
+zenml integration install -i feast -i aws
+```
+
 Uninstalling a specific integration is as simple as typing:
 
 ```bash

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -165,7 +165,7 @@ def export_requirements(
     "--ignore-integration",
     "-i",
     multiple=True,
-    help="List of integrations to ignore explicitly.",
+    help="Integrations to ignore explicitly (passed in separately).",
 )
 @click.option(
     "--yes",
@@ -188,7 +188,7 @@ def install(
     Args:
         integrations: The name of the integration to install the requirements
             for.
-        ignore_integration: List of integrations to ignore explicitly.
+        ignore_integration: Integrations to ignore explicitly (passed in separately).
         force: Force the installation of the required packages.
     """
     from zenml.integrations.registry import integration_registry


### PR DESCRIPTION
`zenml integration install` command needs you to pass ignored integrations in separately, i.e.:

```shell
zenml integration install -y -i feast -i label_studio
```

The help text is / was confusing (and one user had issues getting this to work).

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

