### PR TITLE
Small docs updates

### DIFF
--- a/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
+++ b/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
@@ -127,7 +127,12 @@ zenml integration install sklearn -y
 In this case, ZenML has an integration with `sklearn` so you can use the ZenML CLI to install the right version directly.
 
 {% hint style="info" %}
-The `zenml integration install sklearn` command is simply doing a `pip install` of `sklearn` behind the scenes. If something goes wrong, one can always use `zenml integration requirements sklearn` to see which requirements are compatible and install using pip (or any other tool) directly.
+The `zenml integration install sklearn` command is simply doing a `pip install`
+of `sklearn` behind the scenes. If something goes wrong, one can always use
+`zenml integration requirements sklearn` to see which requirements are
+compatible and install using pip (or any other tool) directly. (If no specific
+requirements are mentioned for an integration then this means we support using
+all possible versions of that integration/package.)
 
 {% endhint %}
 

--- a/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
+++ b/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
@@ -252,6 +252,11 @@ training_pipeline = training_pipeline.with_options(
 training_pipeline()
 ```
 
+The reference to a local file will change depending on where you are executing
+the pipeline and code from, so please bear this in mind. It is best practice to
+put all config files in a configs directory at the root of your repository and
+check them into git history.
+
 A simple version of such a YAML file could be:
 
 ```yaml


### PR DESCRIPTION
- updated integration requirements reference to account for integrations without pinned versions
- added a few words on where the yaml file should be in relation to your execution of the pipeline when using `with_options(config_file=...`)