### PR TITLE
Add DatabricksShell on list of notebooks allowed to show dashboard

### DIFF
--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -261,6 +261,7 @@ class Environment(metaclass=SingletonMetaClass):
             if get_ipython().__class__.__name__ in [
                 "TerminalInteractiveShell",
                 "ZMQInteractiveShell",
+                "DatabricksShell",
             ]:
                 return True
         return False


### PR DESCRIPTION
Add DatabricksShell as a option in the Ipython list to allow the Databricks show the dashboards

## Describe changes
I fixed the list of environment allowed as notebook to achieve the databricks showing the dashboard on notebooks.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [] If my change requires a change to docs, I have updated the documentation accordingly.
- [] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

