### PR TITLE
Feature: use service connectors to authenticate secrets stores.

### DIFF
--- a/src/zenml/integrations/aws/__init__.py
+++ b/src/zenml/integrations/aws/__init__.py
@@ -29,6 +29,10 @@ AWS_CONTAINER_REGISTRY_FLAVOR = "aws"
 AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR = "sagemaker"
 AWS_SAGEMAKER_ORCHESTRATOR_FLAVOR = "sagemaker"
 
+# Service connector constants
+AWS_CONNECTOR_TYPE = "aws"
+AWS_RESOURCE_TYPE = "aws-generic"
+S3_RESOURCE_TYPE = "s3-bucket"
 
 class AWSIntegration(Integration):
     """Definition of AWS integration for ZenML."""

--- a/src/zenml/integrations/aws/flavors/aws_container_registry_flavor.py
+++ b/src/zenml/integrations/aws/flavors/aws_container_registry_flavor.py
@@ -17,11 +17,15 @@ from typing import TYPE_CHECKING, Optional, Type
 
 from pydantic import validator
 
+from zenml.constants import DOCKER_REGISTRY_RESOURCE_TYPE
 from zenml.container_registries.base_container_registry import (
     BaseContainerRegistryConfig,
     BaseContainerRegistryFlavor,
 )
-from zenml.integrations.aws import AWS_CONTAINER_REGISTRY_FLAVOR
+from zenml.integrations.aws import (
+    AWS_CONNECTOR_TYPE,
+    AWS_CONTAINER_REGISTRY_FLAVOR,
+)
 from zenml.models import ServiceConnectorRequirements
 
 if TYPE_CHECKING:
@@ -81,8 +85,8 @@ class AWSContainerRegistryFlavor(BaseContainerRegistryFlavor):
             connector is required for this flavor.
         """
         return ServiceConnectorRequirements(
-            connector_type="aws",
-            resource_type="docker-registry",
+            connector_type=AWS_CONNECTOR_TYPE,
+            resource_type=DOCKER_REGISTRY_RESOURCE_TYPE,
             resource_id_attr="uri",
         )
 

--- a/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
@@ -16,7 +16,10 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from zenml.config.base_settings import BaseSettings
-from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR
+from zenml.integrations.aws import (
+    AWS_RESOURCE_TYPE,
+    AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR,
+)
 from zenml.models import ServiceConnectorRequirements
 from zenml.orchestrators import BaseOrchestratorConfig
 from zenml.orchestrators.base_orchestrator import BaseOrchestratorFlavor
@@ -167,7 +170,7 @@ class SagemakerOrchestratorFlavor(BaseOrchestratorFlavor):
             Requirements for compatible service connectors, if a service
             connector is required for this flavor.
         """
-        return ServiceConnectorRequirements(resource_type="aws-generic")
+        return ServiceConnectorRequirements(resource_type=AWS_RESOURCE_TYPE)
 
     @property
     def docs_url(self) -> Optional[str]:

--- a/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_step_operator_flavor.py
@@ -16,9 +16,9 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from zenml.config.base_settings import BaseSettings
-from zenml.integrations.aws import AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR
-from zenml.integrations.aws.service_connectors.aws_service_connector import (
+from zenml.integrations.aws import (
     AWS_RESOURCE_TYPE,
+    AWS_SAGEMAKER_STEP_OPERATOR_FLAVOR,
 )
 from zenml.models import ServiceConnectorRequirements
 from zenml.step_operators.base_step_operator import (

--- a/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
+++ b/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
@@ -42,6 +42,11 @@ from zenml.constants import (
     KUBERNETES_CLUSTER_RESOURCE_TYPE,
 )
 from zenml.exceptions import AuthorizationException
+from zenml.integrations.aws import (
+    AWS_CONNECTOR_TYPE,
+    AWS_RESOURCE_TYPE,
+    S3_RESOURCE_TYPE,
+)
 from zenml.logger import get_logger
 from zenml.models import (
     AuthenticationMethodModel,
@@ -61,10 +66,6 @@ from zenml.utils.enum_utils import StrEnum
 
 logger = get_logger(__name__)
 
-
-AWS_CONNECTOR_TYPE = "aws"
-AWS_RESOURCE_TYPE = "aws-generic"
-S3_RESOURCE_TYPE = "s3-bucket"
 EKS_KUBE_API_TOKEN_EXPIRATION = 60
 DEFAULT_IAM_ROLE_TOKEN_EXPIRATION = 3600  # 1 hour
 DEFAULT_STS_TOKEN_EXPIRATION = 43200  # 12 hours

--- a/src/zenml/integrations/azure/__init__.py
+++ b/src/zenml/integrations/azure/__init__.py
@@ -29,6 +29,11 @@ AZURE_ARTIFACT_STORE_FLAVOR = "azure"
 AZURE_SECRETS_MANAGER_FLAVOR = "azure"
 AZUREML_STEP_OPERATOR_FLAVOR = "azureml"
 
+# Service connector constants
+AZURE_CONNECTOR_TYPE = "azure"
+AZURE_RESOURCE_TYPE = "azure-generic"
+BLOB_RESOURCE_TYPE = "blob-container"
+
 
 class AzureIntegration(Integration):
     """Definition of Azure integration for ZenML."""

--- a/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
+++ b/src/zenml/integrations/azure/flavors/azure_artifact_store_flavor.py
@@ -19,17 +19,16 @@ from zenml.artifact_stores import (
     BaseArtifactStoreConfig,
     BaseArtifactStoreFlavor,
 )
-from zenml.integrations.azure import AZURE_ARTIFACT_STORE_FLAVOR
+from zenml.integrations.azure import (
+    AZURE_ARTIFACT_STORE_FLAVOR,
+    AZURE_CONNECTOR_TYPE,
+    BLOB_RESOURCE_TYPE,
+)
 from zenml.models import ServiceConnectorRequirements
 from zenml.stack.authentication_mixin import AuthenticationConfigMixin
 
 if TYPE_CHECKING:
     from zenml.integrations.azure.artifact_stores import AzureArtifactStore
-
-
-AZURE_CONNECTOR_TYPE = "azure"
-AZURE_RESOURCE_TYPE = "azure-generic"
-BLOB_RESOURCE_TYPE = "blob-container"
 
 
 class AzureArtifactStoreConfig(

--- a/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
+++ b/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
@@ -34,7 +34,7 @@ from zenml.constants import (
     KUBERNETES_CLUSTER_RESOURCE_TYPE,
 )
 from zenml.exceptions import AuthorizationException
-from zenml.integrations.azure.flavors.azure_artifact_store_flavor import (
+from zenml.integrations.azure import (
     AZURE_CONNECTOR_TYPE,
     AZURE_RESOURCE_TYPE,
     BLOB_RESOURCE_TYPE,

--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -37,6 +37,10 @@ GCP_SECRETS_MANAGER_FLAVOR = "gcp"
 GCP_VERTEX_ORCHESTRATOR_FLAVOR = "vertex"
 GCP_VERTEX_STEP_OPERATOR_FLAVOR = "vertex"
 
+# Service connector constants
+GCP_CONNECTOR_TYPE = "gcp"
+GCP_RESOURCE_TYPE = "gcp-generic"
+GCS_RESOURCE_TYPE = "gcs-bucket"
 
 class GcpIntegration(Integration):
     """Definition of Google Cloud Platform integration for ZenML."""

--- a/src/zenml/integrations/gcp/flavors/gcp_artifact_store_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/gcp_artifact_store_flavor.py
@@ -19,7 +19,7 @@ from zenml.artifact_stores import (
     BaseArtifactStoreConfig,
     BaseArtifactStoreFlavor,
 )
-from zenml.integrations.gcp import GCP_ARTIFACT_STORE_FLAVOR
+from zenml.integrations.gcp import GCP_ARTIFACT_STORE_FLAVOR, GCS_RESOURCE_TYPE
 from zenml.models import ServiceConnectorRequirements
 from zenml.stack.authentication_mixin import AuthenticationConfigMixin
 
@@ -64,7 +64,7 @@ class GCPArtifactStoreFlavor(BaseArtifactStoreFlavor):
             connector is required for this flavor.
         """
         return ServiceConnectorRequirements(
-            resource_type="gcs-bucket",
+            resource_type=GCS_RESOURCE_TYPE,
             resource_id_attr="path",
         )
 

--- a/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/gcp_image_builder_flavor.py
@@ -18,7 +18,11 @@ from typing import TYPE_CHECKING, Optional, Type
 from pydantic import PositiveInt
 
 from zenml.image_builders import BaseImageBuilderConfig, BaseImageBuilderFlavor
-from zenml.integrations.gcp import GCP_IMAGE_BUILDER_FLAVOR
+from zenml.integrations.gcp import (
+    GCP_CONNECTOR_TYPE,
+    GCP_IMAGE_BUILDER_FLAVOR,
+    GCP_RESOURCE_TYPE,
+)
 from zenml.integrations.gcp.google_credentials_mixin import (
     GoogleCredentialsConfigMixin,
 )
@@ -82,8 +86,8 @@ class GCPImageBuilderFlavor(BaseImageBuilderFlavor):
             connector is required for this flavor.
         """
         return ServiceConnectorRequirements(
-            connector_type="gcp",
-            resource_type="gcp-generic",
+            connector_type=GCP_CONNECTOR_TYPE,
+            resource_type=GCP_RESOURCE_TYPE,
         )
 
     @property

--- a/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
@@ -16,7 +16,10 @@
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type
 
 from zenml.config.base_settings import BaseSettings
-from zenml.integrations.gcp import GCP_VERTEX_ORCHESTRATOR_FLAVOR
+from zenml.integrations.gcp import (
+    GCP_RESOURCE_TYPE,
+    GCP_VERTEX_ORCHESTRATOR_FLAVOR,
+)
 from zenml.integrations.gcp.google_credentials_mixin import (
     GoogleCredentialsConfigMixin,
 )
@@ -173,7 +176,7 @@ class VertexOrchestratorFlavor(BaseOrchestratorFlavor):
             connector is required for this flavor.
         """
         return ServiceConnectorRequirements(
-            resource_type="gcp-generic",
+            resource_type=GCP_RESOURCE_TYPE,
         )
 
     @property

--- a/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
@@ -16,7 +16,10 @@
 from typing import TYPE_CHECKING, Optional, Type
 
 from zenml.config.base_settings import BaseSettings
-from zenml.integrations.gcp import GCP_VERTEX_STEP_OPERATOR_FLAVOR
+from zenml.integrations.gcp import (
+    GCP_RESOURCE_TYPE,
+    GCP_VERTEX_STEP_OPERATOR_FLAVOR,
+)
 from zenml.integrations.gcp.google_credentials_mixin import (
     GoogleCredentialsConfigMixin,
 )
@@ -116,7 +119,7 @@ class VertexStepOperatorFlavor(BaseStepOperatorFlavor):
             connector is required for this flavor.
         """
         return ServiceConnectorRequirements(
-            resource_type="gcp-generic",
+            resource_type=GCP_RESOURCE_TYPE,
         )
 
     @property

--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -43,6 +43,11 @@ from zenml.constants import (
     KUBERNETES_CLUSTER_RESOURCE_TYPE,
 )
 from zenml.exceptions import AuthorizationException
+from zenml.integrations.gcp import (
+    GCP_CONNECTOR_TYPE,
+    GCP_RESOURCE_TYPE,
+    GCS_RESOURCE_TYPE,
+)
 from zenml.logger import get_logger
 from zenml.models import (
     AuthenticationMethodModel,
@@ -62,10 +67,6 @@ from zenml.utils.enum_utils import StrEnum
 
 logger = get_logger(__name__)
 
-
-GCP_CONNECTOR_TYPE = "gcp"
-GCP_RESOURCE_TYPE = "gcp-generic"
-GCS_RESOURCE_TYPE = "gcs-bucket"
 GKE_KUBE_API_TOKEN_EXPIRATION = 60
 DEFAULT_IMPERSONATE_TOKEN_EXPIRATION = 3600  # 1 hour
 

--- a/src/zenml/zen_stores/secrets_stores/gcp_secrets_store.py
+++ b/src/zenml/zen_stores/secrets_stores/gcp_secrets_store.py
@@ -16,6 +16,7 @@
 
 import json
 import math
+import os
 import re
 import uuid
 from datetime import datetime
@@ -28,19 +29,28 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 from uuid import UUID
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud.secretmanager import SecretManagerServiceClient
+from google.oauth2 import service_account as gcp_service_account
+from pydantic import root_validator
 
 from zenml.analytics.enums import AnalyticsEvent
 from zenml.analytics.utils import track_decorator
-from zenml.config.secrets_store_config import SecretsStoreConfiguration
 from zenml.enums import (
     SecretsStoreType,
 )
 from zenml.exceptions import EntityExistsError
+from zenml.integrations.gcp import (
+    GCP_CONNECTOR_TYPE,
+    GCP_RESOURCE_TYPE,
+)
+from zenml.integrations.gcp.service_connectors.gcp_service_connector import (
+    GCPAuthenticationMethods,
+)
 from zenml.logger import get_logger
 from zenml.models import (
     Page,
@@ -49,8 +59,9 @@ from zenml.models import (
     SecretResponseModel,
     SecretUpdateModel,
 )
-from zenml.zen_stores.secrets_stores.base_secrets_store import (
-    BaseSecretsStore,
+from zenml.zen_stores.secrets_stores.service_connector_secrets_store import (
+    ServiceConnectorSecretsStore,
+    ServiceConnectorSecretsStoreConfiguration,
 )
 
 logger = get_logger(__name__)
@@ -65,53 +76,111 @@ ZENML_GCP_SECRET_CREATED_KEY = "zenml-secret-created"
 ZENML_GCP_SECRET_UPDATED_KEY = "zenml-secret-updated"
 
 
-class GCPSecretsStoreConfiguration(SecretsStoreConfiguration):
+class GCPSecretsStoreConfiguration(ServiceConnectorSecretsStoreConfiguration):
     """GCP secrets store configuration.
 
     Attributes:
         type: The type of the store.
-        project_id: The GCP project ID where the secrets are stored.
-
     """
 
     type: SecretsStoreType = SecretsStoreType.GCP
-    project_id: str
+
+    @property
+    def project_id(self) -> str:
+        """Get the GCP project ID.
+
+        Returns:
+            The GCP project ID.
+
+        Raises:
+            ValueError: If the project ID is not set.
+        """
+        project_id = self.auth_config.get("project_id")
+        if project_id:
+            return str(project_id)
+
+        raise ValueError("GCP `project_id` must be specified in auth_config.")
+
+    @root_validator(pre=True)
+    def populate_config(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Populate the connector configuration from legacy attributes.
+
+        Args:
+            values: Dict representing user-specified runtime settings.
+
+        Returns:
+            Validated settings.
+
+        Raises:
+            ValueError: If the connector attribute is not set.
+        """
+        if "auth_method" not in values or "auth_config" not in values:
+            values["auth_method"] = GCPAuthenticationMethods.SERVICE_ACCOUNT
+            values["auth_config"] = dict(
+                project_id=values.get("project_id"),
+            )
+            if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+                # Load the service account credentials from the file
+                with open(os.environ["GOOGLE_APPLICATION_CREDENTIALS"]) as f:
+                    values["auth_config"]["service_account_json"] = f.read()
+
+        return values
 
     class Config:
         """Pydantic configuration class."""
 
         # Forbid extra attributes set in the class.
-        extra = "forbid"
+        extra = "allow"
 
 
-class GCPSecretsStore(BaseSecretsStore):
+class GCPSecretsStore(ServiceConnectorSecretsStore):
     """Secrets store implementation that uses the GCP Secrets Manager API."""
 
     config: GCPSecretsStoreConfiguration
     TYPE: ClassVar[SecretsStoreType] = SecretsStoreType.GCP
     CONFIG_TYPE: ClassVar[
-        Type[SecretsStoreConfiguration]
+        Type[ServiceConnectorSecretsStoreConfiguration]
     ] = GCPSecretsStoreConfiguration
+    SERVICE_CONNECTOR_TYPE: ClassVar[str] = GCP_CONNECTOR_TYPE
+    SERVICE_CONNECTOR_RESOURCE_TYPE: ClassVar[str] = GCP_RESOURCE_TYPE
 
     _client: Optional[SecretManagerServiceClient] = None
 
-    def _initialize(self) -> None:
-        """Initialize the GCP secrets store."""
-        logger.debug("Initializing GCPSecretsStore")
-
-        # Initialize the GCP client.
-        _ = self.client
-
     @property
-    def client(self) -> Any:
+    def client(self) -> SecretManagerServiceClient:
         """Initialize and return the GCP Secrets Manager client.
+
+        Returns:
+            The GCP Secrets Manager client instance.
+        """
+        return cast(SecretManagerServiceClient, super().client)
+
+    # ====================================
+    # Secrets Store interface implementation
+    # ====================================
+
+    # --------------------------------
+    # Initialization and configuration
+    # --------------------------------
+
+    def _initialize_client_from_connector(self, client: Any) -> Any:
+        """Initialize the GCP Secrets Manager client from the service connector client.
+
+        Args:
+            client: The authenticated client object returned by the service
+                connector.
 
         Returns:
             The GCP Secrets Manager client.
         """
-        if self._client is None:
-            self._client = SecretManagerServiceClient()
-        return self._client
+        assert isinstance(client, gcp_service_account.Credentials)
+        return SecretManagerServiceClient(
+            project=self.config.project_id, credentials=client
+        )
+
+    # ------
+    # Secrets
+    # ------
 
     @property
     def parent_name(self) -> str:

--- a/src/zenml/zen_stores/secrets_stores/service_connector_secrets_store.py
+++ b/src/zenml/zen_stores/secrets_stores/service_connector_secrets_store.py
@@ -1,0 +1,153 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Base secrets store class used for all secrets stores that use a service connector."""
+
+
+from abc import abstractmethod
+from threading import Lock
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Optional,
+    Type,
+)
+from uuid import uuid4
+
+from pydantic import Field
+
+from zenml.config.secrets_store_config import SecretsStoreConfiguration
+from zenml.logger import get_logger
+from zenml.models import (
+    ServiceConnectorRequest,
+)
+from zenml.service_connectors.service_connector import ServiceConnector
+from zenml.service_connectors.service_connector_registry import (
+    service_connector_registry,
+)
+from zenml.zen_stores.secrets_stores.base_secrets_store import (
+    BaseSecretsStore,
+)
+
+logger = get_logger(__name__)
+
+
+class ServiceConnectorSecretsStoreConfiguration(SecretsStoreConfiguration):
+    """Base configuration for secrets stores that use a service connector.
+
+    Attributes:
+        auth_method: The service connector authentication method to use.
+        auth_config: The service connector authentication configuration.
+    """
+
+    auth_method: str
+    auth_config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ServiceConnectorSecretsStore(BaseSecretsStore):
+    """Base secrets store class for service connector-based secrets stores.
+
+    All secrets store implementations that use a Service Connector to
+    authenticate and connect to the secrets store back-end should inherit from
+    this class and:
+
+    * implement the `_initialize_client_from_connector` method
+    * use a configuration class that inherits from
+    `ServiceConnectorSecretsStoreConfiguration`
+    * set the `SERVICE_CONNECTOR_TYPE` to the service connector type used
+    to connect to the secrets store back-end
+    * set the `SERVICE_CONNECTOR_RESOURCE_TYPE` to the resource type used
+    to connect to the secrets store back-end
+    """
+
+    config: ServiceConnectorSecretsStoreConfiguration
+    CONFIG_TYPE: ClassVar[Type[ServiceConnectorSecretsStoreConfiguration]]
+    SERVICE_CONNECTOR_TYPE: ClassVar[str]
+    SERVICE_CONNECTOR_RESOURCE_TYPE: ClassVar[str]
+
+    _connector: Optional[ServiceConnector] = None
+    _client: Optional[Any] = None
+    _lock: Lock = Lock()
+
+    def _initialize(self) -> None:
+        """Initialize the secrets store."""
+        # Initialize the client early, just to catch any configuration or
+        # authentication errors early, before the Secrets Store is used.
+        _ = self.client
+
+    def _get_client(self) -> Any:
+        """Initialize and return the secrets store API client.
+
+        Returns:
+            The secrets store API client object.
+        """
+        if self._connector is not None:
+            # If the client connector expires, we'll try to get a new one.
+            if self._connector.has_expired():
+                self._connector = None
+                self._client = None
+
+        if self._connector is None:
+            # Initialize a base AWS service connector with the credentials from
+            # the configuration.
+            request = ServiceConnectorRequest(
+                name="secrets-store",
+                connector_type=self.SERVICE_CONNECTOR_TYPE,
+                resource_types=[self.SERVICE_CONNECTOR_RESOURCE_TYPE],
+                user=uuid4(),  # Use a fake user ID
+                workspace=uuid4(),  # Use a fake workspace ID
+                auth_method=self.config.auth_method,
+                configuration=self.config.auth_config,
+            )
+            base_connector = service_connector_registry.instantiate_connector(
+                model=request
+            )
+            self._connector = base_connector.get_connector_client()
+
+        if self._client is None:
+            # Use the connector to get a client object.
+            client = self._connector.connect(
+                # Don't verify again because we already did that when we
+                # initialized the connector.
+                verify=False
+            )
+
+            self._client = self._initialize_client_from_connector(client)
+        return self._client
+
+    @property
+    def client(self) -> Any:
+        """Get the secrets store API client.
+
+        Returns:
+            The secrets store API client instance.
+        """
+        # Multiple API calls can be made to this secrets store in the context
+        # of different threads. We want to make sure that we only initialize
+        # the client once, and then reuse it. We have to use a lock to treat
+        # this method as a critical section.
+        with self._lock:
+            return self._get_client()
+
+    @abstractmethod
+    def _initialize_client_from_connector(self, client: Any) -> Any:
+        """Initialize the client from the service connector.
+
+        Args:
+            client: The authenticated client object returned by the service
+                connector.
+
+        Returns:
+            The initialized client instance.
+        """


### PR DESCRIPTION
## Describe changes
Reuse the AWS/GCP/Azure Service Connector functionality to authenticate the AWS/GCP/Azure Secrets Store instead of relying on the limited configuration currently available in the Secrets Store implementations.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] If I have added an integration, I have updated the [integrations](https://docs.zenml.io/stacks-and-components/component-guide) table and the [corresponding website section](https://zenml.io/integrations).
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

