### PR TITLE
Fix automatic dashboard opening after `zenml up`

### DIFF
--- a/src/zenml/api.py
+++ b/src/zenml/api.py
@@ -46,4 +46,5 @@ def show(ngrok_token: Optional[str] = None) -> None:
         logger.debug(f"Tunneling dashboard from {url} to {ngrok_url}.")
         url = ngrok_url
 
+    url = f"{url}:{port}" if port else url
     show_dashboard(url)


### PR DESCRIPTION
## Describe changes
`zenml up` would open the wrong URL before since the port was not part of the opened URL

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

