### PR TITLE
Fix ZenML Installation when FastAPI is not Installed

### DIFF
--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -19,7 +19,6 @@ from functools import wraps
 from typing import Any, Callable, Optional, Tuple, Type, TypeVar, cast
 from urllib.parse import urlparse
 
-from fastapi import HTTPException
 from pydantic import BaseModel, ValidationError
 
 from zenml.config.global_config import GlobalConfiguration
@@ -228,6 +227,8 @@ def make_dependable(cls: Type[BaseModel]) -> Callable[..., Any]:
     """
 
     def init_cls_and_handle_errors(*args: Any, **kwargs: Any) -> BaseModel:
+        from fastapi import HTTPException
+
         try:
             inspect.signature(init_cls_and_handle_errors).bind(*args, **kwargs)
             return cls(*args, **kwargs)


### PR DESCRIPTION
## Describe changes
FastAPI is an optional `server` dependency, but we previously always required it since it got imported through `zenml.cli.server` -> `zenml.zen_server.utils` -> `fastapi` leading to `ModuleNotFoundError: No module named 'fastapi'` for anyone who installed ZenML without server dependencies.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

