### PR TITLE
Fix fork check syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
   update-templates-to-examples:
     # this doesn't work on forked repositories (i.e. outside contributors)
     # so we disable template updates for those PRs / branches
-    if: github.event.pull_request.head.repo.full_name == "zenml-io/zenml"
+    if: github.event.pull_request.head.repo.full_name == 'zenml-io/zenml'
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
       python-version: "3.8"


### PR DESCRIPTION
This pull request fixes the syntax of the fork check in the GitHub Actions workflow file. The if condition was using double quotes instead of single quotes around the repository name. This caused the fork check to fail. The syntax has been corrected to use single quotes, ensuring that the fork check works correctly for all repositories.