### PR TITLE
Fix Python 3.10 PyYAML Installation Issues

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -78,7 +78,7 @@ runs:
         rm integration-requirements.txt
 
     - name: Install langchain and llama_index integrations
-      if: steps.cache-virtualenv.outputs.cache-hit != 'true' && inputs.install_integrations == 'yes' && inputs.python-version != '3.7'
+      if: steps.cache-virtualenv.outputs.cache-hit != 'true' && inputs.install_integrations == 'yes'
       shell: bash
       run: |
         zenml integration install -y langchain llama_index

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: ./.github/workflows/setup-python-environment.yml
     with:
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: ./.github/workflows/setup-python-environment.yml
     with:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: ./.github/workflows/lint-unit-test.yml
     with:
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
       fail-fast: false
     uses: ./.github/workflows/lint-unit-test.yml
     with:
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         test_environment:
           [
             "default",
@@ -107,8 +107,6 @@ jobs:
           ]
         exclude:
           # docker is time-consuming to run, so we only run it on 3.8
-          - test_environment: docker-server-docker-orchestrator
-            python-version: "3.7"
           - test_environment: docker-server-docker-orchestrator
             python-version: "3.9"
           - test_environment: docker-server-docker-orchestrator
@@ -128,7 +126,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         test_environment: ["default"]
 
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -177,6 +177,10 @@ jobs:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}
 
+      - name: Install docker-compose for non-default environments
+        if: inputs.test_environment != 'default'
+        run: pip install docker-compose
+
       - name: Install Linux System Dependencies
         if: runner.os=='Linux'
         run: sudo apt install graphviz

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,6 @@ on:
         description: 'Python version'
         type: choice
         options:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/.github/workflows/lint-unit-test.yml
+++ b/.github/workflows/lint-unit-test.yml
@@ -32,7 +32,6 @@ on:
         description: 'Python version'
         type: choice
         options:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pyparsing = "<3,>=2.4.0"
 python = ">=3.7.1,<3.11"
 python-dateutil = "^2.8.1"
 python-terraform = { version = "^0.10.1" }
-pyyaml = ">5.4.1"
+pyyaml = ">=6.0.1"
 rich = {extras = ["jupyter"], version = "^12.0.0"}
 sqlalchemy_utils = "0.38.3"
 sqlmodel = "~0.0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ connectors-kubernetes = ["kubernetes"]
 connectors-aws = ["boto3", "kubernetes"]
 connectors-gcp = ["google-cloud-container", "google-cloud-storage", "kubernetes"]
 connectors-azure = ["azure-identity", "azure-mgmt-containerservice", "azure-mgmt-containerregistry", "azure-mgmt-storage", "azure-storage-blob", "kubernetes"]
-dev = ["black", "ruff", "coverage", "pytest", "mypy", "pre-commit", "pyment", "tox", "hypothesis", "typing-extensions", "darglint", "pytest-randomly", "pytest-mock", "pytest-clarity", "mkdocs", "mkdocs-material", "mkdocs-awesome-pages-plugin", "mkdocstrings", "mike", "types-certifi", "types-croniter", "types-futures", "types-Markdown", "types-Pillow", "types-protobuf", "types-PyMySQL", "types-python-dateutil", "types-python-slugify", "types-PyYAML", "types-redis", "types-requests", "types-setuptools", "types-six", "types-termcolor", "types-psutil", "docker-compose"]
+dev = ["black", "ruff", "coverage", "pytest", "mypy", "pre-commit", "pyment", "tox", "hypothesis", "typing-extensions", "darglint", "pytest-randomly", "pytest-mock", "pytest-clarity", "mkdocs", "mkdocs-material", "mkdocs-awesome-pages-plugin", "mkdocstrings", "mike", "types-certifi", "types-croniter", "types-futures", "types-Markdown", "types-Pillow", "types-protobuf", "types-PyMySQL", "types-python-dateutil", "types-python-slugify", "types-PyYAML", "types-redis", "types-requests", "types-setuptools", "types-six", "types-termcolor", "types-psutil"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pyparsing = "<3,>=2.4.0"
 python = ">=3.7.1,<3.11"
 python-dateutil = "^2.8.1"
 python-terraform = { version = "^0.10.1" }
-pyyaml = "^5.4.1"
+pyyaml = ">5.4.1"
 rich = {extras = ["jupyter"], version = "^12.0.0"}
 sqlalchemy_utils = "0.38.3"
 sqlmodel = "~0.0.8"
@@ -160,8 +160,6 @@ types-setuptools = { version = "^57.4.2", optional = true }
 types-six = { version = "^1.16.2", optional = true }
 types-termcolor = { version = "^1.1.2", optional = true }
 types-psutil = { version = "^5.8.13", optional = true }
-# test framework dependencies
-docker-compose = { version = "^1.28", optional = true }
 
 [tool.poetry.extras]
 server = ["fastapi", "uvicorn", "python-multipart", "python-jose", "fastapi-utils", "orjson"]

--- a/src/zenml/integrations/evidently/__init__.py
+++ b/src/zenml/integrations/evidently/__init__.py
@@ -36,7 +36,7 @@ class EvidentlyIntegration(Integration):
     """[Evidently](https://github.com/evidentlyai/evidently) integration for ZenML."""
 
     NAME = EVIDENTLY
-    REQUIREMENTS = ["evidently==0.2.2"]
+    REQUIREMENTS = ["evidently>0.2.6,<=0.2.8"]  # supports old API and pyyaml 6
 
     @staticmethod
     def activate() -> None:

--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -43,20 +43,16 @@ class GcpIntegration(Integration):
 
     NAME = GCP
     REQUIREMENTS = [
-        "kfp==1.8.16",
+        "kfp==1.8.22",  # Only 1.x version that supports pyyaml 6
         "gcsfs",
         "google-cloud-secret-manager",
         "google-cloud-container>=2.21.0",
         "google-cloud-storage>=2.9.0",
-        "google-cloud-aiplatform>=1.11.0",
+        "google-cloud-aiplatform>=1.21.0",  # includes shapely pin fix
         "google-cloud-scheduler>=2.7.3",
         "google-cloud-functions>=1.8.3",
         "google-cloud-build>=3.11.0",
         "kubernetes",
-        # google-cloud-bigquery 2.34.4 is not compatible with shapely 2.0.0
-        # which was released on 2021-12-21. This is a temporary fix until
-        # google-cloud-bigquery is updated.
-        "shapely<2.0",
     ]
 
     @staticmethod

--- a/src/zenml/integrations/kubeflow/__init__.py
+++ b/src/zenml/integrations/kubeflow/__init__.py
@@ -30,7 +30,7 @@ class KubeflowIntegration(Integration):
     """Definition of Kubeflow Integration for ZenML."""
 
     NAME = KUBEFLOW
-    REQUIREMENTS = ["kfp==1.8.16"]
+    REQUIREMENTS = ["kfp==1.8.22"]  # Only 1.x version that supports pyyaml 6
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/tekton/__init__.py
+++ b/src/zenml/integrations/tekton/__init__.py
@@ -31,7 +31,7 @@ class TektonIntegration(Integration):
     """Definition of Tekton Integration for ZenML."""
 
     NAME = TEKTON
-    REQUIREMENTS = ["kfp-tekton==1.4.1"]
+    REQUIREMENTS = ["kfp-tekton==1.7.1"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:


### PR DESCRIPTION
## Background
- PyYAML 5 no longer works with the new Cython 3, resulting in broken ZenML installations under Python 3.10 https://github.com/yaml/pyyaml/issues/601
- PyYAML is apparently not going to release a fix for this: https://github.com/yaml/pyyaml/pull/726

## Describe changes
- Bumped `pyyaml` to `>=6.0.1`
- Bumped `evidently` version to `[0.2.7-0.2.8]` which are the only versions that support both the old Evidently API which our integration code is using as well as PyYAML 6.
- Pinned `kfp` to `1.8.22` which is the only `1.x` version that supports PyYAML 6.
- Pinned `kfk-tekton` to `1.7.1` which is the only version compatible with `kfp==1.8.22`
- Removed `docker-compose` as dev dependency since all available versions require PyYAML 5.  As a workaround, I adjusted the corresponding CI action to lazy-install the package instead.
- Removed Python 3.7 CI checks since the new Tekton version is no longer compatible with Python 3.7 -> let's also merge #1652 before the next release

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

