### PR TITLE
Always open local dashboard after `zenml up`

### DIFF
--- a/src/zenml/api.py
+++ b/src/zenml/api.py
@@ -25,19 +25,20 @@ from zenml.logger import get_logger
 logger = get_logger(__name__)
 
 
-def show(ngrok_token: Optional[str] = None) -> None:
+def show(ngrok_token: Optional[str] = None, local: bool = False) -> None:
     """Show the ZenML dashboard.
 
     Args:
         ngrok_token: An ngrok auth token to use for exposing the ZenML dashboard
             on a public domain. Primarily used for accessing the dashboard in
             Colab.
+        local: If set to True, only show the local dashboard.
     """
     from zenml.utils.dashboard_utils import show_dashboard
     from zenml.utils.networking_utils import get_or_create_ngrok_tunnel
     from zenml.zen_server.utils import get_active_server_details
 
-    url, port = get_active_server_details()
+    url, port = get_active_server_details(local=local)
 
     if ngrok_token and port:
         ngrok_url = get_or_create_ngrok_tunnel(

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -222,7 +222,7 @@ def up(
                 f"'{server.status.url}'. You can connect to it using the "
                 f"'{DEFAULT_USERNAME}' username and an empty password. "
             )
-            zenml.show(ngrok_token=ngrok_token)
+            zenml.show(ngrok_token=ngrok_token, local=True)
 
 
 @click.option(


### PR DESCRIPTION
## Describe changes
When running `zenml up` while connected to a remote server, the dashboard of the remote server was previously opened instead of the local dashboard, similar to running `zenml show`. I adjusted the logic of `zenml up` to always make it open the local dashboard.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

