### PR TITLE
Use the container registry credentials to build images with the local image builder

### DIFF
--- a/src/zenml/image_builders/local_image_builder.py
+++ b/src/zenml/image_builders/local_image_builder.py
@@ -101,7 +101,12 @@ class LocalImageBuilder(BaseImageBuilder):
         """
         self._check_prerequisites()
 
-        docker_client = DockerClient.from_env()
+        if container_registry:
+            # Use the container registry's docker client, which may be
+            # authenticated to access additional registries
+            docker_client = container_registry.docker_client
+        else:
+            docker_client = DockerClient.from_env()
 
         with tempfile.TemporaryFile(mode="w+b") as f:
             build_context.write_archive(f)


### PR DESCRIPTION
## Describe changes
When a custom base image is used to build container images for containerized orchestrators, the base image can also be a private container image coming from the same container registry where the resulting image is pushed. In this case, linking the container registry to a service connector doesn’t authenticate the Docker client in the image building phase, so authentication errors will occur.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

