### PR TITLE
Set `MLflow` configuration as environment variables before deployment subprocess

### DIFF
--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-
+MLFLOW_TRACKING_URI = "MLFLOW_TRACKING_URI"
 MLFLOW_TRACKING_USERNAME = "MLFLOW_TRACKING_USERNAME"
 MLFLOW_TRACKING_PASSWORD = "MLFLOW_TRACKING_PASSWORD"
 MLFLOW_TRACKING_TOKEN = "MLFLOW_TRACKING_TOKEN"
@@ -280,6 +280,7 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
             if self.config.tracking_token:
                 os.environ[DATABRICKS_TOKEN] = self.config.tracking_token
         else:
+            os.environ[MLFLOW_TRACKING_URI] = tracking_uri
             if self.config.tracking_username:
                 os.environ[
                     MLFLOW_TRACKING_USERNAME

--- a/src/zenml/integrations/mlflow/services/mlflow_deployment.py
+++ b/src/zenml/integrations/mlflow/services/mlflow_deployment.py
@@ -23,6 +23,9 @@ from mlflow.version import VERSION as MLFLOW_VERSION
 
 from zenml.client import Client
 from zenml.constants import DEFAULT_SERVICE_START_STOP_TIMEOUT
+from zenml.integrations.mlflow.experiment_trackers.mlflow_experiment_tracker import (
+    MLFlowExperimentTracker,
+)
 from zenml.logger import get_logger
 from zenml.services import (
     HTTPEndpointHealthMonitor,
@@ -199,6 +202,12 @@ class MLFlowDeploymentService(LocalDaemonService, BaseDeploymentService):
                 **backend_kwargs,
             )
             experiment_tracker = Client().active_stack.experiment_tracker
+            if not isinstance(experiment_tracker, MLFlowExperimentTracker):
+                raise ValueError(
+                    "MLflow model deployer step requires an MLflow experiment "
+                    "tracker. Please add an MLflow experiment tracker to your "
+                    "stack."
+                )
             experiment_tracker.configure_mlflow()
             backend.serve(
                 model_uri=self.config.model_uri,

--- a/src/zenml/integrations/mlflow/services/mlflow_deployment.py
+++ b/src/zenml/integrations/mlflow/services/mlflow_deployment.py
@@ -21,6 +21,7 @@ import requests
 from mlflow.pyfunc.backend import PyFuncBackend
 from mlflow.version import VERSION as MLFLOW_VERSION
 
+from zenml.client import Client
 from zenml.constants import DEFAULT_SERVICE_START_STOP_TIMEOUT
 from zenml.logger import get_logger
 from zenml.services import (
@@ -197,6 +198,8 @@ class MLFlowDeploymentService(LocalDaemonService, BaseDeploymentService):
                 install_mlflow=False,
                 **backend_kwargs,
             )
+            experiment_tracker = Client().active_stack.experiment_tracker
+            experiment_tracker.configure_mlflow()
             backend.serve(
                 model_uri=self.config.model_uri,
                 port=self.endpoint.status.port,


### PR DESCRIPTION
## Describe changes
Calling the `configure_mlflow`function before the MLflow backend serves to pass the tracking URL, username, and password to the running subprocess. 

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

