### PR TITLE
Fix double slashes in weblogin

### DIFF
--- a/src/zenml/cli/web_login.py
+++ b/src/zenml/cli/web_login.py
@@ -88,6 +88,10 @@ def web_login(url: str, verify_ssl: Union[str, bool]) -> str:
         python_version=platform.python_version(),
         os=platform.system(),
     )
+
+    # Get rid of any trailing slashes to prevent issues when having double
+    # slashes in the URL
+    url = url.rstrip("/")
     try:
         auth_url = url + API + VERSION_1 + DEVICE_AUTHORIZATION
         response = requests.post(


### PR DESCRIPTION
## Describe changes

When doing `zenml connect --url https://my-server-url.com/` with a trailing slash, the weblogin would fail. This PR
simply removes any trailing slashes in the passed URL to prevent this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

