### PR TITLE
Add helper message for `zenml up --blocking` login

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -185,7 +185,16 @@ def up(
     from zenml.zen_server.deploy.deployment import ServerDeploymentConfig
 
     server_config = ServerDeploymentConfig(**config_attrs)
+    if blocking:
+        from zenml.constants import (
+            DEFAULT_USERNAME,
+        )
 
+        cli_utils.declare(
+            "The local ZenML dashboard is about to deploy in a "
+            "blocking process. You can connect to it using the "
+            f"'{DEFAULT_USERNAME}' username and an empty password."
+        )
     server = deployer.deploy_server(server_config)
 
     assert gc.store is not None


### PR DESCRIPTION
Over on #2213 at https://github.com/zenml-io/zenml/issues/2213#issuecomment-1892549278 it was raised that there's no message about what username and password to use when running `zenml up --blocking`. This would apply to Windows users mainly, so this PR outputs such a message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the server launch process with user guidance for deploying the local ZenML dashboard in a blocking mode, including connection instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->