### PR TITLE
Bugfix/broken links on api docs

### DIFF
--- a/docs/mkdocstrings_helper.py
+++ b/docs/mkdocstrings_helper.py
@@ -113,11 +113,10 @@ def create_entity_docs(
                     out_path=api_doc_file_dir,
                 )
 
-                relative_base_path = "/".join(item.parts[1:-1])
                 if index_file_contents:
                     index_entry = (
                         f"# [{item_name}]"
-                        f"({relative_base_path}/{item.stem})\n\n"
+                        f"({API_DOCS}/{md_prefix}-{item.stem})\n\n"
                         f"::: {zenml_import_path}.{item.stem}\n"
                         f"    handler: python\n"
                         f"    selection:\n"


### PR DESCRIPTION
## Describe changes
I changed the linking of the landing page of the api docs to actually work again.

Initially the index.md looked as follows:
```
# [Pipelines](zenml/pipelines)

::: zenml.pipelines
    handler: python
    selection:
        members: false
```

However the api docs for pipelines are at `core_code_docs/core-pipelines`.

The new implementation will generate a file that looks like this.

```
# [Pipelines](core_code_docs/core-pipelines)

::: zenml.pipelines
    handler: python
    selection:
        members: false
```


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

