### PR TITLE
Use GitHub as trusted publisher for PyPI publication

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -6,6 +6,10 @@ jobs:
   publish_to_pypi:
     name: Publish Python 🐍 package 📦 to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      # This permission is required for trusted publishing.
+      id-token: write
+      contents: read
     env:
       ZENML_DEBUG: 1
       ZENML_ANALYTICS_OPT_IN: false
@@ -26,12 +30,14 @@ jobs:
           virtualenvs-in-project: true
       - name: Include latest dashboard
         run: bash scripts/install-dashboard.sh
-      - name: publish
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      - name: Build package
+        run: poetry build
+      - name: Mint token
+        id: mint
+        uses: tschm/token-mint-action@v1.0.2
+      - name: Publish the package with poetry
         run: |-
           if [ "$(cat src/zenml/VERSION)" = "$(echo ${GITHUB_REF} | sed 's|refs/tags/||g')" ];
-          then ./scripts/publish.sh;
+          then poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}';
           else echo "Version mismatch between src/zenml/VERSION and branch tag" && exit 1;
           fi

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -46,8 +46,14 @@ jobs:
           poetry version $NIGHTLY_VERSION
       - name: Include latest dashboard
         run: bash scripts/install-dashboard.sh
-      - name: publish
-        env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: bash scripts/publish.sh
+      - name: Build package
+        run: poetry build
+      - name: Mint token
+        id: mint
+        uses: tschm/token-mint-action@v1.0.2
+      - name: Publish the package with poetry
+        run: |-
+          if [ "$(cat src/zenml/VERSION)" = "$(echo ${GITHUB_REF} | sed 's|refs/tags/||g')" ];
+          then poetry publish -u __token__ -p '${{ steps.mint.outputs.api-token }}';
+          else echo "Version mismatch between src/zenml/VERSION and branch tag" && exit 1;
+          fi


### PR DESCRIPTION
Poetry publication using a static username and password is no longer possible. This PR makes the necessary fixes for generating a one-time token to enable publication using Poetry. See https://github.com/marketplace/actions/pypi-token-mint for more.

At some point in the future we might want to do it fully in [the way that PyPi recommend](https://docs.pypi.org/trusted-publishers/using-a-publisher/) but for now this should get us back in business quickly.