### PR TITLE
Remove user name from orchestrator run name

### DIFF
--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -52,8 +52,7 @@ def get_orchestrator_run_name(pipeline_name: str) -> str:
     Returns:
         The orchestrator run name.
     """
-    user_name = Client().active_user.name
-    return f"{pipeline_name}_{user_name}_{random.Random().getrandbits(32):08x}"
+    return f"{pipeline_name}_{random.Random().getrandbits(128):32x}"
 
 
 def get_run_id_for_orchestrator_run_id(


### PR DESCRIPTION
## Describe changes

When generating a run name which we use to display in the orchestrator UI, we previously included the user name. For ZenML cloud tenants, that user name is the email of the user, which contains an `@` which leads to failure when running with Airflow.
To fix it, we simply remove the user name and increase the random portion of the run name.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

