### PR TITLE
Convert network_config dict to NetworkConfig object in orchestrator

### DIFF
--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -258,9 +258,10 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             processor_args_for_step["env"] = environment
 
             # Convert network_config to sagemaker.network.NetworkConfig if present
-            if processor_args_for_step.get("network_config") is not None:
+            network_config = processor_args_for_step.get("network_config")
+            if network_config and isinstance(network_config, dict):
                 try:
-                    processor_args_for_step["network_config"] = NetworkConfig(**processor_args_for_step["network_config"])
+                    processor_args_for_step["network_config"] = NetworkConfig(**network_config)
                 except TypeError:
                     # If the network_config passed is not compatible with the NetworkConfig class,
                     # raise a more informative error.


### PR DESCRIPTION
## Describe changes
Currently, it is impossible to use a network configuration with the SageMaker orchestrator, making it impossible to orchestrate in custom VPCs:

* A network configuration must be passed as a `sagemaker.network.NetworkConfig` object per https://sagemaker.readthedocs.io/en/stable/api/utility/network.html#sagemaker.network.NetworkConfig.
* ZenML does not accept said object because it is not JSON serializable, which is expected by ZenML.

This PR allows network configurations to be provided as a dictionary. It does the following:

* Checks whether a network configuration is present and whether it is a dictionary.
* If so, attempt to use it to create a `NetworkConfig` object.
* If it fails resulting in a `TypeError` (which is what `sagemaker.*` raises if the input dictionary does not adhere to the `NetworkConfig` schema defined in `sagemaker`), a more informative error is raised, allowing the ZenML user to understand what is going wrong.
* If any other error is raised, it is reraised, because it is unrelated to the input network configuration.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

