### PR TITLE
Fix DB initialization when using external authentication

### DIFF
--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -599,14 +599,29 @@ def info(
 @cli.command(
     "migrate-database", help="Migrate the ZenML database.", hidden=True
 )
-def migrate_database() -> None:
-    """Migrate the ZenML database."""
+@click.option(
+    "--skip_default_registrations",
+    is_flag=True,
+    default=False,
+    help="Skip registering default workspace, user and stack.",
+    type=bool,
+)
+def migrate_database(skip_default_registrations: bool = False) -> None:
+    """Migrate the ZenML database.
+
+    Args:
+        skip_default_registrations: If `True`, registration of default
+            components will be skipped.
+    """
     from zenml.zen_stores.base_zen_store import BaseZenStore
 
-    global_config = GlobalConfiguration()
-    if global_config.store.type == StoreType.SQL:
+    store_config = (
+        GlobalConfiguration().store
+        or GlobalConfiguration().get_default_store()
+    )
+    if store_config.type == StoreType.SQL:
         BaseZenStore.create_store(
-            global_config.store, skip_default_registrations=True
+            store_config, skip_default_registrations=skip_default_registrations
         )
         cli_utils.declare("Database migration finished.")
     else:

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -36,7 +36,7 @@ from zenml.constants import (
     ENV_ZENML_ENABLE_REPO_INIT_WARNINGS,
     REPOSITORY_DIRECTORY_NAME,
 )
-from zenml.enums import AnalyticsEventSource
+from zenml.enums import AnalyticsEventSource, StoreType
 from zenml.environment import Environment, get_environment
 from zenml.exceptions import GitNotFoundError, InitializationException
 from zenml.integrations.registry import integration_registry
@@ -594,3 +594,22 @@ def info(
 
     if stack:
         cli_utils.print_debug_stack()
+
+
+@cli.command(
+    "migrate-database", help="Migrate the ZenML database.", hidden=True
+)
+def migrate_database() -> None:
+    """Migrate the ZenML database."""
+    from zenml.zen_stores.base_zen_store import BaseZenStore
+
+    global_config = GlobalConfiguration()
+    if global_config.store.type == StoreType.SQL:
+        BaseZenStore.create_store(
+            global_config.store, skip_default_registrations=True
+        )
+        cli_utils.declare("Database migration finished.")
+    else:
+        cli_utils.warning(
+            "Unable to migrate database while connected to a ZenML server."
+        )

--- a/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.zenml.image.repository }}:{{ .Values.zenml.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.zenml.image.pullPolicy }}
-          args: ["status"]
+          args: ["migrate-database"]
           command: ['zenml']
           env:
             {{- if .Values.zenml.debug }}

--- a/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
@@ -61,12 +61,24 @@ spec:
               value: {{ .Values.zenml.defaultProject | quote }}
             - name: ZENML_DEFAULT_USER_NAME
               value: {{ .Values.zenml.defaultUsername | quote }}
-            {{- if .Values.zenml.database.url }}
+            - name: ZENML_SERVER_AUTH_SCHEME
+              value: {{ .Values.zenml.authType | default .Values.zenml.auth.authType | quote }}
+            {{- if .Values.zenml.auth.externalLoginURL }}
+            - name: ZENML_SERVER_EXTERNAL_LOGIN_URL
+              value: {{ .Values.zenml.auth.externalLoginURL | quote }}
+            {{- end }}
+            {{- if .Values.zenml.auth.externalUserInfoURL }}
+            - name: ZENML_SERVER_EXTERNAL_USER_INFO_URL
+              value: {{ .Values.zenml.auth.externalUserInfoURL | quote }}
+            {{- end }}
+            {{- if .Values.zenml.auth.externalCookieName }}
+            - name: ZENML_SERVER_EXTERNAL_COOKIE_NAME
+              value: {{ .Values.zenml.auth.externalCookieName | quote }}
+            {{- end }}
             - name: ZENML_STORE_TYPE
               value: sql
             - name: ZENML_STORE_SSL_VERIFY_SERVER_CERT
               value: {{ .Values.zenml.database.sslVerifyServerCert | default "false" | quote }}
-            {{- end }}
             {{- if .Values.zenml.secretsStore.enabled }}
             - name: ZENML_SECRETS_STORE_TYPE
               value: {{ .Values.zenml.secretsStore.type | quote }}


### PR DESCRIPTION
## Describe changes

This PR fixes two issues regarding database initialization in the Helm chart when using external authentication:
- The init container previously wasn't configured to use external authentication and therefore wrongly created a default user and stack/componens.
- The Helm chart used `zenml status` to initialize the database. The `zenml status` command however also prints the active user (which falls back to the default user) which fails when using external authentication. This PR introduces a separate CLI command which migrates the DB with as little side-effects as possible.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

