### PR TITLE
Replace `black` with `ruff format` / bump `mypy`

### DIFF
--- a/examples/e2e/utils/__init__.py
+++ b/examples/e2e/utils/__init__.py
@@ -1,19 +1,19 @@
 # Apache Software License 2.0
-#
+# 
 # Copyright (c) ZenML GmbH 2023. All rights reserved.
-#
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 # http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+# 
 
 
 from .get_model_from_config import get_model_from_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ adlfs = { version = ">=2021.10.0", optional = true }
 # Optional development dependencies
 bandit = { version = "^1.7.5", optional = true }
 coverage = { extras = ["toml"], version = "^5.5", optional = true }
-mypy = { version = "1.6.1", optional = true }
+mypy = { version = "1.7.1", optional = true }
 pre-commit = { version = "^2.14.0", optional = true }
 pyment = { version = "^0.3.3", optional = true }
 tox = { version = "^3.24.3", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,25 +58,25 @@ pyparsing = "<3,>=2.4.0"
 python = ">=3.8,<3.12"
 python-dateutil = "^2.8.1"
 pyyaml = ">=6.0.1"
-rich = {extras = ["jupyter"], version = ">=12.0.0"}
+rich = { extras = ["jupyter"], version = ">=12.0.0" }
 sqlalchemy_utils = "0.38.3"
 sqlmodel = "0.0.8"
 
 # Optional dependencies for the ZenServer
 fastapi = { version = ">=0.75,<0.100", optional = true }
-uvicorn = { extras = ["standard"], version = ">=0.17.5",  optional = true}
-python-multipart = { version = "~0.0.5", optional = true}
+uvicorn = { extras = ["standard"], version = ">=0.17.5", optional = true }
+python-multipart = { version = "~0.0.5", optional = true }
 pyjwt = { extras = ["crypto"], version = "2.7.*", optional = true }
-fastapi-utils = { version = "~0.2.1", optional = true}
-orjson = { version = "~3.8.3", optional = true}
-Jinja2 = { version = "*", optional = true}
-ipinfo = { version = ">=4.4.3", optional = true}
+fastapi-utils = { version = "~0.2.1", optional = true }
+orjson = { version = "~3.8.3", optional = true }
+Jinja2 = { version = "*", optional = true }
+ipinfo = { version = ">=4.4.3", optional = true }
 
 # Optional dependencies for project templates
 copier = { version = ">=8.1.0", optional = true }
 jinja2-time = { version = "^0.2.0", optional = true }
-black = { version = "^23.10.0", optional = true }
-ruff = { version = "^0.1.0", optional = true }
+# black = { version = "^23.10.0", optional = true }
+ruff = { version = "^0.1.6", optional = true }
 
 # Optional terraform dependency for stack recipes and ZenServer deployments
 python-terraform = { version = "^0.10.1", optional = true }
@@ -173,9 +173,9 @@ server = [
     "fastapi-utils",
     "orjson",
     "Jinja2",
-    "ipinfo"
+    "ipinfo",
 ]
-templates = ["copier", "jinja2-time", "black", "ruff"]
+templates = ["copier", "jinja2-time", "ruff"]
 terraform = ["python-terraform"]
 secrets-aws = ["boto3"]
 secrets-gcp = ["google-cloud-secret-manager"]
@@ -201,7 +201,6 @@ connectors-azure = [
 ]
 dev = [
     "bandit",
-    "black",
     "ruff",
     "coverage",
     "pytest",
@@ -319,6 +318,19 @@ ignore-init-module-imports = true
 # Disable autofix for unused imports (`F401`).
 unfixable = ["F401"]
 
+[tool.ruff.format]
+exclude = [
+    "*.git",
+    "*.hg",
+    ".mypy_cache",
+    ".tox",
+    ".venv",
+    "_build",
+    "buck-out",
+    "build]",
+]
+
+
 [tool.ruff.flake8-import-conventions.aliases]
 altair = "alt"
 "matplotlib.pyplot" = "plt"
@@ -426,19 +438,3 @@ module = [
     "IPython.*",
 ]
 ignore_missing_imports = true
-
-[tool.black]
-line-length = 79
-include = '\.pyi?$'
-exclude = '''
-/(
-	\.git
-| \.hg
-| \.mypy_cache
-| \.tox
-| \.venv
-| _build
-| buck-out
-| build
-)/
-'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ ipinfo = { version = ">=4.4.3", optional = true }
 # Optional dependencies for project templates
 copier = { version = ">=8.1.0", optional = true }
 jinja2-time = { version = "^0.2.0", optional = true }
-# black = { version = "^23.10.0", optional = true }
 ruff = { version = "^0.1.6", optional = true }
 
 # Optional terraform dependency for stack recipes and ZenServer deployments

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -11,4 +11,4 @@ ruff $SRC --select F401,F841 --fix --exclude "__init__.py" --isolated
 
 # sorts imports
 ruff $SRC --select I --fix --ignore D
-black $SRC
+ruff format $SRC

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -16,7 +16,7 @@ ruff $TESTS_EXAMPLES --extend-ignore D
 # autoflake replacement: checks for unused imports and variables
 ruff $SRC --select F401,F841 --exclude "__init__.py" --isolated
 
-black $SRC  --check
+ruff format $SRC  --check
 
 # check type annotations
 mypy $SRC_NO_TESTS

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -106,7 +106,8 @@ MAX_ARGUMENT_VALUE_SIZE = 10240
 
 
 T = TypeVar(
-    "T", bound=Union[BaseResponse, BaseResponseModel]  # type: ignore[type-arg]
+    "T",
+    bound=Union[BaseResponse, BaseResponseModel],  # type: ignore[type-arg]
 )
 
 

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -240,7 +240,8 @@ MODEL_METADATA_YAML_FILE_NAME = "model_metadata.yaml"
 # orchestrator constants
 ORCHESTRATOR_DOCKER_IMAGE_KEY = "orchestrator"
 PIPELINE_API_TOKEN_EXPIRES_MINUTES = handle_int_env_var(
-    ENV_ZENML_PIPELINE_API_TOKEN_EXPIRES_MINUTES, default=60 * 24  # 24 hours
+    ENV_ZENML_PIPELINE_API_TOKEN_EXPIRES_MINUTES,
+    default=60 * 24,  # 24 hours
 )
 
 # Secret constants

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -370,9 +370,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
 
         # Build entrypoint command and args for the orchestrator pod.
         # This will internally also build the command/args for all step pods.
-        command = (
-            KubernetesOrchestratorEntrypointConfiguration.get_entrypoint_command()
-        )
+        command = KubernetesOrchestratorEntrypointConfiguration.get_entrypoint_command()
         args = KubernetesOrchestratorEntrypointConfiguration.get_entrypoint_arguments(
             run_name=orchestrator_run_name,
             deployment_id=deployment.id,

--- a/src/zenml/integrations/seldon/custom_deployer/zenml_custom_model.py
+++ b/src/zenml/integrations/seldon/custom_deployer/zenml_custom_model.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 DEFAULT_MODEL_NAME = "model"
 DEFAULT_LOCAL_MODEL_DIR = "/mnt/models"
 
-Array_Like = Union[np.ndarray, List[Any], str, bytes, Dict[str, Any]]
+Array_Like = Union[np.ndarray[Any], List[Any], str, bytes, Dict[str, Any]]
 
 
 class ZenMLCustomModel:

--- a/src/zenml/integrations/seldon/custom_deployer/zenml_custom_model.py
+++ b/src/zenml/integrations/seldon/custom_deployer/zenml_custom_model.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 DEFAULT_MODEL_NAME = "model"
 DEFAULT_LOCAL_MODEL_DIR = "/mnt/models"
 
-Array_Like = Union[np.ndarray[Any], List[Any], str, bytes, Dict[str, Any]]
+Array_Like = Union[np.ndarray[Any, Any], List[Any], str, bytes, Dict[str, Any]]
 
 
 class ZenMLCustomModel:

--- a/src/zenml/integrations/spark/materializers/spark_model_materializer.py
+++ b/src/zenml/integrations/spark/materializers/spark_model_materializer.py
@@ -49,7 +49,8 @@ class SparkModelMaterializer(BaseMaterializer):
         return model_type.load(path)  # type: ignore[no-any-return]
 
     def save(
-        self, model: Union[Transformer, Estimator, Model]  # type: ignore[type-arg]
+        self,
+        model: Union[Transformer, Estimator, Model],  # type: ignore[type-arg]
     ) -> None:
         """Writes a spark model.
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -132,7 +132,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         self,
         run_name: str,
         tags: List[str],
-        settings: Union[wandb.Settings, Dict[str, Any], None] = None,
+        settings: Union["wandb.Settings", Dict[str, Any], None] = None,
     ) -> None:
         """Initializes a wandb run.
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -30,13 +30,14 @@ from zenml.logger import get_logger
 from zenml.metadata.metadata_types import Uri
 
 if TYPE_CHECKING:
+    from wandb import Settings
+
     from zenml.config.step_run_info import StepRunInfo
     from zenml.metadata.metadata_types import MetadataType
 
 
 logger = get_logger(__name__)
 
-WandbSettingsType = wandb.Settings
 WANDB_API_KEY = "WANDB_API_KEY"
 
 
@@ -132,7 +133,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         self,
         run_name: str,
         tags: List[str],
-        settings: Union[WandbSettingsType, Dict[str, Any], None] = None,
+        settings: Union[Settings, Dict[str, Any], None] = None,
     ) -> None:
         """Initializes a wandb run.
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-
+WandbSettingsType = wandb.Settings
 WANDB_API_KEY = "WANDB_API_KEY"
 
 
@@ -132,7 +132,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         self,
         run_name: str,
         tags: List[str],
-        settings: Union["wandb.Settings", Dict[str, Any], None] = None,
+        settings: Union[WandbSettingsType, Dict[str, Any], None] = None,
     ) -> None:
         """Initializes a wandb run.
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -133,7 +133,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         self,
         run_name: str,
         tags: List[str],
-        settings: Union[Settings, Dict[str, Any], None] = None,
+        settings: Union[Settings, Dict[str, Any], None] = None,  # type: ignore
     ) -> None:
         """Initializes a wandb run.
 

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -44,7 +44,8 @@ class WandbExperimentTrackerSettings(BaseSettings):
 
     run_name: Optional[str] = None
     tags: List[str] = []
-    settings: Dict[str, Any] = {}
+    # Use a string literal for the wandb.Settings type
+    settings: Union[Dict[str, Any], "wandb.Settings"] = {}
 
     @validator("settings", pre=True)
     def _convert_settings(

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -20,7 +20,6 @@ from typing import (
     List,
     Optional,
     Type,
-    TypeVar,
     Union,
     cast,
 )
@@ -36,15 +35,11 @@ from zenml.integrations.wandb import WANDB_EXPERIMENT_TRACKER_FLAVOR
 from zenml.utils.secret_utils import SecretField
 
 if TYPE_CHECKING:
-    import wandb
-
-    WandbSettingsType = wandb.Settings
+    from wandb import Settings
 
     from zenml.integrations.wandb.experiment_trackers import (
         WandbExperimentTracker,
     )
-else:
-    WandbSettingsType = TypeVar("WandbSettingsType", bound=Any)
 
 
 class WandbExperimentTrackerSettings(BaseSettings):
@@ -58,11 +53,11 @@ class WandbExperimentTrackerSettings(BaseSettings):
 
     run_name: Optional[str] = None
     tags: List[str] = []
-    settings: Union[Dict[str, Any], WandbSettingsType] = {}
+    settings: Union[Dict[str, Any], Settings] = {}
 
     @validator("settings", pre=True)
     def _convert_settings(
-        cls, value: Union[Dict[str, Any], WandbSettingsType]
+        cls, value: Union[Dict[str, Any], Settings]
     ) -> Dict[str, Any]:
         """Converts settings to a dictionary.
 

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -28,9 +28,13 @@ from zenml.utils.secret_utils import SecretField
 if TYPE_CHECKING:
     import wandb
 
+    WandbSettingsType = wandb.Settings
+
     from zenml.integrations.wandb.experiment_trackers import (
         WandbExperimentTracker,
     )
+else:
+    WandbSettingsType = Any
 
 
 class WandbExperimentTrackerSettings(BaseSettings):
@@ -44,12 +48,11 @@ class WandbExperimentTrackerSettings(BaseSettings):
 
     run_name: Optional[str] = None
     tags: List[str] = []
-    # Use a string literal for the wandb.Settings type
-    settings: Union[Dict[str, Any], "wandb.Settings"] = {}
+    settings: Union[Dict[str, Any], WandbSettingsType] = {}
 
     @validator("settings", pre=True)
     def _convert_settings(
-        cls, value: Union[Dict[str, Any], "wandb.Settings"]
+        cls, value: Union[Dict[str, Any], WandbSettingsType]
     ) -> Dict[str, Any]:
         """Converts settings to a dictionary.
 

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -53,11 +53,12 @@ class WandbExperimentTrackerSettings(BaseSettings):
 
     run_name: Optional[str] = None
     tags: List[str] = []
-    settings: Union[Dict[str, Any], Settings] = {}
+    settings: Union[Dict[str, Any], Settings] = {}  # type: ignore
 
     @validator("settings", pre=True)
     def _convert_settings(
-        cls, value: Union[Dict[str, Any], Settings]
+        cls,
+        value: Union[Dict[str, Any], Settings],  # type: ignore
     ) -> Dict[str, Any]:
         """Converts settings to a dictionary.
 

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
         WandbExperimentTracker,
     )
 else:
-    WandbSettingsType = Any
+    WandbSettingsType = TypeVar("WandbSettingsType", bound=Any)
 
 
 class WandbExperimentTrackerSettings(BaseSettings):

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -13,7 +13,17 @@
 #  permissions and limitations under the License.
 """Weights & Biases experiment tracker flavor."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from pydantic import validator
 

--- a/src/zenml/models/v2/base/page.py
+++ b/src/zenml/models/v2/base/page.py
@@ -24,7 +24,8 @@ from zenml.models.v2.base.base import BaseResponse
 from zenml.models.v2.base.filter import BaseFilter
 
 B = TypeVar(
-    "B", bound=Union[BaseResponse, BaseResponseModel]  # type: ignore[type-arg]
+    "B",
+    bound=Union[BaseResponse, BaseResponseModel],  # type: ignore[type-arg]
 )
 
 

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -167,9 +167,7 @@ class StepLauncher:
                 self._step.config.name,
             )
 
-            logs_context = StepLogsStorageContext(
-                logs_uri=logs_uri
-            )  # type: ignore[assignment]
+            logs_context = StepLogsStorageContext(logs_uri=logs_uri)  # type: ignore[assignment]
 
             logs_model = LogsRequest(
                 uri=logs_uri,

--- a/src/zenml/pipelines/pipeline_decorator.py
+++ b/src/zenml/pipelines/pipeline_decorator.py
@@ -126,7 +126,7 @@ def pipeline(
             name or func.__name__,
             (BasePipeline,),
             {
-                PIPELINE_INNER_FUNC_NAME: staticmethod(func),  # type: ignore[arg-type]
+                PIPELINE_INNER_FUNC_NAME: staticmethod(func),
                 CLASS_CONFIGURATION: {
                     PARAM_PIPELINE_NAME: name,
                     PARAM_ENABLE_CACHE: enable_cache,

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -1144,9 +1144,7 @@ class BaseStep(metaclass=BaseStepMeta):
         for (
             name,
             field,
-        ) in (
-            self.entrypoint_definition.legacy_params.annotation.__fields__.items()
-        ):
+        ) in self.entrypoint_definition.legacy_params.annotation.__fields__.items():
             if name in self.configuration.parameters:
                 # a value for this parameter has been set already
                 values[name] = self.configuration.parameters[name]

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -407,7 +407,8 @@ class PipelineDockerImageBuilder:
 
             try:
                 local_requirements = subprocess.check_output(
-                    command, shell=True  # nosec
+                    command,
+                    shell=True,  # nosec
                 ).decode()
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(

--- a/src/zenml/zen_server/rbac/endpoint_utils.py
+++ b/src/zenml/zen_server/rbac/endpoint_utils.py
@@ -31,7 +31,8 @@ AnyRequestModel = TypeVar(
     "AnyRequestModel", bound=Union[BaseRequestModel, BaseRequest]
 )
 AnyResponseModel = TypeVar(
-    "AnyResponseModel", bound=Union[BaseResponseModel, BaseResponse]  # type: ignore[type-arg]
+    "AnyResponseModel",
+    bound=Union[BaseResponseModel, BaseResponse],  # type: ignore[type-arg]
 )
 AnyFilterModel = TypeVar("AnyFilterModel", bound=BaseFilter)
 AnyUpdateModel = TypeVar("AnyUpdateModel", bound=BaseModel)

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -43,7 +43,8 @@ from zenml.zen_server.utils import rbac, server_config
 
 AnyOldResponseModel = TypeVar("AnyOldResponseModel", bound=BaseResponseModel)
 AnyNewResponseModel = TypeVar(
-    "AnyNewResponseModel", bound=BaseResponse  # type: ignore[type-arg]
+    "AnyNewResponseModel",
+    bound=BaseResponse,  # type: ignore[type-arg]
 )
 AnyResponseModel = TypeVar(
     "AnyResponseModel",

--- a/src/zenml/zen_server/rbac/zenml_cloud_rbac.py
+++ b/src/zenml/zen_server/rbac/zenml_cloud_rbac.py
@@ -294,4 +294,4 @@ class ZenMLCloudRBAC(RBACInterface):
         if not access_token or not isinstance(access_token, str):
             raise RuntimeError("Could not fetch auth token from auth0.")
 
-        return access_token
+        return str(access_token)

--- a/src/zenml/zen_stores/migrations/alembic.py
+++ b/src/zenml/zen_stores/migrations/alembic.py
@@ -192,7 +192,8 @@ class Alembic:
 
         def do_upgrade(rev: _RevIdType, context: Any) -> List[Any]:
             return self.script_directory._upgrade_revs(
-                revision, rev  # type:ignore [arg-type]
+                revision,
+                rev,  # type:ignore [arg-type]
             )
 
         self.run_migrations(do_upgrade)
@@ -206,7 +207,8 @@ class Alembic:
 
         def do_downgrade(rev: _RevIdType, context: Any) -> List[Any]:
             return self.script_directory._downgrade_revs(
-                revision, rev  # type:ignore [arg-type]
+                revision,
+                rev,  # type:ignore [arg-type]
             )
 
         self.run_migrations(do_downgrade)

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5100,7 +5100,9 @@ class SqlZenStore(BaseZenStore):
         resource_attrs = [
             attr
             for attr in UserSchema.__sqlmodel_relationships__.keys()
-            if not attr.startswith("_") and attr not in
+            if not attr.startswith("_")
+            and attr
+            not in
             # These are not resources owned by the user or  are resources that
             # are deleted automatically when the user is deleted. Secrets in
             # particular are left out because they are automatically deleted
@@ -6376,15 +6378,11 @@ class SqlZenStore(BaseZenStore):
             # Handle model artifact types
             if model_version_artifact_link_filter_model.only_data_artifacts:
                 query = query.where(
-                    ModelVersionArtifactSchema.is_model_artifact
-                    == False  # noqa: E712
+                    ModelVersionArtifactSchema.is_model_artifact == False  # noqa: E712
                 ).where(
-                    ModelVersionArtifactSchema.is_endpoint_artifact
-                    == False  # noqa: E712
+                    ModelVersionArtifactSchema.is_endpoint_artifact == False  # noqa: E712
                 )
-            elif (
-                model_version_artifact_link_filter_model.only_endpoint_artifacts
-            ):
+            elif model_version_artifact_link_filter_model.only_endpoint_artifacts:
                 query = query.where(
                     ModelVersionArtifactSchema.is_endpoint_artifact
                 )

--- a/tests/unit/config/test_compiler.py
+++ b/tests/unit/config/test_compiler.py
@@ -27,7 +27,8 @@ from zenml.steps import step
 
 
 def test_compiling_pipeline_with_invalid_run_name_fails(
-    empty_pipeline, local_stack  # noqa: F811
+    empty_pipeline,
+    local_stack,  # noqa: F811
 ):
     """Tests that compiling a pipeline with an invalid run name fails."""
     pipeline_instance = empty_pipeline

--- a/tests/unit/config/test_compiler.py
+++ b/tests/unit/config/test_compiler.py
@@ -27,8 +27,8 @@ from zenml.steps import step
 
 
 def test_compiling_pipeline_with_invalid_run_name_fails(
-    empty_pipeline,
-    local_stack,  # noqa: F811
+    empty_pipeline,  # noqa: F811
+    local_stack,
 ):
     """Tests that compiling a pipeline with an invalid run name fails."""
     pipeline_instance = empty_pipeline

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -520,7 +520,9 @@ def test_unique_identifier_considers_step_source_code(
 
 
 def test_latest_version_fetching(
-    mocker, empty_pipeline, create_pipeline_model  # noqa: F811
+    mocker,
+    empty_pipeline,
+    create_pipeline_model,  # noqa: F811
 ):
     """Tests fetching the latest pipeline version."""
     mock_list_pipelines = mocker.patch(
@@ -570,7 +572,8 @@ def test_latest_version_fetching(
 
 
 def test_registering_new_pipeline_version(
-    mocker, empty_pipeline  # noqa: F811
+    mocker,
+    empty_pipeline,  # noqa: F811
 ):
     """Tests registering a new pipeline version."""
     mocker.patch(
@@ -600,7 +603,9 @@ def test_registering_new_pipeline_version(
 
 
 def test_reusing_pipeline_version(
-    mocker, empty_pipeline, create_pipeline_model  # noqa: F811
+    mocker,
+    empty_pipeline,
+    create_pipeline_model,  # noqa: F811
 ):
     """Tests reusing an already registered pipeline version."""
     pipeline_model = create_pipeline_model(version="3")
@@ -842,7 +847,8 @@ def test_loading_pipeline_from_old_spec_fails(create_pipeline_model):
 
 
 def test_compiling_a_pipeline_merges_schedule(
-    empty_pipeline, tmp_path  # noqa: F811
+    empty_pipeline,
+    tmp_path,  # noqa: F811
 ):
     """Tests that compiling a pipeline merges the schedule from the config
     file and in-code configuration."""
@@ -867,7 +873,8 @@ def test_compiling_a_pipeline_merges_schedule(
 
 
 def test_compiling_a_pipeline_merges_build(
-    empty_pipeline, tmp_path  # noqa: F811
+    empty_pipeline,
+    tmp_path,  # noqa: F811
 ):
     """Tests that compiling a pipeline merges the build/build ID from the config
     file and in-code configuration."""
@@ -917,7 +924,8 @@ def test_compiling_a_pipeline_merges_build(
 
 
 def test_building_a_pipeline_registers_it(
-    clean_client, empty_pipeline  # noqa: F811
+    clean_client,
+    empty_pipeline,  # noqa: F811
 ):
     """Tests that building a pipeline registers it in the server."""
     pipeline_instance = empty_pipeline

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -521,8 +521,8 @@ def test_unique_identifier_considers_step_source_code(
 
 def test_latest_version_fetching(
     mocker,
-    empty_pipeline,
-    create_pipeline_model,  # noqa: F811
+    empty_pipeline,  # noqa: F811
+    create_pipeline_model,
 ):
     """Tests fetching the latest pipeline version."""
     mock_list_pipelines = mocker.patch(
@@ -604,8 +604,8 @@ def test_registering_new_pipeline_version(
 
 def test_reusing_pipeline_version(
     mocker,
-    empty_pipeline,
-    create_pipeline_model,  # noqa: F811
+    empty_pipeline,  # noqa: F811
+    create_pipeline_model,
 ):
     """Tests reusing an already registered pipeline version."""
     pipeline_model = create_pipeline_model(version="3")
@@ -847,8 +847,8 @@ def test_loading_pipeline_from_old_spec_fails(create_pipeline_model):
 
 
 def test_compiling_a_pipeline_merges_schedule(
-    empty_pipeline,
-    tmp_path,  # noqa: F811
+    empty_pipeline,  # noqa: F811
+    tmp_path,
 ):
     """Tests that compiling a pipeline merges the schedule from the config
     file and in-code configuration."""
@@ -873,8 +873,8 @@ def test_compiling_a_pipeline_merges_schedule(
 
 
 def test_compiling_a_pipeline_merges_build(
-    empty_pipeline,
-    tmp_path,  # noqa: F811
+    empty_pipeline,  # noqa: F811
+    tmp_path,
 ):
     """Tests that compiling a pipeline merges the build/build ID from the config
     file and in-code configuration."""

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -152,7 +152,8 @@ def test_stack_prepare_pipeline_deployment(
 
 
 def test_stack_deployment(
-    stack_with_mock_components, empty_pipeline  # noqa: F811
+    stack_with_mock_components,
+    empty_pipeline,  # noqa: F811
 ):
     """Tests that when a pipeline is deployed on a stack, the stack calls the
     orchestrator to run the pipeline and calls cleanup methods on all of its


### PR DESCRIPTION
`ruff format` is now a drop-in replacement for `black` so we can remove `black` from our dev dependencies.

Some small fixes were made by making the switch, but nothing of consequence.

This PR also bumps our `ruff` and `mypy` versions to the current latest version.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

