### PR TITLE
Catch correct exception when trying to access step context

### DIFF
--- a/src/zenml/integrations/great_expectations/data_validators/ge_data_validator.py
+++ b/src/zenml/integrations/great_expectations/data_validators/ge_data_validator.py
@@ -378,7 +378,7 @@ class GreatExpectationsDataValidator(BaseDataValidator):
                 pipeline_name = step_context.pipeline.name
                 step_name = step_context.step_run.name
                 expectation_suite_name = f"{pipeline_name}_{step_name}"
-            except KeyError:
+            except RuntimeError:
                 raise ValueError(
                     "A expectation suite name is required when not running in "
                     "the context of a pipeline step."
@@ -481,7 +481,7 @@ class GreatExpectationsDataValidator(BaseDataValidator):
             step_context = get_step_context()
             run_name = step_context.pipeline_run.name
             step_name = step_context.step_run.name
-        except KeyError:
+        except RuntimeError:
             # if not running inside a pipeline step, use random values
             run_name = f"pipeline_{random_str(5)}"
             step_name = f"step_{random_str(5)}"

--- a/src/zenml/integrations/whylogs/data_validators/whylogs_data_validator.py
+++ b/src/zenml/integrations/whylogs/data_validators/whylogs_data_validator.py
@@ -139,7 +139,7 @@ class WhylogsDataValidator(BaseDataValidator, AuthenticationMixin):
                 pipeline_name = step_context.pipeline.name
                 step_name = step_context.step_run.name
                 dataset_id = f"{pipeline_name}_{step_name}"
-            except KeyError:
+            except RuntimeError:
                 raise ValueError(
                     "A dataset ID was not specified and could not be "
                     "generated from the current pipeline and step name."

--- a/src/zenml/integrations/whylogs/materializers/whylogs_materializer.py
+++ b/src/zenml/integrations/whylogs/materializers/whylogs_materializer.py
@@ -141,7 +141,7 @@ class WhylogsMaterializer(BaseMaterializer):
         try:
             step_context = get_step_context()
         except RuntimeError:
-            # we are not in a step environment
+            # we are not running as part of a pipeline
             return
 
         run_info = step_context.step_run_info


### PR DESCRIPTION
## Describe changes
During the `StepContext` rework, the `StepEnvironment` was replaced by the `get_step_context()` function to get the pipeline/run name. We used a `try...except` block to catch the `KeyError` that occurred when we're not running inside a pipeline step, but this now needs to be a `RuntimeError` to work with the new `get_step_context()`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

