### PR TITLE
Endpoint artifacts rename to deployment artifacts

### DIFF
--- a/src/zenml/artifacts/external_artifact_config.py
+++ b/src/zenml/artifacts/external_artifact_config.py
@@ -119,7 +119,7 @@ class ExternalArtifactConfiguration(BaseModel):
         for artifact_getter in [
             model_version.get_data_artifact,
             model_version.get_model_artifact,
-            model_version.get_endpoint_artifact,
+            model_version.get_deployment_artifact,
         ]:
             response = artifact_getter(
                 name=self.model_artifact_name,  # type: ignore [arg-type]

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -65,7 +65,9 @@ def _model_version_to_print(
         "stage": model_version.stage,
         "data_artifacts_count": len(model_version.data_artifact_ids),
         "model_artifacts_count": len(model_version.model_artifact_ids),
-        "endpoint_artifacts_count": len(model_version.endpoint_artifact_ids),
+        "deployment_artifacts_count": len(
+            model_version.deployment_artifact_ids
+        ),
         "pipeline_runs_count": len(model_version.pipeline_run_ids),
         "updated": model_version.updated.date(),
     }
@@ -507,7 +509,7 @@ def _print_artifacts_links_generic(
     model_name_or_id: str,
     model_version_name_or_number_or_id: str,
     only_data_artifacts: bool = False,
-    only_endpoint_artifacts: bool = False,
+    only_deployment_artifacts: bool = False,
     only_model_artifacts: bool = False,
     **kwargs: Any,
 ) -> None:
@@ -517,7 +519,7 @@ def _print_artifacts_links_generic(
         model_name_or_id: The ID or name of the model containing version.
         model_version_name_or_number_or_id: The name, number or ID of the model version.
         only_data_artifacts: If set, only print data artifacts.
-        only_endpoint_artifacts: If set, only print endpoint artifacts.
+        only_deployment_artifacts: If set, only print deployment artifacts.
         only_model_artifacts: If set, only print model artifacts.
         **kwargs: Keyword arguments to filter models.
     """
@@ -533,8 +535,8 @@ def _print_artifacts_links_generic(
     type_ = (
         "data artifacts"
         if only_data_artifacts
-        else "endpoint artifacts"
-        if only_endpoint_artifacts
+        else "deployment artifacts"
+        if only_deployment_artifacts
         else "model artifacts"
     )
 
@@ -544,8 +546,8 @@ def _print_artifacts_links_generic(
             and not model_version_response_model.data_artifact_ids
         )
         or (
-            only_endpoint_artifacts
-            and not model_version_response_model.endpoint_artifact_ids
+            only_deployment_artifacts
+            and not model_version_response_model.deployment_artifact_ids
         )
         or (
             only_model_artifacts
@@ -568,7 +570,7 @@ def _print_artifacts_links_generic(
         model_version_id=model_version.id,
         model_version_artifact_link_filter_model=ModelVersionArtifactFilterModel(
             only_data_artifacts=only_data_artifacts,
-            only_endpoint_artifacts=only_endpoint_artifacts,
+            only_deployment_artifacts=only_deployment_artifacts,
             only_model_artifacts=only_model_artifacts,
             **kwargs,
         ),
@@ -644,18 +646,18 @@ def list_model_version_model_artifacts(
 
 
 @version.command(
-    "endpoint_artifacts",
-    help="List endpoint artifacts linked to a model version.",
+    "deployment_artifacts",
+    help="List deployment artifacts linked to a model version.",
 )
 @click.argument("model_name_or_id")
 @click.argument("model_version_name_or_number_or_id", default="0")
 @cli_utils.list_options(ModelVersionArtifactFilterModel)
-def list_model_version_endpoint_artifacts(
+def list_model_version_deployment_artifacts(
     model_name_or_id: str,
     model_version_name_or_number_or_id: str,
     **kwargs: Any,
 ) -> None:
-    """List endpoint artifacts linked to a model version in the Model Control Plane.
+    """List deployment artifacts linked to a model version in the Model Control Plane.
 
     Args:
         model_name_or_id: The ID or name of the model containing version.
@@ -666,7 +668,7 @@ def list_model_version_endpoint_artifacts(
     _print_artifacts_links_generic(
         model_name_or_id=model_name_or_id,
         model_version_name_or_number_or_id=model_version_name_or_number_or_id,
-        only_endpoint_artifacts=True,
+        only_deployment_artifacts=True,
         **kwargs,
     )
 

--- a/src/zenml/model/artifact_config.py
+++ b/src/zenml/model/artifact_config.py
@@ -111,7 +111,7 @@ class DataArtifactConfig(BaseModel):
         artifact_uuid: UUID,
         model_version: "ModelVersion",
         is_model_artifact: bool = False,
-        is_endpoint_artifact: bool = False,
+        is_deployment_artifact: bool = False,
     ) -> None:
         """Link artifact to the model version.
 
@@ -121,7 +121,7 @@ class DataArtifactConfig(BaseModel):
             artifact_uuid: The UUID of the artifact to link.
             model_version: The model version from caller.
             is_model_artifact: Whether the artifact is a model artifact. Defaults to False.
-            is_endpoint_artifact: Whether the artifact is an endpoint artifact. Defaults to False.
+            is_deployment_artifact: Whether the artifact is an deployment artifact. Defaults to False.
         """
         from zenml.client import Client
         from zenml.models.model_models import (
@@ -146,7 +146,7 @@ class DataArtifactConfig(BaseModel):
             model=model_version.model_id,
             model_version=model_version.id,
             is_model_artifact=is_model_artifact,
-            is_endpoint_artifact=is_endpoint_artifact,
+            is_deployment_artifact=is_deployment_artifact,
             overwrite=self.overwrite,
             pipeline_name=self._pipeline_name,
             step_name=self._step_name,
@@ -160,9 +160,9 @@ class DataArtifactConfig(BaseModel):
                 workspace_id=client.active_workspace.id,
                 name=artifact_name,
                 only_data_artifacts=not (
-                    is_model_artifact or is_endpoint_artifact
+                    is_model_artifact or is_deployment_artifact
                 ),
-                only_endpoint_artifacts=is_endpoint_artifact,
+                only_deployment_artifacts=is_deployment_artifact,
                 only_model_artifacts=is_model_artifact,
                 pipeline_name=self._pipeline_name,
                 step_name=self._step_name,
@@ -198,7 +198,7 @@ class DataArtifactConfig(BaseModel):
             artifact_uuid,
             model_version=model_version,
             is_model_artifact=self.IS_MODEL_ARTIFACT,
-            is_endpoint_artifact=self.IS_ENDPOINT_ARTIFACT,
+            is_deployment_artifact=self.IS_ENDPOINT_ARTIFACT,
         )
 
 
@@ -213,6 +213,6 @@ class ModelArtifactConfig(DataArtifactConfig):
 
 
 class EndpointArtifactConfig(DataArtifactConfig):
-    """Used to link an endpoint artifact to the model version."""
+    """Used to link an deployment artifact to the model version."""
 
     IS_ENDPOINT_ARTIFACT = True

--- a/src/zenml/model/model_version.py
+++ b/src/zenml/model/model_version.py
@@ -202,25 +202,25 @@ class ModelVersion(BaseModel):
             step_name=step_name,
         )
 
-    def get_endpoint_artifact(
+    def get_deployment_artifact(
         self,
         name: str,
         version: Optional[str] = None,
         pipeline_name: Optional[str] = None,
         step_name: Optional[str] = None,
     ) -> Optional["ArtifactResponse"]:
-        """Get the endpoint artifact linked to this model version.
+        """Get the deployment artifact linked to this model version.
 
         Args:
-            name: The name of the endpoint artifact to retrieve.
-            version: The version of the endpoint artifact to retrieve (None for latest/non-versioned)
-            pipeline_name: The name of the pipeline generated the endpoint artifact.
-            step_name: The name of the step generated the endpoint artifact.
+            name: The name of the deployment artifact to retrieve.
+            version: The version of the deployment artifact to retrieve (None for latest/non-versioned)
+            pipeline_name: The name of the pipeline generated the deployment artifact.
+            step_name: The name of the step generated the deployment artifact.
 
         Returns:
-            Specific version of the endpoint artifact or None
+            Specific version of the deployment artifact or None
         """
-        return self._get_or_create_model_version().get_endpoint_artifact(
+        return self._get_or_create_model_version().get_deployment_artifact(
             name=name,
             version=version,
             pipeline_name=pipeline_name,

--- a/src/zenml/new/steps/log_artifact_metadata.py
+++ b/src/zenml/new/steps/log_artifact_metadata.py
@@ -81,7 +81,7 @@ def log_model_artifact_metadata(
     )
 
 
-def log_endpoint_artifact_metadata(
+def log_deployment_artifact_metadata(
     output_name: Optional[str] = None,
     description: Optional[str] = None,
     predict_url: Optional[str] = None,
@@ -90,16 +90,16 @@ def log_endpoint_artifact_metadata(
     deployer_ui_url: Optional[str] = None,
     **kwargs: MetadataType,
 ) -> None:
-    """Log metadata for an endpoint artifact.
+    """Log metadata for an deployment artifact.
 
     Args:
-        output_name: The output name of the endpoint artifact to log metadata for. Can
+        output_name: The output name of the deployment artifact to log metadata for. Can
             be omitted if there is only one output artifact.
-        description: A description of the endpoint artifact.
-        predict_url: The predict URL of the endpoint artifact.
-        explain_url: The explain URL of the endpoint artifact.
-        healthcheck_url: The healthcheck URL of the endpoint artifact.
-        deployer_ui_url: The deployer UI URL of the endpoint artifact.
+        description: A description of the deployment artifact.
+        predict_url: The predict URL of the deployment artifact.
+        explain_url: The explain URL of the deployment artifact.
+        healthcheck_url: The healthcheck URL of the deployment artifact.
+        deployer_ui_url: The deployer UI URL of the deployment artifact.
         **kwargs: Other metadata to log.
     """
     if description:

--- a/src/zenml/zen_stores/migrations/versions/14d687c8fa1c_rename_model_config_to_model_version.py
+++ b/src/zenml/zen_stores/migrations/versions/14d687c8fa1c_rename_model_config_to_model_version.py
@@ -65,7 +65,7 @@ def upgrade() -> None:
         )
         batch_op.alter_column(
             "is_deployment",
-            new_column_name="is_endpoint_artifact",
+            new_column_name="is_deployment_artifact",
             existing_type=sa.BOOLEAN(),
         )
 
@@ -98,7 +98,7 @@ def downgrade() -> None:
             existing_type=sa.BOOLEAN(),
         )
         batch_op.alter_column(
-            "is_endpoint_artifact",
+            "is_deployment_artifact",
             new_column_name="is_deployment",
             existing_type=sa.BOOLEAN(),
         )

--- a/src/zenml/zen_stores/schemas/model_schemas.py
+++ b/src/zenml/zen_stores/schemas/model_schemas.py
@@ -286,29 +286,31 @@ class ModelVersionSchema(NamedSchema, table=True):
                 for al1 in self.artifact_links
                 if al1.is_model_artifact
             },
-            endpoint_artifact_ids={
+            deployment_artifact_ids={
                 f"{al1.pipeline_name}::{al1.step_name}::{al1.name}": {
                     al2.version: al2.artifact_id
                     for al2 in self.artifact_links
-                    if al2.is_endpoint_artifact
+                    if al2.is_deployment_artifact
                     and al1.name == al2.name
                     and al1.step_name == al2.step_name
                     and al1.pipeline_name == al2.pipeline_name
                 }
                 for al1 in self.artifact_links
-                if al1.is_endpoint_artifact
+                if al1.is_deployment_artifact
             },
             data_artifact_ids={
                 f"{al1.pipeline_name}::{al1.step_name}::{al1.name}": {
                     al2.version: al2.artifact_id
                     for al2 in self.artifact_links
-                    if not (al2.is_endpoint_artifact or al2.is_model_artifact)
+                    if not (
+                        al2.is_deployment_artifact or al2.is_model_artifact
+                    )
                     and al1.name == al2.name
                     and al1.step_name == al2.step_name
                     and al1.pipeline_name == al2.pipeline_name
                 }
                 for al1 in self.artifact_links
-                if not (al1.is_endpoint_artifact or al1.is_model_artifact)
+                if not (al1.is_deployment_artifact or al1.is_model_artifact)
             },
             pipeline_run_ids={
                 pr.name: pr.pipeline_run_id for pr in self.pipeline_run_links
@@ -399,7 +401,7 @@ class ModelVersionArtifactSchema(NamedSchema, table=True):
     )
 
     is_model_artifact: bool = Field(sa_column=Column(BOOLEAN, nullable=True))
-    is_endpoint_artifact: bool = Field(
+    is_deployment_artifact: bool = Field(
         sa_column=Column(BOOLEAN, nullable=True)
     )
     version: int = Field(sa_column=Column(INTEGER, nullable=False))
@@ -431,7 +433,7 @@ class ModelVersionArtifactSchema(NamedSchema, table=True):
             model_version_id=model_version_artifact_request.model_version,
             artifact_id=model_version_artifact_request.artifact,
             is_model_artifact=model_version_artifact_request.is_model_artifact,
-            is_endpoint_artifact=model_version_artifact_request.is_endpoint_artifact,
+            is_deployment_artifact=model_version_artifact_request.is_deployment_artifact,
             version=version,
         )
 
@@ -461,7 +463,7 @@ class ModelVersionArtifactSchema(NamedSchema, table=True):
             model_version=self.model_version_id,
             artifact=self.artifact_id,
             is_model_artifact=self.is_model_artifact,
-            is_endpoint_artifact=self.is_endpoint_artifact,
+            is_deployment_artifact=self.is_deployment_artifact,
             link_version=self.version,
         )
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -7119,7 +7119,7 @@ class SqlZenStore(BaseZenStore):
                         == False  # noqa: E712
                     )
                     .where(
-                        ModelVersionArtifactSchema.is_endpoint_artifact
+                        ModelVersionArtifactSchema.is_deployment_artifact
                         == False  # noqa: E712
                     )
                     .where(
@@ -7128,11 +7128,11 @@ class SqlZenStore(BaseZenStore):
                     )
                 )
             elif (
-                model_version_artifact_link_filter_model.only_endpoint_artifacts
+                model_version_artifact_link_filter_model.only_deployment_artifacts
             ):
                 query = (
                     select(ModelVersionArtifactSchema)
-                    .where(ModelVersionArtifactSchema.is_endpoint_artifact)
+                    .where(ModelVersionArtifactSchema.is_deployment_artifact)
                     .where(
                         ModelVersionArtifactSchema.is_model_artifact
                         == False  # noqa: E712
@@ -7147,7 +7147,7 @@ class SqlZenStore(BaseZenStore):
                     select(ModelVersionArtifactSchema)
                     .where(ModelVersionArtifactSchema.is_model_artifact)
                     .where(
-                        ModelVersionArtifactSchema.is_endpoint_artifact
+                        ModelVersionArtifactSchema.is_deployment_artifact
                         == False  # noqa: E712
                     )
                     .where(
@@ -7158,7 +7158,7 @@ class SqlZenStore(BaseZenStore):
             else:
                 query = select(ModelVersionArtifactSchema)
             model_version_artifact_link_filter_model.only_data_artifacts = None
-            model_version_artifact_link_filter_model.only_endpoint_artifacts = (
+            model_version_artifact_link_filter_model.only_deployment_artifacts = (
                 None
             )
             model_version_artifact_link_filter_model.only_model_artifacts = (

--- a/tests/integration/functional/cli/test_model.py
+++ b/tests/integration/functional/cli/test_model.py
@@ -294,7 +294,7 @@ def test_model_version_delete_not_found(clean_workspace_with_models):
 
 @pytest.mark.parametrize(
     "command",
-    ("data_artifacts", "endpoint_artifacts", "model_artifacts", "runs"),
+    ("data_artifacts", "deployment_artifacts", "model_artifacts", "runs"),
 )
 def test_model_version_links_list(command: str, clean_workspace_with_models):
     """Test that zenml model version artifacts list fails."""

--- a/tests/integration/functional/model/test_artifact_config.py
+++ b/tests/integration/functional/model/test_artifact_config.py
@@ -53,7 +53,7 @@ def single_output_step_from_context_model() -> (
 def single_output_step_from_context_endpoint() -> (
     Annotated[int, EndpointArtifactConfig()]
 ):
-    """Untyped single output linked as endpoint artifact from step context."""
+    """Untyped single output linked as deployment artifact from step context."""
     return 1
 
 
@@ -90,22 +90,22 @@ def test_link_minimalistic():
         )
         assert links.size == 3
 
-        one_is_endpoint_artifact = False
+        one_is_deployment_artifact = False
         one_is_model_artifact = False
         one_is_data_artifact = False
         for link in links:
             assert link.link_version == 1
             assert link.name == "output"
-            one_is_endpoint_artifact ^= (
-                link.is_endpoint_artifact and not link.is_model_artifact
+            one_is_deployment_artifact ^= (
+                link.is_deployment_artifact and not link.is_model_artifact
             )
             one_is_model_artifact ^= (
-                not link.is_endpoint_artifact and link.is_model_artifact
+                not link.is_deployment_artifact and link.is_model_artifact
             )
             one_is_data_artifact ^= (
-                not link.is_endpoint_artifact and not link.is_model_artifact
+                not link.is_deployment_artifact and not link.is_model_artifact
             )
-        assert one_is_endpoint_artifact
+        assert one_is_deployment_artifact
         assert one_is_model_artifact
         assert one_is_data_artifact
 

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -4729,7 +4729,7 @@ class TestModelVersionArtifactLinks:
                         name=n,
                         artifact=artifact.id,
                         is_model_artifact=mo,
-                        is_endpoint_artifact=dep,
+                        is_deployment_artifact=dep,
                         pipeline_name="pipeline",
                         step_name="step",
                     )
@@ -4763,7 +4763,7 @@ class TestModelVersionArtifactLinks:
             mvls = zs.list_model_version_artifact_links(
                 model_version_id=model_version.id,
                 model_version_artifact_link_filter_model=ModelVersionArtifactFilterModel(
-                    only_endpoint_artifacts=True
+                    only_deployment_artifacts=True
                 ),
             )
             assert len(mvls) == 1 and mvls[0].name == "link3"
@@ -4774,7 +4774,7 @@ class TestModelVersionArtifactLinks:
 
             assert len(mv.model_artifact_ids) == 1
             assert len(mv.data_artifact_ids) == 1
-            assert len(mv.endpoint_artifact_ids) == 1
+            assert len(mv.deployment_artifact_ids) == 1
 
             assert isinstance(
                 mv.get_model_artifact("link2", "1"),
@@ -4785,7 +4785,7 @@ class TestModelVersionArtifactLinks:
                 ArtifactResponse,
             )
             assert isinstance(
-                mv.get_endpoint_artifact("link3", "1"),
+                mv.get_deployment_artifact("link3", "1"),
                 ArtifactResponse,
             )
 
@@ -4799,8 +4799,8 @@ class TestModelVersionArtifactLinks:
                 == mv.model_artifacts["pipeline::step::link2"]["1"]
             )
             assert (
-                mv.get_endpoint_artifact("link3", "1")
-                == mv.endpoint_artifacts["pipeline::step::link3"]["1"]
+                mv.get_deployment_artifact("link3", "1")
+                == mv.deployment_artifacts["pipeline::step::link3"]["1"]
             )
 
             # check how versioned artifacts retrieved


### PR DESCRIPTION
## Describe changes
I renamed endpoint artifacts to deployment artifacts to unify them with existing concepts. Change is breaking methods related to the retrieval of those objects.

This needs adjustment of the template and will go only after majors planned for the upcoming release are in.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

