### PR TITLE
Fix Azure Integration Imports and Improve Flavor Registration Error Handling

### DIFF
--- a/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
+++ b/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
@@ -20,15 +20,16 @@ from zenml.artifact_stores import (
     BaseArtifactStoreFlavor,
 )
 from zenml.integrations.azure import AZURE_ARTIFACT_STORE_FLAVOR
-from zenml.integrations.azure.service_connectors.azure_service_connector import (
-    AZURE_CONNECTOR_TYPE,
-    BLOB_RESOURCE_TYPE,
-)
 from zenml.models.service_connector_models import ServiceConnectorRequirements
 from zenml.stack.authentication_mixin import AuthenticationConfigMixin
 
 if TYPE_CHECKING:
     from zenml.integrations.azure.artifact_stores import AzureArtifactStore
+
+
+AZURE_CONNECTOR_TYPE = "azure"
+AZURE_RESOURCE_TYPE = "azure-generic"
+BLOB_RESOURCE_TYPE = "blob-container"
 
 
 class AzureArtifactStoreConfig(

--- a/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
+++ b/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
@@ -33,6 +33,11 @@ from zenml.constants import (
     KUBERNETES_CLUSTER_RESOURCE_TYPE,
 )
 from zenml.exceptions import AuthorizationException
+from zenml.integrations.azure.flavors.azure_artifact_store_flavor import (
+    AZURE_CONNECTOR_TYPE,
+    AZURE_RESOURCE_TYPE,
+    BLOB_RESOURCE_TYPE,
+)
 from zenml.integrations.kubernetes.service_connectors.kubernetes_service_connector import (
     KubernetesAuthenticationMethods,
     KubernetesServiceConnector,
@@ -57,10 +62,6 @@ from zenml.utils.enum_utils import StrEnum
 
 logger = get_logger(__name__)
 
-
-AZURE_CONNECTOR_TYPE = "azure"
-AZURE_RESOURCE_TYPE = "azure-generic"
-BLOB_RESOURCE_TYPE = "blob-container"
 
 AZURE_MANAGEMENT_TOKEN_SCOPE = "https://management.azure.com/.default"
 AZURE_SESSION_TOKEN_DEFAULT_EXPIRATION_TIME = 60 * 60  # 1 hour


### PR DESCRIPTION
## Describe changes
The Azure artifact store flavor imported the service connector which required. the Azure library.

This is very problematic since it would lead to an error during flavor registration, which would mean that subsequent integrations would be missing, e.g., `zenml model-deployer flavor list` would return an empty list even if all deployer integration requirements were installed.

To prevent integration issues like this to affect other integrations in the future, I also wrapped the flavor registration logic in our flavor registry in a try-catch block.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

