### PR TITLE
feat | add DatabricksShell in_notebook in environment.py

### DIFF
--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -261,6 +261,7 @@ class Environment(metaclass=SingletonMetaClass):
             if get_ipython().__class__.__name__ in [
                 "TerminalInteractiveShell",
                 "ZMQInteractiveShell",
+                "DatabricksShell",
             ]:
                 return True
         return False


### PR DESCRIPTION
Add DatabricksShell as a option in the Ipython list to allow the Databricks show the dashboards

## Describe changes
I implemented/fixed the list of enviroments allowed to be notebook to achieve the databricks notebook showing the dashboards.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [X] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

