### PR TITLE
Flexible use of `ignore_cols` in `evidently_report_step`

### DIFF
--- a/src/zenml/integrations/evidently/steps/evidently_report.py
+++ b/src/zenml/integrations/evidently/steps/evidently_report.py
@@ -55,10 +55,6 @@ def evidently_report_step(
         download_nltk_data: whether to download the NLTK data for the report
             step. Defaults to False.
 
-    Raises:
-        ValueError: If column is not found in reference or comparison
-            dataset
-
     Returns:
         A tuple containing the Evidently report in JSON and HTML
         formats.
@@ -74,7 +70,7 @@ def evidently_report_step(
     if ignored_cols:
         exception_msg = (
             "Columns {extra_cols} configured in the `ignored_cols` "
-            "parameter are not found in the {dataset} dataset."
+            "parameter are not found in the {dataset} dataset. "
         )
         extra_cols = set(ignored_cols) - set(reference_dataset.columns)
         if extra_cols:

--- a/src/zenml/integrations/evidently/steps/evidently_report.py
+++ b/src/zenml/integrations/evidently/steps/evidently_report.py
@@ -54,7 +54,7 @@ def evidently_report_step(
             step. Defaults to False.
         suppress_missing_ignored_cols_error: If columns listed in `ignored_cols` are not
             found in one of the datasets, a `ValueError` is raised if this flag is set
-            to `False`, otherwise it is supressed.
+            to `False`, otherwise it is suppressed.
 
     Raises:
         ValueError: If column is not found in reference or comparison

--- a/src/zenml/integrations/evidently/steps/evidently_report.py
+++ b/src/zenml/integrations/evidently/steps/evidently_report.py
@@ -52,7 +52,7 @@ def evidently_report_step(
         download_nltk_data: whether to download the NLTK data for the report
             step. Defaults to False.
         suppress_missing_ignored_cols_error: If columns listed in `ignored_cols` are not
-            found in one of datasets `ValueError` is raised if this flag is set
+            found in one of the datasets, a `ValueError` is raised if this flag is set
             to `False`, otherwise it is supressed.
 
     Raises:

--- a/src/zenml/integrations/evidently/steps/evidently_report.py
+++ b/src/zenml/integrations/evidently/steps/evidently_report.py
@@ -12,6 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """Implementation of the Evidently Report Step."""
+
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
 import pandas as pd
@@ -81,7 +82,9 @@ def evidently_report_step(
         extra_cols = set(ignored_cols) - set(reference_dataset.columns)
         if extra_cols and not suppress_missing_ignored_cols_error:
             raise ValueError(
-                exception_msg.format(extra_cols=extra_cols, dataset="reference")
+                exception_msg.format(
+                    extra_cols=extra_cols, dataset="reference"
+                )
             )
         reference_dataset = reference_dataset.drop(
             labels=list(set(ignored_cols) - extra_cols), axis=1
@@ -91,7 +94,9 @@ def evidently_report_step(
             extra_cols = set(ignored_cols) - set(comparison_dataset.columns)
             if extra_cols and not suppress_missing_ignored_cols_error:
                 raise ValueError(
-                    exception_msg.format(extra_cols=extra_cols, dataset="comparison")
+                    exception_msg.format(
+                        extra_cols=extra_cols, dataset="comparison"
+                    )
                 )
 
             comparison_dataset = comparison_dataset.drop(


### PR DESCRIPTION
## Describe changes
I implemented `suppress_missing_ignored_cols_error` param in `evidently_report_step` to achieve flexibility while using this step on unequal datasets and avoid the use of wrapper steps. This param is defaulted to `False`, so the behavior is unchanged until the user explicitly raises the flag.
I checked the docs and this change is not affecting it, since `ignore_cols` is not looked at in depth there. Should it be extended then?

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

