### PR TITLE
[Model WatchTower] Reduce exposure of Links logic

### DIFF
--- a/src/zenml/zen_server/routers/models_endpoints.py
+++ b/src/zenml/zen_server/routers/models_endpoints.py
@@ -287,35 +287,6 @@ def list_model_version_artifact_links(
     )
 
 
-@router.delete(
-    "/{model_name_or_id}"
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + ARTIFACTS
-    + "/{model_version_artifact_link_name_or_id}",
-    responses={401: error_response, 404: error_response, 422: error_response},
-)
-@handle_exceptions
-def delete_model_version_artifact_link(
-    model_name_or_id: Union[str, UUID],
-    model_version_name_or_id: Union[str, UUID],
-    model_version_artifact_link_name_or_id: Union[str, UUID],
-    _: AuthContext = Security(authorize, scopes=[PermissionType.WRITE]),
-) -> None:
-    """Deletes a model version link.
-
-    Args:
-        model_name_or_id: name or ID of the model containing the model version.
-        model_version_name_or_id: name or ID of the model version containing the link.
-        model_version_artifact_link_name_or_id: name or ID of the model version to artifact link to be deleted.
-    """
-    zen_store().delete_model_version_artifact_link(
-        model_name_or_id,
-        model_version_name_or_id,
-        model_version_artifact_link_name_or_id,
-    )
-
-
 ##############################
 # Model Version Pipeline Runs
 ##############################
@@ -347,33 +318,4 @@ def list_model_version_pipeline_run_links(
     """
     return zen_store().list_model_version_pipeline_run_links(
         model_version_pipeline_run_link_filter_model=model_version_pipeline_run_link_filter_model,
-    )
-
-
-@router.delete(
-    "/{model_name_or_id}"
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + RUNS
-    + "/{model_version_pipeline_run_link_name_or_id}",
-    responses={401: error_response, 404: error_response, 422: error_response},
-)
-@handle_exceptions
-def delete_model_version_pipeline_run_link(
-    model_name_or_id: Union[str, UUID],
-    model_version_name_or_id: Union[str, UUID],
-    model_version_pipeline_run_link_name_or_id: Union[str, UUID],
-    _: AuthContext = Security(authorize, scopes=[PermissionType.WRITE]),
-) -> None:
-    """Deletes a model version link.
-
-    Args:
-        model_name_or_id: name or ID of the model containing the model version.
-        model_version_name_or_id: name or ID of the model version containing the link.
-        model_version_pipeline_run_link_name_or_id: name or ID of the model version link to be deleted.
-    """
-    zen_store().delete_model_version_pipeline_run_link(
-        model_name_or_id,
-        model_version_name_or_id,
-        model_version_pipeline_run_link_name_or_id,
     )

--- a/src/zenml/zen_server/routers/workspaces_endpoints.py
+++ b/src/zenml/zen_server/routers/workspaces_endpoints.py
@@ -54,11 +54,9 @@ from zenml.models import (
     ModelRequestModel,
     ModelResponseModel,
     ModelVersionArtifactFilterModel,
-    ModelVersionArtifactRequestModel,
     ModelVersionArtifactResponseModel,
     ModelVersionFilterModel,
     ModelVersionPipelineRunFilterModel,
-    ModelVersionPipelineRunRequestModel,
     ModelVersionPipelineRunResponseModel,
     ModelVersionRequestModel,
     ModelVersionResponseModel,
@@ -1315,63 +1313,6 @@ def list_workspace_model_versions(
     )
 
 
-@router.post(
-    WORKSPACES
-    + "/{workspace_name_or_id}"
-    + MODELS
-    + "/{model_name_or_id}"
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + ARTIFACTS,
-    response_model=ModelVersionArtifactResponseModel,
-    responses={401: error_response, 409: error_response, 422: error_response},
-)
-@handle_exceptions
-def create_model_version_artifact_link(
-    workspace_name_or_id: Union[str, UUID],
-    model_name_or_id: Union[str, UUID],
-    model_version_name_or_id: Union[str, UUID],
-    model_version_artifact_link: ModelVersionArtifactRequestModel,
-    auth_context: AuthContext = Security(
-        authorize, scopes=[PermissionType.WRITE]
-    ),
-) -> ModelVersionArtifactResponseModel:
-    """Create a new model version to artifact link.
-
-    Args:
-        model_name_or_id: Name or ID of the model.
-        workspace_name_or_id: Name or ID of the workspace.
-        model_version_name_or_id: Name or ID of the model version.
-        model_version_artifact_link: The model version to artifact link to create.
-        auth_context: Authentication context.
-
-    Returns:
-        The created model version to artifact link.
-
-    Raises:
-        IllegalOperationError: If the workspace or user specified in the
-            model version does not match the current workspace or authenticated
-            user.
-    """
-    workspace = zen_store().get_workspace(workspace_name_or_id)
-
-    if model_version_artifact_link.workspace != workspace.id:
-        raise IllegalOperationError(
-            "Creating model version to artifact links outside of the workspace scope "
-            f"of this endpoint `{workspace_name_or_id}` is "
-            f"not supported."
-        )
-    if model_version_artifact_link.user != auth_context.user.id:
-        raise IllegalOperationError(
-            "Creating model to artifact links for a user other than yourself "
-            "is not supported."
-        )
-    mv = zen_store().create_model_version_artifact_link(
-        model_version_artifact_link
-    )
-    return mv
-
-
 @router.get(
     WORKSPACES
     + "/{workspace_name_or_id}"
@@ -1408,63 +1349,6 @@ def list_workspace_model_version_artifact_links(
     return zen_store().list_model_version_artifact_links(
         model_version_artifact_link_filter_model=model_version_artifact_link_filter_model,
     )
-
-
-@router.post(
-    WORKSPACES
-    + "/{workspace_name_or_id}"
-    + MODELS
-    + "/{model_name_or_id}"
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + RUNS,
-    response_model=ModelVersionPipelineRunResponseModel,
-    responses={401: error_response, 409: error_response, 422: error_response},
-)
-@handle_exceptions
-def create_model_version_pipeline_run_link(
-    workspace_name_or_id: Union[str, UUID],
-    model_name_or_id: Union[str, UUID],
-    model_version_name_or_id: Union[str, UUID],
-    model_version_pipeline_run_link: ModelVersionPipelineRunRequestModel,
-    auth_context: AuthContext = Security(
-        authorize, scopes=[PermissionType.WRITE]
-    ),
-) -> ModelVersionPipelineRunResponseModel:
-    """Create a new model version to pipeline run link.
-
-    Args:
-        model_name_or_id: Name or ID of the model.
-        workspace_name_or_id: Name or ID of the workspace.
-        model_version_name_or_id: Name or ID of the model version.
-        model_version_pipeline_run_link: The model version to pipeline run link to create.
-        auth_context: Authentication context.
-
-    Returns:
-        The created model version to pipeline run link.
-
-    Raises:
-        IllegalOperationError: If the workspace or user specified in the
-            model version does not match the current workspace or authenticated
-            user.
-    """
-    workspace = zen_store().get_workspace(workspace_name_or_id)
-
-    if model_version_pipeline_run_link.workspace != workspace.id:
-        raise IllegalOperationError(
-            "Creating model versions outside of the workspace scope "
-            f"of this endpoint `{workspace_name_or_id}` is "
-            f"not supported."
-        )
-    if model_version_pipeline_run_link.user != auth_context.user.id:
-        raise IllegalOperationError(
-            "Creating models for a user other than yourself "
-            "is not supported."
-        )
-    mv = zen_store().create_model_version_pipeline_run_link(
-        model_version_pipeline_run_link
-    )
-    return mv
 
 
 @router.get(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -101,11 +101,9 @@ from zenml.models import (
     ModelResponseModel,
     ModelUpdateModel,
     ModelVersionArtifactFilterModel,
-    ModelVersionArtifactRequestModel,
     ModelVersionArtifactResponseModel,
     ModelVersionFilterModel,
     ModelVersionPipelineRunFilterModel,
-    ModelVersionPipelineRunRequestModel,
     ModelVersionPipelineRunResponseModel,
     ModelVersionRequestModel,
     ModelVersionResponseModel,
@@ -2478,23 +2476,6 @@ class RestZenStore(BaseZenStore):
     # Model Versions Artifacts
     ###########################
 
-    def create_model_version_artifact_link(
-        self, model_version_artifact_link: ModelVersionArtifactRequestModel
-    ) -> ModelVersionArtifactResponseModel:
-        """Creates a new model version link.
-
-        Args:
-            model_version_artifact_link: the Model Version to Artifact Link to be created.
-
-        Returns:
-            The newly created model version to artifact link.
-        """
-        return self._create_workspace_scoped_resource(
-            resource=model_version_artifact_link,
-            response_model=ModelVersionArtifactResponseModel,
-            route=f"{MODELS}/{model_version_artifact_link.model}{MODEL_VERSIONS}/{model_version_artifact_link.model_version}{ARTIFACTS}",
-        )
-
     def list_model_version_artifact_links(
         self,
         model_version_artifact_link_filter_model: ModelVersionArtifactFilterModel,
@@ -2514,45 +2495,9 @@ class RestZenStore(BaseZenStore):
             filter_model=model_version_artifact_link_filter_model,
         )
 
-    def delete_model_version_artifact_link(
-        self,
-        model_name_or_id: Union[str, UUID],
-        model_version_name_or_id: Union[str, UUID],
-        model_version_artifact_link_name_or_id: Union[str, UUID],
-    ) -> None:
-        """Deletes a model version to artifact link.
-
-        Args:
-            model_name_or_id: name or ID of the model containing the model version.
-            model_version_name_or_id: name or ID of the model version containing the link.
-            model_version_artifact_link_name_or_id: name or ID of the model version to artifact link to be deleted.
-        """
-        self._delete_resource(
-            resource_id=model_version_artifact_link_name_or_id,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}/{model_version_name_or_id}{ARTIFACTS}",
-        )
-
     ###############################
     # Model Versions Pipeline Runs
     ###############################
-
-    def create_model_version_pipeline_run_link(
-        self,
-        model_version_pipeline_run_link: ModelVersionPipelineRunRequestModel,
-    ) -> ModelVersionPipelineRunResponseModel:
-        """Creates a new model version to pipeline run link.
-
-        Args:
-            model_version_pipeline_run_link: the Model Version to Pipeline Run Link to be created.
-
-        Returns:
-            The newly created model version to pipeline run link.
-        """
-        return self._create_workspace_scoped_resource(
-            resource=model_version_pipeline_run_link,
-            response_model=ModelVersionPipelineRunResponseModel,
-            route=f"{MODELS}/{model_version_pipeline_run_link.model}{MODEL_VERSIONS}/{model_version_pipeline_run_link.model_version}{RUNS}",
-        )
 
     def list_model_version_pipeline_run_links(
         self,
@@ -2571,24 +2516,6 @@ class RestZenStore(BaseZenStore):
             route=f"{MODELS}/{model_version_pipeline_run_link_filter_model.model_id}{MODEL_VERSIONS}/{model_version_pipeline_run_link_filter_model.model_version_id}{RUNS}",
             response_model=ModelVersionPipelineRunResponseModel,
             filter_model=model_version_pipeline_run_link_filter_model,
-        )
-
-    def delete_model_version_pipeline_run_link(
-        self,
-        model_name_or_id: Union[str, UUID],
-        model_version_name_or_id: Union[str, UUID],
-        model_version_pipeline_run_link_name_or_id: Union[str, UUID],
-    ) -> None:
-        """Deletes a model version to pipeline run link.
-
-        Args:
-            model_name_or_id: name or ID of the model containing the model version.
-            model_version_name_or_id: name or ID of the model version containing the link.
-            model_version_pipeline_run_link_name_or_id: name or ID of the model version to pipeline run link to be deleted.
-        """
-        self._delete_resource(
-            resource_id=model_version_pipeline_run_link_name_or_id,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}/{model_version_name_or_id}{RUNS}",
         )
 
     # =======================

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -37,11 +37,9 @@ from zenml.models import (
     ModelResponseModel,
     ModelUpdateModel,
     ModelVersionArtifactFilterModel,
-    ModelVersionArtifactRequestModel,
     ModelVersionArtifactResponseModel,
     ModelVersionFilterModel,
     ModelVersionPipelineRunFilterModel,
-    ModelVersionPipelineRunRequestModel,
     ModelVersionPipelineRunResponseModel,
     ModelVersionRequestModel,
     ModelVersionResponseModel,
@@ -1849,22 +1847,6 @@ class ZenStoreInterface(ABC):
     ###########################
 
     @abstractmethod
-    def create_model_version_artifact_link(
-        self, model_version_artifact_link: ModelVersionArtifactRequestModel
-    ) -> ModelVersionArtifactResponseModel:
-        """Creates a new model version link.
-
-        Args:
-            model_version_artifact_link: the Model Version to Artifact Link to be created.
-
-        Returns:
-            The newly created model version to artifact link.
-
-        Raises:
-            EntityExistsError: If a link with the given name already exists.
-        """
-
-    @abstractmethod
     def list_model_version_artifact_links(
         self,
         model_version_artifact_link_filter_model: ModelVersionArtifactFilterModel,
@@ -1879,44 +1861,9 @@ class ZenStoreInterface(ABC):
             A page of all model version to artifact links.
         """
 
-    @abstractmethod
-    def delete_model_version_artifact_link(
-        self,
-        model_name_or_id: Union[str, UUID],
-        model_version_name_or_id: Union[str, UUID],
-        model_version_artifact_link_name_or_id: Union[str, UUID],
-    ) -> None:
-        """Deletes a model version to artifact link.
-
-        Args:
-            model_name_or_id: name or ID of the model containing the model version.
-            model_version_name_or_id: name or ID of the model version containing the link.
-            model_version_artifact_link_name_or_id: name or ID of the model version to artifact link to be deleted.
-
-        Raises:
-            KeyError: specified ID or name not found.
-        """
-
     ###############################
     # Model Versions Pipeline Runs
     ###############################
-
-    @abstractmethod
-    def create_model_version_pipeline_run_link(
-        self,
-        model_version_pipeline_run_link: ModelVersionPipelineRunRequestModel,
-    ) -> ModelVersionPipelineRunResponseModel:
-        """Creates a new model version to pipeline run link.
-
-        Args:
-            model_version_pipeline_run_link: the Model Version to Pipeline Run Link to be created.
-
-        Returns:
-            The newly created model version to pipeline run link.
-
-        Raises:
-            EntityExistsError: If a link with the given ID already exists.
-        """
 
     @abstractmethod
     def list_model_version_pipeline_run_links(
@@ -1931,22 +1878,4 @@ class ZenStoreInterface(ABC):
 
         Returns:
             A page of all model version to pipeline run links.
-        """
-
-    @abstractmethod
-    def delete_model_version_pipeline_run_link(
-        self,
-        model_name_or_id: Union[str, UUID],
-        model_version_name_or_id: Union[str, UUID],
-        model_version_pipeline_run_link_name_or_id: Union[str, UUID],
-    ) -> None:
-        """Deletes a model version to pipeline run link.
-
-        Args:
-            model_name_or_id: name or ID of the model containing the model version.
-            model_version_name_or_id: name or ID of the model version containing the link.
-            model_version_pipeline_run_link_name_or_id: name or ID of the model version to pipeline run link to be deleted.
-
-        Raises:
-            KeyError: specified ID not found.
         """

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -2714,11 +2714,13 @@ class TestModelVersion:
 
 class TestModelVersionArtifactLinks:
     def test_link_create_pass(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_artifacts=1) as (
             model_version,
             artifacts,
         ):
-            zs = Client().zen_store
             zs.create_model_version_artifact_link(
                 ModelVersionArtifactRequestModel(
                     user=model_version.user.id,
@@ -2731,11 +2733,13 @@ class TestModelVersionArtifactLinks:
             )
 
     def test_link_create_duplicated(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_artifacts=1) as (
             model_version,
             artifacts,
         ):
-            zs = Client().zen_store
             zs.create_model_version_artifact_link(
                 ModelVersionArtifactRequestModel(
                     user=model_version.user.id,
@@ -2772,11 +2776,13 @@ class TestModelVersionArtifactLinks:
                 )
 
     def test_link_delete_found(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_artifacts=1) as (
             model_version,
             artifacts,
         ):
-            zs = Client().zen_store
             zs.create_model_version_artifact_link(
                 ModelVersionArtifactRequestModel(
                     user=model_version.user.id,
@@ -2801,8 +2807,10 @@ class TestModelVersionArtifactLinks:
             assert len(mvls) == 0
 
     def test_link_delete_not_found(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True) as model_version:
-            zs = Client().zen_store
             with pytest.raises(KeyError):
                 zs.delete_model_version_artifact_link(
                     model_name_or_id=model_version.model.id,
@@ -2822,11 +2830,13 @@ class TestModelVersionArtifactLinks:
             assert len(mvls) == 0
 
     def test_link_list_populated(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_artifacts=3) as (
             model_version,
             artifacts,
         ):
-            zs = Client().zen_store
             mvls = zs.list_model_version_artifact_links(
                 ModelVersionArtifactFilterModel(
                     model_id=model_version.model.id,
@@ -2919,11 +2929,13 @@ class TestModelVersionArtifactLinks:
 
 class TestModelVersionPipelineRunLinks:
     def test_link_create_pass(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_prs=1) as (
             model_version,
             prs,
         ):
-            zs = Client().zen_store
             zs.create_model_version_pipeline_run_link(
                 ModelVersionPipelineRunRequestModel(
                     user=model_version.user.id,
@@ -2936,11 +2948,13 @@ class TestModelVersionPipelineRunLinks:
             )
 
     def test_link_create_duplicated(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_prs=1) as (
             model_version,
             prs,
         ):
-            zs = Client().zen_store
             zs.create_model_version_pipeline_run_link(
                 ModelVersionPipelineRunRequestModel(
                     user=model_version.user.id,
@@ -2977,11 +2991,13 @@ class TestModelVersionPipelineRunLinks:
                 )
 
     def test_link_delete_found(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_prs=1) as (
             model_version,
             prs,
         ):
-            zs = Client().zen_store
             zs.create_model_version_pipeline_run_link(
                 ModelVersionPipelineRunRequestModel(
                     user=model_version.user.id,
@@ -3004,8 +3020,10 @@ class TestModelVersionPipelineRunLinks:
             assert len(mvls) == 0
 
     def test_link_delete_not_found(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True) as model_version:
-            zs = Client().zen_store
             with pytest.raises(KeyError):
                 zs.delete_model_version_pipeline_run_link(
                     model_version.model.id, model_version.id, "link"
@@ -3023,11 +3041,13 @@ class TestModelVersionPipelineRunLinks:
             assert len(mvls) == 0
 
     def test_link_list_populated(self):
+        zs = Client().zen_store
+        if not isinstance(zs, SqlZenStore):
+            pytest.skip("Test only applies to SQL store")
         with ModelVersionContext(True, create_prs=2) as (
             model_version,
             prs,
         ):
-            zs = Client().zen_store
             mvls = zs.list_model_version_pipeline_run_links(
                 ModelVersionPipelineRunFilterModel(
                     model_id=model_version.model.id,


### PR DESCRIPTION
## Describe changes
I kept only the List functionality public for links. Creates and deletes will go only via SQL Store.
I kept one test running on the Rest Store - query empty list. Not sure, if I can somehow populate the list by switching to SQL for that purpose. If this is doable - guidance is appreciated.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

