### PR TITLE
Fixing the colab issues with stack cache

### DIFF
--- a/src/zenml/models/v2/core/stack.py
+++ b/src/zenml/models/v2/core/stack.py
@@ -14,6 +14,7 @@
 """Models representing stacks."""
 
 import json
+from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional, Union
 from uuid import UUID
 
@@ -91,6 +92,13 @@ class StackUpdate(StackRequest):
 
 class StackResponseBody(WorkspaceScopedResponseBody):
     """Response body for stacks."""
+
+    created: datetime = Field(
+        title="The timestamp when this component was created."
+    )
+    updated: datetime = Field(
+        title="The timestamp when this component was last updated.",
+    )
 
 
 class StackResponseMetadata(WorkspaceScopedResponseMetadata):
@@ -184,6 +192,24 @@ class StackResponse(
         return metadata
 
     # Body and metadata properties
+    @property
+    def created(self) -> datetime:
+        """The`created` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().created
+
+    @property
+    def updated(self) -> datetime:
+        """The `updated` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().updated
+
     @property
     def description(self) -> Optional[str]:
         """The `description` property.

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -33,6 +33,7 @@ from uuid import UUID
 
 from zenml.client import Client
 from zenml.config.build_configuration import BuildConfiguration
+from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import (
     ENV_ZENML_SECRET_VALIDATION_LEVEL,
     ENV_ZENML_SKIP_IMAGE_BUILDER_DEFAULT,
@@ -174,6 +175,15 @@ class Stack:
             components=stack_components,
         )
         _STACK_CACHE[key] = stack
+
+        client = Client()
+        if stack_model.id == client.active_stack_model.id:
+            if stack_model.updated > client.active_stack_model.updated:
+                if client._config:
+                    client._config.set_active_stack(stack_model)
+                else:
+                    GlobalConfiguration().set_active_stack(stack_model)
+
         return stack
 
     @classmethod


### PR DESCRIPTION
## Describe changes
Allow me to quickly summarize what went wrong in the Colab with the order of how things are executed.

- We install ZenML and register a stack **without a model registry.**
- Then, we execute some ZenML-related code, which instantiates a ZenML `Client`.
- This `client`, which is a singleton, has now the `active_stack` set **(again without a model registry).**
- Afterwards, we update the stack through a CLI command.
- Even though the stack gets updated correctly, since this is a CLI command, this does not affect either the `_STACK_CACHE` or the `client` singleton.
- This is where things take an interesting turn. Consecutively, we try to launch a pipeline.
- The pipeline uses the `step_launcher` which is initiated with a `deployment` object.
- This `deployment` object is fetched from the DB by the `load_deployment` method of the step entrypoint.
- Since the fetch happens after the stack is updated, this `deployment` object has the correct and updated version of the stack.
- The step launcher calls the `Stack().from_model` method which, in return, puts the updated second version of the stack in the cache. 
- Even though now the second version of the stack is in the cache, the client singleton has no notion that the stack was actually updated and does not update the `active_stack` property.
- The step eventually tries to use this property to fetch the model registry but can not find it and it fails.

With the proposed solution, if we ever write an updated version of the active stack to the cache, we automatically update the client accordingly.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [X] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

