### PR TITLE
Swap contents for HTMLString and MarkdownString in docs

### DIFF
--- a/docs/book/user-guide/advanced-guide/artifact-management/visualize-artifacts.md
+++ b/docs/book/user-guide/advanced-guide/artifact-management/visualize-artifacts.md
@@ -33,8 +33,8 @@ and build and return this custom return type from one of your steps.
 
 If you already have HTML, Markdown, or CSV data available as a string inside your step, you can simply cast them to one of the following types and return them from your step:
 
-* `zenml.types.HTMLString` for strings in HTML format, e.g., `"# Header\nSome text"`,
-* `zenml.types.MarkdownString` for strings in Markdown format, e.g., `"<h1>Header</h1>Some text"`,
+* `zenml.types.HTMLString` for strings in HTML format, e.g., `"<h1>Header</h1>Some text"`,
+* `zenml.types.MarkdownString` for strings in Markdown format, e.g., `"# Header\nSome text"`,
 * `zenml.types.CSVString` for strings in CSV format, e.g., `"a,b,c\n1,2,3"`.
 
 #### Example:


### PR DESCRIPTION
## Describe changes
The docs accidentally give a Markdown example for `HTMLString` and an HTML example for `MarkdownString`. This PR fixes that.

```
* zenml.types.HTMLString for strings in HTML format, e.g., "# Header\nSome text",
* zenml.types.MarkdownString for strings in Markdown format, e.g., "<h1>Header</h1>Some text",
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

