### PR TITLE
Add extra parameters (e.g. network) to Vertex Step Operator

### DIFF
--- a/docs/book/stacks-and-components/component-guide/step-operators/vertex.md
+++ b/docs/book/stacks-and-components/component-guide/step-operators/vertex.md
@@ -115,9 +115,38 @@ more about how ZenML builds these images and how you can customize them.
 
 #### Additional configuration
 
+You can specify the service account, network and reserved IP ranges to use for the VertexAI CustomJob by passing the `service_account`, `network` and `reserved_ip_ranges` parameters to the `step-operator register` command:
+
+```shell
+    zenml step-operator register <STEP_OPERATOR_NAME> \
+        --flavor=vertex \
+        --project=<GCP_PROJECT> \
+        --region=<REGION> \
+        --service_account=<SERVICE_ACCOUNT> # optionally specify the service account to use for the VertexAI CustomJob
+        --network=<NETWORK> # optionally specify the network to use for the VertexAI CustomJob
+        --reserved_ip_ranges=<RESERVED_IP_RANGES> # optionally specify the reserved IP range to use for the VertexAI CustomJob
+```
+
 For additional configuration of the Vertex step operator, you can pass `VertexStepOperatorSettings` when defining or
-running your pipeline. Check out
-the [SDK docs](https://sdkdocs.zenml.io/latest/integration\_code\_docs/integrations-gcp/#zenml.integrations.gcp.flavors.vertex\_step\_operator\_flavor.VertexStepOperatorSettings)
+running your pipeline.
+
+```python
+from zenml import step
+from zenml.integrations.gcp.flavors.vertex_step_operator_flavor import VertexStepOperatorSettings
+
+@step(step_operator= <NAME>, settings=settings= {"step_operator.vertex": vertex_operator_settings = VertexStepOperatorSettings(
+    accelerator_type  = "NVIDIA_TESLA_T4" # see https://cloud.google.com/vertex-ai/docs/reference/rest/v1/MachineSpec#AcceleratorType
+    accelerator_count = 1
+    machine_type = "n1-standard-2"        # see https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types
+    disk_type = "pd-ssd"                  # see https://cloud.google.com/vertex-ai/docs/training/configure-storage#disk-types
+    disk_size_gb = 100                    # see https://cloud.google.com/vertex-ai/docs/training/configure-storage#disk-size
+    )})
+def trainer(...) -> ...:
+    """Train a model."""
+    # This step will be executed in Vertex.
+```
+
+Check out the [SDK docs](https://sdkdocs.zenml.io/latest/integration\_code\_docs/integrations-gcp/#zenml.integrations.gcp.flavors.vertex\_step\_operator\_flavor.VertexStepOperatorSettings)
 for a full list of available attributes and [this docs page](/docs/book/user-guide/advanced-guide/pipelining-features/configure-steps-pipelines.md) for
 more information on how to specify settings.
 

--- a/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_step_operator_flavor.py
@@ -44,12 +44,18 @@ class VertexStepOperatorSettings(BaseSettings):
             https://cloud.google.com/vertex-ai/docs/training/configure-compute#gpu-compatibility-table.
         machine_type: Machine type specified here
             https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types.
+        disk_type: Disk type specified here
+            https://cloud.google.com/vertex-ai/docs/training/configure-compute#boot_disk_options
+        disk_size_gb: Disk size in GB.
+            https://cloud.google.com/vertex-ai/docs/training/configure-compute#boot_disk_options
 
     """
 
     accelerator_type: Optional[str] = None
     accelerator_count: int = 0
     machine_type: str = "n1-standard-4"
+    disk_type: Optional[str] = None
+    disk_size_gb: Optional[int] = None
 
 
 class VertexStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydantic/pydantic/issues/4173
@@ -62,6 +68,13 @@ class VertexStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydan
     Attributes:
         region: Region name, e.g., `europe-west1`.
         encryption_spec_key_name: Encryption spec key name.
+        network: The full name of the Compute Engine network to which the Job should be peered.
+            For example, projects/12345/global/networks/myVPC
+        reservedIpRanges: A list of names for the reserved ip ranges under the VPC network that can be used
+            for this job. If set, we will deploy the job within the provided ip ranges. Otherwise, the job
+            will be deployed to any ip ranges under the provided VPC network.
+        service_account: Specifies the service account for workload run-as account. Users submitting jobs
+            must have act-as permission on this run-as account.
     """
 
     region: str
@@ -69,6 +82,12 @@ class VertexStepOperatorConfig(  # type: ignore[misc] # https://github.com/pydan
     # customer managed encryption key resource name
     # will be applied to all Vertex AI resources if set
     encryption_spec_key_name: Optional[str] = None
+
+    network: Optional[str] = None
+
+    reservedIpRanges: Optional[str] = None
+
+    service_account: Optional[str] = None
 
     @property
     def is_remote(self) -> bool:

--- a/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
+++ b/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
@@ -236,6 +236,10 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
                             if settings.accelerator_type
                             else 0,
                         },
+                        "disk_spec": {
+                            "boot_disk_type": settings.disk_type,
+                            "boot_disk_size_gb": settings.disk_size_gb,
+                        },
                         "replica_count": 1,
                         "container_spec": {
                             "image_uri": image_name,
@@ -247,7 +251,12 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
                             ],
                         },
                     }
-                ]
+                ],
+                "service_account": self.config.service_account,
+                "network": self.config.network,
+                "reserved_ip_ranges": self.config.reservedIpRanges
+                if self.config.reservedIpRanges
+                else [],
             },
             "labels": job_labels,
             "encryption_spec": {


### PR DESCRIPTION
## Describe changes
I implemented extra config parameters of the Vertex Step Operator:
- Support of the `network` and `reserved_ip_ranges` parameters (allow the `CustomJob` to run in private/shared VPC)
- Support specifying the GCP service account for the CustomJob execution

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [?] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

