### PR TITLE
Copy step instance before applying configuration

### DIFF
--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -14,6 +14,7 @@
 
 """Class to run steps."""
 
+import copy
 import inspect
 from contextlib import nullcontext
 from typing import (
@@ -256,6 +257,7 @@ class StepRunner:
         from zenml.steps import BaseStep
 
         step_instance = BaseStep.load_from_source(self._step.spec.source)
+        step_instance = copy.deepcopy(step_instance)
         step_instance._configuration = self._step.config
         return step_instance
 


### PR DESCRIPTION
## Describe changes
When executing a step, we
- import the step file
- fetch the step instance
- apply the configuration to the instance
- run the underlying step function

When running tests in `pytest` which reuse the same step in different pipelines and test cases, the config could spill over and lead to crashes or unexpected behaviour. This PR fixes it by copying the step instance before applying the configuration.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

