### PR TITLE
Cleanup Local Logging Temp Files

### DIFF
--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -226,6 +226,7 @@ class StepLauncher:
             if zenml_handler:
                 # Still write the logs to the artifact store regardless if we fail or not
                 zenml_handler.flush()
+                zenml_handler.close()
                 root_logger.removeHandler(zenml_handler)
 
     def _get_step_docstring_and_source_code(self) -> Tuple[Optional[str], str]:


### PR DESCRIPTION
## Describe changes
Small bug fix following #1526: When using remote artifact stores the logs are written to local temp files that are then uploaded to the cloud. I added the missing cleanup logic to delete those temp files after the step is finished.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

