### PR TITLE
Adjust model endpoints and methods to conform to the rest of code

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -5075,7 +5075,6 @@ class Client(metaclass=ClientMetaClass):
 
     def delete_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version from Model Control Plane.
@@ -5085,13 +5084,11 @@ class Client(metaclass=ClientMetaClass):
             model_version_name_or_id: name or id of the model version to be deleted.
         """
         self.zen_store.delete_model_version(
-            model_name_or_id=model_name_or_id,
             model_version_name_or_id=model_version_name_or_id,
         )
 
     def get_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_number_or_id: Optional[
             Union[str, int, UUID, ModelStages]
         ] = None,
@@ -5099,7 +5096,6 @@ class Client(metaclass=ClientMetaClass):
         """Get an existing model version from Model Control Plane.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_number_or_id: name, id, stage or number of the model version to be retrieved.
                 If skipped latest version will be retrieved.
 
@@ -5107,7 +5103,6 @@ class Client(metaclass=ClientMetaClass):
             The model version of interest.
         """
         return self.zen_store.get_model_version(
-            model_name_or_id=model_name_or_id,
             model_version_name_or_number_or_id=model_version_name_or_number_or_id,
         )
 
@@ -5130,20 +5125,17 @@ class Client(metaclass=ClientMetaClass):
 
     def update_model_version(
         self,
-        model_version_id: UUID,
         model_version_update_model: ModelVersionUpdateModel,
     ) -> ModelVersionResponseModel:
         """Get all model versions by filter.
 
         Args:
-            model_version_id: The ID of model version to be updated.
             model_version_update_model: The model version to be updated.
 
         Returns:
             An updated model version.
         """
         return self.zen_store.update_model_version(
-            model_version_id=model_version_id,
             model_version_update_model=model_version_update_model,
         )
 

--- a/src/zenml/models/model_models.py
+++ b/src/zenml/models/model_models.py
@@ -341,7 +341,7 @@ class ModelVersionResponseModel(
 class ModelVersionFilterModel(WorkspaceScopedFilterModel):
     """Filter Model for Model Version."""
 
-    model_id: Union[str, UUID] = Field(
+    model_id: Optional[Union[str, UUID]] = Field(
         description="The ID of the Model",
     )
     name: Optional[Union[str, UUID]] = Field(

--- a/src/zenml/zen_server/routers/models_endpoints.py
+++ b/src/zenml/zen_server/routers/models_endpoints.py
@@ -34,13 +34,14 @@ from zenml.models import (
     ModelResponseModel,
     ModelUpdateModel,
     ModelVersionArtifactFilterModel,
+    ModelVersionArtifactRequestModel,
     ModelVersionArtifactResponseModel,
     ModelVersionFilterModel,
     ModelVersionPipelineRunFilterModel,
+    ModelVersionPipelineRunRequestModel,
     ModelVersionPipelineRunResponseModel,
     ModelVersionResponseModel,
-    ModelVersionUpdateModel, ModelVersionPipelineRunRequestModel,
-    ModelVersionArtifactRequestModel,
+    ModelVersionUpdateModel,
 )
 from zenml.models.page_model import Page
 from zenml.zen_server.auth import AuthContext, authorize
@@ -295,9 +296,7 @@ def list_model_version_artifact_links(
 
 
 @model_versions_router.post(
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + ARTIFACTS,
+    +MODEL_VERSIONS + "/{model_version_name_or_id}" + ARTIFACTS,
     response_model=ModelVersionArtifactResponseModel,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
@@ -394,9 +393,7 @@ def list_model_version_pipeline_run_links(
 
 
 @model_versions_router.post(
-    + MODEL_VERSIONS
-    + "/{model_version_name_or_id}"
-    + RUNS,
+    +MODEL_VERSIONS + "/{model_version_name_or_id}" + RUNS,
     response_model=ModelVersionPipelineRunResponseModel,
     responses={401: error_response, 409: error_response, 422: error_response},
 )

--- a/src/zenml/zen_server/routers/models_endpoints.py
+++ b/src/zenml/zen_server/routers/models_endpoints.py
@@ -225,18 +225,21 @@ def get_model_version(
 )
 @handle_exceptions
 def update_model_version(
+    model_version_id: UUID,
     model_version_update_model: ModelVersionUpdateModel,
     _: AuthContext = Security(authorize, scopes=[PermissionType.WRITE]),
 ) -> ModelVersionResponseModel:
     """Get all model versions by filter.
 
     Args:
+        model_version_id: The ID of model version to be updated.
         model_version_update_model: The model version to be updated.
 
     Returns:
         An updated model version.
     """
     return zen_store().update_model_version(
+        model_version_id=model_version_id,
         model_version_update_model=model_version_update_model,
     )
 
@@ -255,9 +258,7 @@ def delete_model_version(
     Args:
         model_version_name_or_id: The name or ID of the model version to delete.
     """
-    zen_store().delete_model_version(
-        model_version_name_or_id
-    )
+    zen_store().delete_model_version(model_version_name_or_id)
 
 
 ##########################
@@ -266,8 +267,7 @@ def delete_model_version(
 
 
 @model_versions_router.get(
-    "/{model_version_name_or_id}"
-    + ARTIFACTS,
+    "/{model_version_name_or_id}" + ARTIFACTS,
     response_model=Page[ModelVersionArtifactResponseModel],
     responses={401: error_response, 404: error_response, 422: error_response},
 )
@@ -325,8 +325,7 @@ def delete_model_version_artifact_link(
 
 
 @model_versions_router.get(
-    "/{model_version_name_or_id}"
-    + RUNS,
+    "/{model_version_name_or_id}" + RUNS,
     response_model=Page[ModelVersionPipelineRunResponseModel],
     responses={401: error_response, 404: error_response, 422: error_response},
 )

--- a/src/zenml/zen_server/routers/models_endpoints.py
+++ b/src/zenml/zen_server/routers/models_endpoints.py
@@ -421,7 +421,6 @@ def create_model_version_pipeline_run_link(
             model version does not match the current workspace or authenticated
             user.
     """
-
     if model_version_pipeline_run_link.user != auth_context.user.id:
         raise IllegalOperationError(
             "Creating models for a user other than yourself "
@@ -431,30 +430,3 @@ def create_model_version_pipeline_run_link(
         model_version_pipeline_run_link
     )
     return mv
-
-
-@model_versions_router.delete(
-    "{model_version_name_or_id}"
-    + RUNS
-    + "/{model_version_pipeline_run_link_name_or_id}",
-    responses={401: error_response, 404: error_response, 422: error_response},
-)
-@handle_exceptions
-def delete_model_version_pipeline_run_link(
-    model_name_or_id: Union[str, UUID],
-    model_version_name_or_id: Union[str, UUID],
-    model_version_pipeline_run_link_name_or_id: Union[str, UUID],
-    _: AuthContext = Security(authorize, scopes=[PermissionType.WRITE]),
-) -> None:
-    """Deletes a model version link.
-
-    Args:
-        model_name_or_id: name or ID of the model containing the model version.
-        model_version_name_or_id: name or ID of the model version containing the link.
-        model_version_pipeline_run_link_name_or_id: name or ID of the model version link to be deleted.
-    """
-    zen_store().delete_model_version_pipeline_run_link(
-        model_name_or_id,
-        model_version_name_or_id,
-        model_version_pipeline_run_link_name_or_id,
-    )

--- a/src/zenml/zen_server/routers/workspaces_endpoints.py
+++ b/src/zenml/zen_server/routers/workspaces_endpoints.py
@@ -19,7 +19,6 @@ from fastapi import APIRouter, Depends, Security
 
 from zenml.constants import (
     API,
-    ARTIFACTS,
     CODE_REPOSITORIES,
     GET_OR_CREATE,
     MODEL_VERSIONS,
@@ -53,13 +52,7 @@ from zenml.models import (
     ModelFilterModel,
     ModelRequestModel,
     ModelResponseModel,
-    ModelVersionArtifactFilterModel,
-    ModelVersionArtifactRequestModel,
-    ModelVersionArtifactResponseModel,
     ModelVersionFilterModel,
-    ModelVersionPipelineRunFilterModel,
-    ModelVersionPipelineRunRequestModel,
-    ModelVersionPipelineRunResponseModel,
     ModelVersionRequestModel,
     ModelVersionResponseModel,
     PipelineBuildFilterModel,
@@ -1235,9 +1228,7 @@ def list_workspace_models(
 
 
 @router.post(
-    WORKSPACES
-    + "/{workspace_name_or_id}"
-    + MODEL_VERSIONS,
+    WORKSPACES + "/{workspace_name_or_id}" + MODEL_VERSIONS,
     response_model=ModelVersionResponseModel,
     responses={401: error_response, 409: error_response, 422: error_response},
 )

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -228,7 +228,8 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
 app.include_router(pipeline_builds_endpoints.router)
 app.include_router(pipeline_deployments_endpoints.router)
 app.include_router(code_repositories_endpoints.router)
-app.include_router(models_endpoints.router)
+app.include_router(models_endpoints.models_router)
+app.include_router(models_endpoints.model_versions_router)
 
 
 def get_root_static_files() -> List[str]:

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2427,9 +2427,7 @@ class RestZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Optional[
-            Union[str, int, UUID, ModelStages]
-        ] = None,
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2427,7 +2427,7 @@ class RestZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages],
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2413,18 +2413,16 @@ class RestZenStore(BaseZenStore):
 
     def delete_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_id: name or id of the model version to be deleted.
         """
         self._delete_resource(
             resource_id=model_version_name_or_id,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}",
+            route=MODEL_VERSIONS,
         )
 
     def get_model_version(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2429,7 +2429,6 @@ class RestZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_number_or_id: Optional[
             Union[str, int, UUID, ModelStages]
         ] = None,
@@ -2437,7 +2436,6 @@ class RestZenStore(BaseZenStore):
         """Get an existing model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_number_or_id: name, id, stage or number of the model version to be retrieved.
                 If skipped latest version will be retrieved.
 
@@ -2447,7 +2445,7 @@ class RestZenStore(BaseZenStore):
         return self._get_resource(
             resource_id=model_version_name_or_number_or_id
             or LATEST_MODEL_VERSION_PLACEHOLDER,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}",
+            route=MODEL_VERSIONS,
             response_model=ModelVersionResponseModel,
             params={
                 "is_number": isinstance(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2464,7 +2464,7 @@ class RestZenStore(BaseZenStore):
             A page of all model versions.
         """
         return self._list_paginated_resources(
-            route=f"{MODELS}/{model_version_filter_model.model_id}{MODEL_VERSIONS}",
+            route=f"{MODEL_VERSIONS}",
             response_model=ModelVersionResponseModel,
             filter_model=model_version_filter_model,
         )
@@ -2509,7 +2509,7 @@ class RestZenStore(BaseZenStore):
         return self._create_workspace_scoped_resource(
             resource=model_version_artifact_link,
             response_model=ModelVersionArtifactResponseModel,
-            route=f"{MODELS}/{model_version_artifact_link.model}{MODEL_VERSIONS}/{model_version_artifact_link.model_version}{ARTIFACTS}",
+            route=f"{MODEL_VERSIONS}/{model_version_artifact_link.model_version}{ARTIFACTS}",
         )
 
     def list_model_version_artifact_links(
@@ -2526,27 +2526,25 @@ class RestZenStore(BaseZenStore):
             A page of all model version to artifact links.
         """
         return self._list_paginated_resources(
-            route=f"{MODELS}/{model_version_artifact_link_filter_model.model_id}{MODEL_VERSIONS}/{model_version_artifact_link_filter_model.model_version_id}{ARTIFACTS}",
+            route=f"{MODEL_VERSIONS}/{model_version_artifact_link_filter_model.model_version_id}{ARTIFACTS}",
             response_model=ModelVersionArtifactResponseModel,
             filter_model=model_version_artifact_link_filter_model,
         )
 
     def delete_model_version_artifact_link(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
         model_version_artifact_link_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version to artifact link.
 
         Args:
-            model_name_or_id: name or ID of the model containing the model version.
             model_version_name_or_id: name or ID of the model version containing the link.
             model_version_artifact_link_name_or_id: name or ID of the model version to artifact link to be deleted.
         """
         self._delete_resource(
             resource_id=model_version_artifact_link_name_or_id,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}/{model_version_name_or_id}{ARTIFACTS}",
+            route=f"{MODEL_VERSIONS}/{model_version_name_or_id}{ARTIFACTS}",
         )
 
     ###############################
@@ -2569,7 +2567,7 @@ class RestZenStore(BaseZenStore):
         return self._create_workspace_scoped_resource(
             resource=model_version_pipeline_run_link,
             response_model=ModelVersionPipelineRunResponseModel,
-            route=f"{MODELS}/{model_version_pipeline_run_link.model}{MODEL_VERSIONS}/{model_version_pipeline_run_link.model_version}{RUNS}",
+            route=f"{MODEL_VERSIONS}/{model_version_pipeline_run_link.model_version}{RUNS}",
         )
 
     def list_model_version_pipeline_run_links(
@@ -2586,27 +2584,25 @@ class RestZenStore(BaseZenStore):
             A page of all model version to pipeline run links.
         """
         return self._list_paginated_resources(
-            route=f"{MODELS}/{model_version_pipeline_run_link_filter_model.model_id}{MODEL_VERSIONS}/{model_version_pipeline_run_link_filter_model.model_version_id}{RUNS}",
+            route=f"{MODEL_VERSIONS}/{model_version_pipeline_run_link_filter_model.model_version_id}{RUNS}",
             response_model=ModelVersionPipelineRunResponseModel,
             filter_model=model_version_pipeline_run_link_filter_model,
         )
 
     def delete_model_version_pipeline_run_link(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
         model_version_pipeline_run_link_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version to pipeline run link.
 
         Args:
-            model_name_or_id: name or ID of the model containing the model version.
             model_version_name_or_id: name or ID of the model version containing the link.
             model_version_pipeline_run_link_name_or_id: name or ID of the model version to pipeline run link to be deleted.
         """
         self._delete_resource(
             resource_id=model_version_pipeline_run_link_name_or_id,
-            route=f"{MODELS}/{model_name_or_id}{MODEL_VERSIONS}/{model_version_name_or_id}{RUNS}",
+            route=f"{MODEL_VERSIONS}/{model_version_name_or_id}{RUNS}",
         )
 
     # ------------------

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5735,15 +5735,11 @@ class SqlZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
-        model_version_name_or_number_or_id: Optional[
-            Union[str, int, UUID, ModelStages]
-        ] = None,
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_number_or_id: name, id, stage or number of the model version to be retrieved.
                 If skipped latest version will be retrieved.
 
@@ -5754,10 +5750,7 @@ class SqlZenStore(BaseZenStore):
             KeyError: specified ID or name not found.
         """
         with Session(self.engine) as session:
-            model = self.get_model(model_name_or_id)
-            query = select(ModelVersionSchema).where(
-                ModelVersionSchema.model_id == model.id
-            )
+            query = select(ModelVersionSchema)
             if (
                 model_version_name_or_number_or_id is None
                 or model_version_name_or_number_or_id

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5735,7 +5735,7 @@ class SqlZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages],
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6230,14 +6230,12 @@ class SqlZenStore(BaseZenStore):
 
     def delete_model_version_pipeline_run_link(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
         model_version_pipeline_run_link_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version to pipeline run link.
 
         Args:
-            model_name_or_id: name or ID of the model containing the model version.
             model_version_name_or_id: name or ID of the model version containing the link.
             model_version_pipeline_run_link_name_or_id: name or ID of the model version to pipeline run link to be deleted.
 
@@ -6245,7 +6243,6 @@ class SqlZenStore(BaseZenStore):
             KeyError: specified ID not found.
         """
         with Session(self.engine) as session:
-            self.get_model(model_name_or_id)
             model_version = self.get_model_version(model_version_name_or_id)
             query = select(ModelVersionPipelineRunSchema).where(
                 ModelVersionPipelineRunSchema.model_version_id

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6126,7 +6126,7 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             self.get_model(model_name_or_id)
             model_version = self.get_model_version(
-                model_name_or_id, model_version_name_or_id
+                model_version_name_or_id
             )
             query = select(ModelVersionArtifactSchema).where(
                 ModelVersionArtifactSchema.model_version_id == model_version.id
@@ -6249,7 +6249,7 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             self.get_model(model_name_or_id)
             model_version = self.get_model_version(
-                model_name_or_id, model_version_name_or_id
+                model_version_name_or_id
             )
             query = select(ModelVersionPipelineRunSchema).where(
                 ModelVersionPipelineRunSchema.model_version_id

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5735,7 +5735,7 @@ class SqlZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages],
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 
@@ -5814,23 +5814,18 @@ class SqlZenStore(BaseZenStore):
 
     def delete_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_id: name or id of the model version to be deleted.
 
         Raises:
             KeyError: specified ID or name not found.
         """
         with Session(self.engine) as session:
-            model = self.get_model(model_name_or_id)
-            query = select(ModelVersionSchema).where(
-                ModelVersionSchema.model_id == model.id
-            )
+            query = select(ModelVersionSchema)
             try:
                 UUID(str(model_version_name_or_id))
                 query = query.where(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6125,9 +6125,7 @@ class SqlZenStore(BaseZenStore):
         """
         with Session(self.engine) as session:
             self.get_model(model_name_or_id)
-            model_version = self.get_model_version(
-                model_version_name_or_id
-            )
+            model_version = self.get_model_version(model_version_name_or_id)
             query = select(ModelVersionArtifactSchema).where(
                 ModelVersionArtifactSchema.model_version_id == model_version.id
             )
@@ -6248,9 +6246,7 @@ class SqlZenStore(BaseZenStore):
         """
         with Session(self.engine) as session:
             self.get_model(model_name_or_id)
-            model_version = self.get_model_version(
-                model_version_name_or_id
-            )
+            model_version = self.get_model_version(model_version_name_or_id)
             query = select(ModelVersionPipelineRunSchema).where(
                 ModelVersionPipelineRunSchema.model_version_id
                 == model_version.id

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5735,7 +5735,7 @@ class SqlZenStore(BaseZenStore):
 
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages],
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1895,14 +1895,12 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def delete_model_version_artifact_link(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
         model_version_artifact_link_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version to artifact link.
 
         Args:
-            model_name_or_id: name or ID of the model containing the model version.
             model_version_name_or_id: name or ID of the model version containing the link.
             model_version_artifact_link_name_or_id: name or ID of the model version to artifact link to be deleted.
 
@@ -1947,7 +1945,6 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def delete_model_version_pipeline_run_link(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
         model_version_pipeline_run_link_name_or_id: Union[str, UUID],
     ) -> None:

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1807,7 +1807,7 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages],
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1807,9 +1807,7 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def get_model_version(
         self,
-        model_version_name_or_number_or_id: Optional[
-            Union[str, int, UUID, ModelStages]
-        ] = None,
+        model_version_name_or_number_or_id: Union[str, int, UUID, ModelStages]
     ) -> ModelVersionResponseModel:
         """Get an existing model version.
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1809,7 +1809,6 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def get_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_number_or_id: Optional[
             Union[str, int, UUID, ModelStages]
         ] = None,
@@ -1817,7 +1816,6 @@ class ZenStoreInterface(ABC):
         """Get an existing model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_number_or_id: name, id, stage or number of the model version to be retrieved.
                 If skipped latest version will be retrieved.
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1793,13 +1793,11 @@ class ZenStoreInterface(ABC):
     @abstractmethod
     def delete_model_version(
         self,
-        model_name_or_id: Union[str, UUID],
         model_version_name_or_id: Union[str, UUID],
     ) -> None:
         """Deletes a model version.
 
         Args:
-            model_name_or_id: name or id of the model containing the model version.
             model_version_name_or_id: name or id of the model version to be deleted.
 
         Raises:

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -2485,11 +2485,10 @@ class TestModelVersion:
 
     def test_get_not_found(self):
         """Test that get fails if not found."""
-        with ModelVersionContext() as model:
+        with ModelVersionContext():
             zs = Client().zen_store
             with pytest.raises(KeyError):
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id="1.0.0",
                 )
 
@@ -2506,7 +2505,6 @@ class TestModelVersion:
                 )
             )
             mv2 = zs.get_model_version(
-                model_name_or_id=model.id,
                 model_version_name_or_number_or_id="great one",
             )
             assert mv1.id == mv2.id
@@ -2549,11 +2547,10 @@ class TestModelVersion:
 
     def test_delete_not_found(self):
         """Test that delete fails if not found."""
-        with ModelVersionContext() as model:
+        with ModelVersionContext():
             zs = Client().zen_store
             with pytest.raises(KeyError):
                 zs.delete_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_id="1.0.0",
                 )
 
@@ -2570,12 +2567,10 @@ class TestModelVersion:
                 )
             )
             zs.delete_model_version(
-                model_name_or_id=model.id,
                 model_version_name_or_id="great one",
             )
             with pytest.raises(KeyError):
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id="great one",
                 )
 
@@ -2622,12 +2617,10 @@ class TestModelVersion:
                 ),
             )
             mv2 = zs.get_model_version(
-                model_name_or_id=model.id,
                 model_version_name_or_number_or_id="staging",
             )
             assert mv1.id == mv2.id
             mv3 = zs.get_model_version(
-                model_name_or_id=model.id,
                 model_version_name_or_number_or_id=ModelStages.STAGING,
             )
             assert mv1.id == mv3.id
@@ -2647,7 +2640,6 @@ class TestModelVersion:
 
             with pytest.raises(KeyError):
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=ModelStages.STAGING,
                 )
 
@@ -2716,7 +2708,6 @@ class TestModelVersion:
             )
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv1.name,
                 ).stage
                 == "staging"
@@ -2733,21 +2724,18 @@ class TestModelVersion:
 
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv1.name,
                 ).stage
                 == "archived"
             )
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv2.id,
                 ).stage
                 == "staging"
             )
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv2.id,
                 ).name
                 == "I changed that..."
@@ -2767,7 +2755,6 @@ class TestModelVersion:
             )
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv1.name,
                 ).stage
                 is None
@@ -2775,7 +2762,6 @@ class TestModelVersion:
             mv1.set_stage("staging")
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv1.name,
                 ).stage
                 == "staging"
@@ -2784,7 +2770,6 @@ class TestModelVersion:
             mv1._update_default_running_version_name()
             assert (
                 zs.get_model_version(
-                    model_name_or_id=model.id,
                     model_version_name_or_number_or_id=mv1.id,
                 ).name
                 == "1"
@@ -2852,7 +2837,6 @@ class TestModelVersion:
         with ModelVersionContext(create_version=True) as model_version:
             zs = Client().zen_store
             found = zs.get_model_version(
-                model_name_or_id=model_version.model.id,
                 model_version_name_or_number_or_id=1,
             )
             assert found.id == model_version.id
@@ -2861,18 +2845,16 @@ class TestModelVersion:
 
     def test_get_not_found_by_number(self):
         """Test that get fails by integer version number, if not found and by string version number, cause treated as name."""
-        with ModelVersionContext(create_version=True) as model_version:
+        with ModelVersionContext(create_version=True):
             zs = Client().zen_store
             # no version numbered as 2
             with pytest.raises(KeyError):
                 zs.get_model_version(
-                    model_name_or_id=model_version.model.id,
                     model_version_name_or_number_or_id=2,
                 )
             # cannot fetch by string number - treated as name
             with pytest.raises(KeyError):
                 zs.get_model_version(
-                    model_name_or_id=model_version.model.id,
                     model_version_name_or_number_or_id="1",
                 )
 
@@ -3111,7 +3093,6 @@ class TestModelVersionArtifactLinks:
                 )
             )
             zs.delete_model_version_artifact_link(
-                model_name_or_id=model_version.model.id,
                 model_version_name_or_id=model_version.id,
                 model_version_artifact_link_name_or_id="link",
             )
@@ -3217,7 +3198,6 @@ class TestModelVersionArtifactLinks:
             assert len(mvls) == 1 and mvls[0].name == "link3"
 
             mv = zs.get_model_version(
-                model_name_or_id=model_version.model.id,
                 model_version_name_or_number_or_id=model_version.id,
             )
 
@@ -3406,7 +3386,6 @@ class TestModelVersionPipelineRunLinks:
             assert len(mvls) == 2
 
             mv = zs.get_model_version(
-                model_name_or_id=model_version.model.id,
                 model_version_name_or_number_or_id=model_version.id,
             )
 


### PR DESCRIPTION
## Describe changes

As a rule of thumb (besides workspaces) we do not have endpoints with 2 layers of unique resources. 

`/model_version/{id}` already uniquely identifies the model_version so
`/model/{id}/model_version{id}` is redundant.

Also

get `.../model/{id}/model_versions` as a list call did not work as the `{id}` was completely ignored, instead the `model_id` field of the filter model was a required field. This behaved differently than filters and list calls for all other resources. So I moved /model_versions into their own group

Here is the new API docs:
![image](https://github.com/zenml-io/zenml/assets/38859294/58478a71-1837-4d42-827e-2d0462f9e84e)


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

