### PR TITLE
Allow extra values when dehydrating response models

### DIFF
--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -112,7 +112,7 @@ def dehydrate_response_model(
         )
 
     dehydrated_values = {}
-    for key, value in model.dict().items():
+    for key, value in model.__dict__.items():
         if key in model.__private_attributes__:
             dehydrated_values[key] = value
         else:
@@ -554,8 +554,9 @@ def get_subresources_for_model(
     """
     resources = set()
 
-    for field_name in model.__fields__.keys():
-        value = getattr(model, field_name)
+    for key, value in model.__dict__.items():
+        if key in model.__private_attributes__:
+            continue
         resources.update(_get_subresources_for_value(value))
 
     return resources


### PR DESCRIPTION
## Describe changes

The dehydration of models removed `extra` pydantic attributes as these were not covered by `model.__fields__`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

