### PR TITLE
Fix MLflow registry methods with empty metadata

### DIFF
--- a/examples/e2e/.copier-answers.yml
+++ b/examples/e2e/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0.43.0
+_commit: '2023-09-28'
 _src_path: gh:zenml-io/template-e2e-batch
 data_quality_checks: true
 email: ''

--- a/examples/e2e/steps/inference/inference_get_current_version.py
+++ b/examples/e2e/steps/inference/inference_get_current_version.py
@@ -40,7 +40,6 @@ def inference_get_current_version() -> Annotated[str, "model_version"]:
 
     current_version = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
-        metadata={},
         stage=MetaConfig.target_env,
     )[0].version
     logger.info(

--- a/examples/e2e/steps/inference/inference_get_current_version.py
+++ b/examples/e2e/steps/inference/inference_get_current_version.py
@@ -40,6 +40,7 @@ def inference_get_current_version() -> Annotated[str, "model_version"]:
 
     current_version = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
+        metadata={},
         stage=MetaConfig.target_env,
     )[0].version
     logger.info(

--- a/examples/e2e/steps/promotion/promote_get_versions.py
+++ b/examples/e2e/steps/promotion/promote_get_versions.py
@@ -48,7 +48,6 @@ def promote_get_versions() -> (
     ### ADD YOUR OWN CODE HERE - THIS IS JUST AN EXAMPLE ###
     none_versions = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
-        metadata={},
         stage=None,
     )
     latest_versions = none_versions[0].version
@@ -56,7 +55,6 @@ def promote_get_versions() -> (
 
     target_versions = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
-        metadata={},
         stage=MetaConfig.target_env,
     )
     current_version = latest_versions

--- a/examples/e2e/steps/promotion/promote_get_versions.py
+++ b/examples/e2e/steps/promotion/promote_get_versions.py
@@ -48,6 +48,7 @@ def promote_get_versions() -> (
     ### ADD YOUR OWN CODE HERE - THIS IS JUST AN EXAMPLE ###
     none_versions = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
+        metadata={},
         stage=None,
     )
     latest_versions = none_versions[0].version
@@ -55,6 +56,7 @@ def promote_get_versions() -> (
 
     target_versions = model_registry.list_model_versions(
         name=MetaConfig.mlflow_model_name,
+        metadata={},
         stage=MetaConfig.target_env,
     )
     current_version = latest_versions

--- a/examples/e2e/steps/promotion/promote_metric_compare_promoter.py
+++ b/examples/e2e/steps/promotion/promote_metric_compare_promoter.py
@@ -88,11 +88,13 @@ def promote_metric_compare_promoter(
                 name=MetaConfig.mlflow_model_name,
                 version=current_version,
                 stage=ModelVersionStage.ARCHIVED,
+                metadata={},
             )
         model_registry.update_model_version(
             name=MetaConfig.mlflow_model_name,
             version=latest_version,
             stage=MetaConfig.target_env,
+            metadata={},
         )
         promoted_version = latest_version
 

--- a/examples/e2e/steps/promotion/promote_metric_compare_promoter.py
+++ b/examples/e2e/steps/promotion/promote_metric_compare_promoter.py
@@ -88,13 +88,11 @@ def promote_metric_compare_promoter(
                 name=MetaConfig.mlflow_model_name,
                 version=current_version,
                 stage=ModelVersionStage.ARCHIVED,
-                metadata={},
             )
         model_registry.update_model_version(
             name=MetaConfig.mlflow_model_name,
             version=latest_version,
             stage=MetaConfig.target_env,
-            metadata={},
         )
         promoted_version = latest_version
 

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -72,7 +72,7 @@ class ZenMLProjectTemplateLocation(BaseModel):
 ZENML_PROJECT_TEMPLATES = dict(
     e2e_batch=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-e2e-batch",
-        github_tag="0.43.0",
+        github_tag="2023-09-28",
     ),
     starter=ZenMLProjectTemplateLocation(
         github_url="zenml-io/zenml-project-templates",

--- a/src/zenml/integrations/mlflow/model_registries/mlflow_model_registry.py
+++ b/src/zenml/integrations/mlflow/model_registries/mlflow_model_registry.py
@@ -22,7 +22,6 @@ from mlflow import MlflowClient
 from mlflow.entities.model_registry import ModelVersion as MLflowModelVersion
 from mlflow.exceptions import MlflowException
 from mlflow.pyfunc import load_model
-from pydantic import Field
 
 from zenml.client import Client
 from zenml.constants import MLFLOW_MODEL_FORMAT
@@ -347,9 +346,7 @@ class MLFlowModelRegistry(BaseModelRegistry):
         version: Optional[str] = None,
         model_source_uri: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         **kwargs: Any,
     ) -> ModelVersion:
         """Register a model version to the MLflow model registry.
@@ -387,9 +384,10 @@ class MLFlowModelRegistry(BaseModelRegistry):
                     f"Registering a new version for the model `'{name}'` "
                     f"a version will be assigned automatically."
                 )
+            metadata_dict = metadata.dict() if metadata else {}
             # Set the run ID and link.
-            run_id = metadata.dict().get("mlflow_run_id", None)
-            run_link = metadata.dict().get("mlflow_run_link", None)
+            run_id = metadata_dict.get("mlflow_run_id", None)
+            run_link = metadata_dict.get("mlflow_run_link", None)
             # Register the model version.
             registered_model_version = self.mlflow_client.create_model_version(
                 name=name,
@@ -397,7 +395,7 @@ class MLFlowModelRegistry(BaseModelRegistry):
                 run_id=run_id,
                 run_link=run_link,
                 description=description,
-                tags=metadata.dict(),
+                tags=metadata_dict,
             )
         except MlflowException as e:
             raise RuntimeError(
@@ -441,9 +439,7 @@ class MLFlowModelRegistry(BaseModelRegistry):
         name: str,
         version: str,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         remove_metadata: Optional[List[str]] = None,
         stage: Optional[ModelVersionStage] = None,
     ) -> ModelVersion:
@@ -558,9 +554,7 @@ class MLFlowModelRegistry(BaseModelRegistry):
         self,
         name: Optional[str] = None,
         model_source_uri: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         stage: Optional[ModelVersionStage] = None,
         count: Optional[int] = None,
         created_after: Optional[datetime] = None,

--- a/src/zenml/model_registries/base_model_registry.py
+++ b/src/zenml/model_registries/base_model_registry.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from zenml.enums import StackComponentType
 from zenml.stack import Flavor, StackComponent
@@ -286,9 +286,7 @@ class BaseModelRegistry(StackComponent, ABC):
         version: Optional[str] = None,
         model_source_uri: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         **kwargs: Any,
     ) -> ModelVersion:
         """Registers a model version in the model registry.
@@ -332,9 +330,7 @@ class BaseModelRegistry(StackComponent, ABC):
         name: str,
         version: str,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         remove_metadata: Optional[List[str]] = None,
         stage: Optional[ModelVersionStage] = None,
     ) -> ModelVersion:
@@ -361,9 +357,7 @@ class BaseModelRegistry(StackComponent, ABC):
         self,
         name: Optional[str] = None,
         model_source_uri: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         stage: Optional[ModelVersionStage] = None,
         count: Optional[int] = None,
         created_after: Optional[datetime] = None,

--- a/tests/integration/functional/cli/test_model.py
+++ b/tests/integration/functional/cli/test_model.py
@@ -17,7 +17,6 @@ from uuid import uuid4
 
 import pytest
 from click.testing import CliRunner
-from pydantic import Field
 
 from zenml.cli.cli import cli
 from zenml.enums import StackComponentType
@@ -88,9 +87,7 @@ class ConcreteModelRegistry(BaseModelRegistry):
         version: Optional[str] = None,
         model_source_uri: Optional[str] = None,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         **kwargs: Any,
     ) -> ModelVersion:
         pass
@@ -107,9 +104,7 @@ class ConcreteModelRegistry(BaseModelRegistry):
         name: str,
         version: str,
         description: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         remove_metadata: Optional[List[str]] = None,
         stage: Optional[ModelVersionStage] = None,
     ) -> ModelVersion:
@@ -119,9 +114,7 @@ class ConcreteModelRegistry(BaseModelRegistry):
         self,
         name: Optional[str] = None,
         model_source_uri: Optional[str] = None,
-        metadata: ModelRegistryModelMetadata = Field(
-            default_factory=ModelRegistryModelMetadata
-        ),
+        metadata: Optional[ModelRegistryModelMetadata] = None,
         stage: Optional[ModelVersionStage] = None,
         count: Optional[int] = None,
         created_after: Optional[datetime] = None,


### PR DESCRIPTION
## Describe changes
The following model registry methods were all broken if no metadata was provided:
- register_model_version
- update_model_version
- list_model_versions

Problem: the function declarations specified `pydantic.Field` as default value which is only viable for Pydantic models and not for regular Python functions.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

