### PR TITLE
Fix dependabot settings autoformatting by `yamlfix`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,12 @@
----
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /.github
-    schedule:
-      interval: weekly
-      day: tuesday
-      time: 07:00
-      timezone: Europe/Amsterdam
-    reviewers: [strickvl]
-    labels: [dependencies, internal]
-    target-branch: develop
+- package-ecosystem: github-actions
+  directory: /.github
+  schedule:
+    interval: weekly
+    day: tuesday
+    time: "07:00"
+    timezone: Europe/Amsterdam
+  reviewers: [strickvl]
+  labels: [dependencies, internal]
+  target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,13 @@
+---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: /.github
-  schedule:
-    interval: weekly
-    day: tuesday
-    time: "07:00"
-    timezone: Europe/Amsterdam
-  reviewers: [strickvl]
-  labels: [dependencies, internal]
-  target-branch: develop
+  - package-ecosystem: github-actions
+    directory: /.github
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: Europe/Amsterdam
+    reviewers: [strickvl]
+    labels: [dependencies, internal]
+    target-branch: develop

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -26,7 +26,7 @@ done
 
 # standardises / formats CI yaml files
 if [ "$SKIP_YAMLFIX" = false ]; then
-    yamlfix .github tests
+    yamlfix .github tests --exclude "dependabot.yml"
 fi
 
 set +x

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -30,7 +30,7 @@ fi
 
 # checks for yaml formatting errors
 if [ "$SKIP_YAMLFIX" = false ]; then
-    yamlfix --check .github tests
+    yamlfix --check .github tests --exclude "dependabot.yml"
 fi
 
 # autoflake replacement: checks for unused imports and variables


### PR DESCRIPTION
`yamlfix` autoformats the `dependabot.yml` file, removing string quotes around the `schedule.time` config, which causes it to fail. I exempted that file from being yamlfixed since [Github objects](https://github.com/zenml-io/zenml/pull/2275/checks?check_run_id=20485294659) to the reformatting.