### PR TITLE
Upgrade Vertex integration `google-cloud-aiplatform` minimum required version to 1.34.0

### DIFF
--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -48,7 +48,7 @@ class GcpIntegration(Integration):
         "google-cloud-secret-manager",
         "google-cloud-container>=2.21.0",
         "google-cloud-storage>=2.9.0",
-        "google-cloud-aiplatform>=1.21.0",  # includes shapely pin fix
+        "google-cloud-aiplatform>=1.34.0",  # includes shapely pin fix
         "google-cloud-build>=3.11.0",
         "kubernetes",
     ]


### PR DESCRIPTION
## Describe changes
Following an issue raised in this [slack conversation](https://zenml.slack.com/archives/C01FWQ5D0TT/p1707313566959909) it appears that using the native Vertex scheduling capacity for scheduling pipelines with the Vertex orchestrator needs `google-cloud-aiplatform>=1.34.0`

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

