### PR TITLE
Make the workspace statistics endpoint more performant

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -17,3 +17,4 @@ internal:
   - '@fa9r'
   - '@dnth'
   - '@Cahllagerfeld'
+  - '@avishniakov'

--- a/src/zenml/models/user_models.py
+++ b/src/zenml/models/user_models.py
@@ -380,6 +380,8 @@ class UserAuthModel(UserBaseModel, BaseResponseModel):
         Returns:
             The user that generated the token if valid, None otherwise.
         """
+        from zenml.zen_stores.sql_zen_store import SqlZenStore
+
         try:
             access_token = JWTToken.decode(
                 token_type=JWTTokenType.ACCESS_TOKEN, token=token
@@ -388,6 +390,8 @@ class UserAuthModel(UserBaseModel, BaseResponseModel):
             return None
 
         zen_store = GlobalConfiguration().zen_store
+        if not isinstance(zen_store, SqlZenStore):
+            return None
         try:
             user = zen_store.get_auth_user(
                 user_name_or_id=access_token.user_id

--- a/src/zenml/utils/analytics_utils.py
+++ b/src/zenml/utils/analytics_utils.py
@@ -15,8 +15,20 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
+from functools import wraps
 from types import TracebackType
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -505,50 +517,6 @@ def track_event(
     return success
 
 
-def parametrized(
-    dec: Callable[..., Callable[..., Any]]
-) -> Callable[..., Callable[[Callable[..., Any]], Callable[..., Any]]]:
-    """A meta-decorator, that is, a decorator for decorators.
-
-    As a decorator is a function, it actually works as a regular decorator
-    with arguments.
-
-    Args:
-        dec: Decorator to be applied to the function.
-
-    Returns:
-        Decorator that applies the given decorator to the function.
-    """
-
-    def layer(
-        *args: Any, **kwargs: Any
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """Internal layer.
-
-        Args:
-            *args: Arguments to be passed to the decorator.
-            **kwargs: Keyword arguments to be passed to the decorator.
-
-        Returns:
-            Decorator that applies the given decorator to the function.
-        """
-
-        def repl(f: Callable[..., Any]) -> Callable[..., Any]:
-            """Internal REPL.
-
-            Args:
-                f: Function to be decorated.
-
-            Returns:
-                Decorated function.
-            """
-            return dec(f, *args, **kwargs)
-
-        return repl
-
-    return layer
-
-
 class AnalyticsTrackerMixin(ABC):
     """Abstract base class for analytics trackers.
 
@@ -596,13 +564,14 @@ class AnalyticsTrackedModelMixin(BaseModel):
         return metadata
 
 
-@parametrized
+F = TypeVar("F", bound=Callable[..., Any])
+
+
 def track(
-    func: Callable[..., Any],
     event: AnalyticsEvent,
     v1: Optional[bool] = True,
     v2: Optional[bool] = False,
-) -> Callable[..., Any]:
+) -> Callable[[F], F]:
     """Decorator to track event.
 
     If the decorated function takes in a `AnalyticsTrackedModelMixin` object as
@@ -624,40 +593,54 @@ def track(
         Decorated function.
     """
 
-    def inner_func(*args: Any, **kwargs: Any) -> Any:
+    def inner_decorator(func: F) -> F:
         """Inner decorator function.
 
         Args:
-            *args: Arguments to be passed to the function.
-            **kwargs: Keyword arguments to be passed to the function.
+            func: Function to decorate.
 
         Returns:
-            Result of the function.
+            Decorated function.
         """
-        with event_handler(event=event, v1=v1, v2=v2) as handler:
-            try:
-                if len(args) and isinstance(args[0], AnalyticsTrackerMixin):
-                    handler.tracker = args[0]
 
-                for obj in list(args) + list(kwargs.values()):
-                    if isinstance(obj, AnalyticsTrackedModelMixin):
-                        handler.metadata = obj.get_analytics_metadata()
-                        break
-            except Exception as e:
-                logger.debug(f"Analytics tracking failure for {func}: {e}")
+        @wraps(func)
+        def inner_func(*args: Any, **kwargs: Any) -> Any:
+            """Inner function.
 
-            result = func(*args, **kwargs)
+            Args:
+                *args: Arguments to be passed to the function.
+                **kwargs: Keyword arguments to be passed to the function.
 
-            try:
-                if isinstance(result, AnalyticsTrackedModelMixin):
-                    handler.metadata = result.get_analytics_metadata()
-            except Exception as e:
-                logger.debug(f"Analytics tracking failure for {func}: {e}")
+            Returns:
+                Result of the function.
+            """
+            with event_handler(event=event, v1=v1, v2=v2) as handler:
+                try:
+                    if len(args) and isinstance(
+                        args[0], AnalyticsTrackerMixin
+                    ):
+                        handler.tracker = args[0]
 
-            return result
+                    for obj in list(args) + list(kwargs.values()):
+                        if isinstance(obj, AnalyticsTrackedModelMixin):
+                            handler.metadata = obj.get_analytics_metadata()
+                            break
+                except Exception as e:
+                    logger.debug(f"Analytics tracking failure for {func}: {e}")
 
-    inner_func.__doc__ = func.__doc__
-    return inner_func
+                result = func(*args, **kwargs)
+
+                try:
+                    if isinstance(result, AnalyticsTrackedModelMixin):
+                        handler.metadata = result.get_analytics_metadata()
+                except Exception as e:
+                    logger.debug(f"Analytics tracking failure for {func}: {e}")
+
+                return result
+
+        return cast(F, inner_func)
+
+    return inner_decorator
 
 
 class event_handler(object):

--- a/src/zenml/utils/analytics_utils.py
+++ b/src/zenml/utils/analytics_utils.py
@@ -584,13 +584,12 @@ def track(
     tracking analytics.
 
     Args:
-        func: Function that is decorated.
         event: Event string to stamp with.
         v1: Flag to determine whether analytics v1 is included.
         v2: Flag to determine whether analytics v2 is included.
 
     Returns:
-        Decorated function.
+        A decorator that applies the analytics tracking to a function.
     """
 
     def inner_decorator(func: F) -> F:

--- a/src/zenml/zen_server/routers/workspaces_endpoints.py
+++ b/src/zenml/zen_server/routers/workspaces_endpoints.py
@@ -1016,9 +1016,10 @@ def get_workspace_statistics(
     return {
         "stacks": zen_store().count_stacks(workspace_id=workspace.id),
         "components": zen_store().count_stack_components(
-            workspace_id=workspace.id),
+            workspace_id=workspace.id
+        ),
         "pipelines": zen_store().count_pipelines(workspace_id=workspace.id),
-        "runs": zen_store().count_runs(workspace_id=workspace.id)
+        "runs": zen_store().count_runs(workspace_id=workspace.id),
     }
 
 

--- a/src/zenml/zen_server/routers/workspaces_endpoints.py
+++ b/src/zenml/zen_server/routers/workspaces_endpoints.py
@@ -1014,20 +1014,11 @@ def get_workspace_statistics(
     workspace = zen_store().get_workspace(workspace_name_or_id)
 
     return {
-        "stacks": zen_store()
-        .list_stacks(StackFilterModel(scope_workspace=workspace.id))
-        .total,
-        "components": zen_store()
-        .list_stack_components(
-            ComponentFilterModel(scope_workspace=workspace.id)
-        )
-        .total,
-        "pipelines": zen_store()
-        .list_pipelines(PipelineFilterModel(scope_workspace=workspace.id))
-        .total,
-        "runs": zen_store()
-        .list_runs(PipelineRunFilterModel(scope_workspace=workspace.id))
-        .total,
+        "stacks": zen_store().count_stacks(workspace_id=workspace.id),
+        "components": zen_store().count_stack_components(
+            workspace_id=workspace.id),
+        "pipelines": zen_store().count_pipelines(workspace_id=workspace.id),
+        "runs": zen_store().count_runs(workspace_id=workspace.id)
     }
 
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -26,14 +26,14 @@ from zenml.constants import (
     ENV_ZENML_SERVER,
     ENV_ZENML_SERVER_ROOT_URL_PATH,
 )
-from zenml.enums import ServerProviderType, StoreType
+from zenml.enums import ServerProviderType
 from zenml.logger import get_logger
 from zenml.zen_server.deploy.deployment import ServerDeployment
 from zenml.zen_server.deploy.local.local_zen_server import (
     LocalServerDeploymentConfig,
 )
 from zenml.zen_server.exceptions import http_exception_from_error
-from zenml.zen_stores.base_zen_store import BaseZenStore
+from zenml.zen_stores.sql_zen_store import SqlZenStore
 
 logger = get_logger(__name__)
 
@@ -41,10 +41,10 @@ logger = get_logger(__name__)
 ROOT_URL_PATH = os.getenv(ENV_ZENML_SERVER_ROOT_URL_PATH, "")
 
 
-_zen_store: Optional[BaseZenStore] = None
+_zen_store: Optional["SqlZenStore"] = None
 
 
-def zen_store() -> BaseZenStore:
+def zen_store() -> "SqlZenStore":
     """Initialize the ZenML Store.
 
     Returns:
@@ -65,24 +65,25 @@ def initialize_zen_store() -> None:
     Raises:
         ValueError: If the ZenML Store is using a REST back-end.
     """
-    global _zen_store
-
     logger.debug("Initializing ZenML Store for FastAPI...")
-    _zen_store = GlobalConfiguration().zen_store
+    zen_store_ = GlobalConfiguration().zen_store
 
-    # We override track_analytics=False because we do not
-    # want to track anything server side.
-    _zen_store.track_analytics = False
-
-    # Use an environment variable to flag the instance as a server
-    os.environ[ENV_ZENML_SERVER] = "true"
-
-    if _zen_store.type == StoreType.REST:
+    if not isinstance(zen_store_, SqlZenStore):
         raise ValueError(
             "Server cannot be started with a REST store type. Make sure you "
             "configure ZenML to use a non-networked store backend "
             "when trying to start the ZenML Server."
         )
+
+    # We override track_analytics=False because we do not
+    # want to track anything server side.
+    zen_store_.track_analytics = False
+
+    # Use an environment variable to flag the instance as a server
+    os.environ[ENV_ZENML_SERVER] = "true"
+
+    global _zen_store
+    _zen_store = zen_store_
 
 
 def get_active_deployment(local: bool = False) -> Optional["ServerDeployment"]:

--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -475,7 +475,7 @@ class BaseZenStore(
                 user_name_or_id=self.get_user().id,
             )
         except KeyError:
-            return self._create_default_stack(  # type: ignore[no-any-return]
+            return self._create_default_stack(
                 workspace_name_or_id=workspace.id,
                 user_name_or_id=self.get_user().id,
             )
@@ -484,7 +484,7 @@ class BaseZenStore(
         try:
             return self._default_workspace
         except KeyError:
-            return self._create_default_workspace()  # type: ignore[no-any-return]
+            return self._create_default_workspace()
 
     # --------------
     # Event Handlers

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -1309,6 +1309,7 @@ class RestZenStore(BaseZenStore):
         Returns:
             The number of pipelines in the workspace.
         """
+        raise NotImplementedError
 
     @track(AnalyticsEvent.UPDATE_PIPELINE)
     def update_pipeline(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -495,6 +495,19 @@ class RestZenStore(BaseZenStore):
             filter_model=stack_filter_model,
         )
 
+    def count_stacks(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """List all stacks matching the given filter criteria.
+
+        Args:
+            workspace_id: The workspace to use for counting stacks
+
+        Returns:
+            The number of stacks in the workspace.
+        """
+        raise NotImplementedError
+
     @track(AnalyticsEvent.UPDATED_STACK)
     def update_stack(
         self, stack_id: UUID, stack_update: StackUpdateModel
@@ -584,6 +597,19 @@ class RestZenStore(BaseZenStore):
             response_model=ComponentResponseModel,
             filter_model=component_filter_model,
         )
+
+    def count_stack_components(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all components, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting components
+
+        Returns:
+            The number of components in the workspace.
+        """
+        raise NotImplementedError
 
     @track(AnalyticsEvent.UPDATED_STACK_COMPONENT)
     def update_stack_component(
@@ -1272,6 +1298,18 @@ class RestZenStore(BaseZenStore):
             filter_model=pipeline_filter_model,
         )
 
+    def count_pipelines(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all pipelines, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting pipelines
+
+        Returns:
+            The number of pipelines in the workspace.
+        """
+
     @track(AnalyticsEvent.UPDATE_PIPELINE)
     def update_pipeline(
         self, pipeline_id: UUID, pipeline_update: PipelineUpdateModel
@@ -1600,6 +1638,19 @@ class RestZenStore(BaseZenStore):
             response_model=PipelineRunResponseModel,
             filter_model=runs_filter_model,
         )
+
+    def count_runs(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all pipeline runs, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting pipeline runs
+
+        Returns:
+            The number of pipeline runs in the workspace.
+        """
+        raise NotImplementedError
 
     def update_run(
         self, run_id: UUID, run_update: PipelineRunUpdateModel

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -16,7 +16,6 @@ import os
 import re
 from pathlib import Path, PurePath
 from typing import (
-    TYPE_CHECKING,
     Any,
     ClassVar,
     Dict,
@@ -173,9 +172,6 @@ from zenml.zen_stores.secrets_stores.rest_secrets_store import (
 )
 
 logger = get_logger(__name__)
-
-if TYPE_CHECKING:
-    from zenml.models import UserAuthModel
 
 # type alias for possible json payloads (the Anys are recursive Json instances)
 Json = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
@@ -495,17 +491,6 @@ class RestZenStore(BaseZenStore):
             filter_model=stack_filter_model,
         )
 
-    def count_stacks(self, workspace_id: Optional[UUID]) -> int:
-        """List all stacks matching the given filter criteria.
-
-        Args:
-            workspace_id: The workspace to use for counting stacks
-
-        Returns:
-            The number of stacks in the workspace.
-        """
-        raise NotImplementedError
-
     @track(AnalyticsEvent.UPDATED_STACK)
     def update_stack(
         self, stack_id: UUID, stack_update: StackUpdateModel
@@ -595,17 +580,6 @@ class RestZenStore(BaseZenStore):
             response_model=ComponentResponseModel,
             filter_model=component_filter_model,
         )
-
-    def count_stack_components(self, workspace_id: Optional[UUID]) -> int:
-        """Count all components, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting components
-
-        Returns:
-            The number of components in the workspace.
-        """
-        raise NotImplementedError
 
     @track(AnalyticsEvent.UPDATED_STACK_COMPONENT)
     def update_stack_component(
@@ -773,24 +747,6 @@ class RestZenStore(BaseZenStore):
         else:
             body = self.get(CURRENT_USER)
             return UserResponseModel.parse_obj(body)
-
-    def get_auth_user(
-        self, user_name_or_id: Union[str, UUID]
-    ) -> "UserAuthModel":
-        """Gets the auth model to a specific user.
-
-        Args:
-            user_name_or_id: The name or ID of the user to get.
-
-        Raises:
-            NotImplementedError: This method is only available for the
-                SQLZenStore.
-        """
-        raise NotImplementedError(
-            "This method is only designed for use"
-            " by the server endpoints. It is not designed"
-            " to be called from the client side."
-        )
 
     def list_users(
         self, user_filter_model: UserFilterModel
@@ -1294,17 +1250,6 @@ class RestZenStore(BaseZenStore):
             filter_model=pipeline_filter_model,
         )
 
-    def count_pipelines(self, workspace_id: Optional[UUID]) -> int:
-        """Count all pipelines, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting pipelines
-
-        Returns:
-            The number of pipelines in the workspace.
-        """
-        raise NotImplementedError
-
     @track(AnalyticsEvent.UPDATE_PIPELINE)
     def update_pipeline(
         self, pipeline_id: UUID, pipeline_update: PipelineUpdateModel
@@ -1633,17 +1578,6 @@ class RestZenStore(BaseZenStore):
             response_model=PipelineRunResponseModel,
             filter_model=runs_filter_model,
         )
-
-    def count_runs(self, workspace_id: Optional[UUID]) -> int:
-        """Count all pipeline runs, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting pipeline runs
-
-        Returns:
-            The number of pipeline runs in the workspace.
-        """
-        raise NotImplementedError
 
     def update_run(
         self, run_id: UUID, run_update: PipelineRunUpdateModel

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -495,9 +495,7 @@ class RestZenStore(BaseZenStore):
             filter_model=stack_filter_model,
         )
 
-    def count_stacks(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stacks(self, workspace_id: Optional[UUID]) -> int:
         """List all stacks matching the given filter criteria.
 
         Args:
@@ -598,9 +596,7 @@ class RestZenStore(BaseZenStore):
             filter_model=component_filter_model,
         )
 
-    def count_stack_components(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stack_components(self, workspace_id: Optional[UUID]) -> int:
         """Count all components, optionally within a workspace scope.
 
         Args:
@@ -1298,9 +1294,7 @@ class RestZenStore(BaseZenStore):
             filter_model=pipeline_filter_model,
         )
 
-    def count_pipelines(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_pipelines(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipelines, optionally within a workspace scope.
 
         Args:
@@ -1640,9 +1634,7 @@ class RestZenStore(BaseZenStore):
             filter_model=runs_filter_model,
         )
 
-    def count_runs(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_runs(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipeline runs, optionally within a workspace scope.
 
         Args:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -47,11 +47,9 @@ from sqlalchemy.exc import (
     OperationalError,
 )
 from sqlalchemy.orm import noload
-from sqlalchemy.sql.functions import count
 from sqlmodel import Session, create_engine, or_, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
 
-from zenml.cli import workspace
 from zenml.config.global_config import GlobalConfiguration
 from zenml.config.secrets_store_config import SecretsStoreConfiguration
 from zenml.config.store_config import StoreConfiguration
@@ -1103,9 +1101,7 @@ class SqlZenStore(BaseZenStore):
                 filter_model=stack_filter_model,
             )
 
-    def count_stacks(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stacks(self, workspace_id: Optional[UUID]) -> int:
         """Count all stacks, optionally within a workspace scope.
 
         Args:
@@ -1119,9 +1115,9 @@ class SqlZenStore(BaseZenStore):
             if workspace_id:
                 query = query.filter(StackSchema.workspace_id == workspace_id)
 
-            count = query.scalar()
+            stack_count = query.scalar()
 
-        return count
+        return stack_count
 
     @track(AnalyticsEvent.UPDATED_STACK, v2=True)
     def update_stack(
@@ -1431,9 +1427,7 @@ class SqlZenStore(BaseZenStore):
             )
             return paged_components
 
-    def count_stack_components(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stack_components(self, workspace_id: Optional[UUID]) -> int:
         """Count all components, optionally within a workspace scope.
 
         Args:
@@ -1449,9 +1443,9 @@ class SqlZenStore(BaseZenStore):
                     StackComponentSchema.workspace_id == workspace_id
                 )
 
-            count = query.scalar()
+            component_count = query.scalar()
 
-        return count
+        return component_count
 
     @track(AnalyticsEvent.UPDATED_STACK_COMPONENT)
     def update_stack_component(
@@ -2871,9 +2865,7 @@ class SqlZenStore(BaseZenStore):
                 filter_model=pipeline_filter_model,
             )
 
-    def count_pipelines(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_pipelines(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipelines, optionally within a workspace scope.
 
         Args:
@@ -2889,9 +2881,9 @@ class SqlZenStore(BaseZenStore):
                     PipelineSchema.workspace_id == workspace_id
                 )
 
-            count = query.scalar()
+            pipelines_count = query.scalar()
 
-        return count
+        return pipelines_count
 
     @track(AnalyticsEvent.UPDATE_PIPELINE)
     def update_pipeline(
@@ -3446,9 +3438,7 @@ class SqlZenStore(BaseZenStore):
                 custom_schema_to_model_conversion=self._run_schema_to_model,
             )
 
-    def count_runs(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_runs(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipeline runs, optionally within a workspace scope.
 
         Args:
@@ -3464,9 +3454,9 @@ class SqlZenStore(BaseZenStore):
                     PipelineRunSchema.workspace_id == workspace_id
                 )
 
-            count = query.scalar()
+            runs_count = query.scalar()
 
-        return count
+        return runs_count
 
     def update_run(
         self, run_id: UUID, run_update: PipelineRunUpdateModel

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1117,7 +1117,7 @@ class SqlZenStore(BaseZenStore):
 
             stack_count = query.scalar()
 
-        return stack_count
+        return int(stack_count)
 
     @track(AnalyticsEvent.UPDATED_STACK, v2=True)
     def update_stack(
@@ -1445,7 +1445,7 @@ class SqlZenStore(BaseZenStore):
 
             component_count = query.scalar()
 
-        return component_count
+        return int(component_count)
 
     @track(AnalyticsEvent.UPDATED_STACK_COMPONENT)
     def update_stack_component(
@@ -2883,7 +2883,7 @@ class SqlZenStore(BaseZenStore):
 
             pipelines_count = query.scalar()
 
-        return pipelines_count
+        return int(pipelines_count)
 
     @track(AnalyticsEvent.UPDATE_PIPELINE)
     def update_pipeline(
@@ -3456,7 +3456,7 @@ class SqlZenStore(BaseZenStore):
 
             runs_count = query.scalar()
 
-        return runs_count
+        return int(runs_count)
 
     def update_run(
         self, run_id: UUID, run_update: PipelineRunUpdateModel

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -230,6 +230,19 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
+    def count_stacks(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """List all stacks matching the given filter criteria.
+
+        Args:
+            workspace_id: The workspace to use for counting stacks
+
+        Returns:
+            The number of stacks in the workspace.
+        """
+
+    @abstractmethod
     def update_stack(
         self, stack_id: UUID, stack_update: StackUpdateModel
     ) -> StackResponseModel:
@@ -290,6 +303,19 @@ class ZenStoreInterface(ABC):
 
         Returns:
             A list of all stack components matching the filter criteria.
+        """
+
+    @abstractmethod
+    def count_stack_components(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all components, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting components
+
+        Returns:
+            The number of components in the workspace.
         """
 
     @abstractmethod
@@ -892,6 +918,19 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
+    def count_pipelines(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all pipelines, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting pipelines
+
+        Returns:
+            The number of pipelines in the workspace.
+        """
+
+    @abstractmethod
     def update_pipeline(
         self,
         pipeline_id: UUID,
@@ -1186,6 +1225,19 @@ class ZenStoreInterface(ABC):
 
         Returns:
             A list of all pipeline runs matching the filter criteria.
+        """
+
+    @abstractmethod
+    def count_runs(
+        self, workspace_id: Optional[UUID]
+    ) -> int:
+        """Count all pipeline runs, optionally within a workspace scope.
+
+        Args:
+            workspace_id: The workspace to use for counting pipeline runs
+
+        Returns:
+            The number of pipeline runs in the workspace.
         """
 
     @abstractmethod

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -75,7 +75,6 @@ from zenml.models import (
     TeamRoleAssignmentRequestModel,
     TeamRoleAssignmentResponseModel,
     TeamUpdateModel,
-    UserAuthModel,
     UserFilterModel,
     UserRequestModel,
     UserResponseModel,
@@ -230,17 +229,6 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_stacks(self, workspace_id: Optional[UUID]) -> int:
-        """List all stacks matching the given filter criteria.
-
-        Args:
-            workspace_id: The workspace to use for counting stacks
-
-        Returns:
-            The number of stacks in the workspace.
-        """
-
-    @abstractmethod
     def update_stack(
         self, stack_id: UUID, stack_update: StackUpdateModel
     ) -> StackResponseModel:
@@ -301,17 +289,6 @@ class ZenStoreInterface(ABC):
 
         Returns:
             A list of all stack components matching the filter criteria.
-        """
-
-    @abstractmethod
-    def count_stack_components(self, workspace_id: Optional[UUID]) -> int:
-        """Count all components, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting components
-
-        Returns:
-            The number of components in the workspace.
         """
 
     @abstractmethod
@@ -471,19 +448,6 @@ class ZenStoreInterface(ABC):
 
         Raises:
             KeyError: If no user with the given name or ID exists.
-        """
-
-    @abstractmethod
-    def get_auth_user(
-        self, user_name_or_id: Union[str, UUID]
-    ) -> UserAuthModel:
-        """Gets the auth model to a specific user.
-
-        Args:
-            user_name_or_id: The name or ID of the user to get.
-
-        Returns:
-            The requested user, if it was found.
         """
 
     @abstractmethod
@@ -914,17 +878,6 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_pipelines(self, workspace_id: Optional[UUID]) -> int:
-        """Count all pipelines, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting pipelines
-
-        Returns:
-            The number of pipelines in the workspace.
-        """
-
-    @abstractmethod
     def update_pipeline(
         self,
         pipeline_id: UUID,
@@ -1219,17 +1172,6 @@ class ZenStoreInterface(ABC):
 
         Returns:
             A list of all pipeline runs matching the filter criteria.
-        """
-
-    @abstractmethod
-    def count_runs(self, workspace_id: Optional[UUID]) -> int:
-        """Count all pipeline runs, optionally within a workspace scope.
-
-        Args:
-            workspace_id: The workspace to use for counting pipeline runs
-
-        Returns:
-            The number of pipeline runs in the workspace.
         """
 
     @abstractmethod

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -230,9 +230,7 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_stacks(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stacks(self, workspace_id: Optional[UUID]) -> int:
         """List all stacks matching the given filter criteria.
 
         Args:
@@ -306,9 +304,7 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_stack_components(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_stack_components(self, workspace_id: Optional[UUID]) -> int:
         """Count all components, optionally within a workspace scope.
 
         Args:
@@ -918,9 +914,7 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_pipelines(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_pipelines(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipelines, optionally within a workspace scope.
 
         Args:
@@ -1228,9 +1222,7 @@ class ZenStoreInterface(ABC):
         """
 
     @abstractmethod
-    def count_runs(
-        self, workspace_id: Optional[UUID]
-    ) -> int:
+    def count_runs(self, workspace_id: Optional[UUID]) -> int:
         """Count all pipeline runs, optionally within a workspace scope.
 
         Args:

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -663,6 +663,17 @@ def test_delete_default_stack_component_fails():
         store.delete_stack_component(default_orchestrator.id)
 
 
+def test_count_stack_components():
+    """Tests that the count stack_component command returns the correct amount."""
+    client = Client()
+    store = client.zen_store
+    active_workspace = client.active_workspace
+    assert store.count_stack_components(workspace_id=active_workspace.id) ==\
+           store.list_stack_components(
+               ComponentFilterModel(scope_workspace=active_workspace.id)
+           ).total
+
+
 def test_list_stack_components_works_with_filters():
     pytest.skip("Not Implemented yet.")
     pass
@@ -1013,6 +1024,29 @@ def test_list_runs_is_ordered():
             pipelines[i].created <= pipelines[i + 1].created
             for i in range(len(pipelines) - 1)
         )
+
+
+def test_count_runs():
+    """Tests that the count runs command returns the correct amount."""
+    client = Client()
+    store = client.zen_store
+    active_workspace = client.active_workspace
+
+    num_runs = store.list_runs(
+               PipelineRunFilterModel(scope_workspace=active_workspace.id)
+           ).total
+
+    # At baseline this should be the same
+    assert store.count_runs(workspace_id=active_workspace.id) == num_runs
+
+    num_runs = 5
+    with PipelineRunContext(num_runs):
+        assert store.count_runs(workspace_id=active_workspace.id) == \
+               store.list_runs(
+                   PipelineRunFilterModel(scope_workspace=active_workspace.id)
+               ).total
+        assert store.count_runs(workspace_id=active_workspace.id) == \
+               num_runs + 5
 
 
 def test_filter_runs_by_code_repo(mocker):

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -668,10 +668,23 @@ def test_count_stack_components():
     client = Client()
     store = client.zen_store
     active_workspace = client.active_workspace
-    assert store.count_stack_components(workspace_id=active_workspace.id) ==\
-           store.list_stack_components(
-               ComponentFilterModel(scope_workspace=active_workspace.id)
-           ).total
+
+    count_before = store.list_stack_components(
+        ComponentFilterModel(scope_workspace=active_workspace.id)
+    ).total
+
+    assert (
+        store.count_stack_components(workspace_id=active_workspace.id)
+        == count_before
+    )
+
+    with ComponentContext(
+        StackComponentType.ARTIFACT_STORE, config={}, flavor="s3"
+    ):
+        assert (
+            store.count_stack_components(workspace_id=active_workspace.id)
+            == count_before + 1
+        )
 
 
 def test_list_stack_components_works_with_filters():
@@ -1033,20 +1046,23 @@ def test_count_runs():
     active_workspace = client.active_workspace
 
     num_runs = store.list_runs(
-               PipelineRunFilterModel(scope_workspace=active_workspace.id)
-           ).total
+        PipelineRunFilterModel(scope_workspace=active_workspace.id)
+    ).total
 
     # At baseline this should be the same
     assert store.count_runs(workspace_id=active_workspace.id) == num_runs
 
     num_runs = 5
     with PipelineRunContext(num_runs):
-        assert store.count_runs(workspace_id=active_workspace.id) == \
-               store.list_runs(
-                   PipelineRunFilterModel(scope_workspace=active_workspace.id)
-               ).total
-        assert store.count_runs(workspace_id=active_workspace.id) == \
-               num_runs + 5
+        assert (
+            store.count_runs(workspace_id=active_workspace.id)
+            == store.list_runs(
+                PipelineRunFilterModel(scope_workspace=active_workspace.id)
+            ).total
+        )
+        assert (
+            store.count_runs(workspace_id=active_workspace.id) == num_runs + 5
+        )
 
 
 def test_filter_runs_by_code_repo(mocker):

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -83,6 +83,7 @@ from zenml.zen_stores.base_zen_store import (
     DEFAULT_USERNAME,
     DEFAULT_WORKSPACE_NAME,
 )
+from zenml.zen_stores.sql_zen_store import SqlZenStore
 
 DEFAULT_NAME = "default"
 
@@ -667,6 +668,8 @@ def test_count_stack_components():
     """Tests that the count stack_component command returns the correct amount."""
     client = Client()
     store = client.zen_store
+    if not isinstance(store, SqlZenStore):
+        pytest.skip("Test only applies to SQL store")
     active_workspace = client.active_workspace
 
     count_before = store.list_stack_components(
@@ -685,16 +688,6 @@ def test_count_stack_components():
             store.count_stack_components(workspace_id=active_workspace.id)
             == count_before + 1
         )
-
-
-def test_list_stack_components_works_with_filters():
-    pytest.skip("Not Implemented yet.")
-    pass
-
-
-def test_list_stack_components_lists_nothing_for_nonexistent_filters():
-    pytest.skip("Not Implemented yet.")
-    pass
 
 
 # .-------------------------.
@@ -1043,6 +1036,8 @@ def test_count_runs():
     """Tests that the count runs command returns the correct amount."""
     client = Client()
     store = client.zen_store
+    if not isinstance(store, SqlZenStore):
+        pytest.skip("Test only applies to SQL store")
     active_workspace = client.active_workspace
 
     num_runs = store.list_runs(

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -1052,8 +1052,7 @@ def test_count_runs():
     # At baseline this should be the same
     assert store.count_runs(workspace_id=active_workspace.id) == num_runs
 
-    num_runs = 5
-    with PipelineRunContext(num_runs):
+    with PipelineRunContext(5):
         assert (
             store.count_runs(workspace_id=active_workspace.id)
             == store.list_runs(


### PR DESCRIPTION
## Describe changes
I implemented a count method for the sql_zen_store for stacks, components, pipelines and runs to make the call to `.../workspaces/<iD>/statistics` more performant.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

