### PR TITLE
Remove NumPy Visualizations for 2D Arrays

### DIFF
--- a/src/zenml/materializers/numpy_materializer.py
+++ b/src/zenml/materializers/numpy_materializer.py
@@ -129,8 +129,8 @@ class NumpyMaterializer(BaseMaterializer):
                 self._save_histogram(histogram_path, arr)
                 return {histogram_path: VisualizationType.IMAGE}
 
-            # Save as image for 2D or 3D arrays with 3 or 4 channels
-            if self._array_can_be_saved_as_image(arr):
+            # Save as image for 3D arrays with 3 or 4 channels
+            if len(arr.shape) == 3 and arr.shape[2] in [3, 4]:
                 image_path = os.path.join(self.uri, "image.png")
                 self._save_image(image_path, arr)
                 return {image_path: VisualizationType.IMAGE}
@@ -157,24 +157,6 @@ class NumpyMaterializer(BaseMaterializer):
         with fileio.open(output_path, "wb") as f:
             plt.savefig(f)
         plt.close()
-
-    @staticmethod
-    def _array_can_be_saved_as_image(arr: "NDArray[Any]") -> bool:
-        """Checks if a numpy array can be saved as an image.
-
-        This is the case if the array is 2D or 3D with 3 or 4 channels.
-
-        Args:
-            arr: The numpy array to check.
-
-        Returns:
-            True if the array can be saved as an image, False otherwise.
-        """
-        if len(arr.shape) == 2:
-            return True
-        if len(arr.shape) == 3 and arr.shape[2] in [3, 4]:
-            return True
-        return False
 
     def _save_image(self, output_path: str, arr: "NDArray[Any]") -> None:
         """Saves a numpy array as an image.


### PR DESCRIPTION
## Describe changes
The `NumpyMaterializer` no longer tries to visualize 2D arrays as images by default since most 2D arrays are not actually images and the visualizations it creates under such circumstances are confusing as shown below:

![dd2c072c-4a1c-43c0-9e90-f4c7a318cbb3](https://github.com/zenml-io/zenml/assets/23118541/03dacfcd-740a-4dcc-a8e5-7c8438ce6216)

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

