### PR TITLE
Update order in which requirements are installed

### DIFF
--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -76,10 +76,11 @@ class DockerSettings(BaseSettings):
     Depending on the configuration of this object, requirements will be
     installed in the following order (each step optional):
     - The packages installed in your local python environment
-    - The packages specified via the `requirements` attribute
-    - The packages specified via the `required_integrations` and potentially
-      stack requirements
     - The packages specified via the `required_hub_plugins` attribute
+    - The packages required by the stack unless this is disabled by setting
+      `install_stack_requirements=False`.
+    - The packages specified via the `required_integrations`
+    - The packages specified via the `requirements` attribute
 
     Attributes:
         parent_image: Full name of the Docker image that should be

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -423,69 +423,6 @@ class PipelineDockerImageBuilder:
                     "- Including python packages from local environment"
                 )
 
-        # Generate/Read requirements file for user-defined requirements
-        if isinstance(docker_settings.requirements, str):
-            path = os.path.abspath(docker_settings.requirements)
-            try:
-                user_requirements = io_utils.read_file_contents_as_string(path)
-            except FileNotFoundError as e:
-                raise FileNotFoundError(
-                    f"Requirements file {path} does not exist."
-                ) from e
-            if log:
-                logger.info(
-                    "- Including user-defined requirements from file `%s`",
-                    path,
-                )
-        elif isinstance(docker_settings.requirements, List):
-            user_requirements = "\n".join(docker_settings.requirements)
-            if log:
-                logger.info(
-                    "- Including user-defined requirements: %s",
-                    ", ".join(f"`{r}`" for r in docker_settings.requirements),
-                )
-        else:
-            user_requirements = None
-
-        if user_requirements:
-            requirements_files.append(
-                (".zenml_user_requirements", user_requirements, [])
-            )
-
-        # Generate requirements file for all required integrations
-        integration_requirements = set(
-            itertools.chain.from_iterable(
-                integration_registry.select_integration_requirements(
-                    integration_name=integration,
-                    target_os=OperatingSystemType.LINUX,
-                )
-                for integration in docker_settings.required_integrations
-            )
-        )
-
-        if docker_settings.install_stack_requirements:
-            integration_requirements.update(stack.requirements())
-            if code_repository:
-                integration_requirements.update(code_repository.requirements)
-
-        if integration_requirements:
-            integration_requirements_list = sorted(integration_requirements)
-            integration_requirements_file = "\n".join(
-                integration_requirements_list
-            )
-            requirements_files.append(
-                (
-                    ".zenml_integration_requirements",
-                    integration_requirements_file,
-                    [],
-                )
-            )
-            if log:
-                logger.info(
-                    "- Including integration requirements: %s",
-                    ", ".join(f"`{r}`" for r in integration_requirements_list),
-                )
-
         # Generate requirements files for all ZenML Hub plugins
         if docker_settings.required_hub_plugins:
             (
@@ -522,6 +459,85 @@ class PipelineDockerImageBuilder:
                         "- Including hub requirements from PyPI: %s",
                         ", ".join(f"`{r}`" for r in hub_pypi_requirements),
                     )
+
+        if docker_settings.install_stack_requirements:
+            stack_requirements = stack.requirements()
+            if code_repository:
+                stack_requirements.update(code_repository.requirements)
+
+            if stack_requirements:
+                stack_requirements_list = sorted(stack_requirements)
+                stack_requirements_file = "\n".join(stack_requirements_list)
+                requirements_files.append(
+                    (
+                        ".zenml_stack_integration_requirements",
+                        stack_requirements_file,
+                        [],
+                    )
+                )
+                if log:
+                    logger.info(
+                        "- Including stack requirements: %s",
+                        ", ".join(f"`{r}`" for r in stack_requirements_list),
+                    )
+
+        # Generate requirements file for all required integrations
+        integration_requirements = set(
+            itertools.chain.from_iterable(
+                integration_registry.select_integration_requirements(
+                    integration_name=integration,
+                    target_os=OperatingSystemType.LINUX,
+                )
+                for integration in docker_settings.required_integrations
+            )
+        )
+
+        if integration_requirements:
+            integration_requirements_list = sorted(integration_requirements)
+            integration_requirements_file = "\n".join(
+                integration_requirements_list
+            )
+            requirements_files.append(
+                (
+                    ".zenml_integration_requirements",
+                    integration_requirements_file,
+                    [],
+                )
+            )
+            if log:
+                logger.info(
+                    "- Including integration requirements: %s",
+                    ", ".join(f"`{r}`" for r in integration_requirements_list),
+                )
+
+        # Generate/Read requirements file for user-defined requirements
+        if isinstance(docker_settings.requirements, str):
+            path = os.path.abspath(docker_settings.requirements)
+            try:
+                user_requirements = io_utils.read_file_contents_as_string(path)
+            except FileNotFoundError as e:
+                raise FileNotFoundError(
+                    f"Requirements file {path} does not exist."
+                ) from e
+            if log:
+                logger.info(
+                    "- Including user-defined requirements from file `%s`",
+                    path,
+                )
+        elif isinstance(docker_settings.requirements, List):
+            user_requirements = "\n".join(docker_settings.requirements)
+            if log:
+                logger.info(
+                    "- Including user-defined requirements: %s",
+                    ", ".join(f"`{r}`" for r in docker_settings.requirements),
+                )
+        else:
+            user_requirements = None
+
+        if user_requirements:
+            requirements_files.append(
+                (".zenml_user_requirements", user_requirements, [])
+            )
 
         return requirements_files
 


### PR DESCRIPTION
## Describe changes
Previously, the requirements in the Docker images we build we installed in the following order:
- The packages of the client environment
- Manually defined packages
- Manually defined integrations and stack integrations
- Hub packages

This makes it very painful for users to override package versions that are required by the ZenML stack.
This PR swaps the installation order to now install the manually defined packages last, which means users can explicitly configure certain versions there and we make sure those get installed correctly.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

