### PR TITLE
mutable names in Model and MV

### DIFF
--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -402,13 +402,22 @@ def list_model_versions(model_name_or_id: str, **kwargs: Any) -> None:
     "--stage",
     "-s",
     type=click.Choice(choices=ModelStages.values()),
+    required=False,
     help="The stage of the model version.",
 )
 @click.option(
     "--name",
     "-n",
     type=str,
+    required=False,
     help="The name of the model version.",
+)
+@click.option(
+    "--description",
+    "-d",
+    type=str,
+    required=False,
+    help="The description of the model version.",
 )
 @click.option(
     "--tag",
@@ -435,8 +444,9 @@ def list_model_versions(model_name_or_id: str, **kwargs: Any) -> None:
 def update_model_version(
     model_name_or_id: str,
     model_version_name_or_number_or_id: str,
-    stage: str,
-    name: str,
+    stage: Optional[str],
+    name: Optional[str],
+    description: Optional[str],
     tag: Optional[List[str]],
     remove_tag: Optional[List[str]],
     force: bool = False,
@@ -448,6 +458,7 @@ def update_model_version(
         model_version_name_or_number_or_id: The ID, number or name of the model version.
         stage: The stage of the model version to be set.
         name: The name of the model version.
+        description: The description of the model version.
         tag: Tags to be added to the model version.
         remove_tag: Tags to be removed from the model version.
         force: Whether existing model version in target stage should be silently archived.
@@ -465,6 +476,7 @@ def update_model_version(
             remove_tags=remove_tag,
             force=force,
             name=name,
+            description=description,
         )
     except RuntimeError:
         if not force:
@@ -487,6 +499,7 @@ def update_model_version(
                 add_tags=tag,
                 remove_tags=remove_tag,
                 force=True,
+                description=description,
             )
     cli_utils.print_table([_model_version_to_print(model_version)])
 

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -210,6 +210,13 @@ def register_model(
 @model.command("update", help="Update an existing model.")
 @click.argument("model_name_or_id")
 @click.option(
+    "--name",
+    "-n",
+    help="The name of the model.",
+    type=str,
+    required=False,
+)
+@click.option(
     "--license",
     "-l",
     help="The license under which the model is created.",
@@ -274,6 +281,7 @@ def register_model(
 )
 def update_model(
     model_name_or_id: str,
+    name: Optional[str],
     license: Optional[str],
     description: Optional[str],
     audience: Optional[str],
@@ -288,6 +296,7 @@ def update_model(
 
     Args:
         model_name_or_id: The name of the model.
+        name: The name of the model.
         license: The license model created under.
         description: The description of the model.
         audience: The target audience of the model.
@@ -301,6 +310,7 @@ def update_model(
     model_id = Client().get_model(model_name_or_id=model_name_or_id).id
     update_dict = remove_none_values(
         dict(
+            name=name,
             license=license,
             description=description,
             audience=audience,
@@ -395,6 +405,12 @@ def list_model_versions(model_name_or_id: str, **kwargs: Any) -> None:
     help="The stage of the model version.",
 )
 @click.option(
+    "--name",
+    "-n",
+    type=str,
+    help="The name of the model version.",
+)
+@click.option(
     "--tag",
     "-t",
     help="Tags to be added to the model.",
@@ -420,6 +436,7 @@ def update_model_version(
     model_name_or_id: str,
     model_version_name_or_number_or_id: str,
     stage: str,
+    name: str,
     tag: Optional[List[str]],
     remove_tag: Optional[List[str]],
     force: bool = False,
@@ -430,6 +447,7 @@ def update_model_version(
         model_name_or_id: The ID or name of the model containing version.
         model_version_name_or_number_or_id: The ID, number or name of the model version.
         stage: The stage of the model version to be set.
+        name: The name of the model version.
         tag: Tags to be added to the model version.
         remove_tag: Tags to be removed from the model version.
         force: Whether existing model version in target stage should be silently archived.
@@ -446,6 +464,7 @@ def update_model_version(
             add_tags=tag,
             remove_tags=remove_tag,
             force=force,
+            name=name,
         )
     except RuntimeError:
         if not force:

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -4495,6 +4495,7 @@ class Client(metaclass=ClientMetaClass):
     def update_model(
         self,
         model_name_or_id: Union[str, UUID],
+        name: Optional[str] = None,
         license: Optional[str] = None,
         description: Optional[str] = None,
         audience: Optional[str] = None,
@@ -4509,6 +4510,7 @@ class Client(metaclass=ClientMetaClass):
 
         Args:
             model_name_or_id: name or id of the model to be deleted.
+            name: The name of the model.
             license: The license under which the model is created.
             description: The description of the model.
             audience: The target audience of the model.
@@ -4527,6 +4529,7 @@ class Client(metaclass=ClientMetaClass):
         return self.zen_store.update_model(
             model_id=model_name_or_id,  # type:ignore[arg-type]
             model_update=ModelUpdate(
+                name=name,
                 license=license,
                 description=description,
                 audience=audience,

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -4779,6 +4779,7 @@ class Client(metaclass=ClientMetaClass):
         stage: Optional[Union[str, ModelStages]] = None,
         force: bool = False,
         name: Optional[str] = None,
+        description: Optional[str] = None,
         add_tags: Optional[List[str]] = None,
         remove_tags: Optional[List[str]] = None,
     ) -> ModelVersionResponse:
@@ -4791,6 +4792,7 @@ class Client(metaclass=ClientMetaClass):
             force: Whether existing model version in target stage should be
                 silently archived or an error should be raised.
             name: Target model version name to be set.
+            description: Target model version description to be set.
             add_tags: Tags to add to the model version.
             remove_tags: Tags to remove from to the model version.
 
@@ -4811,6 +4813,7 @@ class Client(metaclass=ClientMetaClass):
                 stage=stage,
                 force=force,
                 name=name,
+                description=description,
                 add_tags=add_tags,
                 remove_tags=remove_tags,
             ),

--- a/src/zenml/models/v2/core/model.py
+++ b/src/zenml/models/v2/core/model.py
@@ -91,6 +91,7 @@ class ModelRequest(WorkspaceScopedRequest):
 class ModelUpdate(BaseModel):
     """Update model for models."""
 
+    name: Optional[str] = None
     license: Optional[str] = None
     description: Optional[str] = None
     audience: Optional[str] = None

--- a/src/zenml/models/v2/core/model_version.py
+++ b/src/zenml/models/v2/core/model_version.py
@@ -98,6 +98,10 @@ class ModelVersionUpdate(BaseModel):
         description="Target model version name to be set",
         default=None,
     )
+    description: Optional[str] = Field(
+        description="Target model version description to be set",
+        default=None,
+    )
     add_tags: Optional[List[str]] = Field(
         description="Tags to be added to the model version",
         default=None,

--- a/src/zenml/zen_stores/schemas/model_schemas.py
+++ b/src/zenml/zen_stores/schemas/model_schemas.py
@@ -367,12 +367,14 @@ class ModelVersionSchema(NamedSchema, table=True):
         self,
         target_stage: Optional[str] = None,
         target_name: Optional[str] = None,
+        target_description: Optional[str] = None,
     ) -> "ModelVersionSchema":
         """Updates a `ModelVersionSchema` to a target stage.
 
         Args:
             target_stage: The stage to be updated.
             target_name: The version name to be updated.
+            target_description: The version description to be updated.
 
         Returns:
             The updated `ModelVersionSchema`.
@@ -381,6 +383,8 @@ class ModelVersionSchema(NamedSchema, table=True):
             self.stage = target_stage
         if target_name is not None:
             self.name = target_name
+        if target_description is not None:
+            self.description = target_description
         self.updated = datetime.utcnow()
         return self
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6582,6 +6582,7 @@ class SqlZenStore(BaseZenStore):
             existing_model_version.update(
                 target_stage=stage,
                 target_name=model_version_update_model.name,
+                target_description=model_version_update_model.description,
             )
             session.add(existing_model_version)
             session.commit()

--- a/tests/integration/functional/test_client.py
+++ b/tests/integration/functional/test_client.py
@@ -1245,6 +1245,17 @@ class TestModel:
         assert model.ethics == "E"
         assert {t.name for t in model.tags} == {"t", "t3"}
 
+    def test_name_is_mutable(self, clean_client: "Client"):
+        """Test that model version name is mutable."""
+        model = clean_client.create_model(name=self.MODEL_NAME)
+
+        model = clean_client.get_model(model.id)
+        assert model.name == self.MODEL_NAME
+
+        clean_client.update_model(model.id, name="bar")
+        model = clean_client.get_model(model.id)
+        assert model.name == "bar"
+
 
 class TestModelVersion:
     MODEL_NAME = "foo"
@@ -1542,3 +1553,19 @@ class TestModelVersion:
                 model_name_or_id=mv1.model_id,
                 model_version_name_or_number_or_id=ModelStages.STAGING,
             )
+
+    def test_name_is_mutable(self, clean_client: "Client"):
+        """Test that model version name is mutable."""
+        model = clean_client.create_model(name=self.MODEL_NAME)
+        mv = clean_client.create_model_version(model.id)
+
+        mv = clean_client.get_model_version(
+            self.MODEL_NAME, ModelStages.LATEST
+        )
+        assert mv.name == "1"
+
+        clean_client.update_model_version(self.MODEL_NAME, mv.id, name="bar")
+        mv = clean_client.get_model_version(
+            self.MODEL_NAME, ModelStages.LATEST
+        )
+        assert mv.name == "bar"

--- a/tests/integration/functional/test_client.py
+++ b/tests/integration/functional/test_client.py
@@ -1554,18 +1554,22 @@ class TestModelVersion:
                 model_version_name_or_number_or_id=ModelStages.STAGING,
             )
 
-    def test_name_is_mutable(self, clean_client: "Client"):
+    def test_name_and_description_is_mutable(self, clean_client: "Client"):
         """Test that model version name is mutable."""
         model = clean_client.create_model(name=self.MODEL_NAME)
-        mv = clean_client.create_model_version(model.id)
+        mv = clean_client.create_model_version(model.id, description="foo")
 
         mv = clean_client.get_model_version(
             self.MODEL_NAME, ModelStages.LATEST
         )
         assert mv.name == "1"
+        assert mv.description == "foo"
 
-        clean_client.update_model_version(self.MODEL_NAME, mv.id, name="bar")
+        clean_client.update_model_version(
+            self.MODEL_NAME, mv.id, name="bar", description="bar"
+        )
         mv = clean_client.get_model_version(
             self.MODEL_NAME, ModelStages.LATEST
         )
         assert mv.name == "bar"
+        assert mv.description == "bar"

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -117,6 +117,7 @@ from zenml.models import (
 )
 from zenml.models.v2.core.artifact import ArtifactRequest
 from zenml.models.v2.core.component import ComponentRequest
+from zenml.models.v2.core.model import ModelUpdate
 from zenml.models.v2.core.pipeline_deployment import PipelineDeploymentRequest
 from zenml.models.v2.core.pipeline_run import PipelineRunRequest
 from zenml.models.v2.core.run_metadata import RunMetadataRequest
@@ -3603,6 +3604,22 @@ class TestModel:
                 assert zs.get_model(created_model.id).latest_version == mv.name
                 time.sleep(1)  # thanks to MySQL again!
 
+    def test_update_name(self, clean_client: "Client"):
+        """Test that update name works, if model version exists."""
+        with ModelVersionContext() as model_:
+            zs = clean_client.zen_store
+            model = zs.get_model(model_.id)
+            assert model.name == model_.name
+
+            zs.update_model(
+                model_id=model_.id,
+                model_update=ModelUpdate(
+                    name="and yet another one",
+                ),
+            )
+            model = zs.get_model(model_.id)
+            assert model.name == "and yet another one"
+
 
 class TestModelVersion:
     def test_create_pass(self):
@@ -3807,6 +3824,31 @@ class TestModelVersion:
                 ),
             ).items[0]
             assert mv1.id == mv3.id
+
+    def test_update_name(self, clean_client: "Client"):
+        """Test that update name works, if model version exists."""
+        with ModelVersionContext() as model:
+            zs = clean_client.zen_store
+            mv1 = zs.create_model_version(
+                ModelVersionRequest(
+                    user=model.user.id,
+                    workspace=model.workspace.id,
+                    model=model.id,
+                    name="great one",
+                )
+            )
+            mv = zs.get_model_version(mv1.id)
+            assert mv.name == "great one"
+
+            zs.update_model_version(
+                model_version_id=mv1.id,
+                model_version_update_model=ModelVersionUpdate(
+                    model=mv1.model.id,
+                    name="and yet another one",
+                ),
+            )
+            mv = zs.get_model_version(mv1.id)
+            assert mv.name == "and yet another one"
 
     def test_in_stage_not_found(self):
         """Test that get in stage fails if not found."""

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -3825,7 +3825,7 @@ class TestModelVersion:
             ).items[0]
             assert mv1.id == mv3.id
 
-    def test_update_name(self, clean_client: "Client"):
+    def test_update_name_and_description(self, clean_client: "Client"):
         """Test that update name works, if model version exists."""
         with ModelVersionContext() as model:
             zs = clean_client.zen_store
@@ -3835,20 +3835,24 @@ class TestModelVersion:
                     workspace=model.workspace.id,
                     model=model.id,
                     name="great one",
+                    description="this is great",
                 )
             )
             mv = zs.get_model_version(mv1.id)
             assert mv.name == "great one"
+            assert mv.description == "this is great"
 
             zs.update_model_version(
                 model_version_id=mv1.id,
                 model_version_update_model=ModelVersionUpdate(
                     model=mv1.model.id,
                     name="and yet another one",
+                    description="this is great and better",
                 ),
             )
             mv = zs.get_model_version(mv1.id)
             assert mv.name == "and yet another one"
+            assert mv.description == "this is great and better"
 
     def test_in_stage_not_found(self):
         """Test that get in stage fails if not found."""


### PR DESCRIPTION
## Describe changes
I implemented mutable names for Model and ModelVersion entities via Client, CLI, and API to achieve flexibility of names for end users.

API-wise it would mean that `name` is added to the Update Model endpoint and `description` is added to the Update Model Version endpoint. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Users can now optionally specify a `name` when registering, updating, or listing model versions to enhance model management.

- **Bug Fixes**
  - Ensured the `name` parameter is consistently accepted across model management functions.

- **Tests**
  - Added tests to confirm the mutability of model version names and the correct functioning of the new `name` parameter in model operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->