### PR TITLE
`client.get_artifact_version` lazy loading implementation

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -2837,6 +2837,11 @@ class Client(metaclass=ClientMetaClass):
         Returns:
             The artifact version.
         """
+        from zenml.artifacts.utils import _lazy_artifact_get
+
+        if lazy := _lazy_artifact_get(name=name_id_or_prefix, version=version):
+            return lazy
+
         return self._get_entity_version_by_id_or_name_or_prefix(
             get_method=self.zen_store.get_artifact_version,
             list_method=self.list_artifact_versions,

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -34,7 +34,7 @@ from zenml.config.constants import DOCKER_SETTINGS_KEY, RESOURCE_SETTINGS_KEY
 from zenml.config.source import Source, convert_source_validator
 from zenml.config.strict_base_model import StrictBaseModel
 from zenml.logger import get_logger
-from zenml.model.lazy_load import ModelVersionDataLazyLoader
+from zenml.model.lazy_load import DataLazyLoader
 from zenml.model.model_version import ModelVersion
 from zenml.utils import deprecation_utils
 
@@ -153,7 +153,7 @@ class PartialStepConfiguration(StepConfigurationUpdate):
     name: str
     caching_parameters: Mapping[str, Any] = {}
     external_input_artifacts: Mapping[str, ExternalArtifactConfiguration] = {}
-    model_artifacts_or_metadata: Mapping[str, ModelVersionDataLazyLoader] = {}
+    model_artifacts_or_metadata: Mapping[str, DataLazyLoader] = {}
     outputs: Mapping[str, PartialArtifactConfiguration] = {}
 
     # Override the deprecation validator as we do not want to deprecate the

--- a/src/zenml/metadata/lazy_load.py
+++ b/src/zenml/metadata/lazy_load.py
@@ -13,7 +13,8 @@
 #  permissions and limitations under the License.
 """Run Metadata Lazy Loader definition."""
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
+from uuid import UUID
 
 if TYPE_CHECKING:
     from zenml.model.model_version import ModelVersion
@@ -30,8 +31,8 @@ class RunMetadataLazyGetter:
 
     def __init__(
         self,
-        _lazy_load_model_version: "ModelVersion",
-        _lazy_load_artifact_name: Optional[str],
+        _lazy_load_model_version: Optional["ModelVersion"],
+        _lazy_load_artifact_name: Optional[Union[str, UUID]],
         _lazy_load_artifact_version: Optional[str],
     ):
         """Initialize a RunMetadataLazyGetter.

--- a/src/zenml/model/lazy_load.py
+++ b/src/zenml/model/lazy_load.py
@@ -11,24 +11,76 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Model Version Data Lazy Loader definition."""
+"""Data Lazy Loader definition."""
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import BaseModel
 
 from zenml.model.model_version import ModelVersion
 
+if TYPE_CHECKING:
+    from zenml.metadata.metadata_types import MetadataType
+    from zenml.models import ArtifactVersionResponse
 
-class ModelVersionDataLazyLoader(BaseModel):
-    """Model Version Data Lazy Loader helper class.
+
+class DataLazyLoader(BaseModel):
+    """Data Lazy Loader helper class.
 
     It helps the inner codes to fetch proper artifact,
     model version metadata or artifact metadata from the
-    model version during runtime time of the step.
+    model version or directly from client during the
+    runtime time of the step.
     """
 
-    model_version: ModelVersion
+    model_version: Optional[ModelVersion] = None
     artifact_name: Optional[str] = None
     artifact_version: Optional[str] = None
     metadata_name: Optional[str] = None
+
+    def _get_artifact_or_none(
+        self, ignore_metadata_name: bool = False
+    ) -> Optional["ArtifactVersionResponse"]:
+        """Get the artifact version from the model version or directly from client.
+
+        Args:
+            ignore_metadata_name: Whether to ignore the metadata name setting.
+
+        Returns:
+            The artifact version from the model version or directly from client.
+            `None` if the artifact is not found.
+        """
+        from zenml.client import Client
+
+        if (
+            self.metadata_name is None or ignore_metadata_name
+        ) and self.artifact_name:
+            if self.model_version:
+                return self.model_version.get_artifact(
+                    name=self.artifact_name, version=self.artifact_version
+                )
+            else:
+                return Client().get_artifact_version(
+                    name_id_or_prefix=self.artifact_name,
+                    version=self.artifact_version,
+                )
+        return None
+
+    def _get_run_metadata_or_none(self) -> Optional["MetadataType"]:
+        """Get the run metadata from the model version or directly from client.
+
+        Returns:
+            The run metadata from the model version or directly from client.
+            `None` if the metadata is not found.
+        """
+        if self.artifact_name is None and self.metadata_name:
+            if self.model_version:
+                return self.model_version.run_metadata[
+                    self.metadata_name
+                ].value
+        elif self.artifact_name and self.metadata_name:
+            if artifact_ := self._get_artifact_or_none(
+                ignore_metadata_name=True
+            ):
+                return artifact_.run_metadata[self.metadata_name].value
+        return None

--- a/src/zenml/model/model_version.py
+++ b/src/zenml/model/model_version.py
@@ -195,7 +195,9 @@ class ModelVersion(BaseModel):
         Returns:
             Specific version of the artifact or placeholder in the design time of the pipeline.
         """
-        if lazy := self._lazy_artifact_get(name, version):
+        from zenml.artifacts.utils import _lazy_artifact_get
+
+        if lazy := _lazy_artifact_get(name, version, self):
             return lazy
 
         return self._get_or_create_model_version().get_artifact(
@@ -217,7 +219,9 @@ class ModelVersion(BaseModel):
         Returns:
             Specific version of the model artifact or placeholder in the design time of the pipeline.
         """
-        if lazy := self._lazy_artifact_get(name, version):
+        from zenml.artifacts.utils import _lazy_artifact_get
+
+        if lazy := _lazy_artifact_get(name, version, self):
             return lazy
 
         return self._get_or_create_model_version().get_model_artifact(
@@ -239,7 +243,9 @@ class ModelVersion(BaseModel):
         Returns:
             Specific version of the data artifact or placeholder in the design time of the pipeline.
         """
-        if lazy := self._lazy_artifact_get(name, version):
+        from zenml.artifacts.utils import _lazy_artifact_get
+
+        if lazy := _lazy_artifact_get(name, version, self):
             return lazy
 
         return self._get_or_create_model_version().get_data_artifact(
@@ -261,7 +267,9 @@ class ModelVersion(BaseModel):
         Returns:
             Specific version of the deployment artifact or placeholder in the design time of the pipeline.
         """
-        if lazy := self._lazy_artifact_get(name, version):
+        from zenml.artifacts.utils import _lazy_artifact_get
+
+        if lazy := _lazy_artifact_get(name, version, self):
             return lazy
 
         return self._get_or_create_model_version().get_deployment_artifact(
@@ -415,30 +423,6 @@ class ModelVersion(BaseModel):
         """Config class."""
 
         smart_union = True
-
-    def _lazy_artifact_get(
-        self,
-        name: str,
-        version: Optional[str] = None,
-    ) -> Optional["ArtifactVersionResponse"]:
-        from zenml import get_pipeline_context
-        from zenml.models.v2.core.artifact_version import (
-            LazyArtifactVersionResponse,
-        )
-
-        try:
-            get_pipeline_context()
-            return LazyArtifactVersionResponse(
-                _lazy_load_name=name,
-                _lazy_load_version=version,
-                _lazy_load_model_version=ModelVersion(
-                    name=self.name, version=self.version or self.number
-                ),
-            )
-        except RuntimeError:
-            pass
-
-        return None
 
     def __eq__(self, other: object) -> bool:
         """Check two ModelVersions for equality.

--- a/src/zenml/models/v2/core/artifact_version.py
+++ b/src/zenml/models/v2/core/artifact_version.py
@@ -475,9 +475,9 @@ class LazyArtifactVersionResponse(ArtifactVersionResponse):
     """
 
     id: Optional[UUID] = None  # type: ignore[assignment]
-    _lazy_load_name: Optional[str] = None
+    _lazy_load_name: Optional[Union[str, UUID]] = None
     _lazy_load_version: Optional[str] = None
-    _lazy_load_model_version: "ModelVersion"
+    _lazy_load_model_version: Optional["ModelVersion"]
 
     def get_body(self) -> None:  # type: ignore[override]
         """Protects from misuse of the lazy loader.

--- a/src/zenml/models/v2/core/run_metadata.py
+++ b/src/zenml/models/v2/core/run_metadata.py
@@ -200,10 +200,10 @@ class LazyRunMetadataResponse(RunMetadataResponse):
     """
 
     id: Optional[UUID] = None  # type: ignore[assignment]
-    _lazy_load_artifact_name: Optional[str] = None
+    _lazy_load_artifact_name: Optional[Union[str, UUID]] = None
     _lazy_load_artifact_version: Optional[str] = None
     _lazy_load_metadata_name: Optional[str] = None
-    _lazy_load_model_version: "ModelVersion"
+    _lazy_load_model_version: Optional["ModelVersion"] = None
 
     def get_body(self) -> None:  # type: ignore[override]
         """Protects from misuse of the lazy loader.

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -92,7 +92,7 @@ if TYPE_CHECKING:
     from zenml.artifacts.external_artifact import ExternalArtifact
     from zenml.config.base_settings import SettingsOrDict
     from zenml.config.source import Source
-    from zenml.model.lazy_load import ModelVersionDataLazyLoader
+    from zenml.model.lazy_load import DataLazyLoader
     from zenml.model.model_version import ModelVersion
 
     StepConfigurationUpdateOrDict = Union[
@@ -1260,7 +1260,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         step: "BaseStep",
         input_artifacts: Dict[str, StepArtifact],
         external_artifacts: Dict[str, "ExternalArtifact"],
-        model_artifacts_or_metadata: Dict[str, "ModelVersionDataLazyLoader"],
+        model_artifacts_or_metadata: Dict[str, "DataLazyLoader"],
         parameters: Dict[str, Any],
         default_parameters: Dict[str, Any],
         upstream_steps: Set[str],

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
         StepConfiguration,
         StepConfigurationUpdate,
     )
-    from zenml.model.lazy_load import ModelVersionDataLazyLoader
+    from zenml.model.lazy_load import DataLazyLoader
     from zenml.model.model_version import ModelVersion
 
     ParametersOrDict = Union["BaseParameters", Dict[str, Any]]
@@ -443,7 +443,7 @@ class BaseStep(metaclass=BaseStepMeta):
     ) -> Tuple[
         Dict[str, "StepArtifact"],
         Dict[str, "ExternalArtifact"],
-        Dict[str, "ModelVersionDataLazyLoader"],
+        Dict[str, "DataLazyLoader"],
         Dict[str, Any],
         Dict[str, Any],
     ]:
@@ -460,7 +460,7 @@ class BaseStep(metaclass=BaseStepMeta):
             The artifacts, external artifacts, model version artifacts/metadata and parameters for the step.
         """
         from zenml.artifacts.external_artifact import ExternalArtifact
-        from zenml.model.lazy_load import ModelVersionDataLazyLoader
+        from zenml.model.lazy_load import DataLazyLoader
         from zenml.models.v2.core.artifact_version import (
             LazyArtifactVersionResponse,
         )
@@ -504,14 +504,14 @@ class BaseStep(metaclass=BaseStepMeta):
                         "artifacts which will improve this behavior."
                     )
             elif isinstance(value, LazyArtifactVersionResponse):
-                model_artifacts_or_metadata[key] = ModelVersionDataLazyLoader(
+                model_artifacts_or_metadata[key] = DataLazyLoader(
                     model_version=value._lazy_load_model_version,
                     artifact_name=value._lazy_load_name,
                     artifact_version=value._lazy_load_version,
                     metadata_name=None,
                 )
             elif isinstance(value, LazyRunMetadataResponse):
-                model_artifacts_or_metadata[key] = ModelVersionDataLazyLoader(
+                model_artifacts_or_metadata[key] = DataLazyLoader(
                     model_version=value._lazy_load_model_version,
                     artifact_name=value._lazy_load_artifact_name,
                     artifact_version=value._lazy_load_artifact_version,
@@ -1024,7 +1024,7 @@ To avoid this consider setting step parameters only in one place (config or code
         self,
         input_artifacts: Dict[str, "StepArtifact"],
         external_artifacts: Dict[str, "ExternalArtifactConfiguration"],
-        model_artifacts_or_metadata: Dict[str, "ModelVersionDataLazyLoader"],
+        model_artifacts_or_metadata: Dict[str, "DataLazyLoader"],
     ) -> None:
         """Validates the step inputs.
 
@@ -1053,7 +1053,7 @@ To avoid this consider setting step parameters only in one place (config or code
         self,
         input_artifacts: Dict[str, "StepArtifact"],
         external_artifacts: Dict[str, "ExternalArtifactConfiguration"],
-        model_artifacts_or_metadata: Dict[str, "ModelVersionDataLazyLoader"],
+        model_artifacts_or_metadata: Dict[str, "DataLazyLoader"],
     ) -> "StepConfiguration":
         """Finalizes the configuration after the step was called.
 

--- a/src/zenml/steps/step_invocation.py
+++ b/src/zenml/steps/step_invocation.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, Set
 if TYPE_CHECKING:
     from zenml.artifacts.external_artifact import ExternalArtifact
     from zenml.config.step_configurations import StepConfiguration
-    from zenml.model.lazy_load import ModelVersionDataLazyLoader
+    from zenml.model.lazy_load import DataLazyLoader
     from zenml.new.pipelines.pipeline import Pipeline
     from zenml.steps import BaseStep
     from zenml.steps.entrypoint_function_utils import StepArtifact
@@ -32,7 +32,7 @@ class StepInvocation:
         step: "BaseStep",
         input_artifacts: Dict[str, "StepArtifact"],
         external_artifacts: Dict[str, "ExternalArtifact"],
-        model_artifacts_or_metadata: Dict[str, "ModelVersionDataLazyLoader"],
+        model_artifacts_or_metadata: Dict[str, "DataLazyLoader"],
         parameters: Dict[str, Any],
         default_parameters: Dict[str, Any],
         upstream_steps: Set[str],

--- a/tests/integration/functional/pipelines/test_pipeline_context.py
+++ b/tests/integration/functional/pipelines/test_pipeline_context.py
@@ -131,8 +131,6 @@ def test_pipeline_context_can_load_model_artifacts_and_metadata_in_lazy_mode(
         producer()
         with pytest.raises(KeyError):
             clean_client.get_model(model_name)
-        with pytest.raises(KeyError):
-            clean_client.get_artifact_version("bar")
         model_version = get_pipeline_context().model_version
         artifact = model_version.get_artifact("bar")
         artifact_metadata = artifact.run_metadata["foobar"]
@@ -141,4 +139,6 @@ def test_pipeline_context_can_load_model_artifacts_and_metadata_in_lazy_mode(
             artifact, artifact_metadata, model_metadata, after=["producer"]
         )
 
+    with pytest.raises(KeyError):
+        clean_client.get_artifact_version("bar")
     dummy()

--- a/tests/integration/functional/test_client.py
+++ b/tests/integration/functional/test_client.py
@@ -16,7 +16,7 @@ import random
 import string
 from contextlib import ExitStack as does_not_raise
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, Optional
+from typing import Annotated, Any, Dict, Generator, Optional
 from uuid import uuid4
 
 import pytest
@@ -27,7 +27,8 @@ from tests.integration.functional.conftest import (
     int_plus_one_test_step,
 )
 from tests.integration.functional.utils import sample_name
-from zenml import ExternalArtifact
+from zenml import ExternalArtifact, pipeline, save_artifact, step
+from zenml.artifacts.utils import log_artifact_metadata
 from zenml.client import Client
 from zenml.config.pipeline_spec import PipelineSpec
 from zenml.config.source import Source
@@ -1129,6 +1130,30 @@ def test_basic_crud_for_entity(
             pass
 
 
+@step
+def lazy_producer_test_artifact() -> Annotated[str, "new_one"]:
+    """Produce artifact with metadata."""
+    log_artifact_metadata(metadata={"some_meta": "meta_new_one"})
+    return "body_new_one"
+
+
+@step
+def lazy_asserter_test_artifact(
+    artifact_existing: str,
+    artifact_metadata_existing: str,
+    artifact_new: str,
+    artifact_metadata_new: str,
+):
+    """Assert that passed in values are loaded in lazy mode.
+
+    They do not exists before actual run of the pipeline.
+    """
+    assert artifact_existing == "body_preexisting"
+    assert artifact_metadata_existing == "meta_preexisting"
+    assert artifact_new == "body_new_one"
+    assert artifact_metadata_new == "meta_new_one"
+
+
 class TestArtifact:
     def test_prune_full(self, clean_client: "Client"):
         """Test that artifact pruning works."""
@@ -1180,6 +1205,47 @@ class TestArtifact:
             == artifact.artifact.id
         )
         assert os.path.exists(artifact.uri)
+
+    def test_pipeline_can_load_artifacts_lazy_mode(
+        self,
+        clean_client: "Client",
+    ):
+        """Tests that user can load model artifacts and metadata in lazy mode in pipeline codes."""
+
+        @pipeline(enable_cache=False)
+        def dummy():
+            artifact_existing = clean_client.get_artifact_version(
+                name_id_or_prefix="preexisting"
+            )
+            artifact_metadata_existing = artifact_existing.run_metadata[
+                "some_meta"
+            ]
+
+            artifact_new = clean_client.get_artifact_version(
+                name_id_or_prefix="new_one"
+            )
+            artifact_metadata_new = artifact_new.run_metadata["some_meta"]
+
+            lazy_producer_test_artifact()
+            lazy_asserter_test_artifact(
+                artifact_existing,
+                artifact_metadata_existing,
+                artifact_new,
+                artifact_metadata_new,
+                after=["lazy_producer_test_artifact"],
+            )
+
+        save_artifact(
+            data="body_preexisting", name="preexisting", version="1.2.3"
+        )
+        log_artifact_metadata(
+            metadata={"some_meta": "meta_preexisting"},
+            artifact_name="preexisting",
+            artifact_version="1.2.3",
+        )
+        with pytest.raises(KeyError):
+            clean_client.get_artifact_version("new_one")
+        dummy()
 
 
 class TestModel:


### PR DESCRIPTION
## Describe changes
I implemented lazy loading of `client.get_artifact_version` to be used directly in the pipeline body and pass around artifacts and their metadata.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

