### PR TITLE
Changing the links to the public roadmap

### DIFF
--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -28,7 +28,7 @@ framework. Go here if you are a visual learner, and follow along with some tutor
 ### Public roadmap
 
 The feedback from our community plays a significant role in the development of ZenML. That's why we have
-a [public roadmap](https://zenml.hellonext.co/roadmap) that serves as a bridge between our users and our development
+a [public roadmap](https://zenml.io/roadmap) that serves as a bridge between our users and our development
 team. If you have ideas regarding any new features or want to prioritize one over the other, feel free to share your
 thoughts here or vote on existing ideas.
 

--- a/docs/book/user-guide/advanced-guide/pipelining-features/hyper-parameter-tuning.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/hyper-parameter-tuning.md
@@ -6,7 +6,7 @@ description: Running a hyperparameter tuning trial with ZenML.
 
 {% hint style="warning" %}
 Hyperparameter tuning is not yet a first-class citizen in ZenML, but it is 
-[(high up) on our roadmap of features](https://zenml.hellonext.co/p/enable-hyper-parameter-tuning) 
+[(high up) on our roadmap of features](https://zenml.featureos.app/p/enable-hyper-parameter-tuning) 
 and will likely receive first-class ZenML support soon. In the meanwhile, the
 following example shows how hyperparameter tuning can currently be implemented
 within a ZenML run.


### PR DESCRIPTION
## Describe changes
Fixed the links to the public roadmap in the docs.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

