### PR TITLE
Make slack blocks more generic

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -17,6 +17,13 @@ inputs:
     type: string
     required: false
     default: 'yes'
+  runners_cache_access_key_id:
+    description: 'Runner cache AWS access key ID'
+    required: true
+  runners_cache_secret_access_key:
+    description: 'Runner cache AWS secret access key'
+    required: true
+
 
 runs:
   using: "composite"
@@ -25,7 +32,6 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
-
 
     - name: Delete error-causing bash
       shell: bash
@@ -57,7 +63,9 @@ runs:
       id: date
       run: echo "::set-output name=week::$(date +'calendar-week-%W')"
 
+
     - uses: syphar/restore-virtualenv@v1
+      if : ${{ inputs.os != 'ubuntu-dind-runners' }}
       id: cache-virtualenv
       with:
         requirement_files: 'pyproject.toml'
@@ -67,6 +75,23 @@ runs:
         # - any of the integration requirements change (a hash of the
         # __init__.py files is included in the cache key)
         custom_cache_key_element: ${{ inputs.cache_version }}-${{steps.date.outputs.week}}-${{inputs.install_integrations}}-${{ hashFiles('src/zenml/integrations/*/__init__.py') }}
+
+    - uses: tespkg/actions-cache@v1
+      if: ${{ inputs.os == 'ubuntu-dind-runners' }}
+      id: custom-cache-pip
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.runners_cache_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.runners_cache_secret_access_key }}
+      with:
+        endpoint: minio-service.minio.svc.cluster.local  # optional
+        insecure: true # optional, use http instead of https. default false
+        bucket: "caching" # required
+        use-fallback: false # optional, use github actions cache fallback, default false
+        key: ${{ inputs.os }}-${{ inputs.cache_version }}-${{ inputs.python-version }}-${{steps.date.outputs.week}}-${{inputs.install_integrations}}-${{ hashFiles('src/zenml/integrations/*/__init__.py') }}
+        path: |
+          ~/.cache/pip
+        restore-keys: |
+          ${{ inputs.os }}-${{ inputs.cache_version }}-${{ inputs.python-version }}-${{steps.date.outputs.week}}-${{inputs.install_integrations}}-${{ hashFiles('src/zenml/integrations/*/__init__.py') }}
 
     # Disabled for now because it doesn't work well with multiple parallel jobs
     # - uses: syphar/restore-pip-download-cache@v1
@@ -89,17 +114,17 @@ runs:
         brew install hashicorp/tap/terraform
 
     - name: Install ZenML and dependencies
-      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+      if: steps.cache-virtualenv.outputs.cache-hit != 'true' && steps.custom-cache-pip.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        scripts/install-zenml-dev.sh --integrations ${{inputs.install_integrations}}
+        scripts/install-zenml-dev.sh --integrations ${{ inputs.install_integrations }}
 
       # if using a cached virtualenv, just refresh the ZenML installation 
     - name: Refresh ZenML installation
-      if: steps.cache-virtualenv.outputs.cache-hit == 'true'
+      if: steps.cache-virtualenv.outputs.cache-hit == 'true' || steps.custom-cache-pip.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        scripts/install-zenml-dev.sh
+        scripts/install-zenml-dev.sh --integrations ${{ inputs.install_integrations }}
 
     - name: Check Python environment
       shell: bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,9 @@ I implemented/fixed _ to achieve _.
 Please ensure you have done the following:
 - [ ] I have read the **CONTRIBUTING.md** document.
 - [ ] If my change requires a change to docs, I have updated the documentation accordingly.
-- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
 - [ ] I have added tests to cover my changes.
 - [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
+- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.
 
 ## Types of changes
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,10 @@ jobs:
     secrets: inherit
   
   update-templates-to-examples:
-    needs: custom-ubuntu-runners-setup-and-test-python
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
       python-version: "3.8"
-      os: ubuntu-dind-runners
+      os: ubuntu-latest
     secrets: inherit
 
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -180,6 +180,8 @@ jobs:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}
+          runners_cache_access_key_id: ${{ secrets.RUNNERS_CACHE_ACCESS_KEY_ID }}
+          runners_cache_secret_access_key: ${{ secrets.RUNNERS_CACHE_SECRET_ACCESS_KEY }}
 
       - name: Install docker-compose for non-default environments
         if: inputs.test_environment != 'default'

--- a/.github/workflows/setup-python-environment.yml
+++ b/.github/workflows/setup-python-environment.yml
@@ -127,6 +127,8 @@ jobs:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}
           install_integrations: ${{ inputs.install_integrations }}
+          runners_cache_access_key_id: ${{ secrets.RUNNERS_CACHE_ACCESS_KEY_ID }}
+          runners_cache_secret_access_key: ${{ secrets.RUNNERS_CACHE_SECRET_ACCESS_KEY }}
 
       - name: Setup tmate session before tests
         if: ${{ inputs.enable_tmate == 'before-tests' }}

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -882,6 +882,75 @@ You can delete one of your registered code repositories like this:
 zenml code-repository delete <REPOSITORY_NAME_OR_ID>
 ```
 
+Administering your Models
+----------------------------
+
+ZenML provides several CLI commands to help you administer your models and
+model versions as part of the Model Control Plane.
+
+To register a new model, you can use the following CLI command:
+```bash
+zenml model register --name <NAME> [--MODEL_OPTIONS]
+```
+
+To list all registered models, use:
+```bash
+zenml model list
+```
+
+To update a model, use:
+```bash
+zenml model update <MODEL_NAME_OR_ID> [--MODEL_OPTIONS]
+```
+
+If you would like to add or remove tags from the model, use:
+```bash
+zenml model update <MODEL_NAME_OR_ID> --tag <TAG> --tag <TAG> .. 
+   --remove-tag <TAG> --remove-tag <TAG> ..
+```
+
+To delete a model, use:
+```bash
+zenml model delete <MODEL_NAME_OR_ID>
+```
+
+The CLI interface for models also helps to navigate through artifacts linked to a specific model versions.
+```bash
+zenml model data_artifacts <MODEL_NAME_OR_ID> [-v <VERSION>]
+zenml model endpoint_artifacts <MODEL_NAME_OR_ID> [-v <VERSION>]
+zenml model model_artifacts <MODEL_NAME_OR_ID> [-v <VERSION>]
+```
+
+You can also navigate the pipeline runs linked to a specific model versions:
+```bash
+zenml model runs <MODEL_NAME_OR_ID> [-v <VERSION>]
+```
+
+To list the model versions of a specific model, use:
+```bash
+zenml model version list <MODEL_NAME_OR_ID>
+```
+
+To delete a model version, use:
+```bash
+zenml model version delete <MODEL_NAME_OR_ID> <VERSION>
+```
+
+To update a model version, use:
+```bash
+zenml model version update <MODEL_NAME_OR_ID> <VERSION> [--MODEL_VERSION_OPTIONS]
+```
+These are some of the more common uses of model version updates:
+- stage (i.e. promotion)
+```bash
+zenml model version update <MODEL_NAME_OR_ID> <VERSION> --stage <STAGE>
+```
+- tags
+```bash
+zenml model version update <MODEL_NAME_OR_ID> <VERSION> --tag <TAG> --tag <TAG> .. 
+   --remove-tag <TAG> --remove-tag <TAG> ..
+```
+
 Administering your Pipelines
 ----------------------------
 

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -60,6 +60,7 @@ def _model_version_to_print(
         "number": model_version.number,
         "description": model_version.description,
         "stage": model_version.stage,
+        "tags": [t.name for t in model_version.tags],
         "data_artifacts_count": len(model_version.data_artifact_ids),
         "model_artifacts_count": len(model_version.model_artifact_ids),
         "endpoint_artifacts_count": len(model_version.endpoint_artifact_ids),
@@ -391,6 +392,22 @@ def list_model_versions(model_name_or_id: str, **kwargs: Any) -> None:
     help="The stage of the model version.",
 )
 @click.option(
+    "--tag",
+    "-t",
+    help="Tags to be added to the model.",
+    type=str,
+    required=False,
+    multiple=True,
+)
+@click.option(
+    "--remove-tag",
+    "-r",
+    help="Tags to be removed from the model.",
+    type=str,
+    required=False,
+    multiple=True,
+)
+@click.option(
     "--force",
     "-f",
     is_flag=True,
@@ -400,6 +417,8 @@ def update_model_version(
     model_name_or_id: str,
     model_version_name_or_number_or_id: str,
     stage: str,
+    tag: Optional[List[str]],
+    remove_tag: Optional[List[str]],
     force: bool = False,
 ) -> None:
     """Update an existing model version stage in the Model Control Plane.
@@ -408,6 +427,8 @@ def update_model_version(
         model_name_or_id: The ID or name of the model containing version.
         model_version_name_or_number_or_id: The ID, number or name of the model version.
         stage: The stage of the model version to be set.
+        tag: Tags to be added to the model version.
+        remove_tag: Tags to be removed from the model version.
         force: Whether existing model version in target stage should be silently archived.
     """
     model_version = Client().get_model_version(
@@ -415,10 +436,12 @@ def update_model_version(
         model_version_name_or_number_or_id=model_version_name_or_number_or_id,
     )
     try:
-        Client().update_model_version(
+        model_version = Client().update_model_version(
             model_name_or_id=model_name_or_id,
             version_name_or_id=model_version.id,
             stage=stage,
+            add_tags=tag,
+            remove_tags=remove_tag,
             force=force,
         )
     except RuntimeError:
@@ -435,15 +458,15 @@ def update_model_version(
             if not confirmation:
                 cli_utils.declare("Model version stage update canceled.")
                 return
-            Client().update_model_version(
+            model_version = Client().update_model_version(
                 model_name_or_id=model_version.model.id,
                 version_name_or_id=model_version.id,
                 stage=stage,
+                add_tags=tag,
+                remove_tags=remove_tag,
                 force=True,
             )
-    cli_utils.declare(
-        f"Model version '{model_version.name}' stage updated to '{stage}'."
-    )
+    cli_utils.print_table([_model_version_to_print(model_version)])
 
 
 @version.command("delete", help="Delete an existing model version.")

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -4576,6 +4576,7 @@ class Client(metaclass=ClientMetaClass):
         model_name_or_id: Union[str, UUID],
         name: Optional[str] = None,
         description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
     ) -> ModelVersionResponse:
         """Creates a new model version in Model Control Plane.
 
@@ -4584,6 +4585,7 @@ class Client(metaclass=ClientMetaClass):
                 version in.
             name: the name of the Model Version to be created.
             description: the description of the Model Version to be created.
+            tags: Tags associated with the model.
 
         Returns:
             The newly created model version.
@@ -4597,6 +4599,7 @@ class Client(metaclass=ClientMetaClass):
                 user=self.active_user.id,
                 workspace=self.active_workspace.id,
                 model=model_name_or_id,
+                tags=tags,
             )
         )
 
@@ -4754,6 +4757,8 @@ class Client(metaclass=ClientMetaClass):
         stage: Optional[Union[str, ModelStages]] = None,
         force: bool = False,
         name: Optional[str] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
     ) -> ModelVersionResponse:
         """Get all model versions by filter.
 
@@ -4764,6 +4769,8 @@ class Client(metaclass=ClientMetaClass):
             force: Whether existing model version in target stage should be
                 silently archived or an error should be raised.
             name: Target model version name to be set.
+            add_tags: Tags to add to the model version.
+            remove_tags: Tags to remove from to the model version.
 
         Returns:
             An updated model version.
@@ -4782,6 +4789,8 @@ class Client(metaclass=ClientMetaClass):
                 stage=stage,
                 force=force,
                 name=name,
+                add_tags=add_tags,
+                remove_tags=remove_tags,
             ),
         )
 

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -320,6 +320,7 @@ class TaggableResourceTypes(StrEnum):
     ARTIFACT = "artifact"
     ARTIFACT_VERSION = "artifact_version"
     MODEL = "model"
+    MODEL_VERSION = "model_version"
 
 
 class ResponseUpdateStrategy(StrEnum):

--- a/src/zenml/integrations/slack/alerters/slack_alerter.py
+++ b/src/zenml/integrations/slack/alerters/slack_alerter.py
@@ -14,7 +14,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, List, Optional, cast
 
 from pydantic import BaseModel
 from slack_sdk import WebClient
@@ -57,7 +57,7 @@ class SlackAlerterParameters(BaseAlerterStepParameters):
     include_format_blocks: Optional[bool] = True
 
     # Allowing user to use their own custom blocks in the slack post message
-    blocks: Optional[list[dict[str,Any]]] = None
+    blocks: Optional[list[dict[str, Any]]] = None
 
 
 class SlackAlerter(BaseAlerter):
@@ -147,7 +147,7 @@ class SlackAlerter(BaseAlerter):
 
     def _create_blocks(
         self, message: str, params: Optional[BaseAlerterStepParameters]
-    ) -> list[dict[str,Any]]:
+    ) -> list[dict[str, Any]]:
         """Helper function to create slack blocks.
 
         Args:
@@ -160,10 +160,7 @@ class SlackAlerter(BaseAlerter):
         if isinstance(params, SlackAlerterParameters):
             if hasattr(params, "blocks") and params.blocks is not None:
                 return params.blocks
-            elif (
-            hasattr(params, "payload")
-            and params.payload is not None
-            ):
+            elif hasattr(params, "payload") and params.payload is not None:
                 payload = params.payload
                 return [
                     {

--- a/src/zenml/integrations/slack/alerters/slack_alerter.py
+++ b/src/zenml/integrations/slack/alerters/slack_alerter.py
@@ -56,6 +56,9 @@ class SlackAlerterParameters(BaseAlerterStepParameters):
     payload: Optional[SlackAlerterPayload] = None
     include_format_blocks: Optional[bool] = True
 
+    # Allowing user to use their own custom blocks in the slack post message
+    blocks: Optional[list[dict[str,Any]]] = None
+
 
 class SlackAlerter(BaseAlerter):
     """Send messages to Slack channels."""
@@ -144,7 +147,7 @@ class SlackAlerter(BaseAlerter):
 
     def _create_blocks(
         self, message: str, params: Optional[BaseAlerterStepParameters]
-    ) -> List[Dict]:  # type: ignore
+    ) -> list[dict[str,Any]]:
         """Helper function to create slack blocks.
 
         Args:
@@ -154,46 +157,49 @@ class SlackAlerter(BaseAlerter):
         Returns:
             List of slack blocks.
         """
-        if (
-            isinstance(params, SlackAlerterParameters)
-            and hasattr(params, "payload")
+        if isinstance(params, SlackAlerterParameters):
+            if hasattr(params, "blocks") and params.blocks is not None:
+                return params.blocks
+            elif (
+            hasattr(params, "payload")
             and params.payload is not None
-        ):
-            payload = params.payload
-            return [
-                {
-                    "type": "section",
-                    "fields": [
-                        {
-                            "type": "mrkdwn",
-                            "text": f":star: *Pipeline:*\n{payload.pipeline_name}",
+            ):
+                payload = params.payload
+                return [
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f":star: *Pipeline:*\n{payload.pipeline_name}",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f":arrow_forward: *Step:*\n{payload.step_name}",
+                            },
+                            {
+                                "type": "mrkdwn",
+                                "text": f":ring_buoy: *Stack:*\n{payload.stack_name}",
+                            },
+                        ],
+                        "accessory": {
+                            "type": "image",
+                            "image_url": "https://zenml-strapi-media.s3.eu-central-1.amazonaws.com/03_Zen_ML_Logo_Square_White_efefc24ae7.png",
+                            "alt_text": "zenml logo",
                         },
-                        {
-                            "type": "mrkdwn",
-                            "text": f":arrow_forward: *Step:*\n{payload.step_name}",
-                        },
-                        {
-                            "type": "mrkdwn",
-                            "text": f":ring_buoy: *Stack:*\n{payload.stack_name}",
-                        },
-                    ],
-                    "accessory": {
-                        "type": "image",
-                        "image_url": "https://zenml-strapi-media.s3.eu-central-1.amazonaws.com/03_Zen_ML_Logo_Square_White_efefc24ae7.png",
-                        "alt_text": "zenml logo",
                     },
-                },
-                {
-                    "type": "section",
-                    "fields": [
-                        {
-                            "type": "mrkdwn",
-                            "text": f":email: *Message:*\n{message}",
-                        },
-                    ],
-                },
-            ]
-        return []
+                    {
+                        "type": "section",
+                        "fields": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f":email: *Message:*\n{message}",
+                            },
+                        ],
+                    },
+                ]
+            else:
+                return []
 
     def post(
         self, message: str, params: Optional[BaseAlerterStepParameters] = None

--- a/src/zenml/model/model_version.py
+++ b/src/zenml/model/model_version.py
@@ -462,6 +462,7 @@ class ModelVersion(BaseModel):
             name=self.version,
             description=self.description,
             model=model.id,
+            tags=self.tags,
         )
         mv_request = ModelVersionRequest.parse_obj(model_version_request)
         try:

--- a/src/zenml/models/v2/core/model_version.py
+++ b/src/zenml/models/v2/core/model_version.py
@@ -14,13 +14,14 @@
 """Models representing model versions."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, Optional, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, TypeVar, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, PrivateAttr, validator
 
 from zenml.constants import STR_FIELD_MAX_LENGTH, TEXT_FIELD_MAX_LENGTH
 from zenml.enums import ModelStages
+from zenml.models.tag_models import TagResponseModel
 from zenml.models.v2.base.filter import AnyQuery
 from zenml.models.v2.base.scoped import (
     WorkspaceScopedFilter,
@@ -68,6 +69,9 @@ class ModelVersionRequest(WorkspaceScopedRequest):
     model: UUID = Field(
         description="The ID of the model containing version",
     )
+    tags: Optional[List[str]] = Field(
+        title="Tags associated with the model version",
+    )
 
 
 # ------------------ Update Model ------------------
@@ -88,7 +92,16 @@ class ModelVersionUpdate(BaseModel):
         default=False,
     )
     name: Optional[str] = Field(
-        description="Target model version name to be set", default=None
+        description="Target model version name to be set",
+        default=None,
+    )
+    add_tags: Optional[List[str]] = Field(
+        description="Tags to be added to the model version",
+        default=None,
+    )
+    remove_tags: Optional[List[str]] = Field(
+        description="Tags to be removed from the model version",
+        default=None,
     )
 
     @validator("stage")
@@ -133,6 +146,9 @@ class ModelVersionResponseBody(WorkspaceScopedResponseBody):
     pipeline_run_ids: Dict[str, UUID] = Field(
         description="Pipeline runs linked to the model version",
         default={},
+    )
+    tags: List[TagResponseModel] = Field(
+        title="Tags associated with the model version", default=[]
     )
     created: datetime = Field(
         title="The timestamp when this component was created."
@@ -247,6 +263,15 @@ class ModelVersionResponse(
         return self.get_body().updated
 
     @property
+    def tags(self) -> List["TagResponseModel"]:
+        """The `tags` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().tags
+
+    @property
     def description(self) -> Optional[str]:
         """The `description` property.
 
@@ -293,7 +318,7 @@ class ModelVersionResponse(
             limitations=self.model.limitations,
             trade_offs=self.model.trade_offs,
             ethics=self.model.ethics,
-            tags=[t.name for t in self.model.tags],
+            tags=[t.name for t in self.tags],
             version=self.name,
             was_created_in_this_run=was_created_in_this_run,
             suppress_class_validation_warnings=suppress_class_validation_warnings,

--- a/src/zenml/utils/source_utils.py
+++ b/src/zenml/utils/source_utils.py
@@ -289,6 +289,7 @@ def is_standard_lib_file(file_path: str) -> bool:
         otherwise.
     """
     stdlib_root = get_python_lib(standard_lib=True)
+    logger.debug("Standard library root: %s", stdlib_root)
     return Path(stdlib_root).resolve() in Path(file_path).resolve().parents
 
 
@@ -337,13 +338,13 @@ def get_source_type(module: ModuleType) -> SourceType:
     if is_internal_module(module_name=module.__name__):
         return SourceType.INTERNAL
 
-    if is_standard_lib_file(file_path=file_path):
-        return SourceType.BUILTIN
-
     if is_distribution_package_file(
         file_path=file_path, module_name=module.__name__
     ):
         return SourceType.DISTRIBUTION_PACKAGE
+
+    if is_standard_lib_file(file_path=file_path):
+        return SourceType.BUILTIN
 
     # Make sure to check for distribution packages before this to catch the
     # case when a virtual environment is inside our source root

--- a/src/zenml/zen_stores/schemas/model_schemas.py
+++ b/src/zenml/zen_stores/schemas/model_schemas.py
@@ -241,6 +241,14 @@ class ModelVersionSchema(NamedSchema, table=True):
         back_populates="model_version",
         sa_relationship_kwargs={"cascade": "delete"},
     )
+    tags: List["TagResourceSchema"] = Relationship(
+        back_populates="model_version",
+        sa_relationship_kwargs=dict(
+            primaryjoin=f"and_(TagResourceSchema.resource_type=='{TaggableResourceTypes.MODEL_VERSION.value}', foreign(TagResourceSchema.resource_id)==ModelVersionSchema.id)",
+            cascade="delete",
+            overlaps="tags",
+        ),
+    )
 
     number: int = Field(sa_column=Column(INTEGER, nullable=False))
     description: str = Field(sa_column=Column(TEXT, nullable=True))
@@ -331,6 +339,7 @@ class ModelVersionSchema(NamedSchema, table=True):
             data_artifact_ids=data_artifact_ids,
             endpoint_artifact_ids=endpoint_artifact_ids,
             pipeline_run_ids=pipeline_run_ids,
+            tags=[t.tag.to_model() for t in self.tags],
         )
 
         return ModelVersionResponse(

--- a/src/zenml/zen_stores/schemas/tag_schemas.py
+++ b/src/zenml/zen_stores/schemas/tag_schemas.py
@@ -37,7 +37,10 @@ if TYPE_CHECKING:
         ArtifactSchema,
         ArtifactVersionSchema,
     )
-    from zenml.zen_stores.schemas.model_schemas import ModelSchema
+    from zenml.zen_stores.schemas.model_schemas import (
+        ModelSchema,
+        ModelVersionSchema,
+    )
 
 
 class TagSchema(NamedSchema, table=True):
@@ -126,21 +129,28 @@ class TagResourceSchema(BaseSchema, table=True):
         back_populates="tags",
         sa_relationship_kwargs=dict(
             primaryjoin=f"and_(TagResourceSchema.resource_type=='{TaggableResourceTypes.ARTIFACT.value}', foreign(TagResourceSchema.resource_id)==ArtifactSchema.id)",
-            overlaps="tags,model,artifact_version",
+            overlaps="tags,model,artifact_version,model_version",
         ),
     )
     artifact_version: List["ArtifactVersionSchema"] = Relationship(
         back_populates="tags",
         sa_relationship_kwargs=dict(
             primaryjoin=f"and_(TagResourceSchema.resource_type=='{TaggableResourceTypes.ARTIFACT_VERSION.value}', foreign(TagResourceSchema.resource_id)==ArtifactVersionSchema.id)",
-            overlaps="tags,model,artifact",
+            overlaps="tags,model,artifact,model_version",
         ),
     )
     model: List["ModelSchema"] = Relationship(
         back_populates="tags",
         sa_relationship_kwargs=dict(
             primaryjoin=f"and_(TagResourceSchema.resource_type=='{TaggableResourceTypes.MODEL.value}', foreign(TagResourceSchema.resource_id)==ModelSchema.id)",
-            overlaps="tags,artifact,artifact_version",
+            overlaps="tags,artifact,artifact_version,model_version",
+        ),
+    )
+    model_version: List["ModelVersionSchema"] = Relationship(
+        back_populates="tags",
+        sa_relationship_kwargs=dict(
+            primaryjoin=f"and_(TagResourceSchema.resource_type=='{TaggableResourceTypes.MODEL_VERSION.value}', foreign(TagResourceSchema.resource_id)==ModelVersionSchema.id)",
+            overlaps="tags,model,artifact,artifact_version",
         ),
     )
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6403,6 +6403,13 @@ class SqlZenStore(BaseZenStore):
             )
             session.add(model_version_schema)
 
+            if model_version.tags:
+                self._attach_tags_to_resource(
+                    tag_names=model_version.tags,
+                    resource_id=model_version_schema.id,
+                    resource_type=TaggableResourceTypes.MODEL_VERSION,
+                )
+
             session.commit()
             return model_version_schema.to_model(hydrate=True)
 
@@ -6561,6 +6568,19 @@ class SqlZenStore(BaseZenStore):
                         logger.info(
                             f"Model version {existing_model_version_in_target_stage.name} has been set to {ModelStages.ARCHIVED.value}."
                         )
+
+            if model_version_update_model.add_tags:
+                self._attach_tags_to_resource(
+                    tag_names=model_version_update_model.add_tags,
+                    resource_id=existing_model_version.id,
+                    resource_type=TaggableResourceTypes.MODEL_VERSION,
+                )
+            if model_version_update_model.remove_tags:
+                self._detach_tags_from_resource(
+                    tag_names=model_version_update_model.remove_tags,
+                    resource_id=existing_model_version.id,
+                    resource_type=TaggableResourceTypes.MODEL_VERSION,
+                )
 
             existing_model_version.update(
                 target_stage=stage,

--- a/tests/integration/functional/model/test_model_version.py
+++ b/tests/integration/functional/model/test_model_version.py
@@ -87,12 +87,33 @@ class TestModelVersion:
     def test_model_create_model_and_version(self, clean_client: "Client"):
         """Test if model and version are created, not existing before."""
         with ModelContext(clean_client, create_model=False):
-            mv = ModelVersion(name=MODEL_NAME)
+            mv = ModelVersion(name=MODEL_NAME, tags=["tag1", "tag2"])
             with mock.patch("zenml.model.model_version.logger.info") as logger:
                 mv = mv._get_or_create_model_version()
                 logger.assert_called()
             assert mv.name == str(mv.number)
             assert mv.model.name == MODEL_NAME
+            assert {t.name for t in mv.tags} == {"tag1", "tag2"}
+            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
+
+    def test_create_model_version_makes_proper_tagging(
+        self, clean_client: "Client"
+    ):
+        """Test if model versions get unique tags."""
+        with ModelContext(clean_client, create_model=False):
+            mv = ModelVersion(name=MODEL_NAME, tags=["tag1", "tag2"])
+            mv = mv._get_or_create_model_version()
+            assert mv.name == str(mv.number)
+            assert mv.model.name == MODEL_NAME
+            assert {t.name for t in mv.tags} == {"tag1", "tag2"}
+            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
+
+            mv = ModelVersion(name=MODEL_NAME, tags=["tag3", "tag4"])
+            mv = mv._get_or_create_model_version()
+            assert mv.name == str(mv.number)
+            assert mv.model.name == MODEL_NAME
+            assert {t.name for t in mv.tags} == {"tag3", "tag4"}
+            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
 
     def test_model_fetch_model_and_version_by_number(
         self, clean_client: "Client"
@@ -203,7 +224,7 @@ class TestModelVersion:
             tags=["foo", "bar"],
             delete_new_version_on_failure=False,
         )
-        model_id = mv._get_or_create_model().id
+        model_id = mv._get_or_create_model_version().model.id
 
         clean_client.update_model(model_id, add_tags=["tag1", "tag2"])
         model = mv._get_or_create_model()
@@ -215,7 +236,26 @@ class TestModelVersion:
             "tag2",
         }
 
+        clean_client.update_model_version(
+            model_id, "1", add_tags=["tag3", "tag4"]
+        )
+        model_version = mv._get_or_create_model_version()
+        assert len(model_version.tags) == 4
+        assert {t.name for t in model_version.tags} == {
+            "foo",
+            "bar",
+            "tag3",
+            "tag4",
+        }
+
         clean_client.update_model(model_id, remove_tags=["tag1", "tag2"])
         model = mv._get_or_create_model()
         assert len(model.tags) == 2
         assert {t.name for t in model.tags} == {"foo", "bar"}
+
+        clean_client.update_model_version(
+            model_id, "1", remove_tags=["tag3", "tag4"]
+        )
+        model_version = mv._get_or_create_model_version()
+        assert len(model_version.tags) == 2
+        assert {t.name for t in model_version.tags} == {"foo", "bar"}

--- a/tests/integration/functional/test_client.py
+++ b/tests/integration/functional/test_client.py
@@ -1352,6 +1352,14 @@ class TestModelVersion:
         assert model_version.number == 4
         assert model_version.description == "some desc"
 
+        model_version = client_with_model.create_model_version(
+            self.MODEL_NAME, tags=["a", "b"]
+        )
+
+        assert model_version.name == "5"
+        assert model_version.number == 5
+        assert {t.name for t in model_version.tags} == {"a", "b"}
+
     def test_create_model_version_duplicate_fails(
         self, client_with_model: "Client"
     ):


### PR DESCRIPTION
## Describe changes
In https://github.com/zenml-io/zenml/pull/1402 the ability to use slack block kits to customise the slack alert was added. This added more human readable slack messages however, it did not allow thew user to define their own slack blocks but rather implemented a generic one that everyone can use. 

For ease of use, having a generic slack block is great but having the option to define your own brings this to the next level. This PR introduces an additional `blocks` field on the `SlackAlerterParameters` model which can be used by a user to define their own blocks. If the value of `blocks` is empty (which is the default), it reverts to the normal flow so no code changes should be required by any user. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

