### PR TITLE
Improve config section of containerization docs page

### DIFF
--- a/docs/book/user-guide/advanced-guide/containerize-your-pipeline.md
+++ b/docs/book/user-guide/advanced-guide/containerize-your-pipeline.md
@@ -73,14 +73,30 @@ The process described above is automated by ZenML and covers the most basic use 
 
 For a full list of configuration options, check out [our API Docs](https://apidocs.zenml.io/latest/core\_code\_docs/core-config/#zenml.config.docker\_settings.DockerSettings).
 
-For the configuration examples described below, you'll need to import the `DockerSettings` class:
+### How to configure Docker builds for your pipelines
+
+Customizing the Docker builds for your pipelines and steps is done using the `DockerSettings` class
+which you can import like this:
 
 ```python
 from zenml.config import DockerSettings
 ```
 
-Instead of defining the `DockerSettings` on the `@pipeline` decorator like all code snippets below, you can also define them on the `@step` decorator of your steps if you need more control, or by using the `with_options(...)` method on your steps and pipelines:
+There are many ways in which you can supply these settings:
+* Configuring them on a pipeline applies the settings to all steps of that pipeline:
+```python
+docker_settings = DockerSettings()
 
+@pipeline(settings={"docker": docker_settings})
+def my_pipeline() -> None:
+    my_step()
+
+my_pipeline = my_pipeline.with_options(
+    settings={"docker": docker_settings}
+)
+```
+* Configuring them on a step gives you more fine-grained control and enables you
+to build separate specialized Docker images for different steps of your pipelines:
 ```python
 docker_settings = DockerSettings()
 
@@ -91,15 +107,12 @@ def my_step() -> None:
 my_step = my_step.with_options(
     settings={"docker": docker_settings}
 )
-
-@pipeline(settings={"docker": docker_settings})
-def my_pipeline() -> None:
-    my_step()
-
-my_pipeline = my_pipeline.with_options(
-    settings={"docker": docker_settings}
-)
 ```
+* Using a YAML configuration file as described
+[here](./configure-steps-pipelines.md/#method-3-configuring-with-yaml).
+
+Check out [this page](./configure-steps-pipelines.md#hierarchy-and-precedence) for more information
+on the hierarchy and precedence of the various ways in which you can supply the settings.
 
 ### Handling source files
 


### PR DESCRIPTION
## Describe changes
Implements some left over todos from the docs refactoring:
- Give step-level dependencies their own dedicated section
- Mention how to do it with config.yaml


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

