### PR TITLE
Fix Migration Guide Links

### DIFF
--- a/docs/book/reference/migration-guide/migration-zero-forty.md
+++ b/docs/book/reference/migration-guide/migration-zero-forty.md
@@ -135,7 +135,7 @@ def my_pipeline():
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/configure-steps-pipelines.md#parameters-for-your-steps) for more information on how to parameterize your steps.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md#parameters-for-your-steps) for more information on how to parameterize your steps.
 
 ## Calling a step outside of a pipeline
 
@@ -316,7 +316,7 @@ my_pipeline()
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/schedule-pipeline-runs.md) for more information on how to schedule your pipelines.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/schedule-pipeline-runs.md) for more information on how to schedule your pipelines.
 
 ## Fetching pipelines after execution
 
@@ -353,7 +353,7 @@ loaded_model = model.load()
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/fetch-metadata-within-steps.md) for more information on how to programmatically fetch information about previous pipeline runs.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/fetch-metadata-within-steps.md) for more information on how to programmatically fetch information about previous pipeline runs.
 
 ## Controlling the step execution order
 
@@ -385,7 +385,7 @@ def my_pipeline():
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/configure-steps-pipelines.md#control-the-execution-order) for more information on how to control the step execution order.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md#control-the-execution-order) for more information on how to control the step execution order.
 
 ## Defining steps with multiple outputs
 
@@ -424,7 +424,7 @@ def my_step() -> Tuple[
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/configure-steps-pipelines.md#type-annotations) for more information on how to annotate your step outputs.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md#type-annotations) for more information on how to annotate your step outputs.
 
 ## Accessing run information inside steps
 
@@ -457,6 +457,6 @@ def my_step() -> Any:  # New: StepContext is no longer an argument of the step
 {% endtab %}
 {% endtabs %}
 
-Check out [this page](../../user-guide/migration-guide/fetch-metadata-within-steps.md) for more information on how to fetch run information inside your steps using `get_step_context()`.
+Check out [this page](../../user-guide/advanced-guide/pipelining-features/fetch-metadata-within-steps.md) for more information on how to fetch run information inside your steps using `get_step_context()`.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>


### PR DESCRIPTION
## Describe changes
Fixed links from migration guide to advanced guide which got broken between #1691 and #1698 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

