### PR TITLE
Rename log_model_version_metadata to log_model_metadata

### DIFF
--- a/src/zenml/__init__.py
+++ b/src/zenml/__init__.py
@@ -42,6 +42,7 @@ from zenml.artifacts.utils import (
     save_artifact,
     load_artifact,
 )
+from zenml.model.utils import log_model_metadata
 from zenml.artifacts.artifact_config import ArtifactConfig
 from zenml.artifacts.external_artifact import ExternalArtifact
 from zenml.model.model_version import ModelVersion
@@ -57,6 +58,7 @@ __all__ = [
     "get_step_context",
     "load_artifact",
     "log_artifact_metadata",
+    "log_model_metadata",
     "ModelVersion",
     "pipeline",
     "save_artifact",

--- a/src/zenml/model/utils.py
+++ b/src/zenml/model/utils.py
@@ -133,10 +133,6 @@ def log_model_version_metadata(
         model_version: The version of the model to log metadata for. Can
             be omitted when being called inside a step with configured
             `model_version` in decorator.
-
-    Raises:
-        ValueError: If no model name/version is provided and the function is not
-            called inside a step with configured `model_version` in decorator.
     """
     logger.warning(
         "`log_model_version_metadata` is deprecated. Please use "

--- a/src/zenml/model/utils.py
+++ b/src/zenml/model/utils.py
@@ -116,6 +116,37 @@ def link_artifact_config_to_model_version(
         client.zen_store.create_model_version_artifact_link(request)
 
 
+def log_model_version_metadata(
+    metadata: Dict[str, "MetadataType"],
+    model_name: Optional[str] = None,
+    model_version: Optional[Union[ModelStages, int, str]] = None,
+) -> None:
+    """Log model version metadata.
+
+    This function can be used to log metadata for existing model versions.
+
+    Args:
+        metadata: The metadata to log.
+        model_name: The name of the model to log metadata for. Can
+            be omitted when being called inside a step with configured
+            `model_version` in decorator.
+        model_version: The version of the model to log metadata for. Can
+            be omitted when being called inside a step with configured
+            `model_version` in decorator.
+
+    Raises:
+        ValueError: If no model name/version is provided and the function is not
+            called inside a step with configured `model_version` in decorator.
+    """
+    logger.warning(
+        "`log_model_version_metadata` is deprecated. Please use "
+        "`log_model_metadata` instead."
+    )
+    log_model_metadata(
+        metadata=metadata, model_name=model_name, model_version=model_version
+    )
+
+
 def log_model_metadata(
     metadata: Dict[str, "MetadataType"],
     model_name: Optional[str] = None,

--- a/src/zenml/model/utils.py
+++ b/src/zenml/model/utils.py
@@ -116,7 +116,7 @@ def link_artifact_config_to_model_version(
         client.zen_store.create_model_version_artifact_link(request)
 
 
-def log_model_version_metadata(
+def log_model_metadata(
     metadata: Dict[str, "MetadataType"],
     model_name: Optional[str] = None,
     model_version: Optional[Union[ModelStages, int, str]] = None,

--- a/tests/integration/functional/model/test_model_version.py
+++ b/tests/integration/functional/model/test_model_version.py
@@ -20,7 +20,7 @@ from zenml import get_step_context, pipeline, step
 from zenml.client import Client
 from zenml.enums import ModelStages
 from zenml.model.model_version import ModelVersion
-from zenml.model.utils import log_model_version_metadata
+from zenml.model.utils import log_model_metadata
 from zenml.models import TagRequest
 
 MODEL_NAME = "super_model"
@@ -64,7 +64,7 @@ class ModelContext:
 @step
 def step_metadata_logging_functional():
     """Functional logging using implicit ModelVersion from context."""
-    log_model_version_metadata({"foo": "bar"})
+    log_model_metadata({"foo": "bar"})
     assert get_step_context().model_version.metadata["foo"] == "bar"
 
 
@@ -357,7 +357,7 @@ class TestModelVersion:
         )
         mv._get_or_create_model_version()
 
-        log_model_version_metadata(
+        log_model_metadata(
             {"foo": "bar"}, model_name=mv.name, model_version=mv.number
         )
 
@@ -365,9 +365,9 @@ class TestModelVersion:
         assert mv.metadata["foo"] == "bar"
 
         with pytest.raises(ValueError):
-            log_model_version_metadata({"foo": "bar"})
+            log_model_metadata({"foo": "bar"})
 
-        log_model_version_metadata(
+        log_model_metadata(
             {"bar": "foo"}, model_name=mv.name, model_version="latest"
         )
 


### PR DESCRIPTION
## Describe changes
I Renamed log_model_version_metadata to log_model_metadata to make it more consistent with log_artifact_metadata + i made it part of the public api so you can import it like;

```
from zenml import log_model_metadata
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `log_model_metadata` function for enhanced model metadata logging.

- **Deprecated**
  - Deprecated `log_model_version_metadata` in favor of the new logging function.

- **Enhancements**
  - The new logging function now optionally accepts model version and supports a broader range of types.

- **Error Handling**
  - Added error checks to ensure model name/version is provided when necessary.

- **Tests**
  - Updated integration tests to reflect the new function naming and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->