### PR TITLE
[Model Control Plane] link cached artifacts

### DIFF
--- a/src/zenml/model/artifact_config.py
+++ b/src/zenml/model/artifact_config.py
@@ -74,7 +74,7 @@ class ArtifactConfig(BaseModel):
         """
         try:
             model_config = get_step_context().model_config
-        except StepContextError:
+        except (StepContextError, RuntimeError):
             model_config = None
         # Check if a specific model name is provided and it doesn't match the context name
         if (self.model_name is not None) and (

--- a/src/zenml/models/model_base_model.py
+++ b/src/zenml/models/model_base_model.py
@@ -145,7 +145,7 @@ class ModelConfigModel(ModelBaseModel):
             if version is None:
                 if not suppress_warnings:
                     logger.info(
-                        "Creation of new model version was requested, but no version name was explicitly provided."
+                        "Creation of new model version was requested, but no version name was explicitly provided. "
                         f"Setting `version` to `{RUNNING_MODEL_VERSION}`."
                     )
                 values["version"] = RUNNING_MODEL_VERSION


### PR DESCRIPTION
## Describe changes
I fixed the linking of cached artifacts to Model Versions in the Control Plane to achieve consistency between cached and non-cached runs of pipelines dealing with Models in the Control Plane.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

