### PR TITLE
Update README and CONTRIBUTING.md docs with links to good first issues for contribution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,15 +50,17 @@ general guidelines that cover both:
 A friendly ping in the comment thread to the submitter or a contributor can help
 draw attention if your issue is blocking.
 
+### Good First Issues for New Contributors
+
 The best way to start is to check the
-[`good-first-issue`](https://github.com/zenml-io/zenml/labels/good%20first%20issue)
+[`good-first-issue`](https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Azenml-io+label%3A%22good+first+issue%22)
 label on the issue board. The core team creates these issues as necessary
 smaller tasks that you can work on to get deeper into ZenML internals. These
 should generally require relatively simple changes, probably affecting just one
 or two files which we think are ideal for people new to ZenML.
 
 The next step after that would be to look at the
-[`good-second-issue`](https://github.com/zenml-io/zenml/labels/good%20second%20issue)
+[`good-second-issue`](https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Azenml-io+label%3A%22good+second+issue%22)
 label on the issue board. These are a bit more complex, might involve more
 files, but should still be well-defined and achievable to people relatively new
 to ZenML.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@
     ·
     <a href="https://zenml.io/discussion">Vote New Features</a>
     ·
-    <a href="https://blog.zenml.io/">Read Blog</a>
+    <a href="https://www.zenml.io/blog">Read Blog</a>
+    ·
+    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Azenml-io+label%3A%22good+first+issue%22">Contribute to Open Source</a>
     ·
     <a href="https://www.zenml.io/company#team">Meet the Team</a>
     <br />
@@ -277,9 +279,10 @@ and you can directly influence the roadmap as follows:
 
 # 🙌 Contributing and Community
 
-We would love to develop ZenML together with our community! Best way to get
+We would love to develop ZenML together with our community! The best way to get
 started is to select any issue from the [`good-first-issue`
-label](https://github.com/zenml-io/zenml/labels/good%20first%20issue). If you
+label](https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Azenml-io+label%3A%22good+first+issue%22)
+and open up a Pull Request! If you
 would like to contribute, please review our [Contributing
 Guide](CONTRIBUTING.md) for all relevant details.
 


### PR DESCRIPTION
Updated links in our README and CONTRIBUTING.md files to help suggest good first issues for external OSS contributions.

Also updated the link for our blog on the README (which, while functional, was redirecting to the new link).