### PR TITLE
Bump mlflow to v2.10.0

### DIFF
--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -35,7 +35,7 @@ class MlflowIntegration(Integration):
     # does not pin it. They fixed this in a later version, so we can probably
     # remove this once we update the mlflow version.
     REQUIREMENTS = [
-        "mlflow>=2.1.1,<=2.9.2",
+        "mlflow>=2.1.1,<=2.10.0",
         "mlserver>=1.3.3",
         "mlserver-mlflow>=1.3.3",
     ]


### PR DESCRIPTION
## Describe changes
This PR bumps `mlflow` in the ZenML MLflow integration to its [most recent release](https://github.com/mlflow/mlflow/releases/tag/v2.10.0), `v2.10.0`.

* There seem to be no breaking changes when reading the changelog.
* We have upgraded our MLFlow installation to `v2.10.0` and it runs nicely.
* We ran a test pipeline which does the following using `sklearn` and the IRIS dataset:
  * Perform autologging during training
  * Perform manual logging during evaluation
  * Upload artifacts into MLFlow, including the model
  * Download the uploaded model from MLflow in another ZenML step.

It completed without issues.

![image](https://github.com/zenml-io/zenml/assets/6450612/1a402968-2add-4ce6-be56-b9ba2b78f4cd)

![image](https://github.com/zenml-io/zenml/assets/6450612/c54d1d98-b8e9-4b68-b19e-1a73cddf74c5)



## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

