### PR TITLE
Remove `config.yaml` references in example docs

### DIFF
--- a/examples/huggingface/README.md
+++ b/examples/huggingface/README.md
@@ -154,22 +154,10 @@ For sequence classification:
 python run.py --nlp_task=sequence-classification --pretrained_model=distilbert-base-uncased --epochs=1 --batch_size=16 --dataset_name=imdb --text_column=text --label_column=label
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/sequence_classifier_pipeline/sequence_classifier_pipeline.py -c sequence_classification_config.yaml
-```
-
 For the token classification task:
 
 ```shell
 python run.py --nlp_task=token-classification --pretrained_model=distilbert-base-uncased --epochs=1 --batch_size=16 --dataset_name=conll2003 --text_column=tokens --label_column=ner_tags
-```
-
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/token_classifier_pipeline/token_classifier_pipeline.py -c token_classification_config.yaml
 ```
 
 By default, these will run on a very small subset of their datasets in order to 

--- a/examples/lightgbm/README.md
+++ b/examples/lightgbm/README.md
@@ -62,12 +62,6 @@ Now we're ready. Execute:
 python run.py
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/lgbm_pipeline/lgbm_pipeline.py -c config.yaml
-```
-
 ### 🧽 Clean up
 
 In order to clean up, delete the remaining ZenML references.

--- a/examples/mlflow_registry/README.md
+++ b/examples/mlflow_registry/README.md
@@ -199,17 +199,7 @@ Now we're ready. Execute:
 python run.py
 ```
 
-Alternatively, if you want to run based on the `config.yaml` you can run with:
-
-```bash
-# For Training pipeline Use:
-zenml pipeline run pipelines/training_pipeline/training_pipeline.py -c training_pipeline_config.yaml
-# For Deployment pipeline Use:
-zenml pipeline run pipelines/deployment_inference_pipeline/deployment_inference_pipeline.py -c deployment_pipeline_config.yaml
-```
-
 ## Running on a local Kubernetes cluster
-
 
 ## 📄 Infrastructure Requirements (Pre-requisites)
 

--- a/examples/mlflow_tracking/README.md
+++ b/examples/mlflow_tracking/README.md
@@ -149,12 +149,6 @@ Now we're ready. Execute:
 python run.py
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/training_pipeline/training_pipeline.py -c config.yaml
-```
-
 ## Running on a local Kubernetes cluster
 
 

--- a/examples/neural_prophet/README.md
+++ b/examples/neural_prophet/README.md
@@ -62,12 +62,6 @@ Now we're ready. Execute:
 python run.py
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/neural_prophet_pipeline/neural_prophet_pipeline.py -c config.yaml
-```
-
 After running the pipeline, you may inspect the accompanying notebook to visualize results:
 
 ```shell

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -54,12 +54,6 @@ Now we're ready. Execute the pipeline:
 python run.py
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/fashion_mnist_pipeline.py -c config.yaml
-```
-
 This will train a PyTorch model on the Fashion MNIST dataset.
 
 ### 🧽 Clean up

--- a/examples/scipy/README.md
+++ b/examples/scipy/README.md
@@ -60,13 +60,6 @@ Now we're ready. Execute:
 python run.py
 ```
 
-Alternatively, if you want to run based on the config.yaml you can run with:
-
-```bash
-zenml pipeline run pipelines/training_pipeline/training_pipeline.py -c config.yaml
-```
-
-
 ### 🧽 Clean up
 
 In order to clean up, delete the remaining ZenML references.


### PR DESCRIPTION
Some of our docs README files are still telling people to use nonexistent `config.yaml` files to run their pipelines. I removed those references.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

