### PR TITLE
Add Error Handling for Empty Pipelines

### DIFF
--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -151,9 +151,7 @@ class Compiler:
         pipeline = copy.deepcopy(pipeline)
 
         invocations = [
-            self._get_step_spec(
-                invocation=invocation,
-            )
+            self._get_step_spec(invocation=invocation)
             for _, invocation in self._get_sorted_invocations(
                 pipeline=pipeline
             )
@@ -552,8 +550,20 @@ class Compiler:
 
         Returns:
             The pipeline spec.
+
+        Raises:
+            ValueError: If the pipeline has no steps.
         """
         from zenml.pipelines import BasePipeline
+
+        if not step_specs:
+            raise ValueError(
+                f"Pipeline '{pipeline.name}' cannot be compiled because it has "
+                f"no steps. Please make sure that your steps are decorated "
+                "with `@step` and that at least one step is called within the "
+                "pipeline. For more information, see "
+                "https://docs.zenml.io/user-guide/starter-guide."
+            )
 
         additional_spec_args: Dict[str, Any] = {}
         if isinstance(pipeline, BasePipeline):

--- a/tests/unit/config/test_compiler.py
+++ b/tests/unit/config/test_compiler.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 import pytest
 
+from tests.unit.conftest_new import empty_pipeline  # noqa: F401
 from zenml.config import ResourceSettings
 from zenml.config.base_settings import BaseSettings
 from zenml.config.compiler import Compiler
@@ -26,10 +27,10 @@ from zenml.steps import step
 
 
 def test_compiling_pipeline_with_invalid_run_name_fails(
-    empty_pipeline, local_stack
+    empty_pipeline, local_stack  # noqa: F811
 ):
     """Tests that compiling a pipeline with an invalid run name fails."""
-    pipeline_instance = empty_pipeline()
+    pipeline_instance = empty_pipeline
     with pipeline_instance:
         pipeline_instance.entrypoint()
     with pytest.raises(ValueError):
@@ -39,6 +40,24 @@ def test_compiling_pipeline_with_invalid_run_name_fails(
             run_configuration=PipelineRunConfiguration(
                 run_name="{invalid_placeholder}"
             ),
+        )
+
+
+@pipeline
+def _no_step_pipeline():
+    pass
+
+
+def test_compiling_pipeline_without_steps_fails(local_stack):
+    """Tests that compiling a pipeline without steps fails."""
+    pipeline_instance = _no_step_pipeline()
+    with pipeline_instance:
+        pipeline_instance.entrypoint()
+    with pytest.raises(ValueError):
+        Compiler().compile(
+            pipeline=pipeline_instance,
+            stack=local_stack,
+            run_configuration=PipelineRunConfiguration(),
         )
 
 
@@ -100,7 +119,9 @@ def test_pipeline_and_steps_dont_get_modified_during_compilation(
     assert pipeline_instance.enable_cache is True
 
 
-def test_compiling_pipeline_with_invalid_run_configuration(empty_pipeline):
+def test_compiling_pipeline_with_invalid_run_configuration(
+    empty_pipeline,  # noqa: F811
+):
     """Tests that compiling with a run configuration containing invalid steps
     fails."""
     run_config = PipelineRunConfiguration(
@@ -110,7 +131,7 @@ def test_compiling_pipeline_with_invalid_run_configuration(empty_pipeline):
     )
     with pytest.raises(KeyError):
         Compiler()._apply_run_configuration(
-            pipeline=empty_pipeline(), config=run_config
+            pipeline=empty_pipeline, config=run_config
         )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -252,17 +252,6 @@ def generate_empty_steps():
 
 
 @pytest.fixture
-def empty_pipeline():
-    """Pytest fixture that returns an empty pipeline."""
-
-    @pipeline
-    def _pipeline():
-        pass
-
-    return _pipeline
-
-
-@pytest.fixture
 def one_step_pipeline():
     """Pytest fixture that returns a pipeline which takes a single step named `step_`."""
 

--- a/tests/unit/conftest_new.py
+++ b/tests/unit/conftest_new.py
@@ -1,0 +1,19 @@
+import pytest
+
+from zenml import pipeline, step
+from zenml.new.pipelines.pipeline import Pipeline
+
+
+@step
+def empty_step() -> None:
+    return None
+
+
+@pipeline
+def _empty_pipeline() -> None:
+    empty_step()
+
+
+@pytest.fixture
+def empty_pipeline() -> Pipeline:
+    return _empty_pipeline.copy()

--- a/tests/unit/pipelines/test_build_utils.py
+++ b/tests/unit/pipelines/test_build_utils.py
@@ -21,6 +21,7 @@ from uuid import UUID, uuid4
 import pytest
 
 import zenml
+from tests.unit.conftest_new import empty_pipeline  # noqa
 from zenml.code_repositories import BaseCodeRepository, LocalRepositoryContext
 from zenml.config import DockerSettings
 from zenml.config.build_configuration import BuildConfiguration
@@ -143,7 +144,9 @@ def test_stack_with_container_registry_creates_non_local_build(
     assert build.is_local is False
 
 
-def test_build_uses_correct_settings(clean_client, mocker, empty_pipeline):
+def test_build_uses_correct_settings(
+    clean_client, mocker, empty_pipeline  # noqa: F811
+):
     """Tests that the build settings and pipeline ID get correctly forwarded."""
     build_config = BuildConfiguration(
         key="key",
@@ -167,7 +170,7 @@ def test_build_uses_correct_settings(clean_client, mocker, empty_pipeline):
         step_configurations={},
     )
 
-    pipeline_instance = empty_pipeline()
+    pipeline_instance = empty_pipeline
     pipeline_id = pipeline_instance.register().id
     build = build_utils.create_pipeline_build(
         deployment=deployment, pipeline_id=pipeline_id

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 
+from tests.unit.conftest_new import empty_pipeline  # noqa
 from zenml.config import DockerSettings
 from zenml.config.build_configuration import BuildConfiguration
 from zenml.config.compiler import Compiler
@@ -151,7 +152,7 @@ def test_stack_prepare_pipeline_deployment(
 
 
 def test_stack_deployment(
-    stack_with_mock_components, one_step_pipeline, empty_step
+    stack_with_mock_components, empty_pipeline  # noqa: F811
 ):
     """Tests that when a pipeline is deployed on a stack, the stack calls the
     orchestrator to run the pipeline and calls cleanup methods on all of its
@@ -164,9 +165,10 @@ def test_stack_deployment(
         pipeline_run_return_value
     )
 
-    pipeline = one_step_pipeline(empty_step())
+    with empty_pipeline:
+        empty_pipeline.entrypoint()
     deployment = Compiler().compile(
-        pipeline=pipeline,
+        pipeline=empty_pipeline,
         stack=stack_with_mock_components,
         run_configuration=PipelineRunConfiguration(),
     )


### PR DESCRIPTION
## Describe changes

If a pipeline does not contain any steps, we no longer register the pipeline and raise a compile-time error like so:

```
ValueError: Pipeline 'empty_pipeline' cannot be compiled because it has no steps. Please make sure that your steps are decorated with `@step` and that
at least one step is called within the pipeline. For more information, see https://docs.zenml.io/user-guide/starter-guide.
```

(Accidentally clicked merged on previous PR #1734 before tests were adjusted, so I reverted the previous PR in #1735)

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

