### PR TITLE
Relax dependency on `rich` and `uvicorn`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ sqlmodel = "~0.0.8"
 
 # Optional dependencies for the ZenServer
 fastapi = { version = ">=0.75,<0.100", optional = true }
-uvicorn = { extras = ["standard"], version = "~0.17.5",  optional = true}
+uvicorn = { extras = ["standard"], version = ">=0.17.5",  optional = true}
 python-multipart = { version = "~0.0.5", optional = true}
 python-jose = { extras = ["cryptography"], version = "~3.3.0", optional = true}
 fastapi-utils = { version = "~0.2.1", optional = true}


### PR DESCRIPTION
## Describe changes
I changed the dependency on `rich` to allow for version 13. This should not break anything (famous last words!) but is needed in order to test more recent versions of Evidently

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

