### PR TITLE
CI comments for slow CI and more conditional membership checking

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -35,6 +35,9 @@ jobs:
           fi
   comment-workflow-link:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      github.event.pull_request.draft == false && contains(github.event.comment.body,
+      '/fulltest'))
     steps:
       - name: Post Comment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
   check-membership:
     runs-on: ubuntu-latest
+    # if team member commented, not a draft, on a PR, using /fulltest
+    if: >
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.pull_request.draft == false && contains(github.event.comment.body, '/fulltest')) ||
+      (github.event_name == 'workflow_dispatch')
     outputs:
       member_check: ${{ steps.is_member.outputs.member_check }}
     steps:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     # if team member commented, not a draft, on a PR, using /fulltest
     if: >
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.pull_request.draft == false && contains(github.event.comment.body, '/fulltest')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      github.event.pull_request.draft == false && contains(github.event.comment.body,
+      '/fulltest')) ||
       (github.event_name == 'workflow_dispatch')
     outputs:
       member_check: ${{ steps.is_member.outputs.member_check }}
@@ -31,6 +33,16 @@ jobs:
           else
             echo "::set-output name=member_check::false"
           fi
+  comment-workflow-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Triggered Slow CI: [Workflow Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          reactions: rocket
   docstring-check:
     needs: check-membership
     # if team member commented, not a draft, on a PR, using /fulltest

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -309,3 +309,33 @@ jobs:
       test_environment: ${{ matrix.test_environment }}
       is-slow-ci: true
     secrets: inherit
+  post-ready-to-merge-comment:
+    runs-on: ubuntu-latest
+    needs:
+      - check-membership
+      - comment-workflow-link
+      - small-checks
+      - sqlite-db-migration-testing
+      - custom-ubuntu-unit-test
+      - windows-unit-test
+      - macos-unit-test
+      - windows-integration-test
+      - macos-integration-test
+      - custom-ubuntu-integration-test
+      - update-templates-to-examples
+      - docstring-check
+    # if team member commented, not a draft, on a PR, using /fulltest
+    if: >
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      github.event.pull_request.draft == false && contains(github.event.comment.body,
+      '/fulltest')) ||
+      (github.event_name == 'workflow_dispatch')
+    steps:
+      - name: Post Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            🦭 All tests passed!
+            You are ready to merge this PR. 🚀
+          reactions: rocket


### PR DESCRIPTION
I added a conditional to prevent the slow CI from triggering when any comment (however automated) is made on an open PR. We were seeing bot comments trigger the slow CI (or our own comments).

I also added an extra step early on in the process which will make a comment to the PR with the workflow URL (for visibility).

Added a final comment when tests pass.