### PR TITLE
Add warnings/updates to Huggingface Spaces deployment docs

### DIFF
--- a/docs/book/deploying-zenml/zenml-self-hosted/deploy-using-huggingface-spaces.md
+++ b/docs/book/deploying-zenml/zenml-self-hosted/deploy-using-huggingface-spaces.md
@@ -42,25 +42,26 @@ HuggingFace [documentation reference guide](https://huggingface.co/docs/hub/spac
 After creating your Space, you'll notice a 'Building' status along with logs displayed on the screen. When this switches
 to 'Running', your Space is ready for use. If the ZenML login UI isn't visible, try refreshing the page.
 
-Use our default login to access the dashboard (username: 'default', password: (leave it empty)).
+In the upper-right hand corner of your space you'll see a button with three dots
+which, when you click on it, will offer you a menu option to "Embed this Space".
+(See [the HuggingFace
+documentation](https://huggingface.co/docs/hub/spaces-embed) for more details on
+this feature.) Copy the "Direct URL" shown in the box that you can now see on
+the screen. This should look something like this:
+`https://<YOUR_USERNAME>-<SPACE_NAME>.hf.space`. Open that URL and use our default 
+login to access the dashboard (username: 'default', password: (leave it empty)).
 
 ## Connecting to your ZenML Server from your local machine
 
-Once you have your ZenML server up and running, you can connect to it from your local machine. To do this, you'll need
-to get your Space's URL.
+Once you have your ZenML server up and running, you can connect to it from your local machine. 
+To do this, you'll need to get your Space's 'Direct URL' (see above).
 
 {% hint style="warning" %}
 Your Space's URL will only be available and usable for connecting from your local machine if the visibility of the space
 is set to 'Public'.
 {% endhint %}
 
-In the upper-right-hand corner of your space, you'll see a button with three dots which, when you click on it, will
-offer you a menu option to "Embed this Space". (
-See [the HuggingFace documentation](https://huggingface.co/docs/hub/spaces-embed) for more details on this feature.)
-Copy the "Direct URL" shown in the box that you can now see on the screen. This should look something like
-this: `https://<YOUR_USERNAME>-<SPACE_NAME>.hf.space`.
-
-You can now use this URL to connect to your ZenML server from your local machine with the following CLI command (after
+You can use the 'Direct URL' to connect to your ZenML server from your local machine with the following CLI command (after
 installing ZenML, and using your custom URL instead of the placeholder):
 
 ```shell
@@ -69,6 +70,13 @@ zenml connect --url '<YOUR_HF_SPACES_DIRECT_URL>'
 
 You can also use the Direct URL in your browser to use the ZenML dashboard as a fullscreen application (i.e. without the
 HuggingFace Spaces wrapper around it).
+
+{% hint style="warning" %}
+The ZenML dashboard will currently not work when viewed from within the Huggingface 
+webpage (i.e. wrapped in the main `https://huggingface.co/...` website). This is on 
+account of a limitation in how cookies are handled between ZenML and Huggingface. 
+You **must** view the dashboard from the 'Direct URL' (see above).
+{% endhint %}
 
 ## Extra configuration options
 


### PR DESCRIPTION
ZenML >0.45.0 recently changed some things about how the dashboard issues / handles cookies and so currently the dashboard doesn't work from within the Huggingface website wrapper (only via the direct URL).

I've amended the documentation to reflect this and to guide people in how to get it working.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

