### PR TITLE
A faster pandas materializer

### DIFF
--- a/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
@@ -50,7 +50,7 @@ ZENML_DEBUG=false
 ## Pandas materializer
 
 When using `pandas.DataFrame` or `pandas.Series` objects the default `PandasMaterializer` 
-is used. This allows configuration with two environmnetal variables:
+is used. This allows configuration with two environment variables:
 
 ```shell
 # The compression type (e.g. can be "gzip")

--- a/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
@@ -50,7 +50,7 @@ ZENML_DEBUG=false
 ## Pandas materializer
 
 When using `pandas.DataFrame` or `pandas.Series` objects the default `PandasMaterializer` 
-is used. This allows the configuration with two environmnetal variables:
+is used. This allows configuration with two environmnetal variables:
 
 ```shell
 # The compression type (e.g. can be "gzip")

--- a/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
+++ b/docs/book/user-guide/advanced-guide/environment-management/environment-variables.md
@@ -47,6 +47,22 @@ Setting to `true` switches to developer mode:
 ZENML_DEBUG=false
 ```
 
+## Pandas materializer
+
+When using `pandas.DataFrame` or `pandas.Series` objects the default `PandasMaterializer` 
+is used. This allows the configuration with two environmnetal variables:
+
+```shell
+# The compression type (e.g. can be "gzip")
+ZENML_PANDAS_COMPRESSION_TYPE="snappy"
+# The number of rows to split the pandas dataframe into
+# while writing on disk
+ZENML_PANDAS_CHUNK_SIZE="10000"
+```
+
+Please note that these environmental variables also need to be set in the [DockerSettings](containerize-your-pipeline.md#customize-the-docker-building) to work in the case of remote
+orchestrators.
+
 ## Active stack
 
 Setting the `ZENML_ACTIVE_STACK_ID` to a specific UUID will make the 

--- a/src/zenml/materializers/pandas_materializer.py
+++ b/src/zenml/materializers/pandas_materializer.py
@@ -31,7 +31,7 @@ PARQUET_FILENAME = "df.parquet"
 # Get the compression type from the environment variable
 COMPRESSION_TYPE = os.getenv("ZENML_PANDAS_COMPRESSION_TYPE", "snappy")
 # Get the chunk size from the environment variable
-CHUNK_SIZE = os.getenv("ZENML_PANDAS_CHUNK_SIZE", 100000)
+CHUNK_SIZE = int(os.getenv("ZENML_PANDAS_CHUNK_SIZE", "100000"))
 
 CSV_FILENAME = "df.csv"
 

--- a/src/zenml/materializers/pandas_materializer.py
+++ b/src/zenml/materializers/pandas_materializer.py
@@ -172,9 +172,7 @@ class PandasMaterializer(BaseMaterializer):
                 with fileio.open(
                     f"{self.parquet_path}_{i//CHUNK_SIZE}", mode="wb"
                 ) as f:
-                    chunk.to_parquet(
-                        f, compression=COMPRESSION_TYPE, engine="pyarrow"
-                    )
+                    chunk.to_parquet(f, compression=COMPRESSION_TYPE)
         else:
             with fileio.open(self.csv_path, mode="wb") as f:
                 df.to_csv(f, index=True)


### PR DESCRIPTION
## Describe changes

I create a faster pandas materializer that uses `snappy` and chunks to write to disk. This works better in cases where the dataframe is >10000 rows of data. I have ensured that it is backwards compatible and not a breaking change, however I have not tested the case of backwards compatibility myself (Some help here is appreciated).

This materializer has been tested manually on a S3 artifact store.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced environment variables specific to the Pandas materializer for enhanced configuration.
  - Added support for chunked parquet file handling in the Pandas materializer, improving performance for large datasets.

- **Documentation**
  - Updated the advanced guide with instructions for setting environment variables in DockerSettings.
  - Corrected documentation links for better user navigation.

- **Bug Fixes**
  - Adjusted default compression settings for parquet files to optimize storage and access efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->