### PR TITLE
Allow spellcheck to run for docs changes

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,10 +5,10 @@ on:
   workflow_call:
   push:
     branches: [main]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml']
+    paths-ignore: [docker/**, '*', '!pyproject.toml']
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml']
+    paths-ignore: [docker/**, '*', '!pyproject.toml']
 concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Spellcheck used to be part of the main CI flow, but it's since been moved out. We should allow it to run when docs changes are made.