### PR TITLE
Disable template updates for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,11 @@ jobs:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
     secrets: inherit
-  
+
   update-templates-to-examples:
+    # this doesn't work on forked repositories (i.e. outside contributors)
+    # so we disable template updates for those PRs / branches
+    if: github.repository == 'zenml-io/zenml'
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
       python-version: "3.8"


### PR DESCRIPTION
This pull request disables template updates for forked repositories. Previously, template updates were enabled for all repositories, including forked ones. However, this caused issues for outside contributors, so we have decided to disable template updates for forked repositories. This change ensures that template updates only occur for non-forked repositories. (This prevents a failing CI from showing up for external contributors when there's no way for them to fix it).