### PR TITLE
fix error on scheduled pipelines with KubernetesOrchestrator

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -248,11 +248,11 @@ def build_cron_job_manifest(
     job_spec = k8s_client.V1beta1CronJobSpec(
         schedule=cron_expression,
         job_template=k8s_client.V1beta1JobTemplateSpec(
-            metadata=pod_manifest["metadata"],
+            metadata=pod_manifest.metadata,
             spec=k8s_client.V1JobSpec(
                 template=k8s_client.V1PodTemplateSpec(
-                    metadata=pod_manifest["metadata"],
-                    spec=pod_manifest["spec"],
+                    metadata=pod_manifest.metadata,
+                    spec=pod_manifest.spec,
                 ),
             ),
         ),
@@ -261,7 +261,7 @@ def build_cron_job_manifest(
     job_manifest = k8s_client.V1beta1CronJob(
         kind="CronJob",
         api_version="batch/v1beta1",
-        metadata=pod_manifest["metadata"],
+        metadata=pod_manifest.metadata,
         spec=job_spec,
     )
 


### PR DESCRIPTION
## Describe changes
I fixed the build of K8s `CronJob` spec when specifying a cronjob expression (scheduled pipeline), that used to raise `TypeError: 'V1Pod' object is not subscriptable` when using the `KubernetesOrchestrator`

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [X] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

