### PR TITLE
Fix mlflow 'run_name' variable overwriting

### DIFF
--- a/src/zenml/integrations/mlflow/steps/mlflow_registry.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_registry.py
@@ -90,7 +90,7 @@ def mlflow_register_model_step(
     # get pipeline name, step name and run id
     step_context = get_step_context()
     pipeline_name = step_context.pipeline.name
-    run_name = step_context.pipeline_run.name
+    current_run_name = step_context.pipeline_run.name
     pipeline_run_uuid = str(step_context.pipeline_run.id)
     zenml_workspace = str(model_registry.workspace)
 
@@ -98,7 +98,7 @@ def mlflow_register_model_step(
     # pipeline name and run name
     mlflow_run_id = run_id or experiment_tracker.get_run_id(
         experiment_name=experiment_name or pipeline_name,
-        run_name=run_name or run_name,
+        run_name=run_name or current_run_name,
     )
     # If no value was set at all, raise an error
     if not mlflow_run_id:


### PR DESCRIPTION
## Describe changes
In the model registry Mlflow implementation, in the function mlflow_register_model_step, the args provided run_name is written over instead of being used.
Rename run_name to current_run_name and change to 
```
    mlflow_run_id = run_id or experiment_tracker.get_run_id(
        experiment_name=experiment_name or pipeline_name,
        run_name=run_name or current_run_name,
    )
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

