### PR TITLE
Add warning header to docs for version 0.46.1

### DIFF
--- a/docs/book/deploying-zenml/zenml-cloud/cloud-system-architecture.md
+++ b/docs/book/deploying-zenml/zenml-cloud/cloud-system-architecture.md
@@ -2,6 +2,11 @@
 description: Different variations of the ZenML Cloud architecture depending on your needs.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Cloud Architecture
 
 {% hint style="info" %}

--- a/docs/book/deploying-zenml/zenml-cloud/zenml-cloud.md
+++ b/docs/book/deploying-zenml/zenml-cloud/zenml-cloud.md
@@ -2,6 +2,11 @@
 description: Your one-stop MLOps control plane.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ☁ ZenML Cloud
 
 ZenML Cloud is a Software-as-a-Service (SaaS) platform that extends the capabilities of the open-source ZenML product. It provides you with a centralized control plane to effortlessly launch and manage their ZenML server instances. The core foundation of ZenML Cloud remains the powerful open-source offering, but with ZenML Cloud, you gain access to a host of additional features designed to streamline the machine learning workflow.

--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-using-huggingface-spaces.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-using-huggingface-spaces.md
@@ -2,6 +2,11 @@
 description: Deploying ZenML to Huggingface Spaces.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy using HuggingFace Spaces
 
 A quick way to deploy ZenML and get started is to use [HuggingFace Spaces](https://huggingface.co/spaces). HuggingFace

--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-custom-image.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-custom-image.md
@@ -2,6 +2,11 @@
 description: Deploying ZenML with custom Docker images.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 In most cases, deploying ZenML with the default `zenmlhub/zenml-server` Docker 
 image should work just fine. However, there are some scenarios when you 
 might need to deploy ZenML with a custom Docker image:

--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-docker.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-docker.md
@@ -2,6 +2,11 @@
 description: Deploying ZenML in a Docker container.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy with Docker
 
 The ZenML server container image is available at [`zenmldocker/zenml-server`](https://hub.docker.com/r/zenmldocker/zenml/) and can be used to deploy ZenML with a container management or orchestration tool like docker and docker-compose, or a serverless platform like [Cloud Run](https://cloud.google.com/run), [Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/overview), and more! This guide walks you through the various configuration options that the ZenML server container expects as well as a few deployment use cases.

--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-helm.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-helm.md
@@ -2,6 +2,11 @@
 description: Deploying ZenML in a Kubernetes cluster with Helm.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy with Helm
 
 If you wish to manually deploy and manage ZenML in a Kubernetes cluster of your choice, ZenML also includes a Helm chart among its available deployment options.

--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-zenml-cli.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-with-zenml-cli.md
@@ -2,6 +2,11 @@
 description: Deploying ZenML on cloud using the ZenML CLI.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy with ZenML CLI
 
 The easiest and fastest way to get running on the cloud is by using the `deploy` CLI command. It currently only supports deploying to Kubernetes on managed cloud services. You can check the [overview page](zenml-self-hosted.md) to learn about other options that you have.

--- a/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/manage-the-deployed-services.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/manage-the-deployed-services.md
@@ -2,6 +2,11 @@
 description: Once deployed, here's how to manage ZenML and its Stack Components
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Manage deployed services
 
 Maintaining and troubleshooting your ZenML deployment and the stack components deployed through ZenML is quite easy. Here are a few guides that will explain how:

--- a/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/troubleshoot-stack-components.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/troubleshoot-stack-components.md
@@ -2,6 +2,11 @@
 description: Learn how to troubleshoot Stack Components deployed with ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Troubleshoot stack components
 
 There are two ways in which you can understand if something has gone wrong while deploying your stack or stack components.

--- a/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/troubleshoot-your-deployed-server.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/troubleshoot-your-deployed-server.md
@@ -2,6 +2,11 @@
 description: Troubleshooting tips for your ZenML deployment
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Troubleshoot the deployed server
 
 In this document, we will go over some common issues that you might face when deploying ZenML and how to solve them.

--- a/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/upgrade-the-version-of-the-zenml-server.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/manage-the-deployed-services/upgrade-the-version-of-the-zenml-server.md
@@ -2,6 +2,11 @@
 description: Learn how to upgrade your server to a new version of ZenML for the different deployment options.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Upgrade the version of the ZenML server
 
 The way to upgrade your ZenML server depends a lot on how you deployed it.

--- a/docs/book/deploying-zenml/zenml-self-hosted/zenml-self-hosted.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/zenml-self-hosted.md
@@ -2,6 +2,11 @@
 description: A guide on how to deploy ZenML in a self-hosted environment.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🔧 ZenML Self-Hosted
 
 A ZenML deployment typically looks like this:

--- a/docs/book/getting-started/core-concepts.md
+++ b/docs/book/getting-started/core-concepts.md
@@ -2,6 +2,11 @@
 description: Discovering the core concepts behind ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🪄 Core concepts
 
 **ZenML** is an extensible, open-source MLOps framework for creating portable, production-ready **MLOps pipelines**. It's built for data scientists, ML Engineers, and MLOps Developers to collaborate as they develop to production. In order to achieve this goal, ZenML introduces various concepts for different aspects of an ML workflow and we can categorize these concepts under three different threads:

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -2,6 +2,11 @@
 description: Installing ZenML and getting started.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🧙 Installation
 
 **ZenML** is a Python package that can be installed directly via `pip`:

--- a/docs/book/introduction.md
+++ b/docs/book/introduction.md
@@ -2,6 +2,11 @@
 description: Welcome to ZenML!
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ⭐ Introduction
 
 **ZenML** is an extensible, open-source MLOps framework for creating portable, production-ready machine learning pipelines. By decoupling infrastructure from code, ZenML enables developers across your organization to collaborate more effectively as they develop to production.

--- a/docs/book/learning/projects/projects.md
+++ b/docs/book/learning/projects/projects.md
@@ -2,6 +2,11 @@
 description: Resources to learn how to use ZenML practically.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🧩 Projects
 
 ZenML Projects are small-scale production-grade ML use cases powered by ZenML. They are fully fleshed-out, end-to-end, projects that showcase ZenML's capabilities. They can also serve as a template from which to start similar projects.

--- a/docs/book/reference/community-and-content.md
+++ b/docs/book/reference/community-and-content.md
@@ -2,6 +2,11 @@
 description: All possible ways for our community to get in touch with ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 💜 Community & content
 
 The ZenML team and community have put together a list of references that can be used to get in touch with the

--- a/docs/book/reference/faq.md
+++ b/docs/book/reference/faq.md
@@ -2,6 +2,11 @@
 description: Find answers to the most frequently asked questions about ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ❓ FAQ
 
 #### Why did you build ZenML?

--- a/docs/book/reference/how-do-i.md
+++ b/docs/book/reference/how-do-i.md
@@ -2,6 +2,11 @@
 description: Links to common use cases, workflows and tasks using ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ❓ How do I...?
 
 **Last Updated**: October 17, 2023

--- a/docs/book/reference/migration-guide/migration-guide.md
+++ b/docs/book/reference/migration-guide/migration-guide.md
@@ -2,6 +2,11 @@
 description: How to migrate your ZenML code to the newest version.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ♻ Migration guide
 
 Migrations are necessary for ZenML releases that include breaking changes, which are currently all releases that increment the minor version of the release, e.g., `0.X` -> `0.Y`. Furthermore, all releases that increment the first non-zero digit of the version contain major breaking changes or paradigm shifts that are explained in separate migration guides below.

--- a/docs/book/reference/migration-guide/migration-zero-forty.md
+++ b/docs/book/reference/migration-guide/migration-zero-forty.md
@@ -2,6 +2,11 @@
 description: How to migrate your ZenML pipelines and steps from version <=0.39.1 to 0.41.0.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Migration guide 0.39.1 → 0.41.0
 
 ZenML versions 0.40.0 to 0.41.0 introduced a new and more flexible syntax to define ZenML steps and pipelines. This page contains code samples that show you how to upgrade your steps and pipelines to the new syntax.

--- a/docs/book/reference/migration-guide/migration-zero-thirty.md
+++ b/docs/book/reference/migration-guide/migration-zero-thirty.md
@@ -3,6 +3,11 @@ description: How to migrate from ZenML 0.20.0-0.23.0 to 0.30.0-0.39.1.
 ---
 
 {% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
+{% hint style="warning" %}
 Migrating to `0.30.0` performs non-reversible database changes so downgrading
 to `<=0.23.0` is not possible afterwards. If you are running on an older ZenML 
 version, please follow the 

--- a/docs/book/reference/migration-guide/migration-zero-twenty.md
+++ b/docs/book/reference/migration-guide/migration-zero-twenty.md
@@ -2,6 +2,11 @@
 description: How to migrate from ZenML <=0.13.2 to 0.20.0.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Migration guide 0.13.2 → 0.20.0
 
 The ZenML 0.20.0 release brings a number of big changes to its architecture and its features, some of which are not backwards compatible with previous versions. This guide walks you through these changes and offers instructions on how to migrate your existing ZenML stacks and pipelines to the new version with minimal effort and disruption to your existing workloads.

--- a/docs/book/stacks-and-components/auth-management/auth-management.md
+++ b/docs/book/stacks-and-components/auth-management/auth-management.md
@@ -4,6 +4,11 @@ description: >-
   services and resources.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🔐 Auth management
 
 A production-grade MLOps platform involves interactions between a diverse combination of third-party libraries and external services sourced from various different vendors. One of the most daunting hurdles in building and operating an MLOps platform composed of multiple components is configuring and maintaining uninterrupted and secured access to the infrastructure resources and services that it consumes.

--- a/docs/book/stacks-and-components/auth-management/aws-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/aws-service-connector.md
@@ -4,6 +4,11 @@ description: >-
   buckets, EKS Kubernetes clusters and ECR container registries.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # AWS Service Connector
 
 The ZenML AWS Service Connector facilitates the authentication and access to managed AWS services and resources. These encompass a range of resources, including S3 buckets, ECR container repositories, and EKS clusters. The connector provides support for various authentication methods, including explicit long-lived AWS secret keys, IAM roles, short-lived STS tokens, and implicit authentication.

--- a/docs/book/stacks-and-components/auth-management/azure-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/azure-service-connector.md
@@ -5,6 +5,11 @@ description: >-
   registries.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Azure Service Connector
 
 The ZenML Azure Service Connector facilitates the authentication and access to managed Azure services and resources. These encompass a range of resources, including blob storage containers, ACR repositories, and AKS clusters.

--- a/docs/book/stacks-and-components/auth-management/best-security-practices.md
+++ b/docs/book/stacks-and-components/auth-management/best-security-practices.md
@@ -4,6 +4,11 @@ description: >-
   Service Connectors.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Security best practices
 
 Service Connector Types, especially those targeted at cloud providers, offer a plethora of authentication methods matching those supported by remote cloud platforms. While there is no single authentication standard that unifies this process, there are some patterns that are easily identifiable and can be used as guidelines when deciding which authentication method to use to configure a Service Connector.

--- a/docs/book/stacks-and-components/auth-management/docker-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/docker-service-connector.md
@@ -2,6 +2,11 @@
 description: Configuring Docker Service Connectors to connect ZenML to Docker container registries.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Docker Service Connector
 
 The ZenML Docker Service Connector allows authenticating with a Docker or OCI container registry and managing Docker clients for the registry. This connector provides pre-authenticated python-docker Python clients to Stack Components that are linked to it.

--- a/docs/book/stacks-and-components/auth-management/gcp-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/gcp-service-connector.md
@@ -4,6 +4,11 @@ description: >-
   GCS buckets, GKE Kubernetes clusters, and GCR container registries.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # GCP Service Connector
 
 The ZenML GCP Service Connector facilitates the authentication and access to managed GCP services and resources. These encompass a range of resources, including GCS buckets, GCR container repositories, and GKE clusters. The connector provides support for various authentication methods, including GCP user accounts, service accounts, short-lived OAuth 2.0 tokens, and implicit authentication.

--- a/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
+++ b/docs/book/stacks-and-components/auth-management/kubernetes-service-connector.md
@@ -2,6 +2,11 @@
 description: Configuring Kubernetes Service Connectors to connect ZenML to Kubernetes clusters.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Kubernetes Service Connector
 
 The ZenML Kubernetes service connector facilitates authenticating and connecting to a Kubernetes cluster. The connector can be used to access to any generic Kubernetes cluster by providing pre-authenticated Kubernetes python clients to Stack Components that are linked to it and also allows configuring the local Kubernetes CLI (i.e. `kubectl`).

--- a/docs/book/stacks-and-components/auth-management/service-connectors-guide.md
+++ b/docs/book/stacks-and-components/auth-management/service-connectors-guide.md
@@ -4,6 +4,11 @@ description: >-
   external resources.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Service Connectors guide
 
 This documentation section contains everything that you need to use Service Connectors to connect ZenML to external resources. A lot of information is covered, so it might be useful to use the following guide to navigate it:

--- a/docs/book/stacks-and-components/component-guide/alerters/alerters.md
+++ b/docs/book/stacks-and-components/component-guide/alerters/alerters.md
@@ -2,6 +2,11 @@
 description: Sending automated alerts to chat services.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Alerters
 
 **Alerters** allow you to send messages to chat services (like Slack, Discord, Mattermost, etc.) from within your

--- a/docs/book/stacks-and-components/component-guide/alerters/custom.md
+++ b/docs/book/stacks-and-components/component-guide/alerters/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom alerter.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Alerter
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/alerters/discord.md
+++ b/docs/book/stacks-and-components/component-guide/alerters/discord.md
@@ -2,6 +2,11 @@
 description: Sending automated alerts to a Discord channel.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Discord Alerter
 
 The `DiscordAlerter` enables you to send messages to a dedicated Discord channel 

--- a/docs/book/stacks-and-components/component-guide/alerters/slack.md
+++ b/docs/book/stacks-and-components/component-guide/alerters/slack.md
@@ -2,6 +2,11 @@
 description: Sending automated alerts to a Slack channel.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Slack Alerter
 
 The `SlackAlerter` enables you to send messages to a dedicated Slack channel 

--- a/docs/book/stacks-and-components/component-guide/annotators/annotators.md
+++ b/docs/book/stacks-and-components/component-guide/annotators/annotators.md
@@ -2,6 +2,11 @@
 description: Annotating the data in your workflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Annotators
 
 Annotators are a stack component that enables the use of data annotation as part of your ZenML stack and pipelines. You

--- a/docs/book/stacks-and-components/component-guide/annotators/custom.md
+++ b/docs/book/stacks-and-components/component-guide/annotators/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom annotator.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Annotator
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/annotators/label-studio.md
+++ b/docs/book/stacks-and-components/component-guide/annotators/label-studio.md
@@ -2,6 +2,11 @@
 description: Annotating data using Label Studio.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Label Studio
 
 Label Studio is one of the leading open-source annotation platforms available to data scientists and ML practitioners.

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/artifact-stores.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/artifact-stores.md
@@ -2,6 +2,11 @@
 description: Setting up a persistent storage for your artifacts.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Artifact Stores
 
 The Artifact Store is a central component in any MLOps stack. As the name suggests, it acts as a data persistence layer

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/azure.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/azure.md
@@ -2,6 +2,11 @@
 description: Storing artifacts using Azure Blob Storage
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Azure Blob Storage
 
 The Azure Artifact Store is an [Artifact Store](artifact-stores.md) flavor provided with the Azure ZenML integration

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/custom.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom artifact store.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a custom artifact store
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/gcp.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/gcp.md
@@ -2,6 +2,11 @@
 description: Storing artifacts using GCP Cloud Storage.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud Storage (GCS)
 
 The GCS Artifact Store is an [Artifact Store](artifact-stores.md) flavor provided with the GCP ZenML integration that

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/local.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/local.md
@@ -2,6 +2,11 @@
 description: Storing artifacts on your local filesystem.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Local Artifact Store
 
 The local Artifact Store is a built-in ZenML [Artifact Store](artifact-stores.md) flavor that uses a folder on your

--- a/docs/book/stacks-and-components/component-guide/artifact-stores/s3.md
+++ b/docs/book/stacks-and-components/component-guide/artifact-stores/s3.md
@@ -2,6 +2,11 @@
 description: Storing artifacts in an AWS S3 bucket.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Amazon Simple Cloud Storage (S3)
 
 The S3 Artifact Store is an [Artifact Store](artifact-stores.md) flavor provided with the S3 ZenML integration that

--- a/docs/book/stacks-and-components/component-guide/component-guide.md
+++ b/docs/book/stacks-and-components/component-guide/component-guide.md
@@ -2,6 +2,11 @@
 description: Overview of categories of MLOps components.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 📜 Component guide
 
 If you are new to the world of MLOps, it is often daunting to be immediately faced with a sea of tools that seemingly all promise and do the same things. It is useful in this case to try to categorize tools in various groups in order to understand their value in your toolchain in a more precise manner.

--- a/docs/book/stacks-and-components/component-guide/container-registries/aws.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/aws.md
@@ -2,6 +2,11 @@
 description: Storing container images in Amazon ECR.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Amazon Elastic Container Registry (ECR)
 
 The AWS container registry is a [container registry](container-registries.md) flavor provided with the ZenML `aws`

--- a/docs/book/stacks-and-components/component-guide/container-registries/azure.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/azure.md
@@ -2,6 +2,11 @@
 description: Storing container images in Azure.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Azure Container Registry
 
 The Azure container registry is a [container registry](container-registries.md) flavor that comes built-in with ZenML

--- a/docs/book/stacks-and-components/component-guide/container-registries/container-registries.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/container-registries.md
@@ -2,6 +2,11 @@
 description: Setting up a storage for Docker images.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Container Registries
 
 The container registry is an essential part of most remote MLOps stacks. It is used to store container images that are

--- a/docs/book/stacks-and-components/component-guide/container-registries/custom.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom container registry.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Container Registry
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/container-registries/default.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/default.md
@@ -2,6 +2,11 @@
 description: Storing container images locally.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Default Container Registry
 
 The Default container registry is a [container registry](container-registries.md) flavor that comes built-in with ZenML

--- a/docs/book/stacks-and-components/component-guide/container-registries/dockerhub.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/dockerhub.md
@@ -2,6 +2,11 @@
 description: Storing container images in DockerHub.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # DockerHub
 
 The DockerHub container registry is a [container registry](container-registries.md) flavor that comes built-in with

--- a/docs/book/stacks-and-components/component-guide/container-registries/gcp.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/gcp.md
@@ -2,6 +2,11 @@
 description: Storing container images in GCP.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud Container Registry
 
 The GCP container registry is a [container registry](container-registries.md) flavor that comes built-in with ZenML and

--- a/docs/book/stacks-and-components/component-guide/container-registries/github.md
+++ b/docs/book/stacks-and-components/component-guide/container-registries/github.md
@@ -2,6 +2,11 @@
 description: Storing container images in GitHub.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # GitHub Container Registry
 
 The GitHub container registry is a [container registry](container-registries.md) flavor that comes built-in with ZenML

--- a/docs/book/stacks-and-components/component-guide/data-validators/custom.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/custom.md
@@ -2,6 +2,11 @@
 description: How to develop a custom data validator
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a custom data validator
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/data-validators/data-validators.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/data-validators.md
@@ -2,6 +2,11 @@
 description: How to enhance and maintain the quality of your data and the performance of your models with data profiling and validation
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 Without good data, even the best machine learning models will yield questionable
 results. A lot of effort goes into ensuring and maintaining data quality not
 only in the initial stages of model development, but throughout the entire

--- a/docs/book/stacks-and-components/component-guide/data-validators/deepchecks.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/deepchecks.md
@@ -4,6 +4,11 @@ description: >-
   suites
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deepchecks
 
 The Deepchecks [Data Validator](data-validators.md) flavor provided with the ZenML integration uses [Deepchecks](https://deepchecks.com/) to run data integrity, data drift, model drift and model performance tests on the datasets and models circulated in your ZenML pipelines. The test results can be used to implement automated corrective actions in your pipelines or to render interactive representations for further visual interpretation, evaluation and documentation.

--- a/docs/book/stacks-and-components/component-guide/data-validators/evidently.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/evidently.md
@@ -4,6 +4,11 @@ description: >-
   with Evidently profiling
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Evidently
 
 The Evidently [Data Validator](data-validators.md) flavor provided with the ZenML integration uses [Evidently](https://evidentlyai.com/) to perform data quality, data drift, model drift and model performance analyses, to generate reports and run checks. The reports and check results can be used to implement automated corrective actions in your pipelines or to render interactive representations for further visual interpretation, evaluation and documentation.

--- a/docs/book/stacks-and-components/component-guide/data-validators/great-expectations.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/great-expectations.md
@@ -4,6 +4,11 @@ description: >-
   document the results
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Great Expectations
 
 The Great Expectations [Data Validator](data-validators.md) flavor provided with the ZenML integration uses [Great Expectations](https://greatexpectations.io/) to run data profiling and data quality tests on the data circulated through your pipelines. The test results can be used to implement automated corrective actions in your pipelines. They are also automatically rendered into documentation for further visual interpretation and evaluation.

--- a/docs/book/stacks-and-components/component-guide/data-validators/whylogs.md
+++ b/docs/book/stacks-and-components/component-guide/data-validators/whylogs.md
@@ -4,6 +4,11 @@ description: >-
   data with whylogs/WhyLabs profiling.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Whylogs
 
 The whylogs/WhyLabs [Data Validator](data-validators.md) flavor provided with the ZenML integration uses [whylogs](https://whylabs.ai/whylogs) and [WhyLabs](https://whylabs.ai) to generate and track data profiles, highly accurate descriptive representations of your data. The profiles can be used to implement automated corrective actions in your pipelines, or to render interactive representations for further visual interpretation, evaluation and documentation.

--- a/docs/book/stacks-and-components/component-guide/experiment-trackers/custom.md
+++ b/docs/book/stacks-and-components/component-guide/experiment-trackers/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom experiment tracker.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Experiment Tracker
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/experiment-trackers/experiment-trackers.md
+++ b/docs/book/stacks-and-components/component-guide/experiment-trackers/experiment-trackers.md
@@ -2,6 +2,11 @@
 description: Logging and visualizing ML experiments.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Experiment Trackers
 
 Experiment trackers let you track your ML experiments by logging extended information about your models, datasets,

--- a/docs/book/stacks-and-components/component-guide/experiment-trackers/mlflow.md
+++ b/docs/book/stacks-and-components/component-guide/experiment-trackers/mlflow.md
@@ -2,6 +2,11 @@
 description: Logging and visualizing experiments with MLflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # MLflow
 
 The MLflow Experiment Tracker is an [Experiment Tracker](experiment-trackers.md) flavor provided with the MLflow ZenML

--- a/docs/book/stacks-and-components/component-guide/experiment-trackers/neptune.md
+++ b/docs/book/stacks-and-components/component-guide/experiment-trackers/neptune.md
@@ -2,6 +2,11 @@
 description: Logging and visualizing experiments with neptune.ai
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Neptune
 
 The Neptune Experiment Tracker is an [Experiment Tracker](experiment-trackers.md) flavor provided with the Neptune-ZenML

--- a/docs/book/stacks-and-components/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/stacks-and-components/component-guide/experiment-trackers/wandb.md
@@ -2,6 +2,11 @@
 description: Logging and visualizing experiments with Weights & Biases.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Weights & Biases
 
 The Weights & Biases Experiment Tracker is an [Experiment Tracker](experiment-trackers.md) flavor provided with the

--- a/docs/book/stacks-and-components/component-guide/feature-stores/custom.md
+++ b/docs/book/stacks-and-components/component-guide/feature-stores/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom feature store.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Feature Store
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/feature-stores/feast.md
+++ b/docs/book/stacks-and-components/component-guide/feature-stores/feast.md
@@ -2,6 +2,11 @@
 description: Managing data in Feast feature stores.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Feast
 
 Feast (Feature Store) is an operational data system for managing and serving machine learning features to models in

--- a/docs/book/stacks-and-components/component-guide/feature-stores/feature-stores.md
+++ b/docs/book/stacks-and-components/component-guide/feature-stores/feature-stores.md
@@ -2,6 +2,11 @@
 description: Managing data in feature stores.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Feature Stores
 
 Feature stores allow data teams to serve data via an offline store and an online low-latency store where data is kept in

--- a/docs/book/stacks-and-components/component-guide/image-builders/custom.md
+++ b/docs/book/stacks-and-components/component-guide/image-builders/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom image builder.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Image Builder
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/image-builders/gcp.md
+++ b/docs/book/stacks-and-components/component-guide/image-builders/gcp.md
@@ -2,6 +2,11 @@
 description: Building container images with Google Cloud Build
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud Image Builder
 
 The Google Cloud image builder is an [image builder](image-builders.md) flavor provided by the ZenML `gcp` integration

--- a/docs/book/stacks-and-components/component-guide/image-builders/image-builders.md
+++ b/docs/book/stacks-and-components/component-guide/image-builders/image-builders.md
@@ -2,6 +2,11 @@
 description: Building container images for your ML workflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Image Builders
 
 The image builder is an essential part of most remote MLOps stacks. It is used to build container images such that your

--- a/docs/book/stacks-and-components/component-guide/image-builders/kaniko.md
+++ b/docs/book/stacks-and-components/component-guide/image-builders/kaniko.md
@@ -2,6 +2,11 @@
 description: Building container images with Kaniko.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Kaniko Image Builder
 
 The Kaniko image builder is an [image builder](image-builders.md) flavor provided by the ZenML `kaniko` integration that

--- a/docs/book/stacks-and-components/component-guide/image-builders/local.md
+++ b/docs/book/stacks-and-components/component-guide/image-builders/local.md
@@ -2,6 +2,11 @@
 description: Building container images locally.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Local Image Builder
 
 The local image builder is an [image builder](image-builders.md) flavor that comes built-in with ZenML and uses the

--- a/docs/book/stacks-and-components/component-guide/integration-overview.md
+++ b/docs/book/stacks-and-components/component-guide/integration-overview.md
@@ -2,6 +2,11 @@
 description: Overview of third-party ZenML integrations.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Integration overview
 
 Categorizing the MLOps stack is a good way to write abstractions

--- a/docs/book/stacks-and-components/component-guide/model-deployers/bentoml.md
+++ b/docs/book/stacks-and-components/component-guide/model-deployers/bentoml.md
@@ -2,6 +2,11 @@
 description: Deploying your models locally with BentoML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # BentoML
 
 BentoML is an open-source framework for machine learning model serving. it can be used to deploy models locally, in a

--- a/docs/book/stacks-and-components/component-guide/model-deployers/custom.md
+++ b/docs/book/stacks-and-components/component-guide/model-deployers/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom model deployer.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Model Deployer
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/model-deployers/mlflow.md
+++ b/docs/book/stacks-and-components/component-guide/model-deployers/mlflow.md
@@ -2,6 +2,11 @@
 description: Deploying your models locally with MLflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # MLflow
 
 The MLflow Model Deployer is one of the available flavors of the [Model Deployer](model-deployers.md) stack component.

--- a/docs/book/stacks-and-components/component-guide/model-deployers/model-deployers.md
+++ b/docs/book/stacks-and-components/component-guide/model-deployers/model-deployers.md
@@ -2,6 +2,11 @@
 description: Deploying your models and serve real-time predictions.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Model Deployers
 
 Model Deployment is the process of making a machine learning model available to make predictions and decisions on

--- a/docs/book/stacks-and-components/component-guide/model-deployers/seldon.md
+++ b/docs/book/stacks-and-components/component-guide/model-deployers/seldon.md
@@ -2,6 +2,11 @@
 description: Deploying models to Kubernetes with Seldon Core.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Seldon
 
 [Seldon Core](https://github.com/SeldonIO/seldon-core) is a production grade

--- a/docs/book/stacks-and-components/component-guide/model-registries/custom.md
+++ b/docs/book/stacks-and-components/component-guide/model-registries/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom model registry.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Model Registry
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/model-registries/mlflow.md
+++ b/docs/book/stacks-and-components/component-guide/model-registries/mlflow.md
@@ -2,6 +2,11 @@
 description: Managing MLFlow logged models and artifacts
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # MLflow Model Registry
 
 [MLflow](https://www.mlflow.org/docs/latest/tracking.html) is a popular

--- a/docs/book/stacks-and-components/component-guide/model-registries/model-registries.md
+++ b/docs/book/stacks-and-components/component-guide/model-registries/model-registries.md
@@ -2,6 +2,11 @@
 description: Tracking and managing ML models.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Model Registries
 
 Model registries are centralized storage solutions for managing and tracking machine learning models across various

--- a/docs/book/stacks-and-components/component-guide/orchestrators/airflow.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/airflow.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Airflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Airflow Orchestrator
 
 ZenML pipelines can be executed natively as [Airflow](https://airflow.apache.org/) 

--- a/docs/book/stacks-and-components/component-guide/orchestrators/custom.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom orchestrator.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Orchestrator
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/orchestrators/kubeflow.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/kubeflow.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Kubeflow.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Kubeflow Orchestrator
 
 The Kubeflow orchestrator is an [orchestrator](orchestrators.md) flavor provided by the ZenML `kubeflow` integration

--- a/docs/book/stacks-and-components/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/kubernetes.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Kubernetes clusters.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Kubernetes Orchestrator
 
 Using the ZenML `kubernetes` integration, you can orchestrate and scale your

--- a/docs/book/stacks-and-components/component-guide/orchestrators/local-docker.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/local-docker.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run in Docker.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Local Docker Orchestrator
 
 The local Docker orchestrator is an [orchestrator](orchestrators.md) flavor that comes built-in with ZenML and runs your

--- a/docs/book/stacks-and-components/component-guide/orchestrators/local.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/local.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run locally.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Local Orchestrator
 
 The local orchestrator is an [orchestrator](orchestrators.md) flavor that comes built-in with ZenML and runs your

--- a/docs/book/stacks-and-components/component-guide/orchestrators/orchestrators.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/orchestrators.md
@@ -2,6 +2,11 @@
 description: Orchestrating the execution of ML pipelines.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Orchestrators
 
 The orchestrator is an essential component in any MLOps stack as it is responsible for running your machine learning

--- a/docs/book/stacks-and-components/component-guide/orchestrators/sagemaker.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/sagemaker.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Amazon Sagemaker.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # AWS Sagemaker Orchestrator
 
 [Sagemaker Pipelines](https://aws.amazon.com/sagemaker/pipelines)

--- a/docs/book/stacks-and-components/component-guide/orchestrators/skypilot-vm.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/skypilot-vm.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on VMs using SkyPilot.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # SkyPilot VM Orchestrator
 
 The SkyPilot VM Orchestrator is an integration provided by ZenML that allows you to

--- a/docs/book/stacks-and-components/component-guide/orchestrators/tekton.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/tekton.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Tekton.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Tekton Orchestrator
 
 [Tekton](https://tekton.dev/) is a powerful and flexible open-source framework 

--- a/docs/book/stacks-and-components/component-guide/orchestrators/vertex.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/vertex.md
@@ -2,6 +2,11 @@
 description: Orchestrating your pipelines to run on Vertex AI.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud VertexAI Orchestrator
 
 [Vertex AI Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines/introduction)

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/aws.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/aws.md
@@ -2,6 +2,11 @@
 description: Storing secrets in AWS
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # AWS Secrets Manager
 
 The AWS secrets manager is a [secrets manager](secrets-managers.md) flavor provided with the ZenML `aws` integration

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/azure.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/azure.md
@@ -2,6 +2,11 @@
 description: Storing secrets in Azure.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Azure Secrets Manager
 
 The Azure secrets manager is a [secrets manager](secrets-managers.md) flavor provided with the ZenML `azure` integration

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/gcp.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/gcp.md
@@ -2,6 +2,11 @@
 description: Storing secrets in GCP.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud Secrets Manager
 
 The GCP secrets manager is a [secrets manager](secrets-managers.md) flavor provided with the ZenML `gcp` integration

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/local.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/local.md
@@ -2,6 +2,11 @@
 description: Storing secrets locally.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Local Secrets Manager
 
 The local secrets manager is a [secrets manager](secrets-managers.md) flavor that comes built-in with ZenML and uses the

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/secrets-managers.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/secrets-managers.md
@@ -2,6 +2,11 @@
 description: Setting up a storage for secrets.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Secrets Managers
 
 Secrets managers provide a secure way of storing confidential information that is needed to run your ML pipelines. Most

--- a/docs/book/stacks-and-components/component-guide/secrets-managers/vault.md
+++ b/docs/book/stacks-and-components/component-guide/secrets-managers/vault.md
@@ -2,6 +2,11 @@
 description: Storing secrets in HashiCorp Vault.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # HashiCorp Vault Secrets Manager
 
 The HashiCorp Vault secrets manager is a [secrets manager](secrets-managers.md) flavor provided with the ZenML `vault`

--- a/docs/book/stacks-and-components/component-guide/step-operators/azureml.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/azureml.md
@@ -2,6 +2,11 @@
 description: Executing individual steps in AzureML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # AzureML
 
 [AzureML](https://azure.microsoft.com/en-us/services/machine-learning/) offers

--- a/docs/book/stacks-and-components/component-guide/step-operators/custom.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/custom.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom step operator.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Develop a Custom Step Operator
 
 {% hint style="info" %}

--- a/docs/book/stacks-and-components/component-guide/step-operators/sagemaker.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/sagemaker.md
@@ -2,6 +2,11 @@
 description: Executing individual steps in SageMaker.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Amazon SageMaker
 
 [SageMaker](https://aws.amazon.com/sagemaker/) offers specialized compute 

--- a/docs/book/stacks-and-components/component-guide/step-operators/spark-kubernetes.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/spark-kubernetes.md
@@ -299,6 +299,11 @@ roleRef:
   name: edit
   apiGroup: rbac.authorization.k8s.io
 ---
+
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
 ```
 
 And then execute the following command to create the resources:

--- a/docs/book/stacks-and-components/component-guide/step-operators/step-operators.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/step-operators.md
@@ -2,6 +2,11 @@
 description: Executing individual steps in specialized environments.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Step Operators
 
 The step operator enables the execution of individual pipeline steps in specialized runtime environments that are

--- a/docs/book/stacks-and-components/component-guide/step-operators/vertex.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/vertex.md
@@ -2,6 +2,11 @@
 description: Executing individual steps in Vertex AI.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Google Cloud VertexAI
 
 [Vertex AI](https://cloud.google.com/vertex-ai) offers specialized compute 

--- a/docs/book/stacks-and-components/custom-solutions/implement-a-custom-integration.md
+++ b/docs/book/stacks-and-components/custom-solutions/implement-a-custom-integration.md
@@ -2,6 +2,11 @@
 description: Creating an external integration and contributing to ZenML
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Implement a custom integration
 
 ![ZenML integrates with a bunch of tools from the MLOps landscape](../../../.gitbook/assets/sam-side-by-side-full-text.png)

--- a/docs/book/stacks-and-components/custom-solutions/implement-a-custom-stack-component.md
+++ b/docs/book/stacks-and-components/custom-solutions/implement-a-custom-stack-component.md
@@ -2,6 +2,11 @@
 description: How to write a custom stack component flavor
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Implement a custom stack component
 
 When building a sophisticated MLOps Platform, you will often need to come up 

--- a/docs/book/stacks-and-components/stack-deployment/cloud-stacks/minimal-gcp-stack.md
+++ b/docs/book/stacks-and-components/stack-deployment/cloud-stacks/minimal-gcp-stack.md
@@ -2,6 +2,11 @@
 description: A simple guide to quickly set up a minimal stack on GCP.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Set up a minimal GCP stack
 
 This page aims to quickly set up a minimal production stack on GCP. With just a 

--- a/docs/book/stacks-and-components/stack-deployment/contribute-flavors-or-components.md
+++ b/docs/book/stacks-and-components/stack-deployment/contribute-flavors-or-components.md
@@ -2,6 +2,11 @@
 description: Creating your custom stack component solutions.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Contribute flavors or components
 
 Before you can start contributing, it is important to know that the stack component deploy CLI also makes use of the stack recipes (specifically, the modular stack recipes) in the background. Thus, contributing a new deployment option for both the deployment methods that we have seen, involves making a contribution to the base recipe.

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
@@ -2,6 +2,11 @@
 description: Individually deploying different stack components.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy a stack component
 
 If you have used ZenML before, you must be familiar with the flow of registering new stack components. It goes something like this:

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
@@ -2,6 +2,11 @@
 description: Deploying an entire stack with mlstacks.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Deploy a stack using mlstacks
 
 MLStacks is a Python package that allows you to quickly spin up MLOps

--- a/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
+++ b/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
@@ -2,6 +2,11 @@
 description: Deploying your stack components directly from the ZenML CLI
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ⚒ Stack deployment
 
 The first step in running your pipelines on remote infrastructure is to deploy all the components that you would need, like an MLflow tracking server, a Seldon Core model deployer, and more to your cloud.

--- a/docs/book/user-guide/advanced-guide/advanced-guide.md
+++ b/docs/book/user-guide/advanced-guide/advanced-guide.md
@@ -2,6 +2,11 @@
 description: Taking your ZenML workflow to the next level.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🐔 Advanced guide
 
 The aim of this section is to provide you with detailed explanations and documentation regarding specific cases, problems, and solutions frequently encountered in ML workflows.

--- a/docs/book/user-guide/advanced-guide/artifact-management/artifact-management.md
+++ b/docs/book/user-guide/advanced-guide/artifact-management/artifact-management.md
@@ -2,6 +2,11 @@
 description: Managing your data with ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Artifact management
 
 ZenML seamlessly integrates data versioning and lineage into its core functionality. When a pipeline is executed, each run generates automatically tracked and managed artifacts. One can easily [view the entire lineage](../../starter-guide/fetch-runs-after-execution.md) of how artifacts are created and interact with them. The dashboard is also a way to interact with the artifacts produced by different pipeline runs. ZenML's artifact management, caching, lineage tracking, and visualization capabilities can help gain valuable insights, streamline the experimentation process, and ensure the reproducibility and reliability of machine learning workflows.

--- a/docs/book/user-guide/advanced-guide/artifact-management/handle-custom-data-types.md
+++ b/docs/book/user-guide/advanced-guide/artifact-management/handle-custom-data-types.md
@@ -2,6 +2,11 @@
 description: Using materializers to pass custom data types through steps.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Handle custom data types
 
 A ZenML pipeline is built in a data-centric way. The outputs and inputs of steps define how steps are connected and the order in which they are executed. Each step should be considered as its very own process that reads and writes its inputs and outputs from and to the [artifact store](../../../stacks-and-components/component-guide/artifact-stores/artifact-stores.md). This is where **materializers** come into play.

--- a/docs/book/user-guide/advanced-guide/artifact-management/visualize-artifacts.md
+++ b/docs/book/user-guide/advanced-guide/artifact-management/visualize-artifacts.md
@@ -2,6 +2,11 @@
 description: Configuring ZenML to display data visualizations in the dashboard.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Visualize artifacts
 
 ZenML automatically saves visualizations of many common data types and allows you to view these visualizations in the ZenML dashboard:

--- a/docs/book/user-guide/advanced-guide/environment-management/connect-your-git-repository.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/connect-your-git-repository.md
@@ -4,6 +4,11 @@ description: >-
   git repo.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Connect your git repository
 
 A code repository in ZenML refers to a remote storage location for your code. 

--- a/docs/book/user-guide/advanced-guide/environment-management/containerize-your-pipeline.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/containerize-your-pipeline.md
@@ -2,6 +2,11 @@
 description: Using Docker images to run your pipeline.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Containerize your pipeline
 
 ZenML executes pipeline steps sequentially in the active Python environment when running locally. However, with remote [orchestrators](../../../stacks-and-components/component-guide/orchestrators/orchestrators.md) or [step operators](../../../stacks-and-components/component-guide/step-operators/step-operators.md), ZenML builds [Docker](https://www.docker.com/) images to run your pipeline in an isolated, well-defined environment.

--- a/docs/book/user-guide/advanced-guide/environment-management/debug-and-solve-issues.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/debug-and-solve-issues.md
@@ -2,6 +2,11 @@
 description: A guide to debug common issues and get help.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 If you stumbled upon this page, chances are you're facing issues with using 
 ZenML. This page documents suggestions and best practices to let you debug, 
 get help, and solve issues quickly.

--- a/docs/book/user-guide/advanced-guide/environment-management/environment-management.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/environment-management.md
@@ -2,6 +2,11 @@
 description: Navigating multiple development environments.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Environment management
 
 {% hint style="warning" %}

--- a/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
@@ -2,6 +2,11 @@
 description: How to control ZenML behavior with environmental variables.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # ZenML Environment Variables
 
 There are a few pre-defined environmental variables that can be used to control 

--- a/docs/book/user-guide/advanced-guide/environment-management/global-settings-of-zenml.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/global-settings-of-zenml.md
@@ -2,6 +2,11 @@
 description: Understanding the global settings of your ZenML installation.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Global settings of ZenML
 
 The information about the global settings of ZenML on a machine is kept in a folder commonly referred to as the **ZenML Global Config Directory** or the **ZenML Config Path**. The location of this folder depends on the operating system type and the current system user, but is usually located in the following locations:

--- a/docs/book/user-guide/advanced-guide/environment-management/handling-dependencies.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/handling-dependencies.md
@@ -2,6 +2,11 @@
 description: How to handle issues with conflicting dependencies
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Dependency Resolution and ZenML
 
 This page documents a some of the common issues that arise when using ZenML with

--- a/docs/book/user-guide/advanced-guide/environment-management/scale-compute-to-the-cloud.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/scale-compute-to-the-cloud.md
@@ -2,6 +2,11 @@
 description: Ensuring your pipelines or steps run on GPU-backed hardware.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Scale compute to the cloud
 
 There are several reasons why you may want to scale your machine learning pipelines to the cloud, such as utilizing more powerful hardware or distributing tasks across multiple nodes. In order to achieve this with ZenML you'll need to run your steps on GPU-backed hardware using `ResourceSettings` to allocate greater resources on an orchestrator node and/or make some adjustments to the container environment.

--- a/docs/book/user-guide/advanced-guide/environment-management/use-the-client.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/use-the-client.md
@@ -2,6 +2,11 @@
 description: Interacting with your ZenML instance through the ZenML Client.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Use the Client
 
 Pipelines, runs, stacks, and many other ZenML resources are stored and versioned in a database within your ZenML instance behind the scenes. The ZenML `Client` allows you to fetch, update, or even create any of these resources programmatically in Python.

--- a/docs/book/user-guide/advanced-guide/environment-management/use-the-hub.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/use-the-hub.md
@@ -2,6 +2,11 @@
 description: Collaborating with the ZenML community.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Leverage community-contributed plugins
 
 The ZenML Hub is a central platform that enables our users to search, share and discover community-contributed code, such as flavors, materializers, and steps, that can be used across organizations. The goal is to allow our users to extend their ZenML experience by leveraging the community's diverse range of implementations.

--- a/docs/book/user-guide/advanced-guide/pipelining-features/compose-pipelines.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/compose-pipelines.md
@@ -2,6 +2,11 @@
 description: Composing your ZenML pipelines.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Compose pipelines
 
 Sometimes it can be useful to extract some common functionality into separate functions

--- a/docs/book/user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md
@@ -2,6 +2,11 @@
 description: Configuring pipelines, steps, and stack components in ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Configure steps/pipelines
 
 ## Define steps

--- a/docs/book/user-guide/advanced-guide/pipelining-features/fetch-metadata-within-pipeline.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/fetch-metadata-within-pipeline.md
@@ -2,6 +2,11 @@
 description: Accessing meta information during pipeline composition.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Fetch metadata during pipeline composition
 
 ### Pipeline configuration using the `PipelineContext`

--- a/docs/book/user-guide/advanced-guide/pipelining-features/fetch-metadata-within-steps.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/fetch-metadata-within-steps.md
@@ -2,6 +2,11 @@
 description: Accessing meta information in real-time within your pipeline.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Fetch metadata within steps
 
 ### Step & run information using the `StepContext`

--- a/docs/book/user-guide/advanced-guide/pipelining-features/hyper-parameter-tuning.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/hyper-parameter-tuning.md
@@ -2,6 +2,11 @@
 description: Running a hyperparameter tuning trial with ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Hyperparameter Tuning
 
 {% hint style="warning" %}

--- a/docs/book/user-guide/advanced-guide/pipelining-features/pipelining-features.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/pipelining-features.md
@@ -2,6 +2,11 @@
 description: Focusing on the advanced usage of ZenML pipelines
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Pipelining features
 
 <table data-card-size="large" data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><mark style="color:purple;"><strong>Configure steps/pipelines</strong></mark></td><td>Configuring pipelines, steps, and stack components in ZenML.</td><td><a href="configure-steps-pipelines.md">configure-steps-pipelines.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Compose pipelines</strong></mark></td><td>Composing your ZenML pipelines.</td><td><a href="compose-pipelines.md">compose-pipelines.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Schedule pipeline runs</strong></mark></td><td>Planning runs to add automation to your pipelines.</td><td><a href="schedule-pipeline-runs.md">schedule-pipeline-runs.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Fetch metadata within steps</strong></mark></td><td>Accessing meta information in real-time within your pipeline.</td><td><a href="fetch-metadata-within-steps.md">fetch-metadata-within-steps.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Fetch metadata during pipeline composition</strong></mark></td><td>Accessing meta information during pipeline composition.</td><td><a href="fetch-metadata-within-pipeline.md">fetch-metadata-within-pipeline.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Use failure/success hooks</strong></mark></td><td>Running failure and success hooks after step execution.</td><td><a href="use-failure-success-hooks.md">use-failure-success-hooks.md</a></td></tr><tr><td><mark style="color:purple;"><strong>Hyperparameter tuning</strong></mark></td><td>Running a hyperparameter tuning trial with ZenML.</td><td><a href="hyper-parameter-tuning.md">hyper-parameter-tuning.md</a></td></tr></tbody></table>

--- a/docs/book/user-guide/advanced-guide/pipelining-features/schedule-pipeline-runs.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/schedule-pipeline-runs.md
@@ -2,6 +2,11 @@
 description: Planning runs to add automation to your pipelines.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Schedule pipeline runs
 
 In the world of MLOps, scheduling orchestration jobs is an important aspect of automating the processes involved in deploying and maintaining machine learning (ML) models in production environments. Scheduling orchestration jobs allows you to automate tasks such as training and evaluating ML models, deploying models to production, or running periodic checks to ensure that the models are functioning as expected. This can help ensure that your ML pipelines are executed at the right time and in the right order, and can save you time and effort by eliminating the need to manually trigger these tasks.

--- a/docs/book/user-guide/advanced-guide/pipelining-features/use-failure-success-hooks.md
+++ b/docs/book/user-guide/advanced-guide/pipelining-features/use-failure-success-hooks.md
@@ -2,6 +2,11 @@
 description: Running failure and success hooks after step execution.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Use failure/success hooks
 
 Hooks are a way to perform an action after a step has completed execution. They can be useful in a variety of scenarios, such as sending notifications, logging, or cleaning up resources after a step has been completed.

--- a/docs/book/user-guide/advanced-guide/secret-management/custom-secret-stores.md
+++ b/docs/book/user-guide/advanced-guide/secret-management/custom-secret-stores.md
@@ -2,6 +2,11 @@
 description: Learning how to develop a custom secret store.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Create a custom secret store
 
 The secrets store acts as the one-stop shop for all the secrets to which your pipeline or stack components might need

--- a/docs/book/user-guide/advanced-guide/secret-management/interact-with-secrets.md
+++ b/docs/book/user-guide/advanced-guide/secret-management/interact-with-secrets.md
@@ -2,6 +2,11 @@
 description: Managing your secrets with ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Interact with secrets
 
 ## How to create a secret

--- a/docs/book/user-guide/advanced-guide/secret-management/secret-management.md
+++ b/docs/book/user-guide/advanced-guide/secret-management/secret-management.md
@@ -2,6 +2,11 @@
 description: Registering and utilizing secrets.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Use the Secret Store
 
 ## What is a ZenML secret?

--- a/docs/book/user-guide/starter-guide/cache-previous-executions.md
+++ b/docs/book/user-guide/starter-guide/cache-previous-executions.md
@@ -2,6 +2,11 @@
 description: Iterating quickly with ZenML through caching.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Cache previous executions
 
 Developing machine learning pipelines is very iterative. ZenML speeds you up in this work with the caching feature of steps and pipelines.

--- a/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
+++ b/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
@@ -2,6 +2,11 @@
 description: Learning how to configure pipelines and their steps.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Create an ML pipeline
 
 In this section, we build out the first ML pipeline. For this, let's get the imports out of the way first:

--- a/docs/book/user-guide/starter-guide/fetch-runs-after-execution.md
+++ b/docs/book/user-guide/starter-guide/fetch-runs-after-execution.md
@@ -2,6 +2,11 @@
 description: Inspecting a finished pipeline run and its outputs.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Fetch runs after execution
 
 Once a pipeline run has been completed, we can access the corresponding

--- a/docs/book/user-guide/starter-guide/follow-best-practices.md
+++ b/docs/book/user-guide/starter-guide/follow-best-practices.md
@@ -2,6 +2,11 @@
 description: Recommended repository structure and best practices.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Follow best practices
 
 Until now, you probably have kept all your code in one single file. In production, it is recommended to split up your steps and pipelines into separate files.

--- a/docs/book/user-guide/starter-guide/starter-guide.md
+++ b/docs/book/user-guide/starter-guide/starter-guide.md
@@ -2,6 +2,11 @@
 description: Everything you need to know to start using ZenML.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # 🐣 Starter guide
 
 ZenML helps you standardize your ML workflows as **Pipelines** consisting of decoupled, modular **Steps**. This enables you to write portable code that can be moved from experimentation to production in seconds.

--- a/docs/book/user-guide/starter-guide/switch-to-production.md
+++ b/docs/book/user-guide/starter-guide/switch-to-production.md
@@ -2,6 +2,11 @@
 description: Learning about the ZenML server.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Switch to production
 
 Transitioning your machine learning pipelines to production means deploying your models on real-world data to make predictions that drive business decisions. To achieve this, you need an infrastructure that can handle the demands of running machine learning models at scale. However, setting up such an infrastructure involves careful planning and consideration of various factors, such as data storage, compute resources, monitoring, and security.

--- a/docs/book/user-guide/starter-guide/understand-stacks.md
+++ b/docs/book/user-guide/starter-guide/understand-stacks.md
@@ -2,6 +2,11 @@
 description: Learning how to switch the infrastructure backend of your code.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Understand stacks
 
 In the previous section, you might have already noticed the term `stack` in the logs and on the dashboard.

--- a/docs/book/user-guide/starter-guide/using-project-templates.md
+++ b/docs/book/user-guide/starter-guide/using-project-templates.md
@@ -2,6 +2,11 @@
 description: Rocketstart your ZenML journey!
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Project templates
 
 What would you need to get a quick understanding of the ZenML framework and start building your ML pipelines? The answer is one of ZenML project templates to cover major use cases of ZenML: a collection of steps and pipelines and, to top it all off, a simple but useful CLI. This is exactly what the ZenML templates are all about!

--- a/docs/book/user-guide/starter-guide/version-pipelines.md
+++ b/docs/book/user-guide/starter-guide/version-pipelines.md
@@ -2,6 +2,11 @@
 description: Understanding how and when the version of a pipeline is incremented.
 ---
 
+{% hint style="warning" %}
+This is an older version of the ZenML documentation. To read and view the latest version please [visit this up-to-date URL](https://docs.zenml.io).
+{% endhint %}
+
+
 # Version pipelines
 
 You might have noticed that when you run a pipeline in ZenML with the same name, but with different steps, it creates a new **version** of the pipeline. Consider our example pipeline:


### PR DESCRIPTION
This PR updates the documentation for version 0.46.1 with the warning message to be displayed on Gitbook.