### PR TITLE
Make error message nicer for when two artifacts that share a prefix are found

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -5391,11 +5391,15 @@ class Client(metaclass=ClientMetaClass):
 
         # If more than one entity with the same name is found, raise an error.
         entity_label = get_method.__name__.replace("get_", "") + "s"
+        formatted_entity_items = [
+            f"- {item.name}: (id: {item.id}, flavor: {item.flavor})\n"
+            for item in entity.items
+        ]
         raise ZenKeyError(
             f"{entity.total} {entity_label} have been found that have "
             f"a name that matches the provided "
             f"string '{name_id_or_prefix}':\n"
-            f"{[entity.items]}.\n"
+            f"{formatted_entity_items}.\n"
             f"Please use the id to uniquely identify "
             f"only one of the {entity_label}s."
         )

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -5392,7 +5392,7 @@ class Client(metaclass=ClientMetaClass):
         # If more than one entity with the same name is found, raise an error.
         entity_label = get_method.__name__.replace("get_", "") + "s"
         formatted_entity_items = [
-            f"- {item.name}: (id: {item.id}, flavor: {item.flavor})\n"
+            f"- {item.name}: (id: {item.id})\n"
             for item in entity.items
         ]
         raise ZenKeyError(


### PR DESCRIPTION
Addresses this situation:
![CleanShot 2023-11-06 at 11 39 28@2x](https://github.com/zenml-io/zenml/assets/3348134/90b19f74-5e98-4644-a9d4-96bdcee4f60d)

with nicer error messages.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

