### PR TITLE
Support refreshing service connector credentials in the Vertex step operator to support long-running jobs

### DIFF
--- a/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
+++ b/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
@@ -21,6 +21,7 @@ google_cloud_ai_platform/training_clients.py
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 
+from google.api_core.exceptions import ServerError
 from google.cloud import aiplatform
 
 from zenml import __version__
@@ -300,19 +301,20 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
             try:
                 response = client.get_custom_job(name=job_id)
                 retry_count = 0
-            # Handle transient connection error.
-            except ConnectionError as err:
+            # Handle transient connection errors and credential expiration by
+            # recreating the Python API client.
+            except (ConnectionError, ServerError) as err:
                 if retry_count < CONNECTION_ERROR_RETRY_LIMIT:
                     retry_count += 1
                     logger.warning(
-                        "ConnectionError (%s) encountered when polling job: "
-                        "%s. Trying to recreate the API client.",
-                        err,
-                        job_id,
+                        f"Error encountered when polling job "
+                        f"{job_id}: {err}\nRetrying...",
                     )
+                    # This call will refresh the credentials if they expired.
+                    credentials, project_id = self._get_authentication()
                     # Recreate the Python API client.
                     client = aiplatform.gapic.JobServiceClient(
-                        client_options=client_options
+                        credentials=credentials, client_options=client_options
                     )
                 else:
                     logger.error(
@@ -320,7 +322,6 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
                         CONNECTION_ERROR_RETRY_LIMIT,
                     )
                     raise
-
             if response.state in VERTEX_JOB_STATES_FAILED:
                 err_msg = (
                     "Job '{}' did not succeed.  Detailed response {}.".format(

--- a/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
+++ b/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
@@ -187,7 +187,6 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
 
         Raises:
             RuntimeError: If the run fails.
-            ConnectionError: If the run fails due to a connection error.
         """
         resource_settings = info.config.resource_settings
         if resource_settings.cpu_count or resource_settings.memory:
@@ -317,11 +316,14 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
                         credentials=credentials, client_options=client_options
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         "Request failed after %s retries.",
                         CONNECTION_ERROR_RETRY_LIMIT,
                     )
-                    raise
+                    raise RuntimeError(
+                        f"Request failed after {CONNECTION_ERROR_RETRY_LIMIT} "
+                        f"retries: {err}"
+                    )
             if response.state in VERTEX_JOB_STATES_FAILED:
                 err_msg = (
                     "Job '{}' did not succeed.  Detailed response {}.".format(


### PR DESCRIPTION
## Describe changes
When synchronous orchestrators and step operator runs take a long time to complete, the service connector credentials used to poll their status can expire. This PR only addresses this problem for the Vertex step operator by refreshing credentials before they expire and can cause errors. A generic solution that targets all affected orchestrators, step operators and potentially other stack components will be devised in a separate upcoming change request.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

