### PR TITLE
Add upper limit to our Pillow integration

### DIFF
--- a/src/zenml/integrations/pillow/__init__.py
+++ b/src/zenml/integrations/pillow/__init__.py
@@ -21,7 +21,7 @@ class PillowIntegration(Integration):
     """Definition of Pillow integration for ZenML."""
 
     NAME = PILLOW
-    REQUIREMENTS = ["Pillow>=9.2.0"]
+    REQUIREMENTS = ["Pillow>=9.2.0,<10.0.0"]
 
     @classmethod
     def activate(cls) -> None:


### PR DESCRIPTION
Have seen some reports of quite a few breaking changes following Pillow's 10.0.0 release, so pre-emptively adding this upper ceiling to our integration until we can upgrade / make any necessary fixes.

(See [here](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html) for the full release notes.)

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

