### PR TITLE
fix: `BasePyTorchMaterliazer` -> `Materializer`

### DIFF
--- a/src/zenml/integrations/neural_prophet/materializers/neural_prophet_materializer.py
+++ b/src/zenml/integrations/neural_prophet/materializers/neural_prophet_materializer.py
@@ -19,7 +19,7 @@ from neuralprophet import NeuralProphet
 
 from zenml.enums import ArtifactType
 from zenml.integrations.pytorch.materializers.base_pytorch_materializer import (
-    BasePyTorchMaterliazer,
+    BasePyTorchMaterializer,
 )
 
 # TODO [ENG-794]: The integration consists of a simple materializer that uses the
@@ -30,7 +30,7 @@ from zenml.integrations.pytorch.materializers.base_pytorch_materializer import (
 DEFAULT_FILENAME = "entire_model.pt"
 
 
-class NeuralProphetMaterializer(BasePyTorchMaterliazer):
+class NeuralProphetMaterializer(BasePyTorchMaterializer):
     """Materializer to read/write NeuralProphet models."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (NeuralProphet,)

--- a/src/zenml/integrations/pytorch/materializers/base_pytorch_materializer.py
+++ b/src/zenml/integrations/pytorch/materializers/base_pytorch_materializer.py
@@ -25,7 +25,7 @@ from zenml.materializers.base_materializer import BaseMaterializer
 DEFAULT_FILENAME = "obj.pt"
 
 
-class BasePyTorchMaterliazer(BaseMaterializer):
+class BasePyTorchMaterializer(BaseMaterializer):
     """Base class for PyTorch materializers."""
 
     FILENAME: ClassVar[str] = DEFAULT_FILENAME

--- a/src/zenml/integrations/pytorch/materializers/pytorch_dataloader_materializer.py
+++ b/src/zenml/integrations/pytorch/materializers/pytorch_dataloader_materializer.py
@@ -20,7 +20,7 @@ from torch.utils.data.dataloader import DataLoader
 
 from zenml.enums import ArtifactType
 from zenml.integrations.pytorch.materializers.base_pytorch_materializer import (
-    BasePyTorchMaterliazer,
+    BasePyTorchMaterializer,
 )
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 DEFAULT_FILENAME = "entire_dataloader.pt"
 
 
-class PyTorchDataLoaderMaterializer(BasePyTorchMaterliazer):
+class PyTorchDataLoaderMaterializer(BasePyTorchMaterializer):
     """Materializer to read/write PyTorch dataloaders and datasets."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (DataLoader, Dataset)

--- a/src/zenml/integrations/pytorch/materializers/pytorch_module_materializer.py
+++ b/src/zenml/integrations/pytorch/materializers/pytorch_module_materializer.py
@@ -22,7 +22,7 @@ from torch.nn import Module
 
 from zenml.enums import ArtifactType
 from zenml.integrations.pytorch.materializers.base_pytorch_materializer import (
-    BasePyTorchMaterliazer,
+    BasePyTorchMaterializer,
 )
 from zenml.integrations.pytorch.utils import count_module_params
 from zenml.io import fileio
@@ -34,7 +34,7 @@ DEFAULT_FILENAME = "entire_model.pt"
 CHECKPOINT_FILENAME = "checkpoint.pt"
 
 
-class PyTorchModuleMaterializer(BasePyTorchMaterliazer):
+class PyTorchModuleMaterializer(BasePyTorchMaterializer):
     """Materializer to read/write Pytorch models.
 
     Inspired by the guide:

--- a/src/zenml/integrations/pytorch_lightning/materializers/pytorch_lightning_materializer.py
+++ b/src/zenml/integrations/pytorch_lightning/materializers/pytorch_lightning_materializer.py
@@ -19,13 +19,13 @@ from torch.nn import Module
 
 from zenml.enums import ArtifactType
 from zenml.integrations.pytorch.materializers.base_pytorch_materializer import (
-    BasePyTorchMaterliazer,
+    BasePyTorchMaterializer,
 )
 
 CHECKPOINT_NAME = "final_checkpoint.ckpt"
 
 
-class PyTorchLightningMaterializer(BasePyTorchMaterliazer):
+class PyTorchLightningMaterializer(BasePyTorchMaterializer):
     """Materializer to read/write PyTorch models."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Module,)


### PR DESCRIPTION
`BasePyTorchMaterliazer` contains a typo, for example, at https://github.com/zenml-io/zenml/blob/f333d27099783da7da2b784f855c6b98a0bc8bcc/src/zenml/integrations/pytorch/materializers/base_pytorch_materializer.py#L28 

See this [search](https://github.com/search?q=repo%3Azenml-io%2Fzenml+BasePyTorchMaterliazer&type=code) for the incorrect form, which should become empty after merge

- [x] rename `BasePyTorchMaterliazer` to `BasePyTorchMaterializer`

