### PR TITLE
Fix TensorFlow Requirements for Rosetta Mac

### DIFF
--- a/src/zenml/integrations/tensorflow/__init__.py
+++ b/src/zenml/integrations/tensorflow/__init__.py
@@ -30,10 +30,7 @@ class TensorflowIntegration(Integration):
         """Activates the integration."""
         # need to import this explicitly to load the Tensorflow file IO support
         # for S3 and other file systems
-        if (
-            not platform.system() == "Darwin"
-            or not platform.machine() == "arm64"
-        ):
+        if not platform.system() == "Darwin":
             import tensorflow_io  # type: ignore [import]
 
         from zenml.integrations.tensorflow import materializers  # noqa
@@ -49,7 +46,7 @@ class TensorflowIntegration(Integration):
             A list of requirements.
         """
         target_os = target_os or platform.system()
-        if target_os == "Darwin" and platform.machine() == "arm64":
+        if target_os == "Darwin":
             requirements = [
                 "tensorflow-macos>=2.8.0",
             ]


### PR DESCRIPTION
## Describe changes
If you run on an M1/M2 Mac under Rosetta, the TF requirements are currently set incorrectly because `platform.machine() == 'x86_64'` under Rosetta. 

I guess `tensorflow-macos` should work under all Mac versions so I simply removed the platform requirement, but I would be happy to implement this differently if there are any better suggestions.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

