### PR TITLE
Don't run whylogs example on windows

### DIFF
--- a/tests/harness/cfg/tests.yaml
+++ b/tests/harness/cfg/tests.yaml
@@ -140,6 +140,9 @@ tests:
         stacks:
           - type: data_validator
             flavor: whylogs
+        system_os:
+           - linux
+           - macos
       - capabilities:
           synchronized: true
 


### PR DESCRIPTION
## Describe changes
Skip running the whylogs example in the CI on Windows, because it locks up and keeps runners busy for 5+ hours.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

