### PR TITLE
Allow more recent `adlfs` and `s3fs` versions

### DIFF
--- a/src/zenml/integrations/azure/__init__.py
+++ b/src/zenml/integrations/azure/__init__.py
@@ -39,7 +39,7 @@ class AzureIntegration(Integration):
 
     NAME = AZURE
     REQUIREMENTS = [
-        "adlfs==2021.10.0",
+        "adlfs>=2021.10.0",
         "azure-keyvault-keys",
         "azure-keyvault-secrets",
         "azure-identity==1.10.0",

--- a/src/zenml/integrations/s3/__init__.py
+++ b/src/zenml/integrations/s3/__init__.py
@@ -42,7 +42,7 @@ class S3Integration(Integration):
     # The above command installs boto3==1.26.76, so we use the same version
     # here to avoid the dependency resolution overhead.
     REQUIREMENTS = [
-        "s3fs>2022.3.0,<=2023.4.0",
+        "s3fs>2022.3.0",
         "boto3<=1.26.76",
         # The following dependencies are only required for the AWS connector.
         "aws-profile-manager",


### PR DESCRIPTION
This PR allows for more recent versions of `adlfs` and `s3fs` in our azure and s3 integrations. This is to support PRs like #2376 which requires a more recent version of a dependency of the two dependencies in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated Azure and S3 integrations to support broader versions of `adlfs` and `s3fs` dependencies, enhancing compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->