### PR TITLE
Lock in airflow version as higher versions will fail

### DIFF
--- a/docs/book/stacks-and-components/component-guide/orchestrators/airflow.md
+++ b/docs/book/stacks-and-components/component-guide/orchestrators/airflow.md
@@ -75,7 +75,7 @@ zenml stack register <STACK_NAME> -o <ORCHESTRATOR_NAME> ... --set
 In the local case, we need to install one additional Python package that is needed for the local Airflow server:
 
 ```bash
-pip install apache-airflow-providers-docker
+pip install apache-airflow-providers-docker apache-airflow~=2.5.0
 ```
 
 Once that is installed, we can start the local Airflow server by running:


### PR DESCRIPTION
## Describe changes
This line installed airflow version 2.7.3 which has breaking changes that our airflow integration does not work with.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

