### PR TITLE
Bring dashboard back to the release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ zenml_tutorial/
 mlstacks_reset.sh
 
 .local/
+# PLEASE KEEP THIS LINE AT THE EOF: never include here src/zenml/zen_server/dashboard, since it is affecting release flow

--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,3 @@ zenml_tutorial/
 mlstacks_reset.sh
 
 .local/
-
-# exclude installed dashboard folder
-src/zenml/zen_server/dashboard


### PR DESCRIPTION
## Describe changes
I reverted the poor .gitignore change to bring the dashboard back to the release.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

