### PR TITLE
Add `mlstacks` installation instructions to docs

### DIFF
--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
@@ -19,7 +19,18 @@ stack with a single command 🚀. You can also customize your components easily 
 passing in flags (more on that later).
 
 {% hint style="info" %}
-To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install
+"zenml[mlstacks]"` to install it along with ZenML.
+
+MLStacks uses Terraform on the backend to manage infrastructure. You will need
+to have Terraform installed. Please visit [the Terraform
+docs](https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform)
+for installation instructions.
+
+MLStacks also uses Helm to deploy Kubernetes resources. You will need to have
+Helm installed. Please visit [the Helm
+docs](https://helm.sh/docs/intro/install/#from-script) for installation
+instructions.
 {% endhint %}
 
 For example, to deploy an artifact store on a GCP account, you can run:

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
@@ -19,7 +19,7 @@ stack with a single command 🚀. You can also customize your components easily 
 passing in flags (more on that later).
 
 {% hint style="info" %}
-To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
 {% endhint %}
 
 For example, to deploy an artifact store on a GCP account, you can run:

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-component.md
@@ -14,12 +14,19 @@ Commands like these assume that you already have the stack component deployed. I
 
 We took inspiration from this design to build something that feels natural to use and is also sufficiently powerful to take care of the deployment of the respective stack components for you. This is where the \<STACK\_COMPONENT> `deploy` CLI comes in!
 
-The `deploy` command allows you to deploy individual components of your MLOps stack with a single command 🚀. You can also customize your components easily by passing in flags (more on that later).
+The `deploy` command allows you to deploy individual components of your MLOps
+stack with a single command 🚀. You can also customize your components easily by
+passing in flags (more on that later).
+
+{% hint style="info" %}
+To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+{% endhint %}
 
 For example, to deploy an artifact store on a GCP account, you can run:
 
 {% code overflow="wrap" %}
 ```bash
+# after installing mlstacks
 zenml artifact-store deploy -f gcp -p gcp -r us-east1 -x project_id=zenml my_store
 ```
 {% endcode %}

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
@@ -33,7 +33,18 @@ To answer this question, here are some pros and cons in comparison to [the stack
 
 ## Installing the mlstacks extra
 
-To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install
+"zenml[mlstacks]"` to install it along with ZenML.
+
+MLStacks uses Terraform on the backend to manage infrastructure. You will need
+to have Terraform installed. Please visit [the Terraform
+docs](https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform)
+for installation instructions.
+
+MLStacks also uses Helm to deploy Kubernetes resources. You will need to have
+Helm installed. Please visit [the Helm
+docs](https://helm.sh/docs/intro/install/#from-script) for installation
+instructions.
 
 ## Deploying a stack
 

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
@@ -31,6 +31,10 @@ To answer this question, here are some pros and cons in comparison to [the stack
 {% endtab %}
 {% endtabs %}
 
+## Installing the mlstacks extra
+
+To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+
 ## Deploying a stack
 
 A simple stack deployment can be done using the following command:

--- a/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
+++ b/docs/book/stacks-and-components/stack-deployment/deploy-a-stack-using-mlstacks.md
@@ -33,7 +33,7 @@ To answer this question, here are some pros and cons in comparison to [the stack
 
 ## Installing the mlstacks extra
 
-To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
 
 ## Deploying a stack
 

--- a/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
+++ b/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
@@ -39,7 +39,7 @@ components as well as whole stacks using MLStacks. These stacks will be useful f
 
 ## Installing the mlstacks extra
 
-To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
 
 ## Deploying a stack component
 

--- a/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
+++ b/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
@@ -37,6 +37,10 @@ components as well as whole stacks using MLStacks. These stacks will be useful f
   different tools.
 - You are looking for guidelines for production-grade deployments.
 
+## Installing the mlstacks extra
+
+To install `mlstacks`, either run `pip install mlstacks` or `pip install zenml[mlstacks]` to install it along with ZenML.
+
 ## Deploying a stack component
 
 The ZenML CLI allows you to deploy individual stack components using the

--- a/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
+++ b/docs/book/stacks-and-components/stack-deployment/stack-deployment.md
@@ -39,7 +39,18 @@ components as well as whole stacks using MLStacks. These stacks will be useful f
 
 ## Installing the mlstacks extra
 
-To install `mlstacks`, either run `pip install mlstacks` or `pip install "zenml[mlstacks]"` to install it along with ZenML.
+To install `mlstacks`, either run `pip install mlstacks` or `pip install
+"zenml[mlstacks]"` to install it along with ZenML.
+
+MLStacks uses Terraform on the backend to manage infrastructure. You will need
+to have Terraform installed. Please visit [the Terraform
+docs](https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform)
+for installation instructions.
+
+MLStacks also uses Helm to deploy Kubernetes resources. You will need to have
+Helm installed. Please visit [the Helm
+docs](https://helm.sh/docs/intro/install/#from-script) for installation
+instructions.
 
 ## Deploying a stack component
 


### PR DESCRIPTION
This pull request updates the installation instructions for mlstacks in the documentation. The instructions now include the option to install mlstacks along with ZenML using the command "pip install zenml[mlstacks]".