### PR TITLE
Add warning generation scripts for Gitbook docs

### DIFF
--- a/scripts/add-docs-warning.py
+++ b/scripts/add-docs-warning.py
@@ -1,0 +1,87 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Adds a warning to a version of ZenML Gitbook documentation."""
+
+import os
+import re
+
+
+def get_version(version_file_path: str) -> str:
+    """Get the ZenML version from the VERSION file.
+
+    Args:
+        version_file_path (str): Path to the VERSION file.
+
+    Returns:
+        str: The ZenML version.
+    """
+    with open(version_file_path, "r", encoding="utf-8") as vf:
+        return vf.read().strip()
+
+
+def process_files(root_dir: str, version: str) -> None:
+    """Add the warning string to all markdown files.
+
+    Args:
+        root_dir (str): The root directory of the documentation.
+        version (str): The ZenML version.
+    """
+    pattern = re.compile(r"---\ndescription: (?:.*| >-)\n---\n", re.DOTALL)
+    warning_string = (
+        '\n{% hint style="warning" %}\n'
+        "This is an older version of the ZenML documentation. "
+        "To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).\n"
+        "{% endhint %}\n\n"
+    )
+    weird_files_path = "/Users/strickvl/Desktop/weird-files.txt"
+
+    for root, _, files in os.walk(root_dir):
+        # Skip the drafts folder
+        if "docs/book/drafts" in root:
+            continue
+
+        for file in files:
+            # Skip toc.md
+            if file == "toc.md":
+                continue
+
+            if file.endswith(".md"):
+                file_path = os.path.join(root, file)
+                with open(file_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+
+                # Skip if warning string is already present
+                if warning_string in content:
+                    continue
+
+                match = pattern.match(content)
+                if match:
+                    new_content = (
+                        content[: match.end()]
+                        + warning_string
+                        + content[match.end() :]
+                    )
+                elif file in ["glossary.md", "usage-analytics.md"]:
+                    new_content = warning_string + content
+                else:
+                    with open(weird_files_path, "a", encoding="utf-8") as wf:
+                        wf.write(f"{version}: {file_path}\n")
+                        continue  # Skip the rest of this iteration
+
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(new_content)
+
+
+version = get_version("src/zenml/VERSION")
+process_files("docs/book", version)

--- a/scripts/add-docs-warning.py
+++ b/scripts/add-docs-warning.py
@@ -41,10 +41,10 @@ def process_files(root_dir: str, version: str) -> None:
     warning_string = (
         '\n{% hint style="warning" %}\n'
         "This is an older version of the ZenML documentation. "
-        "To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).\n"
+        "To read and view the latest version please "
+        "[visit this up-to-date URL](https://docs.zenml.io).\n"
         "{% endhint %}\n\n"
     )
-    weird_files_path = "/Users/strickvl/Desktop/weird-files.txt"
 
     for root, _, files in os.walk(root_dir):
         # Skip the drafts folder
@@ -75,9 +75,10 @@ def process_files(root_dir: str, version: str) -> None:
                 elif file in ["glossary.md", "usage-analytics.md"]:
                     new_content = warning_string + content
                 else:
-                    with open(weird_files_path, "a", encoding="utf-8") as wf:
-                        wf.write(f"{version}: {file_path}\n")
-                        continue  # Skip the rest of this iteration
+                    print(
+                        f"Version {version}: Couldn't process file {file_path}"
+                    )
+                    continue  # Skip the rest of this iteration
 
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write(new_content)

--- a/scripts/add-docs-warning.sh
+++ b/scripts/add-docs-warning.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+set -x
+set -o pipefail
+
+# Define the function to process each version
+process_version() {
+    version=$1
+    echo "Processing version $version..."
+    
+    # Checkout and update the release branch
+    git checkout "release/$version"
+    git pull origin "release/$version"
+    
+    # Create a new branch for the updates
+    new_branch="backport/automated-update-version-$version-docs"
+    git checkout -b "$new_branch"
+    
+    # Run the Python script to update the documentation
+    python3 scripts/add-docs-warning.py
+
+    # Commit and push the updates
+    find docs/book -name '*.md' -exec git add {} +
+    git commit -m "Update old docs with warning message"
+    git push origin "$new_branch"
+    
+    # Open a Pull Request
+    gh pr create --base "release/$version" --head "$new_branch" \
+        --title "Add warning header to docs for version $version" \
+        --body "This PR updates the documentation for version $version with the warning message to be displayed on Gitbook." \
+        --label "documentation" --label "backport" --label "internal"
+    
+    # Pause for 5 seconds
+    sleep 5
+}
+
+versions=$@
+
+# Process each version
+for version in $versions; do
+    process_version $version
+done


### PR DESCRIPTION
Added a bash script (and a supporting Python script) that is used as part of our release flow.

The script(s):

- check out a specific previous release,
- update all markdown files contained in the docs for that release
- commit and push the changes and open a PR for review containing the updates

Updating our Notion release doc to include this as part of the release flow, and tagging OSS team members for visibility. @bcdurak @safoinme 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

