### PR TITLE
Fix sagemaker orchestrator and step operator env vars and other minor bugs 

### DIFF
--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -1324,8 +1324,17 @@ def describe_pydantic_object(schema_json: Dict[str, Any]) -> None:
         warning("Properties", bold=True)
         for prop, prop_schema in properties.items():
             if "$ref" not in prop_schema.keys():
+                if "type" in prop_schema.keys():
+                    prop_type = prop_schema["type"]
+                elif "anyOf" in prop_schema.keys():
+                    prop_type = ", ".join(
+                        [p["type"] for p in prop_schema["anyOf"]]
+                    )
+                    prop_type = f"one of: {prop_type}"
+                else:
+                    prop_type = "object"
                 warning(
-                    f"{prop}, {prop_schema['type']}"
+                    f"{prop}, {prop_type}"
                     f"{', REQUIRED' if prop in required else ''}"
                 )
 

--- a/src/zenml/integrations/aws/container_registries/aws_container_registry.py
+++ b/src/zenml/integrations/aws/container_registries/aws_container_registry.py
@@ -17,7 +17,7 @@ import re
 from typing import List, Optional, cast
 
 import boto3
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from zenml.container_registries.base_container_registry import (
     BaseContainerRegistry,
@@ -80,7 +80,7 @@ class AWSContainerRegistry(BaseContainerRegistry):
             response = boto3.client(
                 "ecr", region_name=self._get_region()
             ).describe_repositories()
-        except NoCredentialsError:
+        except (BotoCoreError, ClientError):
             logger.warning(
                 "Amazon ECR requires you to create a repository before you can "
                 f"push an image to it. ZenML is trying to push the image "

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -30,11 +30,13 @@ from zenml.config.base_settings import BaseSettings
 from zenml.constants import (
     METADATA_ORCHESTRATOR_URL,
 )
-from zenml.entrypoints import StepEntrypointConfiguration
 from zenml.enums import StackComponentType
 from zenml.integrations.aws.flavors.sagemaker_orchestrator_flavor import (
     SagemakerOrchestratorConfig,
     SagemakerOrchestratorSettings,
+)
+from zenml.integrations.aws.orchestrators.sagemaker_orchestrator_entrypoint_config import (
+    SagemakerEntrypointConfiguration,
 )
 from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType, Uri
@@ -206,12 +208,25 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             boto_session=boto_session, default_bucket=self.config.bucket
         )
 
+        # Sagemaker does not allow environment variables longer
+        # than 256 characters. If an environment variable is
+        # longer than 256 characters, we split it into multiple
+        # environment variables (chunks) and re-construct it on the other side
+        # using the entrypoint configuration.
+        environment = (
+            SagemakerEntrypointConfiguration.split_environment_variables(
+                environment
+            )
+        )
+
         sagemaker_steps = []
         for step_name, step in deployment.step_configurations.items():
             image = self.get_image(deployment=deployment, step_name=step_name)
-            command = StepEntrypointConfiguration.get_entrypoint_command()
-            arguments = StepEntrypointConfiguration.get_entrypoint_arguments(
-                step_name=step_name, deployment_id=deployment.id
+            command = SagemakerEntrypointConfiguration.get_entrypoint_command()
+            arguments = (
+                SagemakerEntrypointConfiguration.get_entrypoint_arguments(
+                    step_name=step_name, deployment_id=deployment.id
+                )
             )
             entrypoint = command + arguments
 

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -215,8 +215,9 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
         # is longer than 256 characters, we split it into multiple environment
         # variables (chunks) and re-construct it on the other side using the
         # custom entrypoint configuration.
-        environment = split_environment_variables(
-            environment, size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT
+        split_environment_variables(
+            size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT,
+            env=environment,
         )
 
         sagemaker_steps = []

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -36,7 +36,7 @@ from zenml.integrations.aws.flavors.sagemaker_orchestrator_flavor import (
     SagemakerOrchestratorSettings,
 )
 from zenml.integrations.aws.orchestrators.sagemaker_orchestrator_entrypoint_config import (
-    SAGEMAKER_ENV_VAR_SIZE_LIMIT,
+    SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT,
     SagemakerEntrypointConfiguration,
 )
 from zenml.logger import get_logger
@@ -216,7 +216,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
         # variables (chunks) and re-construct it on the other side using the
         # custom entrypoint configuration.
         environment = split_environment_variables(
-            environment, size_limit=SAGEMAKER_ENV_VAR_SIZE_LIMIT
+            environment, size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT
         )
 
         sagemaker_steps = []

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
@@ -1,0 +1,106 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Entrypoint configuration for ZenML Sagemaker pipeline steps."""
+import os
+from typing import Dict, List
+
+from zenml.entrypoints.step_entrypoint_configuration import (
+    StepEntrypointConfiguration,
+)
+
+ENV_VAR_CHUNK_SUFFIX = "_CHUNK_"
+
+
+class SagemakerEntrypointConfiguration(StepEntrypointConfiguration):
+    """Entrypoint configuration for ZenML Sagemaker pipeline steps.
+
+    The only purpose of this entrypoint configuration is to reconstruct the
+    environment variables that exceed the maximum length of 256 characters
+    from their individual components.
+    """
+
+    def run(self) -> None:
+        """Runs the step."""
+        # Reconstruct the environment variables that exceed the maximum length
+        # of 256 characters from their individual chunks
+        self.reconstruct_environment_variables()
+
+        # Run the step
+        super().run()
+
+    @staticmethod
+    def split_environment_variables(
+        env: Dict[str, str],
+    ) -> Dict[str, str]:
+        """Split long environment variables into chunks.
+
+        Splits the environment variables that exceed the Sagemaker maximum
+        length of 256 characters into individual components.
+
+        Args:
+            env: The environment variables.
+
+        Returns:
+            The updated environment variables.
+        """
+        updated_env = env.copy()
+        for key, value in env.items():
+            if len(value) <= 256:
+                continue
+
+            # We keep the number of chunks to a maximum of 10 to avoid passing
+            # too many environment variables to the Sagemaker job and also to
+            # make the reconstruction easier to implement
+            if len(value) > 256 * 10:
+                raise RuntimeError(
+                    f"Environment variable {key} exceeds the maximum length of "
+                    f"2560 characters."
+                )
+
+            updated_env.pop(key)
+
+            # Split the environment variable into chunks of 256 characters
+            chunks = [value[i : i + 256] for i in range(0, len(value), 256)]
+            for i, chunk in enumerate(chunks):
+                updated_env[f"{key}{ENV_VAR_CHUNK_SUFFIX}{i}"] = chunk
+
+        return updated_env
+
+    @staticmethod
+    def reconstruct_environment_variables() -> None:
+        """Reconstruct environment variables that were split into chunks.
+
+        Reconstructs the environment variables with values that exceed the
+        Sagemaker maximum length of 256 characters from their individual
+        chunks.
+        """
+        chunks: Dict[str, List[str]] = {}
+        for key in os.environ.keys():
+            if not key[:-1].endswith(ENV_VAR_CHUNK_SUFFIX):
+                continue
+
+            # Collect all chunks of the same environment variable
+            original_key = key[: -(len(ENV_VAR_CHUNK_SUFFIX) + 1)]
+            chunks.setdefault(original_key, [])
+            chunks[original_key].append(key)
+
+        # Reconstruct the environment variables from their chunks
+        for key, chunk_keys in chunks.items():
+            chunk_keys.sort()
+            value = "".join([os.environ[key] for key in chunk_keys])
+            os.environ[key] = value
+
+            # Remove the chunk environment variables
+            for key in chunk_keys:
+                os.environ.pop(key)

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
@@ -12,14 +12,13 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """Entrypoint configuration for ZenML Sagemaker pipeline steps."""
-import os
-from typing import Dict, List
 
 from zenml.entrypoints.step_entrypoint_configuration import (
     StepEntrypointConfiguration,
 )
+from zenml.utils.env_utils import reconstruct_environment_variables
 
-ENV_VAR_CHUNK_SUFFIX = "_CHUNK_"
+SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT = 256
 
 
 class SagemakerEntrypointConfiguration(StepEntrypointConfiguration):
@@ -27,84 +26,14 @@ class SagemakerEntrypointConfiguration(StepEntrypointConfiguration):
 
     The only purpose of this entrypoint configuration is to reconstruct the
     environment variables that exceed the maximum length of 256 characters
-    from their individual components.
+    allowed for Sagemaker Processor steps from their individual components.
     """
 
     def run(self) -> None:
         """Runs the step."""
         # Reconstruct the environment variables that exceed the maximum length
         # of 256 characters from their individual chunks
-        self.reconstruct_environment_variables()
+        reconstruct_environment_variables()
 
         # Run the step
         super().run()
-
-    @staticmethod
-    def split_environment_variables(
-        env: Dict[str, str],
-    ) -> Dict[str, str]:
-        """Split long environment variables into chunks.
-
-        Splits the environment variables that exceed the Sagemaker maximum
-        length of 256 characters into individual components.
-
-        Args:
-            env: The environment variables.
-
-        Returns:
-            The updated environment variables.
-
-        Raises:
-            RuntimeError: If an environment variable exceeds the maximum length
-                of 2560 characters.
-        """
-        updated_env = env.copy()
-        for key, value in env.items():
-            if len(value) <= 256:
-                continue
-
-            # We keep the number of chunks to a maximum of 10 to avoid passing
-            # too many environment variables to the Sagemaker job and also to
-            # make the reconstruction easier to implement
-            if len(value) > 256 * 10:
-                raise RuntimeError(
-                    f"Environment variable {key} exceeds the maximum length of "
-                    f"2560 characters."
-                )
-
-            updated_env.pop(key)
-
-            # Split the environment variable into chunks of 256 characters
-            chunks = [value[i : i + 256] for i in range(0, len(value), 256)]
-            for i, chunk in enumerate(chunks):
-                updated_env[f"{key}{ENV_VAR_CHUNK_SUFFIX}{i}"] = chunk
-
-        return updated_env
-
-    @staticmethod
-    def reconstruct_environment_variables() -> None:
-        """Reconstruct environment variables that were split into chunks.
-
-        Reconstructs the environment variables with values that exceed the
-        Sagemaker maximum length of 256 characters from their individual
-        chunks.
-        """
-        chunks: Dict[str, List[str]] = {}
-        for key in os.environ.keys():
-            if not key[:-1].endswith(ENV_VAR_CHUNK_SUFFIX):
-                continue
-
-            # Collect all chunks of the same environment variable
-            original_key = key[: -(len(ENV_VAR_CHUNK_SUFFIX) + 1)]
-            chunks.setdefault(original_key, [])
-            chunks[original_key].append(key)
-
-        # Reconstruct the environment variables from their chunks
-        for key, chunk_keys in chunks.items():
-            chunk_keys.sort()
-            value = "".join([os.environ[key] for key in chunk_keys])
-            os.environ[key] = value
-
-            # Remove the chunk environment variables
-            for key in chunk_keys:
-                os.environ.pop(key)

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator_entrypoint_config.py
@@ -53,6 +53,10 @@ class SagemakerEntrypointConfiguration(StepEntrypointConfiguration):
 
         Returns:
             The updated environment variables.
+
+        Raises:
+            RuntimeError: If an environment variable exceeds the maximum length
+                of 2560 characters.
         """
         updated_env = env.copy()
         for key, value in env.items():

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -183,8 +183,9 @@ class SagemakerStepOperator(BaseStepOperator):
         # is longer than 512 characters, we split it into multiple environment
         # variables (chunks) and re-construct it on the other side using the
         # custom entrypoint configuration.
-        environment = split_environment_variables(
-            environment, size_limit=SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT
+        split_environment_variables(
+            env=environment,
+            size_limit=SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT,
         )
 
         image_name = info.get_image(key=SAGEMAKER_DOCKER_IMAGE_KEY)

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator_entrypoint_config.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator_entrypoint_config.py
@@ -1,0 +1,39 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Entrypoint configuration for ZenML Sagemaker step operator."""
+
+from zenml.step_operators.step_operator_entrypoint_configuration import (
+    StepOperatorEntrypointConfiguration,
+)
+from zenml.utils.env_utils import reconstruct_environment_variables
+
+SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT = 512
+
+
+class SagemakerEntrypointConfiguration(StepOperatorEntrypointConfiguration):
+    """Entrypoint configuration for ZenML Sagemaker step operator.
+
+    The only purpose of this entrypoint configuration is to reconstruct the
+    environment variables that exceed the maximum length of 512 characters
+    allowed for Sagemaker Estimator steps from their individual components.
+    """
+
+    def run(self) -> None:
+        """Runs the step."""
+        # Reconstruct the environment variables that exceed the maximum length
+        # of 512 characters from their individual chunks
+        reconstruct_environment_variables()
+
+        # Run the step
+        super().run()

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -508,17 +508,14 @@ class StepLauncher:
             step_operator_name: The name of the step operator to use.
             step_run_info: Additional information needed to run the step.
         """
-        from zenml.step_operators.step_operator_entrypoint_configuration import (
-            StepOperatorEntrypointConfiguration,
-        )
-
         step_operator = _get_step_operator(
             stack=self._stack,
             step_operator_name=step_operator_name,
         )
+        entrypoint_cfg_class = step_operator.entrypoint_config_class
         entrypoint_command = (
-            StepOperatorEntrypointConfiguration.get_entrypoint_command()
-            + StepOperatorEntrypointConfiguration.get_entrypoint_arguments(
+            entrypoint_cfg_class.get_entrypoint_command()
+            + entrypoint_cfg_class.get_entrypoint_arguments(
                 step_name=self._step_name,
                 deployment_id=self._deployment.id,
                 step_run_id=str(step_run_info.step_run_id),

--- a/src/zenml/step_operators/base_step_operator.py
+++ b/src/zenml/step_operators/base_step_operator.py
@@ -20,6 +20,9 @@ from zenml.enums import StackComponentType
 from zenml.logger import get_logger
 from zenml.stack import Flavor, StackComponent
 from zenml.stack.stack_component import StackComponentConfig
+from zenml.step_operators.step_operator_entrypoint_configuration import (
+    StepOperatorEntrypointConfiguration,
+)
 
 if TYPE_CHECKING:
     from zenml.config.step_run_info import StepRunInfo
@@ -42,6 +45,21 @@ class BaseStepOperator(StackComponent, ABC):
             The config of the step operator.
         """
         return cast(BaseStepOperatorConfig, self._config)
+
+    @property
+    def entrypoint_config_class(
+        self,
+    ) -> Type[StepOperatorEntrypointConfiguration]:
+        """Returns the entrypoint configuration class for this step operator.
+
+        Concrete step operator implementations may override this property
+        to return a custom entrypoint configuration class if they need to
+        customize the entrypoint configuration.
+
+        Returns:
+            The entrypoint configuration class for this step operator.
+        """
+        return StepOperatorEntrypointConfiguration
 
     @abstractmethod
     def launch(

--- a/src/zenml/utils/env_utils.py
+++ b/src/zenml/utils/env_utils.py
@@ -13,33 +13,34 @@
 #  permissions and limitations under the License.
 """Utility functions for handling environment variables."""
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional, cast
 
 ENV_VAR_CHUNK_SUFFIX = "_CHUNK_"
 
 
 def split_environment_variables(
-    env: Dict[str, str],
     size_limit: int,
-) -> Dict[str, str]:
+    env: Optional[Dict[str, str]] = None,
+) -> None:
     """Split long environment variables into chunks.
 
     Splits the input environment variables with values that exceed the supplied
-    maximum length into individual components.
+    maximum length into individual components. The input environment variables
+    are modified in-place.
 
     Args:
-        env: Input environment variables.
         size_limit: Maximum length of an environment variable value.
-
-    Returns:
-        The updated environment variables.
+        env: Input environment variables dictionary. If not supplied, the
+            OS environment variables are used.
 
     Raises:
         RuntimeError: If an environment variable value is too large and requires
             more than 10 chunks.
     """
-    updated_env = env.copy()
-    for key, value in env.items():
+    if env is None:
+        env = cast(Dict[str, str], os.environ)
+
+    for key, value in env.copy().items():
         if len(value) <= size_limit:
             continue
 
@@ -52,26 +53,34 @@ def split_environment_variables(
                 f"{size_limit * 10} characters."
             )
 
-        updated_env.pop(key)
+        env.pop(key)
 
         # Split the environment variable into chunks
         chunks = [
             value[i : i + size_limit] for i in range(0, len(value), size_limit)
         ]
         for i, chunk in enumerate(chunks):
-            updated_env[f"{key}{ENV_VAR_CHUNK_SUFFIX}{i}"] = chunk
-
-    return updated_env
+            env[f"{key}{ENV_VAR_CHUNK_SUFFIX}{i}"] = chunk
 
 
-def reconstruct_environment_variables() -> None:
+def reconstruct_environment_variables(
+    env: Optional[Dict[str, str]] = None
+) -> None:
     """Reconstruct environment variables that were split into chunks.
 
     Reconstructs the environment variables with values that were split into
-    individual chunks because they were too large.
+    individual chunks because they were too large. The input environment
+    variables are modified in-place.
+
+    Args:
+        env: Input environment variables dictionary. If not supplied, the OS
+            environment variables are used.
     """
+    if env is None:
+        env = cast(Dict[str, str], os.environ)
+
     chunks: Dict[str, List[str]] = {}
-    for key in os.environ.keys():
+    for key in env.keys():
         if not key[:-1].endswith(ENV_VAR_CHUNK_SUFFIX):
             continue
 
@@ -83,9 +92,9 @@ def reconstruct_environment_variables() -> None:
     # Reconstruct the environment variables from their chunks
     for key, chunk_keys in chunks.items():
         chunk_keys.sort()
-        value = "".join([os.environ[key] for key in chunk_keys])
-        os.environ[key] = value
+        value = "".join([env[key] for key in chunk_keys])
+        env[key] = value
 
         # Remove the chunk environment variables
         for key in chunk_keys:
-            os.environ.pop(key)
+            env.pop(key)

--- a/src/zenml/utils/env_utils.py
+++ b/src/zenml/utils/env_utils.py
@@ -1,0 +1,91 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Utility functions for handling environment variables."""
+import os
+from typing import Dict, List
+
+ENV_VAR_CHUNK_SUFFIX = "_CHUNK_"
+
+
+def split_environment_variables(
+    env: Dict[str, str],
+    size_limit: int,
+) -> Dict[str, str]:
+    """Split long environment variables into chunks.
+
+    Splits the input environment variables with values that exceed the supplied
+    maximum length into individual components.
+
+    Args:
+        env: Input environment variables.
+        size_limit: Maximum length of an environment variable value.
+
+    Returns:
+        The updated environment variables.
+
+    Raises:
+        RuntimeError: If an environment variable value is too large and requires
+            more than 10 chunks.
+    """
+    updated_env = env.copy()
+    for key, value in env.items():
+        if len(value) <= size_limit:
+            continue
+
+        # We keep the number of chunks to a maximum of 10 to avoid generating
+        # too many environment variables chunks and also to make the
+        # reconstruction easier to implement
+        if len(value) > size_limit * 10:
+            raise RuntimeError(
+                f"Environment variable {key} exceeds the maximum length of "
+                f"{size_limit * 10} characters."
+            )
+
+        updated_env.pop(key)
+
+        # Split the environment variable into chunks
+        chunks = [
+            value[i : i + size_limit] for i in range(0, len(value), size_limit)
+        ]
+        for i, chunk in enumerate(chunks):
+            updated_env[f"{key}{ENV_VAR_CHUNK_SUFFIX}{i}"] = chunk
+
+    return updated_env
+
+
+def reconstruct_environment_variables() -> None:
+    """Reconstruct environment variables that were split into chunks.
+
+    Reconstructs the environment variables with values that were split into
+    individual chunks because they were too large.
+    """
+    chunks: Dict[str, List[str]] = {}
+    for key in os.environ.keys():
+        if not key[:-1].endswith(ENV_VAR_CHUNK_SUFFIX):
+            continue
+
+        # Collect all chunks of the same environment variable
+        original_key = key[: -(len(ENV_VAR_CHUNK_SUFFIX) + 1)]
+        chunks.setdefault(original_key, [])
+        chunks[original_key].append(key)
+
+    # Reconstruct the environment variables from their chunks
+    for key, chunk_keys in chunks.items():
+        chunk_keys.sort()
+        value = "".join([os.environ[key] for key in chunk_keys])
+        os.environ[key] = value
+
+        # Remove the chunk environment variables
+        for key in chunk_keys:
+            os.environ.pop(key)

--- a/tests/unit/utils/test_env_utils.py
+++ b/tests/unit/utils/test_env_utils.py
@@ -1,0 +1,72 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from contextlib import ExitStack as does_not_raise
+
+import pytest
+
+from zenml.utils.env_utils import (
+    reconstruct_environment_variables,
+    split_environment_variables,
+)
+
+
+def test_split_reconstruct_large_env_vars():
+    """Test that splitting and reconstructing large environment variables works."""
+    env = {
+        "ARIA_TEST_ENV_VAR": "aria",
+        "AXL_TEST_ENV_VAR": "axl is gray and puffy",
+        "BLUPUS_TEST_ENV_VAR": "blupus",
+    }
+
+    split_environment_variables(env=env, size_limit=4)
+
+    assert env == {
+        "ARIA_TEST_ENV_VAR": "aria",
+        "AXL_TEST_ENV_VAR_CHUNK_0": "axl ",
+        "AXL_TEST_ENV_VAR_CHUNK_1": "is g",
+        "AXL_TEST_ENV_VAR_CHUNK_2": "ray ",
+        "AXL_TEST_ENV_VAR_CHUNK_3": "and ",
+        "AXL_TEST_ENV_VAR_CHUNK_4": "puff",
+        "AXL_TEST_ENV_VAR_CHUNK_5": "y",
+        "BLUPUS_TEST_ENV_VAR_CHUNK_0": "blup",
+        "BLUPUS_TEST_ENV_VAR_CHUNK_1": "us",
+    }
+
+    reconstruct_environment_variables(env=env)
+
+    assert env == {
+        "ARIA_TEST_ENV_VAR": "aria",
+        "AXL_TEST_ENV_VAR": "axl is gray and puffy",
+        "BLUPUS_TEST_ENV_VAR": "blupus",
+    }
+
+
+def test_split_too_large_env_var_fails():
+    """Test that splitting and reconstructing too large an environment variable fails."""
+    env = {
+        "ARIA_TEST_ENV_VAR": "aria",
+        "AXL_TEST_ENV_VAR": "axl is gray and puffy and wonderful",
+    }
+
+    with does_not_raise():
+        split_environment_variables(env=env, size_limit=4)
+
+    env = {
+        "ARIA_TEST_ENV_VAR": "aria",
+        "AXL_TEST_ENV_VAR": "axl is gray and puffy and wonderful and otherworldly",
+    }
+
+    with pytest.raises(RuntimeError):
+        split_environment_variables(env=env, size_limit=4)


### PR DESCRIPTION
## Describe changes
This PR fixes the following issues:
* Sagemaker has a limit on the size of the environment variable values passed to processing steps (256) and estimator steps (512). We exceed the 256 limit with our API Tokens now. Fixed by splitting large env var values into multiple chunks and reconstructing them on the other side
* the AWS container registry still runs into errors if the local AWS credentials don't have access to check that the repository exists
* `zenml orchestrator flavor describe sagemaker` and `zenml step-operator flavor describe sagemaker` fail because the configuration includes attributes that have a `Union` type and that is not currently supported by the CLI

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

