### PR TITLE
Make sure vertex job id is only lower case letter, number or dash

### DIFF
--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -30,6 +30,7 @@
 """Implementation of the VertexAI orchestrator."""
 
 import os
+import re
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, cast
 from uuid import UUID
 
@@ -103,7 +104,14 @@ def _clean_pipeline_name(pipeline_name: str) -> str:
     Returns:
         Cleaned pipeline name.
     """
-    return pipeline_name.replace("_", "-").lower()
+    pipeline_name = pipeline_name.lower()
+
+    # This pattern matches anything that is not a lowercase letter,
+    #  a number, or a dash
+    pattern = r"[^a-z0-9-]"
+
+    # Replace any characters matching the pattern with a dash
+    return re.sub(pattern, "-", pipeline_name)
 
 
 class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):


### PR DESCRIPTION
## Describe changes
Vertex job id's were failing because of zenml cloud usernames containing @ and .

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

