### PR TITLE
Relax `fastapi` dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ sqlalchemy_utils = "0.38.3"
 sqlmodel = "~0.0.8"
 
 # Optional dependencies for the ZenServer
-fastapi = { version = "~0.75.0", optional = true }
+fastapi = { version = ">=0.75,<0.100", optional = true }
 uvicorn = { extras = ["standard"], version = "~0.17.5",  optional = true}
 python-multipart = { version = "~0.0.5", optional = true}
 python-jose = { extras = ["cryptography"], version = "~3.3.0", optional = true}

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -90,7 +90,7 @@ def parse_return_type_annotations(
             "Using the `Output` class to define the outputs of your steps is "
             "deprecated. You should instead use the standard Python way of "
             "type annotating your functions. Check out our documentation "
-            "https://docs.zenml.io/user-guide/advanced-guide/configure-steps-pipelines#step-output-names"
+            "https://docs.zenml.io/user-guide/advanced-guide/configure-steps-pipelines#step-output-names "
             "for more information on how to assign custom names to your step "
             "outputs."
         )

--- a/src/zenml/zen_server/routers/workspaces_endpoints.py
+++ b/src/zenml/zen_server/routers/workspaces_endpoints.py
@@ -786,7 +786,7 @@ def create_pipeline_run(
 
 @router.post(
     WORKSPACES + "/{workspace_name_or_id}" + RUNS + GET_OR_CREATE,
-    response_model=Tuple[PipelineRunResponseModel, bool],  # type: ignore[arg-type]
+    response_model=Tuple[PipelineRunResponseModel, bool],
     responses={401: error_response, 409: error_response, 422: error_response},
 )
 @handle_exceptions


### PR DESCRIPTION
## Describe changes
I relaxed the `fastapi` dependency to support newer versions up to `0.99.X`. Manual tests with `0.99.1` seemed good.

`fastapi>=0.100` is still excluded since it will depend on pydantic 2.0: https://github.com/tiangolo/fastapi/issues/9710

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

