### PR TITLE
Remove azure library import in flavor definition

### DIFF
--- a/src/zenml/integrations/azure/constants.py
+++ b/src/zenml/integrations/azure/constants.py
@@ -1,0 +1,18 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Azure integration constants."""
+
+AZURE_CONNECTOR_TYPE = "azure"
+AZURE_RESOURCE_TYPE = "azure-generic"
+BLOB_RESOURCE_TYPE = "blob-container"

--- a/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
+++ b/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
@@ -20,7 +20,7 @@ from zenml.artifact_stores import (
     BaseArtifactStoreFlavor,
 )
 from zenml.integrations.azure import AZURE_ARTIFACT_STORE_FLAVOR
-from zenml.integrations.azure.service_connectors.azure_service_connector import (
+from zenml.integrations.azure.constants import (
     AZURE_CONNECTOR_TYPE,
     BLOB_RESOURCE_TYPE,
 )

--- a/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
+++ b/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
@@ -33,6 +33,11 @@ from zenml.constants import (
     KUBERNETES_CLUSTER_RESOURCE_TYPE,
 )
 from zenml.exceptions import AuthorizationException
+from zenml.integrations.azure.constants import (
+    AZURE_CONNECTOR_TYPE,
+    AZURE_RESOURCE_TYPE,
+    BLOB_RESOURCE_TYPE,
+)
 from zenml.integrations.kubernetes.service_connectors.kubernetes_service_connector import (
     KubernetesAuthenticationMethods,
     KubernetesServiceConnector,
@@ -57,10 +62,6 @@ from zenml.utils.enum_utils import StrEnum
 
 logger = get_logger(__name__)
 
-
-AZURE_CONNECTOR_TYPE = "azure"
-AZURE_RESOURCE_TYPE = "azure-generic"
-BLOB_RESOURCE_TYPE = "blob-container"
 
 AZURE_MANAGEMENT_TOKEN_SCOPE = "https://management.azure.com/.default"
 AZURE_SESSION_TOKEN_DEFAULT_EXPIRATION_TIME = 60 * 60  # 1 hour


### PR DESCRIPTION
## Describe changes
Listing the flavors of the `azure` integration mistakenly imported the service connector which required the `azure` library.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

