### PR TITLE
Fix `external_input_artifacts` backward compatibility

### DIFF
--- a/src/zenml/orchestrators/input_utils.py
+++ b/src/zenml/orchestrators/input_utils.py
@@ -76,9 +76,12 @@ def resolve_step_inputs(
         name,
         external_artifact,
     ) in step.config.external_input_artifacts.items():
-        artifact_id = external_artifact.get_artifact_id(
-            model_config=model_config
-        )
+        if isinstance(external_artifact, UUID):
+            artifact_id = external_artifact
+        else:
+            artifact_id = external_artifact.get_artifact_id(
+                model_config=model_config
+            )
         input_artifacts[name] = Client().get_artifact(artifact_id=artifact_id)
 
     parent_step_ids = [

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -256,7 +256,7 @@ class StepRunner:
                             pipeline_run=pipeline_run,
                             artifact_names=list(output_artifact_ids.keys()),
                             external_artifacts=list(
-                                step_run.config.external_input_artifacts.values()
+                                step_run.config.new_external_input_artifacts.values()
                             ),
                         )
                     StepContext._clear()  # Remove the step context singleton

--- a/tests/unit/config/test_step_configurations.py
+++ b/tests/unit/config/test_step_configurations.py
@@ -13,7 +13,16 @@
 #  permissions and limitations under the License.
 
 
-from zenml.config.step_configurations import InputSpec, StepSpec
+from uuid import uuid4
+
+from zenml.artifacts.external_artifact_config import (
+    ExternalArtifactConfiguration,
+)
+from zenml.config.step_configurations import (
+    InputSpec,
+    PartialStepConfiguration,
+    StepSpec,
+)
 
 
 def test_step_spec_source_equality():
@@ -93,3 +102,30 @@ def test_step_spec_pipeline_parameter_name_equality():
         upstream_steps=[],
         pipeline_parameter_name="different_name",
     )
+
+
+def test_step_config_can_recover_from_json():
+    """Tests that step spec can be recovered from json."""
+    uuid = uuid4()
+    from_json = PartialStepConfiguration.parse_raw(
+        '{"name":"foo","external_input_artifacts": {"bar":"'
+        + str(uuid)
+        + '"}}'
+    )
+    from_object = PartialStepConfiguration(
+        name="foo", external_input_artifacts={"bar": uuid}
+    )
+    assert from_json == from_object
+
+    from_json = PartialStepConfiguration.parse_raw(
+        '{"name":"foo","external_input_artifacts": {"bar":{"id":"'
+        + str(uuid)
+        + '"}}}'
+    )
+    from_object = PartialStepConfiguration(
+        name="foo",
+        external_input_artifacts={
+            "bar": ExternalArtifactConfiguration(id=uuid)
+        },
+    )
+    assert from_json == from_object


### PR DESCRIPTION
## Describe changes
I fixed the `external_input_artifacts` backward compatibility issue

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

