### PR TITLE
Add Error Handling for Empty Pipelines

### DIFF
--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -151,9 +151,7 @@ class Compiler:
         pipeline = copy.deepcopy(pipeline)
 
         invocations = [
-            self._get_step_spec(
-                invocation=invocation,
-            )
+            self._get_step_spec(invocation=invocation)
             for _, invocation in self._get_sorted_invocations(
                 pipeline=pipeline
             )
@@ -552,8 +550,20 @@ class Compiler:
 
         Returns:
             The pipeline spec.
+
+        Raises:
+            ValueError: If the pipeline has no steps.
         """
         from zenml.pipelines import BasePipeline
+
+        if not step_specs:
+            raise ValueError(
+                f"Pipeline '{pipeline.name}' cannot be compiled because it has "
+                f"no steps. Please make sure that your steps are decorated "
+                "with `@step` and that at least one step is called within the "
+                "pipeline. For more information, see "
+                "https://docs.zenml.io/user-guide/starter-guide."
+            )
 
         additional_spec_args: Dict[str, Any] = {}
         if isinstance(pipeline, BasePipeline):


### PR DESCRIPTION
## Describe changes

If a pipeline does not contain any steps, we no longer register the pipeline and raise a compile-time error like so:

```
ValueError: Pipeline 'empty_pipeline' cannot be compiled because it has no steps. Please make sure that your steps are decorated with `@step` and that
at least one step is called within the pipeline. For more information, see https://docs.zenml.io/user-guide/starter-guide.
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

