### PR TITLE
Update Data Management starter guide docs

### DIFF
--- a/docs/book/user-guide/starter-guide/manage-artifacts.md
+++ b/docs/book/user-guide/starter-guide/manage-artifacts.md
@@ -30,7 +30,7 @@ from zenml import pipeline, step
 def training_data_loader() -> Annotated[pd.DataFrame, "iris_dataset"]:
     """Load the iris dataset as pandas dataframe."""
     iris = load_iris(as_frame=True)
-    return iris
+    return iris.get("frame")
 
 
 @pipeline
@@ -51,7 +51,7 @@ Artifacts named `iris_dataset` can then be found swiftly using various ZenML int
 {% tabs %}
 {% tab title="OSS (CLI)" %}
 
-To list artifacts: `zenml artifacts list`
+To list artifacts: `zenml artifact list`
 
 {% endtab %}
 {% tab title="Cloud (Dashboard)" %}
@@ -109,7 +109,7 @@ After execution, `iris_dataset` and its version `raw_2023` can be seen using:
 {% tabs %}
 {% tab title="OSS (CLI)" %}
 
-To list versions: `zenml artifacts versions list`
+To list versions: `zenml artifact version list`
 
 {% endtab %}
 {% tab title="Cloud (Dashboard)" %}
@@ -308,7 +308,7 @@ def model_finetuner_step(
 For further depth, there is an [advanced metadata logging guide](../advanced-guide/data-management/logging-metadata.md) that goes more into detail about logging metadata in ZenML.
 
 Additionally, there is a lot more to learn about artifacts within ZenML. Please read
-the [dedicated data management guide](../advanced-guide/data-management/) for more information.
+the [dedicated data management guide](../advanced-guide/data-management/data-management.md) for more information.
 
 ## Code example
 


### PR DESCRIPTION
update docs

## Describe changes
I have fixed some issues on management artifacts starter guide.
- Some commands were not correctly, e.g. `zenml artifacts `instead of `zenml artifact`
- the link to data-management doc was not set correctly

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)
  - update docs

