### PR TITLE
Upgrade typing extensions within api docs build workflow

### DIFF
--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -68,7 +68,7 @@ zenml integration install -y kserve
 zenml integration install -y --ignore-integration feast --ignore-integration label_studio --ignore-integration kserve --ignore-integration airflow --ignore-integration bentoml
 pip install -e ".[server,dev,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs]"
 pip install jinja2==3.0.3 protobuf==3.20.0 numpy~=1.21.5
-
+pip install typing-extensions --upgrade
 
 ################################# Initialize DB and delete unnecessary alembic files ###################################
 


### PR DESCRIPTION
## Describe changes
I added the upgrade of typing extensions to the slew of installs at the beginning of the api docs build workflow to fix a failure in the typing of feast with v4.5.0

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/component-gallery/integrations) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

