### PR TITLE
Rename `transition_model_stage` to `transition_model_version_stage`

### DIFF
--- a/src/zenml/integrations/mlflow/model_registries/mlflow_model_registry.py
+++ b/src/zenml/integrations/mlflow/model_registries/mlflow_model_registry.py
@@ -509,7 +509,7 @@ class MLFlowModelRegistry(BaseModelRegistry):
         # Update the model stage.
         if stage:
             try:
-                self.mlflow_client.transition_model_stage(
+                self.mlflow_client.transition_model_version_stage(
                     name=name,
                     version=version,
                     stage=stage.value,


### PR DESCRIPTION
## Describe changes
I fixed the typo in the MlFlow client method name.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

