### PR TITLE
Allow specifying extra hosts for LocalDockerOrchestrator

### DIFF
--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -164,8 +164,11 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                 user = os.getuid()
             logger.info("Running step `%s` in Docker:", step_name)
 
-            run_environment = settings.run_args.pop("environment", {})
-            run_environment.update(environment)
+            docker_environment = settings.run_args.pop("environment", {})
+            docker_environment.update(environment)
+
+            docker_volumes = settings.run_args.pop("volumes", {})
+            docker_volumes.update(volumes)
 
             extra_hosts = settings.run_args.pop("extra_hosts", {})
             extra_hosts["host.docker.internal"] = "host-gateway"
@@ -176,8 +179,8 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                     entrypoint=entrypoint,
                     command=arguments,
                     user=user,
-                    volumes=volumes,
-                    environment=run_environment,
+                    volumes=docker_volumes,
+                    environment=docker_environment,
                     stream=True,
                     extra_hosts=extra_hosts,
                     **settings.run_args,

--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Implementation of the ZenML local Docker orchestrator."""
 
+import copy
 import json
 import os
 import sys
@@ -164,13 +165,14 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                 user = os.getuid()
             logger.info("Running step `%s` in Docker:", step_name)
 
-            docker_environment = settings.run_args.pop("environment", {})
+            run_args = copy.deepcopy(settings.run_args)
+            docker_environment = run_args.pop("environment", {})
             docker_environment.update(environment)
 
-            docker_volumes = settings.run_args.pop("volumes", {})
+            docker_volumes = run_args.pop("volumes", {})
             docker_volumes.update(volumes)
 
-            extra_hosts = settings.run_args.pop("extra_hosts", {})
+            extra_hosts = run_args.pop("extra_hosts", {})
             extra_hosts["host.docker.internal"] = "host-gateway"
 
             try:
@@ -183,7 +185,7 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                     environment=docker_environment,
                     stream=True,
                     extra_hosts=extra_hosts,
-                    **settings.run_args,
+                    **run_args,
                 )
 
                 for line in logs:

--- a/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
+++ b/src/zenml/orchestrators/local_docker/local_docker_orchestrator.py
@@ -164,6 +164,12 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                 user = os.getuid()
             logger.info("Running step `%s` in Docker:", step_name)
 
+            run_environment = settings.run_args.pop("environment", {})
+            run_environment.update(environment)
+
+            extra_hosts = settings.run_args.pop("extra_hosts", {})
+            extra_hosts["host.docker.internal"] = "host-gateway"
+
             try:
                 logs = docker_client.containers.run(
                     image=image,
@@ -171,9 +177,9 @@ class LocalDockerOrchestrator(ContainerizedOrchestrator):
                     command=arguments,
                     user=user,
                     volumes=volumes,
-                    environment=environment,
+                    environment=run_environment,
                     stream=True,
-                    extra_hosts={"host.docker.internal": "host-gateway"},
+                    extra_hosts=extra_hosts,
                     **settings.run_args,
                 )
 


### PR DESCRIPTION
## Describe changes
The `LocalDockerOrchestrator` failed when users tried to specify volumes, environment variables or extra hosts as these were reserved by ZenML. This PR fixes this by merging these dictionaries.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

