### PR TITLE
Remove --name from service account creation in docs

### DIFF
--- a/docs/book/user-guide/advanced-guide/infrastructure-management/connecting-to-zenml.md
+++ b/docs/book/user-guide/advanced-guide/infrastructure-management/connecting-to-zenml.md
@@ -69,7 +69,7 @@ serverless function. In these cases, you can configure a service account and an
 API key and use the API key to authenticate to the ZenML server:
 
 ```bash
-zenml service-account create --name <SERVICE_ACCOUNT_NAME>
+zenml service-account create <SERVICE_ACCOUNT_NAME>
 ```
 
 This command creates a service account and an API key for it. The API key is


### PR DESCRIPTION
## Describe changes
Docs suggest to create service accounts this way:

```bash
zenml service-account create --name <SERVICE_ACCOUNT_NAME>
```

While in fact, `0.54.0` requires you to create them this way:

```bash
zenml service-account create <SERVICE_ACCOUNT_NAME>
```

This PR updates the docs.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the user guide on connecting to ZenML with the revised `zenml service-account create` command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->