### PR TITLE
Fix: ZenML DB migrations don't run if zenml is installed in path with spaces

### DIFF
--- a/src/zenml/zen_stores/migrations/alembic.py
+++ b/src/zenml/zen_stores/migrations/alembic.py
@@ -100,9 +100,6 @@ class Alembic:
         self.config.set_main_option(
             "script_location", str(Path(__file__).parent)
         )
-        self.config.set_main_option(
-            "version_locations", str(Path(__file__).parent / "versions")
-        )
 
         self.script_directory = ScriptDirectory.from_config(self.config)
         if context is None:


### PR DESCRIPTION
## Describe changes
ZenML DB migrations don't run if zenml is installed in path with spaces. This PR fixes it by removing the `version_locations` setting from the Alembic configuration.

More context: if set, the `version_locations` setting is by default interpreted as a space-separated list of locations where migration scripts are located. The following is an excerpt from the alembic code:

```python
        version_locations_str = config.get_main_option("version_locations")
        version_locations: Optional[List[str]]
        if version_locations_str:
            version_path_separator = config.get_main_option(
                "version_path_separator"
            )

            split_on_path = {
                None: None,
                "space": " ",
                "os": os.pathsep,
                ":": ":",
                ";": ";",
            }

...
                    version_locations = [
                        x for x in version_locations_str.split(split_char) if x
                    ]
```

However, if the configuration setting isn't specified, it defaults to `versions` just like it should:

```python
    @util.memoized_property
    def _version_locations(self):
        if self.version_locations:
            return [
                os.path.abspath(util.coerce_resource_to_filename(location))
                for location in self.version_locations
            ]
        else:
            return (os.path.abspath(os.path.join(self.dir, "versions")),)
```


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

