### PR TITLE
Handle irregular plural of `code_repository` for error message

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -5053,7 +5053,11 @@ class Client(metaclass=ClientMetaClass):
         if entity.total == 1:
             return entity.items[0]
 
-        entity_label = get_method.__name__.replace("get_", "") + "s"
+        irregular_plurals = {"code_repository": "code_repositories"}
+        entity_label = irregular_plurals.get(
+            get_method.__name__.replace("get_", ""),
+            get_method.__name__.replace("get_", "") + "s",
+        )
 
         prefix_description = (
             "a name/ID prefix" if allow_name_prefix_match else "an ID prefix"


### PR DESCRIPTION
Tiny fix. Uses `code_repositories` for error message now instead of `code_repositorys`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

