### PR TITLE
Simplified Page Iteration

### DIFF
--- a/src/zenml/models/page_model.py
+++ b/src/zenml/models/page_model.py
@@ -98,7 +98,7 @@ class Page(GenericModel, Generic[B]):
 
         This enables `for item in page` loops, but breaks `dict(page)`.
 
-        Returns:
+        Yields:
             An iterator over the items in the page.
         """
         for item in self.items.__iter__():

--- a/src/zenml/models/page_model.py
+++ b/src/zenml/models/page_model.py
@@ -38,7 +38,7 @@
 The code contained within this file has been inspired by the
 fastapi-pagination library: https://github.com/uriyyo/fastapi-pagination
 """
-from typing import Generic, List, TypeVar
+from typing import Generator, Generic, List, TypeVar
 
 from pydantic import SecretStr
 from pydantic.generics import GenericModel
@@ -73,6 +73,8 @@ class Page(GenericModel, Generic[B]):
     def __len__(self) -> int:
         """Return the item count of the page.
 
+        This enables `len(page)`.
+
         Returns:
             The amount of items in the page.
         """
@@ -80,6 +82,8 @@ class Page(GenericModel, Generic[B]):
 
     def __getitem__(self, index: int) -> B:
         """Return the item at the given index.
+
+        This enables `page[index]`.
 
         Args:
             index: The index to get the item from.
@@ -89,8 +93,21 @@ class Page(GenericModel, Generic[B]):
         """
         return self.items[index]
 
+    def __iter__(self) -> Generator[B, None, None]:  # type: ignore[override]
+        """Return an iterator over the items in the page.
+
+        This enables `for item in page` loops, but break `dict(page)`.
+
+        Returns:
+            An iterator over the items in the page.
+        """
+        for item in self.items.__iter__():
+            yield item
+
     def __contains__(self, item: B) -> bool:
         """Returns whether the page contains a specific item.
+
+        This enables `item in page` checks.
 
         Args:
             item: The item to check for.

--- a/src/zenml/models/page_model.py
+++ b/src/zenml/models/page_model.py
@@ -96,7 +96,7 @@ class Page(GenericModel, Generic[B]):
     def __iter__(self) -> Generator[B, None, None]:  # type: ignore[override]
         """Return an iterator over the items in the page.
 
-        This enables `for item in page` loops, but break `dict(page)`.
+        This enables `for item in page` loops, but breaks `dict(page)`.
 
         Returns:
             An iterator over the items in the page.

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -651,7 +651,7 @@ class Pipeline:
 
             runs = Client().list_pipeline_runs(
                 deployment_id=deployment_model.id,
-                sort_by="asc:start_time",
+                sort_by="desc:start_time",
                 size=1,
             )
 


### PR DESCRIPTION
## Describe changes

I added a custom `Page.__iter__()` method implementation so we can iterate over pages Python-natively. 

Note that this breaks `dict(page)` since that relies on the overridden `BaseModel.__iter__()` method.

### Before

```python
for item in page.items:
    ...
```

### After

```python
for item in page:
    ...
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

