### PR TITLE
Default/Non-Default step params produce conflict with yaml ones as defaults are set in code

### DIFF
--- a/.github/workflows/setup-python-environment.yml
+++ b/.github/workflows/setup-python-environment.yml
@@ -89,6 +89,8 @@ jobs:
         if: ${{ inputs.enable_tmate == 'before-tests' }}
         uses: mxschmitt/action-tmate@v3.17
       - name: Lint check
+        env:
+          OS: ${{ inputs.os }}
         run: |
           bash scripts/lint.sh
       - name: Spelling checker

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,14 +15,18 @@ ruff $SRC_NO_TESTS
 ruff $TESTS_EXAMPLES --extend-ignore D
 
 # Flag check for skipping yamlfix
-SKIP_YAMLFIX=false
-for arg in "$@"
-do
-    if [ "$arg" = "--no-yamlfix" ]; then
-        SKIP_YAMLFIX=true
-        break
-    fi
-done
+if [ "$OS" = "windows-latest" ]; then
+    SKIP_YAMLFIX=true
+else
+    SKIP_YAMLFIX=false
+    for arg in "$@"
+    do
+        if [ "$arg" = "--no-yamlfix" ]; then
+            SKIP_YAMLFIX=true
+            break
+        fi
+    done
+fi
 
 # checks for yaml formatting errors
 if [ "$SKIP_YAMLFIX" = false ]; then

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -133,7 +133,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         self,
         run_name: str,
         tags: List[str],
-        settings: Union["Settings", Dict[str, Any], None] = None,  # type: ignore
+        settings: Union["Settings", Dict[str, Any], None] = None,
     ) -> None:
         """Initializes a wandb run.
 

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -58,7 +58,7 @@ class WandbExperimentTrackerSettings(BaseSettings):
     @validator("settings", pre=True)
     def _convert_settings(
         cls,
-        value: Union[Dict[str, Any], "Settings"],  # type: ignore
+        value: Union[Dict[str, Any], "Settings"],
     ) -> Dict[str, Any]:
         """Converts settings to a dictionary.
 

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -1260,6 +1260,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         input_artifacts: Dict[str, StepArtifact],
         external_artifacts: Dict[str, "ExternalArtifact"],
         parameters: Dict[str, Any],
+        default_parameters: Dict[str, Any],
         upstream_steps: Set[str],
         custom_id: Optional[str] = None,
         allow_id_suffix: bool = True,
@@ -1271,6 +1272,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             input_artifacts: The input artifacts for the invocation.
             external_artifacts: The external artifacts for the invocation.
             parameters: The parameters for the invocation.
+            default_parameters: The default parameters for the invocation.
             upstream_steps: The upstream steps for the invocation.
             custom_id: Custom ID to use for the invocation.
             allow_id_suffix: Whether a suffix can be appended to the invocation
@@ -1306,6 +1308,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             input_artifacts=input_artifacts,
             external_artifacts=external_artifacts,
             parameters=parameters,
+            default_parameters=default_parameters,
             upstream_steps=upstream_steps,
             pipeline=self,
         )

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -443,6 +443,7 @@ class BaseStep(metaclass=BaseStepMeta):
         Dict[str, "StepArtifact"],
         Dict[str, "ExternalArtifact"],
         Dict[str, Any],
+        Dict[str, Any],
     ]:
         """Parses the call args for the step entrypoint.
 
@@ -470,6 +471,7 @@ class BaseStep(metaclass=BaseStepMeta):
         artifacts = {}
         external_artifacts = {}
         parameters = {}
+        default_parameters = {}
 
         for key, value in bound_args.arguments.items():
             self.entrypoint_definition.validate_input(key=key, value=value)
@@ -510,9 +512,9 @@ class BaseStep(metaclass=BaseStepMeta):
                 and key not in external_artifacts
                 and key not in self.configuration.parameters
             ):
-                parameters[key] = value
+                default_parameters[key] = value
 
-        return artifacts, external_artifacts, parameters
+        return artifacts, external_artifacts, parameters, default_parameters
 
     def __call__(
         self,
@@ -548,6 +550,7 @@ class BaseStep(metaclass=BaseStepMeta):
             input_artifacts,
             external_artifacts,
             parameters,
+            default_parameters,
         ) = self._parse_call_args(*args, **kwargs)
 
         upstream_steps = {
@@ -563,6 +566,7 @@ class BaseStep(metaclass=BaseStepMeta):
             input_artifacts=input_artifacts,
             external_artifacts=external_artifacts,
             parameters=parameters,
+            default_parameters=default_parameters,
             upstream_steps=upstream_steps,
             custom_id=id,
             allow_id_suffix=not id,

--- a/src/zenml/steps/step_invocation.py
+++ b/src/zenml/steps/step_invocation.py
@@ -32,6 +32,7 @@ class StepInvocation:
         input_artifacts: Dict[str, "StepArtifact"],
         external_artifacts: Dict[str, "ExternalArtifact"],
         parameters: Dict[str, Any],
+        default_parameters: Dict[str, Any],
         upstream_steps: Set[str],
         pipeline: "Pipeline",
     ) -> None:
@@ -43,6 +44,7 @@ class StepInvocation:
             input_artifacts: The input artifacts for the invocation.
             external_artifacts: The external artifacts for the invocation.
             parameters: The parameters for the invocation.
+            default_parameters: The default parameters for the invocation.
             upstream_steps: The upstream steps for the invocation.
             pipeline: The parent pipeline of the invocation.
         """
@@ -51,6 +53,7 @@ class StepInvocation:
         self.input_artifacts = input_artifacts
         self.external_artifacts = external_artifacts
         self.parameters = parameters
+        self.default_parameters = default_parameters
         self.invocation_upstream_steps = upstream_steps
         self.pipeline = pipeline
 
@@ -129,6 +132,14 @@ class StepInvocation:
             for key, value in self.parameters.items()
             if key not in parameters_to_ignore
         }
+        parameters_to_apply.update(
+            {
+                key: value
+                for key, value in self.default_parameters.items()
+                if key not in parameters_to_ignore
+                and key not in parameters_to_apply
+            }
+        )
         self.step.configure(parameters=parameters_to_apply)
 
         external_artifacts: Dict[str, ExternalArtifactConfiguration] = {}

--- a/tests/integration/functional/pipelines/test_pipeline_config.py
+++ b/tests/integration/functional/pipelines/test_pipeline_config.py
@@ -300,7 +300,7 @@ def test_pipeline_config_from_file_works_with_pipeline_parameters_on_conflict_wi
     clean_workspace, tmp_path
 ):
     """Test that the pipeline will not fail with error.
-    
+
     If configured with parameters from a yaml file for the steps
     and same parameters are set with some defaults in the code.
     """

--- a/tests/integration/functional/pipelines/test_pipeline_config.py
+++ b/tests/integration/functional/pipelines/test_pipeline_config.py
@@ -299,8 +299,10 @@ def test_pipeline_config_from_file_fails_with_pipeline_parameters_on_conflict_wi
 def test_pipeline_config_from_file_works_with_pipeline_parameters_on_conflict_with_default_parameters(
     clean_workspace, tmp_path
 ):
-    """Test that the pipeline will not fail with error, if configured with parameters
-    from a yaml file for the steps and same parameters are set with some defaults in the code.
+    """Test that the pipeline will not fail with error.
+    
+    If configured with parameters from a yaml file for the steps
+    and same parameters are set with some defaults in the code.
     """
     config_path = tmp_path / "config.yaml"
     file_config = {

--- a/tests/integration/functional/pipelines/test_pipeline_config.py
+++ b/tests/integration/functional/pipelines/test_pipeline_config.py
@@ -196,6 +196,17 @@ def assert_input_params(bar: str):
     assert bar == "bar"
 
 
+@step
+def assert_input_params_with_defaults(
+    bar: str,
+    foo: str = "some default value",
+    this_will_be_default: str = "bar",
+):
+    assert bar == "bar"
+    assert foo == "bar"
+    assert this_will_be_default == "bar"
+
+
 def test_pipeline_config_from_file_works_with_pipeline_parameters(
     clean_workspace, tmp_path
 ):
@@ -283,3 +294,29 @@ def test_pipeline_config_from_file_fails_with_pipeline_parameters_on_conflict_wi
         "`assert_input_params_pipe` conflict with parameter passed in runtime",
     ):
         p(foo="foo")
+
+
+def test_pipeline_config_from_file_works_with_pipeline_parameters_on_conflict_with_default_parameters(
+    clean_workspace, tmp_path
+):
+    """Test that the pipeline will not fail with error, if configured with parameters
+    from a yaml file for the steps and same parameters are set with some defaults in the code.
+    """
+    config_path = tmp_path / "config.yaml"
+    file_config = {
+        "steps": {
+            "assert_input_params_with_defaults": {
+                "parameters": {"foo": "bar", "bar": "bar"}
+            }
+        },
+        "enable_cache": False,
+    }
+    config_path.write_text(yaml.dump(file_config))
+
+    @pipeline(enable_cache=False)
+    def assert_input_params_pipe():
+        assert_input_params_with_defaults()
+
+    p = assert_input_params_pipe.with_options(config_path=str(config_path))
+
+    p()

--- a/tests/unit/orchestrators/test_cache_utils.py
+++ b/tests/unit/orchestrators/test_cache_utils.py
@@ -38,6 +38,7 @@ def _compile_step(step: BaseStep) -> Step:
         input_artifacts={},
         external_artifacts={},
         parameters={},
+        default_parameters={},
         upstream_steps=set(),
         pipeline=pipeline,
     )


### PR DESCRIPTION
## Describe changes
I fixed how default step params are handled together with configuration YAML files. Before the fix, ZenML was treating default values as set and conflicting in case the step had only default parameters.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for default parameters in pipeline steps.

- **Enhancements**
	- Improved parameter handling in pipelines and steps for better configuration management.

- **Tests**
	- Added integration tests to validate default parameter functionality and configuration precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->