### PR TITLE
Update Neptune dependency: `neptune-client` > `neptune`

### DIFF
--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -264,15 +264,6 @@ def install(
     ):
         with console.status("Installing integrations..."):
             install_packages(requirements)
-            if "label_studio" in integrations:
-                warning(
-                    "There is a known issue with Label Studio installations "
-                    "via zenml. You might find that the Label Studio "
-                    "installation breaks the ZenML CLI. In this case, "
-                    "please run `pip install 'pydantic<1.11,>=1.9.0'` to "
-                    "fix the issue or message us on Slack if you need help "
-                    "with this. We are working on a more definitive fix."
-                )
 
 
 @integration.command(
@@ -397,12 +388,3 @@ def upgrade(
     ):
         with console.status("Upgrading integrations..."):
             install_packages(requirements, upgrade=True)
-            if "label_studio" in integrations:
-                warning(
-                    "There is a known issue with Label Studio installations "
-                    "via zenml. You might find that the Label Studio "
-                    "installation breaks the ZenML CLI. In this case, please "
-                    "run `pip install 'pydantic<1.11,>=1.9.0'` to fix the "
-                    "issue or message us on Slack if you need help with this. "
-                    "We are working on a more definitive fix."
-                )

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -897,6 +897,13 @@ def install_packages(
         packages: List of packages to install.
         upgrade: Whether to upgrade the packages if they are already installed.
     """
+    if "neptune" in packages:
+        declare(
+            "Uninstalling legacy `neptune-client` package to avoid version "
+            "conflicts with new `neptune` package..."
+        )
+        uninstall_package("neptune-client")
+
     if upgrade:
         command = [
             sys.executable,
@@ -915,6 +922,16 @@ def install_packages(
         ]
 
     subprocess.check_call(command)
+
+    if "label-studio" in packages:
+        warning(
+            "There is a known issue with Label Studio installations "
+            "via zenml. You might find that the Label Studio "
+            "installation breaks the ZenML CLI. In this case, please "
+            "run `pip install 'pydantic<1.11,>=1.9.0'` to fix the "
+            "issue or message us on Slack if you need help with this. "
+            "We are working on a more definitive fix."
+        )
 
 
 def uninstall_package(package: str) -> None:

--- a/src/zenml/integrations/neptune/__init__.py
+++ b/src/zenml/integrations/neptune/__init__.py
@@ -29,9 +29,7 @@ class NeptuneIntegration(Integration):
     """Definition of the neptune.ai integration with ZenML."""
 
     NAME = NEPTUNE
-    REQUIREMENTS = [
-        "neptune-client>=0.16.10",
-    ]
+    REQUIREMENTS = ["neptune"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/neptune/experiment_trackers/run_state.py
+++ b/src/zenml/integrations/neptune/experiment_trackers/run_state.py
@@ -16,7 +16,7 @@
 from hashlib import md5
 from typing import TYPE_CHECKING, Any, List, Optional
 
-import neptune
+import neptune  # type: ignore[import]
 
 import zenml
 from zenml.client import Client

--- a/src/zenml/integrations/neptune/experiment_trackers/run_state.py
+++ b/src/zenml/integrations/neptune/experiment_trackers/run_state.py
@@ -14,22 +14,17 @@
 """Contains objects that create a Neptune run and store its state throughout the pipeline."""
 
 from hashlib import md5
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
-try:
-    # neptune-client>=1.0.0 package structure
-    import neptune
-    from neptune import Run
-except ImportError:
-    # neptune-client=0.9.0+ package structure
-    import neptune.new as neptune  # type: ignore
-    from neptune.new.metadata_containers import Run  # type: ignore
-
+import neptune
 
 import zenml
 from zenml.client import Client
 from zenml.integrations.constants import NEPTUNE
 from zenml.utils.singleton import SingletonMetaClass
+
+if TYPE_CHECKING:
+    from neptune import Run
 
 _INTEGRATION_VERSION_KEY = "source_code/integrations/zenml"
 
@@ -122,7 +117,7 @@ class RunProvider(metaclass=SingletonMetaClass):
         self._tags = tags
 
     @property
-    def active_run(self) -> Run:
+    def active_run(self) -> "Run":
         """Initializes a new neptune run every time it is called.
 
         The run is closed and the active run state is set to stopped
@@ -147,7 +142,7 @@ class RunProvider(metaclass=SingletonMetaClass):
         self._active_run = None
 
 
-def get_neptune_run() -> Run:
+def get_neptune_run() -> "Run":
     """Helper function to fetch an existing Neptune run or create a new one.
 
     Returns:

--- a/tests/unit/integrations/label_studio/label_config_generators/test_label_config_generators.py
+++ b/tests/unit/integrations/label_studio/label_config_generators/test_label_config_generators.py
@@ -26,8 +26,17 @@ from zenml.integrations.label_studio.label_config_generators import (
     generate_text_classification_label_config,
 )
 
+HYPOTHESIS_MAX_TEXT_SIZE = 20
+HYPOTHESIS_MAX_LIST_SIZE = 20
 
-@given(label_list=lists(text(min_size=1), min_size=1))
+
+@given(
+    label_list=lists(
+        text(min_size=1, max_size=HYPOTHESIS_MAX_TEXT_SIZE),
+        min_size=1,
+        max_size=HYPOTHESIS_MAX_LIST_SIZE,
+    )
+)
 def test_text_classification_label_config_generator(label_list: List[str]):
     (
         label_config,
@@ -39,7 +48,13 @@ def test_text_classification_label_config_generator(label_list: List[str]):
     assert label_config is not None
 
 
-@given(label_list=lists(text(min_size=1), min_size=1))
+@given(
+    label_list=lists(
+        text(min_size=1, max_size=HYPOTHESIS_MAX_TEXT_SIZE),
+        min_size=1,
+        max_size=HYPOTHESIS_MAX_LIST_SIZE,
+    )
+)
 def test_image_classification_label_config_generator(label_list: List[str]):
     (
         label_config,
@@ -51,7 +66,13 @@ def test_image_classification_label_config_generator(label_list: List[str]):
     assert label_config is not None
 
 
-@given(label_list=lists(text(min_size=1), min_size=1))
+@given(
+    label_list=lists(
+        text(min_size=1, max_size=HYPOTHESIS_MAX_TEXT_SIZE),
+        min_size=1,
+        max_size=HYPOTHESIS_MAX_LIST_SIZE,
+    )
+)
 def test_object_detection_label_config_generator(label_list: List[str]):
     (
         label_config,
@@ -63,7 +84,13 @@ def test_object_detection_label_config_generator(label_list: List[str]):
     assert label_config is not None
 
 
-@given(label_list=lists(text(min_size=1), min_size=1))
+@given(
+    label_list=lists(
+        text(min_size=1, max_size=HYPOTHESIS_MAX_TEXT_SIZE),
+        min_size=1,
+        max_size=HYPOTHESIS_MAX_LIST_SIZE,
+    )
+)
 def test_ocr_label_config_generator(label_list: List[str]):
     (label_config, label_config_type) = generate_basic_ocr_label_config(
         label_list


### PR DESCRIPTION
## Describe changes
The `neptune-client` Python package is deprecated in favor of `neptune`. I adjusted our Neptune integration to depend on the new package. Upon doing `zenml integration install neptune`, we also uninstall `neptune-client` first to prevent version conflicts.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

