### PR TITLE
Update copier command in test-migrations.sh

### DIFF
--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -16,7 +16,7 @@ function run_tests_for_version() {
     # hardcoded to 0.43.0 since this is the latest template-starter repo
     # release tag
     git clone -b "release/0.43.0" https://github.com/zenml-io/template-starter
-    copier copy template-starter/ test_starter --trust --defaults
+    copier copy --trust -l --trust -r release/0.43.0 https://github.com/zenml-io/template-starter.git .
     cd test_starter
 
     export ZENML_ANALYTICS_OPT_IN=false

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -15,7 +15,7 @@ function run_tests_for_version() {
     # Initialize zenml with the appropriate template
     # hardcoded to 0.43.0 since this is the latest template-starter repo
     # release tag
-    copier copy --trust -l --trust -r release/0.43.0 https://github.com/zenml-io/template-starter.git .
+    copier copy --trust -l --trust -r release/0.43.0 https://github.com/zenml-io/template-starter.git test_starter
     cd test_starter
 
     export ZENML_ANALYTICS_OPT_IN=false

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -15,7 +15,6 @@ function run_tests_for_version() {
     # Initialize zenml with the appropriate template
     # hardcoded to 0.43.0 since this is the latest template-starter repo
     # release tag
-    git clone -b "release/0.43.0" https://github.com/zenml-io/template-starter
     copier copy --trust -l --trust -r release/0.43.0 https://github.com/zenml-io/template-starter.git .
     cd test_starter
 


### PR DESCRIPTION
This pull request updates the copier command in the test-migrations.sh file to use the latest release tag of the template-starter repository. This ensures that the correct version of the template-starter is used when running the tests.