### PR TITLE
Label triggered slow ci

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -11,11 +11,11 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   run-slow-ci-label-is-set:
-    permissions:
-      contents: read
-      pull-requests: write # this premission is a bit too much, but it is required
     runs-on: ubuntu-latest
     steps:
       # this step just fakes config

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -15,7 +15,9 @@ jobs:
   run-slow-ci-label-is-set:
     runs-on: ubuntu-latest
     steps:
-      # using this instead of 
+      # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')
+      # to make it dynamic, otherwise github context is fixed at the moment of trigger event.
+      # With dynamic approach dev can set label and rerun this flow to make it running.
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.8

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -15,7 +15,7 @@ jobs:
   run-slow-ci-label-is-set:
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # this premission is a bit too much, but it is required
     runs-on: ubuntu-latest
     steps:
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -12,22 +12,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  
-  run-slow-ci-label-not-set:
+  run-slow-ci-label-is-set:
     runs-on: ubuntu-latest
     steps:
+      # using this instead of 
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.8
 
       - name: Slow CI label not set
-        if: contains(steps.pr-labels.outputs.labels, ' run-slow-ci ')
+        if: ${{ !contains(steps.pr-labels.outputs.labels, ' run-slow-ci ') }}
         run: |
           echo "Please add the 'run-slow-ci' label to this PR before merging."
           exit 1
   
   docstring-check:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -40,7 +40,7 @@ jobs:
       - name: Check docstrings
         run: bash scripts/docstring.sh
   sqlite-db-migration-testing:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     runs-on: ubuntu-dind-runners
     steps:
       - uses: actions/checkout@v4.1.1
@@ -51,7 +51,7 @@ jobs:
       - name: Test migrations across versions
         run: bash scripts/test-migrations-mysql.sh sqlite
   small-checks:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -88,7 +88,7 @@ jobs:
           pip install alembic
           bash scripts/check-alembic-branches.sh
   update-templates-to-examples:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     # this doesn't work on forked repositories (i.e. outside contributors)
     # so we disable template updates for those PRs / branches
     uses: ./.github/workflows/update-templates-to-examples.yml
@@ -97,7 +97,7 @@ jobs:
       os: ubuntu-latest
     secrets: inherit
   custom-ubuntu-unit-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [ubuntu-dind-runners]
@@ -109,7 +109,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-unit-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [windows-latest]
@@ -121,7 +121,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   macos-unit-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [macos-latest]
@@ -133,7 +133,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-integration-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [windows-latest]
@@ -148,7 +148,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   macos-integration-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [macos-latest]
@@ -163,7 +163,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   custom-ubuntu-integration-test:
-    needs: run-slow-ci-label-not-set
+    needs: run-slow-ci-label-is-set
     strategy:
       matrix:
         os: [ubuntu-dind-runners]

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Make .github/labler.yml
         run: |
-          touch .github/labler.yml
+          mkdir .github && touch .github/labler.yml
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')
       # to make it dynamic, otherwise github context is fixed at the moment of trigger event.
       # With dynamic approach dev can set label and rerun this flow to make it running.

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -11,9 +11,6 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  contents: read
-  pull-requests: write
 jobs:
   run-slow-ci-label-is-set:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -31,13 +31,11 @@ jobs:
             });
             const labelNames = labels.map(label => label.name);
             core.setOutput('all-labels', labelNames.join(','));
-
       - name: Slow CI label not set
         if: ${{ !contains(steps.pr-labels.outputs.all-labels, 'run-slow-ci') }}
         run: |
           echo "Please add the 'run-slow-ci' label to this PR before merging."
           exit 1
-  
   docstring-check:
     needs: run-slow-ci-label-is-set
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -15,19 +15,22 @@ jobs:
   run-slow-ci-label-is-set:
     runs-on: ubuntu-latest
     steps:
-      # this step just fakes config
-      - name: Make empty .github/labeler.yml
-        run: |
-          mkdir .github && touch .github/labeler.yml
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')
       # to make it dynamic, otherwise github context is fixed at the moment of trigger event.
       # With dynamic approach dev can set label and rerun this flow to make it running.
       - name: Get PR labels
         id: pr-labels
-        uses: actions/labeler@v5
+        uses: actions/github-script@v5
         with:
-          pr-number: ${{ github.event.pull_request.number }}
-          configuration-path: .github/labeler.yml
+          script: |
+            const prNumber = ${{ github.event.pull_request.number }};
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const labelNames = labels.map(label => label.name);
+            core.setOutput('all-labels', labelNames.join(','));
 
       - name: Slow CI label not set
         if: ${{ !contains(steps.pr-labels.outputs.all-labels, 'run-slow-ci') }}
@@ -97,9 +100,9 @@ jobs:
           pip install alembic
           bash scripts/check-alembic-branches.sh
   update-templates-to-examples:
-    needs: run-slow-ci-label-is-set
     # this doesn't work on forked repositories (i.e. outside contributors)
     # so we disable template updates for those PRs / branches
+    needs: run-slow-ci-label-is-set
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
       python-version: '3.8'

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -18,6 +18,9 @@ jobs:
       pull-requests: write # this premission is a bit too much, but it is required
     runs-on: ubuntu-latest
     steps:
+      - name: Make .github/labler.yml
+        run: |
+          touch .github/labler.yml
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')
       # to make it dynamic, otherwise github context is fixed at the moment of trigger event.
       # With dynamic approach dev can set label and rerun this flow to make it running.

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Get PR labels
         id: pr-labels
         uses: actions/labeler@v5
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Slow CI label not set
         if: ${{ !contains(steps.pr-labels.outputs.all-labels, 'run-slow-ci') }}

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -13,6 +13,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   run-slow-ci-label-is-set:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -15,7 +15,7 @@ jobs:
   run-slow-ci-label-is-set:
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -99,15 +99,6 @@ jobs:
         run: |
           pip install alembic
           bash scripts/check-alembic-branches.sh
-  update-templates-to-examples:
-    # this doesn't work on forked repositories (i.e. outside contributors)
-    # so we disable template updates for those PRs / branches
-    needs: run-slow-ci-label-is-set
-    uses: ./.github/workflows/update-templates-to-examples.yml
-    with:
-      python-version: '3.8'
-      os: ubuntu-latest
-    secrets: inherit
   custom-ubuntu-unit-test:
     needs: run-slow-ci-label-is-set
     strategy:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -1,14 +1,27 @@
 ---
 name: Slow CI
 on:
+  push:
+    branches: [main]
+    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
   pull_request:
-    types: [ready_for_review]
+    types: [opened, synchronize, ready_for_review]
+    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
 concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  slow-label-not-set:
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'run-slow-ci' ) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slow CI label not set
+        run: |
+          echo "Please add the 'run-slow-ci' label to this PR before merging."
+          exit 1
   docstring-check:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -21,6 +34,7 @@ jobs:
       - name: Check docstrings
         run: bash scripts/docstring.sh
   sqlite-db-migration-testing:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     runs-on: ubuntu-dind-runners
     steps:
       - uses: actions/checkout@v4.1.1
@@ -31,6 +45,7 @@ jobs:
       - name: Test migrations across versions
         run: bash scripts/test-migrations-mysql.sh sqlite
   small-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -67,6 +82,7 @@ jobs:
           pip install alembic
           bash scripts/check-alembic-branches.sh
   update-templates-to-examples:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     # this doesn't work on forked repositories (i.e. outside contributors)
     # so we disable template updates for those PRs / branches
     uses: ./.github/workflows/update-templates-to-examples.yml
@@ -75,6 +91,7 @@ jobs:
       os: ubuntu-latest
     secrets: inherit
   custom-ubuntu-unit-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [ubuntu-dind-runners]
@@ -86,6 +103,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-unit-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [windows-latest]
@@ -97,6 +115,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   macos-unit-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [macos-latest]
@@ -108,6 +127,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-integration-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [windows-latest]
@@ -122,6 +142,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   macos-integration-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [macos-latest]
@@ -136,6 +157,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   custom-ubuntu-integration-test:
+    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
     strategy:
       matrix:
         os: [ubuntu-dind-runners]

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -15,6 +15,7 @@ jobs:
   run-slow-ci-label-is-set:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -12,16 +12,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  
   run-slow-ci-label-not-set:
-    if: ${{ !contains( github.event.pull_request.labels.*.name, 'run-slow-ci' ) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.8
+
       - name: Slow CI label not set
+        if: contains(steps.pr-labels.outputs.labels, ' run-slow-ci ')
         run: |
           echo "Please add the 'run-slow-ci' label to this PR before merging."
           exit 1
+  
   docstring-check:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -34,7 +40,7 @@ jobs:
       - name: Check docstrings
         run: bash scripts/docstring.sh
   sqlite-db-migration-testing:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     runs-on: ubuntu-dind-runners
     steps:
       - uses: actions/checkout@v4.1.1
@@ -45,7 +51,7 @@ jobs:
       - name: Test migrations across versions
         run: bash scripts/test-migrations-mysql.sh sqlite
   small-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -82,7 +88,7 @@ jobs:
           pip install alembic
           bash scripts/check-alembic-branches.sh
   update-templates-to-examples:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     # this doesn't work on forked repositories (i.e. outside contributors)
     # so we disable template updates for those PRs / branches
     uses: ./.github/workflows/update-templates-to-examples.yml
@@ -91,7 +97,7 @@ jobs:
       os: ubuntu-latest
     secrets: inherit
   custom-ubuntu-unit-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [ubuntu-dind-runners]
@@ -103,7 +109,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-unit-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [windows-latest]
@@ -115,7 +121,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   macos-unit-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [macos-latest]
@@ -127,7 +133,7 @@ jobs:
       os: ${{ matrix.os }}
     secrets: inherit
   windows-integration-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [windows-latest]
@@ -142,7 +148,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   macos-integration-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [macos-latest]
@@ -157,7 +163,7 @@ jobs:
       is-slow-ci: true
     secrets: inherit
   custom-ubuntu-integration-test:
-    if: contains( github.event.pull_request.labels.*.name, 'run-slow-ci' )
+    needs: run-slow-ci-label-not-set
     strategy:
       matrix:
         os: [ubuntu-dind-runners]

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -18,9 +18,10 @@ jobs:
       pull-requests: write # this premission is a bit too much, but it is required
     runs-on: ubuntu-latest
     steps:
-      - name: Make .github/labler.yml
+      # this step just fakes config
+      - name: Make empty .github/labeler.yml
         run: |
-          mkdir .github && touch .github/labler.yml
+          mkdir .github && touch .github/labeler.yml
       # using this instead of contains(github.event.pull_request.labels.*.name, 'run-slow-ci')
       # to make it dynamic, otherwise github context is fixed at the moment of trigger event.
       # With dynamic approach dev can set label and rerun this flow to make it running.
@@ -29,6 +30,7 @@ jobs:
         uses: actions/labeler@v5
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          configuration-path: .github/labeler.yml
 
       - name: Slow CI label not set
         if: ${{ !contains(steps.pr-labels.outputs.all-labels, 'run-slow-ci') }}

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -20,10 +20,10 @@ jobs:
       # With dynamic approach dev can set label and rerun this flow to make it running.
       - name: Get PR labels
         id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.8
+        uses: actions/labeler@v5
 
       - name: Slow CI label not set
-        if: ${{ !contains(steps.pr-labels.outputs.labels, ' run-slow-ci ') }}
+        if: ${{ !contains(steps.pr-labels.outputs.all-labels, 'run-slow-ci') }}
         run: |
           echo "Please add the 'run-slow-ci' label to this PR before merging."
           exit 1

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  slow-label-not-set:
+  run-slow-ci-label-not-set:
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'run-slow-ci' ) }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -78,8 +78,9 @@ jobs:
             echo "No active Git changes found."
             echo "changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Active Git changes found."
+            echo "vvv Active Git changes found vvv"
             echo "changes=true" >> $GITHUB_OUTPUT
+            git diff "origin/${{ github.event.pull_request.head.ref }}"
           fi
       - name: Commit and push template
         if: steps.check_changes.outputs.changes == 'true'
@@ -148,8 +149,9 @@ jobs:
             echo "No active Git changes found."
             echo "changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Active Git changes found."
+            echo "vvv Active Git changes found vvv"
             echo "changes=true" >> $GITHUB_OUTPUT
+            git diff "origin/${{ github.event.pull_request.head.ref }}"
           fi
       - name: Commit and push template
         if: steps.check_changes.outputs.changes == 'true'
@@ -220,8 +222,9 @@ jobs:
             echo "No active Git changes found."
             echo "changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Active Git changes found."
+            echo "vvv Active Git changes found vvv"
             echo "changes=true" >> $GITHUB_OUTPUT
+            git diff "origin/${{ github.event.pull_request.head.ref }}"
           fi
       - name: Commit and push template
         if: steps.check_changes.outputs.changes == 'true'


### PR DESCRIPTION
## Describe changes
This PR has a couple of improvements to the current Fast/Slow CI concept:
- Running decision for Slow CI is controlled by `run-slow-ci` label
- Fast CI always runs
- Slow CI always runs, but In Slow CI we first check, if the label is set, if not set - it fails. 
- If PR is ready for Slow CI: dev can fix above mentioned error by applying a tag and rerunning slow flow
- If PR is not yet ready for Slow CI: just ignore, it until it is ready and go to the previous bullet

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Enhanced CI workflow by adding and modifying event triggers for better control.
	- Introduced new CI jobs for specific label checks and updating templates, improving automation and efficiency.
	- Adjusted job dependencies to streamline the CI process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->