### PR TITLE
Free `sklearn` dependency to allow all versions

### DIFF
--- a/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
+++ b/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
@@ -127,7 +127,8 @@ zenml integration install sklearn -y
 In this case, ZenML has an integration with `sklearn` so you can use the ZenML CLI to install the right version directly.
 
 {% hint style="info" %}
-The `zenml integration install sklearn` command is simply doing a `pip install sklearn>1.3` behind the scenes. If something goes wrong, one can always use `zenml integration requirements sklearn` to see which requirements are compatible and install using pip (or any other tool) directly.
+The `zenml integration install sklearn` command is simply doing a `pip install` of `sklearn` behind the scenes. If something goes wrong, one can always use `zenml integration requirements sklearn` to see which requirements are compatible and install using pip (or any other tool) directly.
+
 {% endhint %}
 
 ### Define a data loader with multiple outputs

--- a/src/zenml/integrations/sklearn/__init__.py
+++ b/src/zenml/integrations/sklearn/__init__.py
@@ -21,7 +21,7 @@ class SklearnIntegration(Integration):
     """Definition of sklearn integration for ZenML."""
 
     NAME = SKLEARN
-    REQUIREMENTS = ["scikit-learn>1.3"]
+    REQUIREMENTS = ["scikit-learn"]
 
     @classmethod
     def activate(cls) -> None:


### PR DESCRIPTION
I merged #2271 without checking / noting that a key change request wasn't actually made. This makes the fix for the dependency as well as the docs change which also wasn't added.

Regarding CI: already tested and passed on #2271.