### PR TITLE
Set nightly builds to run at half-past the hour

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run this workflow every day at midnight
-    - cron: '0 0 * * *'
+    - cron: '30 0 * * *'
 
 jobs:
     setup-and-test:


### PR DESCRIPTION
[GH Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) suggest that it's preferable to setting them to run on the hour (when queued jobs might be dropped).

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

