### PR TITLE
Use configured template REF in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,136 +16,136 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mlstacks-compatibility-check:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+  # mlstacks-compatibility-check:
+  #   if: github.event.pull_request.draft == false
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8"
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: "3.8"
 
-      - name: Install current package as editable
-        run: pip install -e .
+  #     - name: Install current package as editable
+  #       run: pip install -e .
 
-      - name: Install mlstacks package
-        run: pip install mlstacks
+  #     - name: Install mlstacks package
+  #       run: pip install mlstacks
 
-      - name: Check for broken dependencies
-        run: pip check
+  #     - name: Check for broken dependencies
+  #       run: pip check
 
-  ubuntu-setup-and-test-python:
-    if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-      fail-fast: false
-    uses: ./.github/workflows/setup-python-environment.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      os: ${{ matrix.os }}
-    secrets: inherit
+  # ubuntu-setup-and-test-python:
+  #   if: github.event.pull_request.draft == false
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/setup-python-environment.yml
+  #   with:
+  #     python-version: ${{ matrix.python-version }}
+  #     os: ${{ matrix.os }}
+  #   secrets: inherit
 
-  windows-setup-and-test-python:
-    if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-      fail-fast: false
-    uses: ./.github/workflows/setup-python-environment.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      os: ${{ matrix.os }}
-    secrets: inherit
+  # windows-setup-and-test-python:
+  #   if: github.event.pull_request.draft == false
+  #   strategy:
+  #     matrix:
+  #       os: [windows-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/setup-python-environment.yml
+  #   with:
+  #     python-version: ${{ matrix.python-version }}
+  #     os: ${{ matrix.os }}
+  #   secrets: inherit
 
-  macos-setup-and-test-python:
-    if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-      fail-fast: false
-    uses: ./.github/workflows/setup-python-environment.yml
-    with:
-      python-version: ${{ matrix.python-version }}
-      os: ${{ matrix.os }}
-    secrets: inherit
+  # macos-setup-and-test-python:
+  #   if: github.event.pull_request.draft == false
+  #   strategy:
+  #     matrix:
+  #       os: [macos-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/setup-python-environment.yml
+  #   with:
+  #     python-version: ${{ matrix.python-version }}
+  #     os: ${{ matrix.os }}
+  #   secrets: inherit
   
   update-e2e-template:
-    needs: ubuntu-setup-and-test-python
+    # needs: ubuntu-setup-and-test-python
     uses: ./.github/workflows/update-e2e-template.yml
     with:
       python-version: "3.8"
       os: ubuntu-latest
     secrets: inherit
 
-  ubuntu-integration-test:
-    needs: 
-      - ubuntu-setup-and-test-python
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        test_environment:
-          [
-            "default",
-            "docker-server-docker-orchestrator",
-          ]
-        exclude:
-          # docker is time-consuming to run, so we only run it on 3.8
-          - test_environment: docker-server-docker-orchestrator
-            python-version: "3.9"
-          - test_environment: docker-server-docker-orchestrator
-            python-version: "3.10"
-          - test_environment: docker-server-docker-orchestrator
-            python-version: "3.11"
+  # ubuntu-integration-test:
+  #   needs: 
+  #     - ubuntu-setup-and-test-python
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #       test_environment:
+  #         [
+  #           "default",
+  #           "docker-server-docker-orchestrator",
+  #         ]
+  #       exclude:
+  #         # docker is time-consuming to run, so we only run it on 3.8
+  #         - test_environment: docker-server-docker-orchestrator
+  #           python-version: "3.9"
+  #         - test_environment: docker-server-docker-orchestrator
+  #           python-version: "3.10"
+  #         - test_environment: docker-server-docker-orchestrator
+  #           python-version: "3.11"
 
-      fail-fast: false
+  #     fail-fast: false
 
-    uses: ./.github/workflows/integration-test.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test_environment: ${{ matrix.test_environment }}
-    secrets: inherit
+  #   uses: ./.github/workflows/integration-test.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     python-version: ${{ matrix.python-version }}
+  #     test_environment: ${{ matrix.test_environment }}
+  #   secrets: inherit
 
-  windows-integration-test:
-    needs: 
-      - windows-setup-and-test-python
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        test_environment: ["default"]
+  # windows-integration-test:
+  #   needs: 
+  #     - windows-setup-and-test-python
+  #   strategy:
+  #     matrix:
+  #       os: [windows-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #       test_environment: ["default"]
 
-      fail-fast: false
+  #     fail-fast: false
 
-    uses: ./.github/workflows/integration-test.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test_environment: ${{ matrix.test_environment }}
-    secrets: inherit
+  #   uses: ./.github/workflows/integration-test.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     python-version: ${{ matrix.python-version }}
+  #     test_environment: ${{ matrix.test_environment }}
+  #   secrets: inherit
 
-  macos-integration-test:
-    needs: 
-      - macos-setup-and-test-python
-    strategy:
-      matrix:
-        os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        test_environment: ["default"]
+  # macos-integration-test:
+  #   needs: 
+  #     - macos-setup-and-test-python
+  #   strategy:
+  #     matrix:
+  #       os: [macos-latest]
+  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
+  #       test_environment: ["default"]
 
-      fail-fast: false
+  #     fail-fast: false
 
-    uses: ./.github/workflows/integration-test.yml
-    with:
-      os: ${{ matrix.os }}
-      python-version: ${{ matrix.python-version }}
-      test_environment: ${{ matrix.test_environment }}
-    secrets: inherit
+  #   uses: ./.github/workflows/integration-test.yml
+  #   with:
+  #     os: ${{ matrix.os }}
+  #     python-version: ${{ matrix.python-version }}
+  #     test_environment: ${{ matrix.test_environment }}
+  #   secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,136 +16,136 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # mlstacks-compatibility-check:
-  #   if: github.event.pull_request.draft == false
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v2
+  mlstacks-compatibility-check:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: "3.8"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
 
-  #     - name: Install current package as editable
-  #       run: pip install -e .
+      - name: Install current package as editable
+        run: pip install -e .
 
-  #     - name: Install mlstacks package
-  #       run: pip install mlstacks
+      - name: Install mlstacks package
+        run: pip install mlstacks
 
-  #     - name: Check for broken dependencies
-  #       run: pip check
+      - name: Check for broken dependencies
+        run: pip check
 
-  # ubuntu-setup-and-test-python:
-  #   if: github.event.pull_request.draft == false
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/setup-python-environment.yml
-  #   with:
-  #     python-version: ${{ matrix.python-version }}
-  #     os: ${{ matrix.os }}
-  #   secrets: inherit
+  ubuntu-setup-and-test-python:
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+    uses: ./.github/workflows/setup-python-environment.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+    secrets: inherit
 
-  # windows-setup-and-test-python:
-  #   if: github.event.pull_request.draft == false
-  #   strategy:
-  #     matrix:
-  #       os: [windows-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/setup-python-environment.yml
-  #   with:
-  #     python-version: ${{ matrix.python-version }}
-  #     os: ${{ matrix.os }}
-  #   secrets: inherit
+  windows-setup-and-test-python:
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        os: [windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+    uses: ./.github/workflows/setup-python-environment.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+    secrets: inherit
 
-  # macos-setup-and-test-python:
-  #   if: github.event.pull_request.draft == false
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #     fail-fast: false
-  #   uses: ./.github/workflows/setup-python-environment.yml
-  #   with:
-  #     python-version: ${{ matrix.python-version }}
-  #     os: ${{ matrix.os }}
-  #   secrets: inherit
+  macos-setup-and-test-python:
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+      fail-fast: false
+    uses: ./.github/workflows/setup-python-environment.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      os: ${{ matrix.os }}
+    secrets: inherit
   
   update-e2e-template:
-    # needs: ubuntu-setup-and-test-python
+    needs: ubuntu-setup-and-test-python
     uses: ./.github/workflows/update-e2e-template.yml
     with:
       python-version: "3.8"
       os: ubuntu-latest
     secrets: inherit
 
-  # ubuntu-integration-test:
-  #   needs: 
-  #     - ubuntu-setup-and-test-python
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #       test_environment:
-  #         [
-  #           "default",
-  #           "docker-server-docker-orchestrator",
-  #         ]
-  #       exclude:
-  #         # docker is time-consuming to run, so we only run it on 3.8
-  #         - test_environment: docker-server-docker-orchestrator
-  #           python-version: "3.9"
-  #         - test_environment: docker-server-docker-orchestrator
-  #           python-version: "3.10"
-  #         - test_environment: docker-server-docker-orchestrator
-  #           python-version: "3.11"
+  ubuntu-integration-test:
+    needs: 
+      - ubuntu-setup-and-test-python
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        test_environment:
+          [
+            "default",
+            "docker-server-docker-orchestrator",
+          ]
+        exclude:
+          # docker is time-consuming to run, so we only run it on 3.8
+          - test_environment: docker-server-docker-orchestrator
+            python-version: "3.9"
+          - test_environment: docker-server-docker-orchestrator
+            python-version: "3.10"
+          - test_environment: docker-server-docker-orchestrator
+            python-version: "3.11"
 
-  #     fail-fast: false
+      fail-fast: false
 
-  #   uses: ./.github/workflows/integration-test.yml
-  #   with:
-  #     os: ${{ matrix.os }}
-  #     python-version: ${{ matrix.python-version }}
-  #     test_environment: ${{ matrix.test_environment }}
-  #   secrets: inherit
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      test_environment: ${{ matrix.test_environment }}
+    secrets: inherit
 
-  # windows-integration-test:
-  #   needs: 
-  #     - windows-setup-and-test-python
-  #   strategy:
-  #     matrix:
-  #       os: [windows-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #       test_environment: ["default"]
+  windows-integration-test:
+    needs: 
+      - windows-setup-and-test-python
+    strategy:
+      matrix:
+        os: [windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        test_environment: ["default"]
 
-  #     fail-fast: false
+      fail-fast: false
 
-  #   uses: ./.github/workflows/integration-test.yml
-  #   with:
-  #     os: ${{ matrix.os }}
-  #     python-version: ${{ matrix.python-version }}
-  #     test_environment: ${{ matrix.test_environment }}
-  #   secrets: inherit
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      test_environment: ${{ matrix.test_environment }}
+    secrets: inherit
 
-  # macos-integration-test:
-  #   needs: 
-  #     - macos-setup-and-test-python
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest]
-  #       python-version: ["3.8", "3.9", "3.10", "3.11"]
-  #       test_environment: ["default"]
+  macos-integration-test:
+    needs: 
+      - macos-setup-and-test-python
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        test_environment: ["default"]
 
-  #     fail-fast: false
+      fail-fast: false
 
-  #   uses: ./.github/workflows/integration-test.yml
-  #   with:
-  #     os: ${{ matrix.os }}
-  #     python-version: ${{ matrix.python-version }}
-  #     test_environment: ${{ matrix.test_environment }}
-  #   secrets: inherit
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      test_environment: ${{ matrix.test_environment }}
+    secrets: inherit

--- a/.github/workflows/update-e2e-template.yml
+++ b/.github/workflows/update-e2e-template.yml
@@ -100,18 +100,13 @@ jobs:
       #         body: 'E2E template updates in `examples/e2e` have been pushed.'
       #       })
 
-      - name: Get template ref
-        run: |
-          ref_template=$(ZENML_LOGGING_VERBOSITY=INFO && python3 -c "from zenml.cli.base import ZENML_PROJECT_TEMPLATES; print(ZENML_PROJECT_TEMPLATES['e2e_batch'].github_tag);")
-          echo "REF_TEMPLATE=$ref_template" >> $GITHUB_ENV
-
       - name: Run template tests for zenml-io/template-e2e-batch
         uses: zenml-io/template-e2e-batch/.github/actions/e2e_template_test@main
         with:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
-          ref-template: ${{ env.REF_TEMPLATE }}
+          ref-template: 0.43.0 # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from zenml/cli/base.py
 
       - name: message-on-error
         if: failure()

--- a/.github/workflows/update-e2e-template.yml
+++ b/.github/workflows/update-e2e-template.yml
@@ -61,44 +61,49 @@ jobs:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}
 
-      - name: Check-out fresh E2E template
-        run: |
-          mkdir -p examples/e2e
-          printf 'info@zenml.io' | zenml init --path examples/e2e --template e2e_batch --template-with-defaults
-          bash scripts/format.sh
+      # - name: Check-out fresh E2E template
+      #   run: |
+      #     mkdir -p examples/e2e
+      #     printf 'info@zenml.io' | zenml init --path examples/e2e --template e2e_batch --template-with-defaults
+      #     bash scripts/format.sh
 
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if git diff --quiet "origin/${{ github.event.pull_request.head.ref }}"; then
-            echo "No active Git changes found."
-            echo "changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "Active Git changes found."
-            echo "changes=true" >> $GITHUB_OUTPUT
-          fi
+      # - name: Check for changes
+      #   id: check_changes
+      #   run: |
+      #     if git diff --quiet "origin/${{ github.event.pull_request.head.ref }}"; then
+      #       echo "No active Git changes found."
+      #       echo "changes=false" >> $GITHUB_OUTPUT
+      #     else
+      #       echo "Active Git changes found."
+      #       echo "changes=true" >> $GITHUB_OUTPUT
+      #     fi
           
-      - name: Commit and push template
-        if: steps.check_changes.outputs.changes == 'true'
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git add .
-          git commit -am "Auto-update of E2E template"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      # - name: Commit and push template
+      #   if: steps.check_changes.outputs.changes == 'true'
+      #   run: |
+      #     git config --global user.name "GitHub Actions"
+      #     git config --global user.email "actions@github.com"
+      #     git add .
+      #     git commit -am "Auto-update of E2E template"
+      #     git push origin HEAD:${{ github.event.pull_request.head.ref }}
 
-      - name: Create PR comment
-        if: steps.check_changes.outputs.changes == 'true'
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.createComment({
-              issue_number: ${{ github.event.pull_request.number }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'E2E template updates in `examples/e2e` have been pushed.'
-            })
+      # - name: Create PR comment
+      #   if: steps.check_changes.outputs.changes == 'true'
+      #   uses: actions/github-script@v4
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       github.issues.createComment({
+      #         issue_number: ${{ github.event.pull_request.number }},
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         body: 'E2E template updates in `examples/e2e` have been pushed.'
+      #       })
+
+      - name: Get template ref
+        run: |
+          ref_template=$(python3 -c "from zenml.cli.base import ZENML_PROJECT_TEMPLATES; print(ZENML_PROJECT_TEMPLATES['e2e_batch'].github_tag);")
+          echo "REF_TEMPLATE=$ref_template" >> $GITHUB_ENV
 
       - name: Run template tests for zenml-io/template-e2e-batch
         uses: zenml-io/template-e2e-batch/.github/actions/e2e_template_test@main
@@ -106,6 +111,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
+          ref-template: ${{ env.REF_TEMPLATE }}
 
       - name: message-on-error
         if: failure()

--- a/.github/workflows/update-e2e-template.yml
+++ b/.github/workflows/update-e2e-template.yml
@@ -61,44 +61,44 @@ jobs:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}
 
-      # - name: Check-out fresh E2E template
-      #   run: |
-      #     mkdir -p examples/e2e
-      #     printf 'info@zenml.io' | zenml init --path examples/e2e --template e2e_batch --template-with-defaults
-      #     bash scripts/format.sh
+      - name: Check-out fresh E2E template
+        run: |
+          mkdir -p examples/e2e
+          printf 'info@zenml.io' | zenml init --path examples/e2e --template e2e_batch --template-with-defaults
+          bash scripts/format.sh
 
-      # - name: Check for changes
-      #   id: check_changes
-      #   run: |
-      #     if git diff --quiet "origin/${{ github.event.pull_request.head.ref }}"; then
-      #       echo "No active Git changes found."
-      #       echo "changes=false" >> $GITHUB_OUTPUT
-      #     else
-      #       echo "Active Git changes found."
-      #       echo "changes=true" >> $GITHUB_OUTPUT
-      #     fi
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet "origin/${{ github.event.pull_request.head.ref }}"; then
+            echo "No active Git changes found."
+            echo "changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Active Git changes found."
+            echo "changes=true" >> $GITHUB_OUTPUT
+          fi
           
-      # - name: Commit and push template
-      #   if: steps.check_changes.outputs.changes == 'true'
-      #   run: |
-      #     git config --global user.name "GitHub Actions"
-      #     git config --global user.email "actions@github.com"
-      #     git add .
-      #     git commit -am "Auto-update of E2E template"
-      #     git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      - name: Commit and push template
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add .
+          git commit -am "Auto-update of E2E template"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
 
-      # - name: Create PR comment
-      #   if: steps.check_changes.outputs.changes == 'true'
-      #   uses: actions/github-script@v4
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       github.issues.createComment({
-      #         issue_number: ${{ github.event.pull_request.number }},
-      #         owner: context.repo.owner,
-      #         repo: context.repo.repo,
-      #         body: 'E2E template updates in `examples/e2e` have been pushed.'
-      #       })
+      - name: Create PR comment
+        if: steps.check_changes.outputs.changes == 'true'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: ${{ github.event.pull_request.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'E2E template updates in `examples/e2e` have been pushed.'
+            })
 
       - name: Run template tests for zenml-io/template-e2e-batch
         uses: zenml-io/template-e2e-batch/.github/actions/e2e_template_test@main

--- a/.github/workflows/update-e2e-template.yml
+++ b/.github/workflows/update-e2e-template.yml
@@ -106,7 +106,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
-          ref-template: 0.43.0 # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from zenml/cli/base.py
+          ref-template: 2023-09-28 # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from zenml/cli/base.py
 
       - name: message-on-error
         if: failure()

--- a/.github/workflows/update-e2e-template.yml
+++ b/.github/workflows/update-e2e-template.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Get template ref
         run: |
-          ref_template=$(python3 -c "from zenml.cli.base import ZENML_PROJECT_TEMPLATES; print(ZENML_PROJECT_TEMPLATES['e2e_batch'].github_tag);")
+          ref_template=$(ZENML_LOGGING_VERBOSITY=INFO && python3 -c "from zenml.cli.base import ZENML_PROJECT_TEMPLATES; print(ZENML_PROJECT_TEMPLATES['e2e_batch'].github_tag);")
           echo "REF_TEMPLATE=$ref_template" >> $GITHUB_ENV
 
       - name: Run template tests for zenml-io/template-e2e-batch

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -72,7 +72,7 @@ class ZenMLProjectTemplateLocation(BaseModel):
 ZENML_PROJECT_TEMPLATES = dict(
     e2e_batch=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-e2e-batch",
-        github_tag="0.43.0",
+        github_tag="0.43.0",  # Make sure it is aligned with .github/workflows/update-e2e-template.yml
     ),
     starter=ZenMLProjectTemplateLocation(
         github_url="zenml-io/zenml-project-templates",


### PR DESCRIPTION
## Describe changes
I added the hard link to a specific release of the template in CI, so we test and use the same release in code and in CI. This also prevents us from issues observed from last week, then CI was running versus the main branch of the template, but develop changes in the core were not yet in development.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

