### PR TITLE
Add support for empty API token in Kubernetes service connector.

### DIFF
--- a/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
@@ -38,6 +38,8 @@ Two authentication methods are supported:
 1. username and password. This is not recommended for production purposes.
 2. authentication token with or without client certificates.
 
+For Kubernetes clusters that don't use neither username and password nor authentication tokens, such as local K3D clusters, the authentication token method can be used with an empty token. 
+
 {% hint style="warning" %}
 This Service Connector does not support generating short-lived credentials from the credentials configured in the Service Connector. In effect, this means that the configured credentials will be distributed directly to clients and used to authenticate to the target Kubernetes API. It is recommended therefore to use API tokens accompanied by client certificates if possible.
 {% endhint %}

--- a/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
@@ -38,7 +38,7 @@ Two authentication methods are supported:
 1. username and password. This is not recommended for production purposes.
 2. authentication token with or without client certificates.
 
-For Kubernetes clusters that don't use neither username and password nor authentication tokens, such as local K3D clusters, the authentication token method can be used with an empty token. 
+For Kubernetes clusters that use neither username and password nor authentication tokens, such as local K3D clusters, the authentication token method can be used with an empty token. 
 
 {% hint style="warning" %}
 This Service Connector does not support generating short-lived credentials from the credentials configured in the Service Connector. In effect, this means that the configured credentials will be distributed directly to clients and used to authenticate to the target Kubernetes API. It is recommended therefore to use API tokens accompanied by client certificates if possible.


### PR DESCRIPTION
## Describe changes
The K3D kubectl configuration has no API token and no username/password set, only client certificates.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

