### PR TITLE
Fix Build Options of `GCPImageBuilder`

### DIFF
--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -130,6 +130,9 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
             build_context=build_context,
             parent_path_directory_name="cloud-build-contexts",
         )
+        docker_build_options = {
+            "--" + key: value for key, value in docker_build_options.items()
+        }
         build = self._configure_cloud_build(
             image_name=image_name,
             cloud_build_context=cloud_build_context,

--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -181,10 +181,10 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
             if isinstance(value, list):
                 for val in value:
                     docker_build_args.extend([option, val])
-            elif value is None or isinstance(value, bool):
-                docker_build_args.append(option)
-            else:
-                docker_build_args.extend([key, value])
+            elif value is not None and not isinstance(value, bool):
+                docker_build_args.extend([option, value])
+            elif value is not False:
+                docker_build_args.extend([option])
 
         return cloudbuild_v1.Build(
             source=cloudbuild_v1.Source(

--- a/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
+++ b/src/zenml/integrations/gcp/image_builders/gcp_image_builder.py
@@ -130,9 +130,6 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
             build_context=build_context,
             parent_path_directory_name="cloud-build-contexts",
         )
-        docker_build_options = {
-            "--" + key: value for key, value in docker_build_options.items()
-        }
         build = self._configure_cloud_build(
             image_name=image_name,
             cloud_build_context=cloud_build_context,
@@ -180,9 +177,12 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
         # Convert the docker_build_options dictionary to a list of strings
         docker_build_args = []
         for key, value in build_options.items():
+            option = f"--{key}"
             if isinstance(value, list):
                 for val in value:
-                    docker_build_args.extend([key, val])
+                    docker_build_args.extend([option, val])
+            elif value is None or isinstance(value, bool):
+                docker_build_args.append(option)
             else:
                 docker_build_args.extend([key, value])
 
@@ -201,7 +201,7 @@ class GCPImageBuilder(BaseImageBuilder, GoogleCredentialsMixin):
                         "-t",
                         image_name,
                         ".",
-                        *build_options,
+                        *docker_build_args,
                     ],
                 },
                 {

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -635,6 +635,7 @@ class Pipeline:
                 )
 
             stack = Client().active_stack
+            stack.validate()
 
             new_version_requests = self.get_new_version_requests(deployment)
             deployment = self.update_new_versions_requests(

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -120,7 +120,7 @@ class PipelineDockerImageBuilder:
             # pipeline?
             return docker_settings.parent_image, dockerfile, requirements
 
-        stack.validate_image_builder()
+        stack.validate()
         image_builder = stack.image_builder
         if not image_builder:
             raise RuntimeError(


### PR DESCRIPTION
## Describe changes
Fixed build options format for `GCPImageBuilder` and also added stack validation before image building to ensure the image builder is in a compatible stack before trying to build.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

