### PR TITLE
Fix the s3 integration dependencies

### DIFF
--- a/src/zenml/integrations/s3/__init__.py
+++ b/src/zenml/integrations/s3/__init__.py
@@ -32,7 +32,16 @@ class S3Integration(Integration):
     NAME = S3
     # boto3 isn't required for the filesystem to work, but it is required
     # for the AWS/S3 connector that can be used with the artifact store.
-    REQUIREMENTS = ["s3fs>2022.3.0,<=2023.4.0", "boto3<=1.24.59"]
+    # NOTE: to keep the dependency resolution for botocore consistent and fast
+    # between s3fs and boto3, the boto3 upper version used here should be the
+    # same as the one resolved by pip when installing boto3 without a
+    # restriction alongside s3fs, e.g.:
+    #
+    #   pip install 's3fs>2022.3.0,<=2023.4.0' boto3
+    #
+    # The above command installs boto3==1.26.76, so we use the same version
+    # here to avoid the dependency resolution overhead.
+    REQUIREMENTS = ["s3fs>2022.3.0,<=2023.4.0", "boto3<=1.26.76"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:


### PR DESCRIPTION
## Describe changes
It takes forever to install the S3 zenml integration due to the common `botocore` dependency that both `s3fs` and `boto3` share. Using a boto3 version that is aligned to s3fs makes the pip dependency resolution 100 times faster.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

