### PR TITLE
Fix to file path for notebook quickstart

### DIFF
--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -470,8 +470,7 @@ def go() -> None:
             zenml_go_notebook_tutorial_message(ipynb_files), width=80
         )
         input("Press ENTER to continue...")
-    notebook_path = os.path.join(zenml_tutorial_path, "notebooks")
-    subprocess.check_call(["jupyter", "notebook"], cwd=notebook_path)
+    subprocess.check_call(["jupyter", "notebook"], cwd=zenml_tutorial_path)
 
 
 def _prompt_email(event_source: AnalyticsEventSource) -> bool:


### PR DESCRIPTION
## Describe changes
When running `zenml go` for the guided quickstart as instructed in Readme, I get following:

`FileNotFoundError: [Errno 2] No such file or directory: '~/.../zenml_tutorial/notebooks'`

`notebooks` path does not get created in files download so I have removed from Jupyter notebook call.

Link to issue: https://github.com/zenml-io/zenml/issues/2289

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for launching Jupyter notebooks within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->