### PR TITLE
Update outdated CLI docs

### DIFF
--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -620,7 +620,7 @@ Once you have registered your feature store as a stack component, you can use it
 in your ZenML Stack.
 
 Interacting with Model Deployers
------------------------------------------
+--------------------------------
 
 Model deployers are stack components responsible for online model serving.
 They are responsible for deploying models to a remote server. Model deployers
@@ -1388,91 +1388,20 @@ zenml permission list
 Deploying ZenML to the cloud
 ----------------------------
 
-The ZenML CLI provides a simple way to deploy ZenML to the cloud.
-
-Deploying cloud resources using Stack Recipes
------------------------------------------------
-
-Stack Recipes allow you to quickly deploy fully-fledged MLOps stacks with just
-a few commands. Each recipe uses Terraform modules under the hood and once
-executed can set up a ZenML stack, ready to run your pipelines!
-
-A number of stack recipes are already available at [the `mlstacks` repository](https://github.com/zenml-io/mlstacks/). List them
-using the following command:
+The ZenML CLI provides a simple way to deploy ZenML to the cloud. Simply run
 
 ```bash
-zenml stack recipes list
+zenml deploy
 ```
 
-If you want to pull any specific recipe to your local system, use the `pull`
-command:
+You will be prompted to provide a name for your deployment and details like what
+cloud provider you want to deploy to, in addition to the username, password, and
+email you want to set for the default user — and that's it! It creates the
+database and any VPCs, permissions, and more that are needed.
 
-```bash
-zenml stack recipe pull <stack-recipe-name>
-```
-
-If you don't specify a name, `zenml stack recipe pull` will pull all the
-recipes.
-
-If you notice any inconsistency with the locally-pulled version and the GitHub
-repository, run the `pull` command with the `-y` flag to download any recent
-changes.
-
-```bash
-zenml stack recipe pull <stack-recipe-name> -y
-```
-
-Optionally, you can specify the relative path at which you want to install the
-stack recipe(s). Use the `-p` or `--path` flag.
-```bash
-zenml stack recipe pull <stack-recipe-name> --path=<PATH>
-```
-By default, all recipes get downloaded under a directory called
-`zenml_stack_recipes`.
-
-To deploy a recipe, use the `deploy` command. Before running deploy, review the 
-`zenml_stack_recipes/<stack-recipe-name>/locals.tf` file for configuring
-non-sensitive variables and the
-`zenml_stack_recipes/<stack-recipe-name>/values.tfvars`
-file to add sensitive information like access keys and passwords.
-
-```bash
-zenml stack recipe deploy <stack-recipe-name>
-```
-
-Running deploy without any options will create a new ZenML stack with the same
-name as the stack recipe name. Use the `--stack-name` option to specify your
-own name.
-
-```bash
-zenml stack recipe deploy <stack-recipe-name> --stack-name=my_stack
-```
-
-If you wish to review the stack information from the newly-generated resources
-before importing, you can run `deploy` with the `--no-import` flag.
-
-```bash
-zenml stack recipe deploy <stack-recipe-name> --no-import
-```
-This will still create a stack YAML configuration file but will not auto-import
-it. You can make any changes you want to the configuration and then run
-`zenml stack import` manually.
-
-To remove all resources created as part of the recipe, run the `destroy`
-command.
-
-```bash
-zenml stack recipe destroy <stack-recipe-name>
-```
-
-To delete all the recipe files from your system, you can use the `clean`
- command.
-
-```bash
-zenml stack recipe clean
-```
-
-This deletes all the recipes from the default path where they were downloaded.
+In order to be able to run the deploy command, you should have your cloud
+provider's CLI configured locally with permissions to create resources like
+MySQL databases and networks.
 
 Interacting with the ZenML Hub
 ------------------------------


### PR DESCRIPTION
- Removed `zenml stack recipe` docs
- added missing basic instructions for `zenml deploy` command

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

