### PR TITLE
Always set the active workspace to be the default workspace server side

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -44,6 +44,7 @@ from zenml.constants import (
     ENV_ZENML_ACTIVE_WORKSPACE_ID,
     ENV_ZENML_ENABLE_REPO_INIT_WARNINGS,
     ENV_ZENML_REPOSITORY_PATH,
+    ENV_ZENML_SERVER,
     PAGE_SIZE_DEFAULT,
     PAGINATION_STARTING_PAGE,
     REPOSITORY_DIRECTORY_NAME,
@@ -1365,6 +1366,13 @@ class Client(metaclass=ClientMetaClass):
             workspace_id = os.environ[ENV_ZENML_ACTIVE_WORKSPACE_ID]
             return self.get_workspace(workspace_id)
 
+        from zenml.zen_stores.base_zen_store import DEFAULT_WORKSPACE_NAME
+
+        # If running in a ZenML server environment, the active workspace is
+        # not relevant
+        if ENV_ZENML_SERVER in os.environ:
+            return self.get_workspace(DEFAULT_WORKSPACE_NAME)
+
         workspace = (
             self._config.active_workspace if self._config else None
         ) or GlobalConfiguration().get_active_workspace()
@@ -1374,8 +1382,6 @@ class Client(metaclass=ClientMetaClass):
                 "`zenml workspace set WORKSPACE_NAME` to set the active "
                 "workspace."
             )
-
-        from zenml.zen_stores.base_zen_store import DEFAULT_WORKSPACE_NAME
 
         if workspace.name != DEFAULT_WORKSPACE_NAME:
             logger.warning(


### PR DESCRIPTION
## Describe changes
Always set the active workspace to be the default workspace server side. This is still called by the visualization and logging features running on the server.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

