### PR TITLE
Add `save models to registry` setting of a model to CLI methods

### DIFF
--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -42,6 +42,9 @@ def _model_to_print(model: ModelResponse) -> Dict[str, Any]:
         "latest_version": model.latest_version_name,
         "description": model.description,
         "tags": [t.name for t in model.tags],
+        "save_to_registry": ":white_check_mark:"
+        if model.save_models_to_registry
+        else "",
         "use_cases": model.use_cases,
         "audience": model.audience,
         "limitations": model.limitations,
@@ -168,6 +171,13 @@ def list_models(**kwargs: Any) -> None:
     required=False,
     multiple=True,
 )
+@click.option(
+    "--save-models-to-registry",
+    "-s",
+    help="Whether to automatically save model artifacts to the model registry.",
+    type=click.BOOL,
+    required=False,
+)
 def register_model(
     name: str,
     license: Optional[str],
@@ -178,6 +188,7 @@ def register_model(
     ethical: Optional[str],
     limitations: Optional[str],
     tag: Optional[List[str]],
+    save_models_to_registry: Optional[bool],
 ) -> None:
     """Register a new model in the Model Control Plane.
 
@@ -191,18 +202,25 @@ def register_model(
         ethical: The ethical implications of the model.
         limitations: The know limitations of the model.
         tag: Tags associated with the model.
+        save_models_to_registry: Whether to save the model to the
+            registry.
     """
     try:
         model = Client().create_model(
-            name=name,
-            license=license,
-            description=description,
-            audience=audience,
-            use_cases=use_cases,
-            trade_offs=tradeoffs,
-            ethics=ethical,
-            limitations=limitations,
-            tags=tag,
+            **remove_none_values(
+                dict(
+                    name=name,
+                    license=license,
+                    description=description,
+                    audience=audience,
+                    use_cases=use_cases,
+                    trade_offs=tradeoffs,
+                    ethics=ethical,
+                    limitations=limitations,
+                    tags=tag,
+                    save_models_to_registry=save_models_to_registry,
+                )
+            )
         )
     except (EntityExistsError, ValueError) as e:
         cli_utils.error(str(e))
@@ -282,6 +300,13 @@ def register_model(
     required=False,
     multiple=True,
 )
+@click.option(
+    "--save-models-to-registry",
+    "-s",
+    help="Whether to automatically save model artifacts to the model registry.",
+    type=click.BOOL,
+    required=False,
+)
 def update_model(
     model_name_or_id: str,
     name: Optional[str],
@@ -294,6 +319,7 @@ def update_model(
     limitations: Optional[str],
     tag: Optional[List[str]],
     remove_tag: Optional[List[str]],
+    save_models_to_registry: Optional[bool],
 ) -> None:
     """Register a new model in the Model Control Plane.
 
@@ -309,6 +335,8 @@ def update_model(
         limitations: The know limitations of the model.
         tag: Tags to be added to the model.
         remove_tag: Tags to be removed from the model.
+        save_models_to_registry: Whether to save the model to the
+            registry.
     """
     model_id = Client().get_model(model_name_or_id=model_name_or_id).id
     update_dict = remove_none_values(
@@ -323,6 +351,7 @@ def update_model(
             limitations=limitations,
             add_tags=tag,
             remove_tags=remove_tag,
+            save_models_to_registry=save_models_to_registry,
         )
     )
     model = Client().update_model(model_name_or_id=model_id, **update_dict)

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -177,6 +177,7 @@ def list_models(**kwargs: Any) -> None:
     help="Whether to automatically save model artifacts to the model registry.",
     type=click.BOOL,
     required=False,
+    default=True,
 )
 def register_model(
     name: str,
@@ -306,6 +307,7 @@ def register_model(
     help="Whether to automatically save model artifacts to the model registry.",
     type=click.BOOL,
     required=False,
+    default=True,
 )
 def update_model(
     model_name_or_id: str,

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -4745,6 +4745,7 @@ class Client(metaclass=ClientMetaClass):
         ethics: Optional[str] = None,
         add_tags: Optional[List[str]] = None,
         remove_tags: Optional[List[str]] = None,
+        save_models_to_registry: Optional[bool] = None,
     ) -> ModelResponse:
         """Updates an existing model in Model Control Plane.
 
@@ -4760,6 +4761,8 @@ class Client(metaclass=ClientMetaClass):
             ethics: The ethical implications of the model.
             add_tags: Tags to add to the model.
             remove_tags: Tags to remove from to the model.
+            save_models_to_registry: Whether to save the model to the
+                registry.
 
         Returns:
             The updated model.
@@ -4779,6 +4782,7 @@ class Client(metaclass=ClientMetaClass):
                 ethics=ethics,
                 add_tags=add_tags,
                 remove_tags=remove_tags,
+                save_models_to_registry=save_models_to_registry,
             ),
         )
 

--- a/src/zenml/models/v2/core/model.py
+++ b/src/zenml/models/v2/core/model.py
@@ -105,6 +105,7 @@ class ModelUpdate(BaseModel):
     ethics: Optional[str] = None
     add_tags: Optional[List[str]] = None
     remove_tags: Optional[List[str]] = None
+    save_models_to_registry: Optional[bool] = None
 
 
 # ------------------ Response Model ------------------

--- a/tests/integration/functional/cli/test_model.py
+++ b/tests/integration/functional/cli/test_model.py
@@ -62,6 +62,8 @@ def test_model_create_short_names(clean_client_with_models: "Client"):
             "j",
             "-t",
             "k",
+            "-s",
+            "true",
         ],
     )
     assert result.exit_code == 0, result.stderr
@@ -75,6 +77,7 @@ def test_model_create_short_names(clean_client_with_models: "Client"):
     assert model.trade_offs == "f"
     assert model.ethics == "g"
     assert model.limitations == "e"
+    assert model.save_models_to_registry
     assert {t.name for t in model.tags} == {"i", "j", "k"}
 
 
@@ -108,6 +111,8 @@ def test_model_create_full_names(clean_client_with_models: "Client"):
             "j",
             "--tag",
             "k",
+            "--save-models-to-registry",
+            "false",
         ],
     )
     assert result.exit_code == 0, result.stderr
@@ -121,6 +126,7 @@ def test_model_create_full_names(clean_client_with_models: "Client"):
     assert model.trade_offs == "f"
     assert model.ethics == "g"
     assert model.limitations == "e"
+    assert not model.save_models_to_registry
     assert {t.name for t in model.tags} == {"i", "j", "k"}
 
 
@@ -144,6 +150,7 @@ def test_model_create_only_required(clean_client_with_models: "Client"):
     assert model.trade_offs is None
     assert model.ethics is None
     assert model.limitations is None
+    assert model.save_models_to_registry
     assert len(model.tags) == 0
 
 
@@ -164,7 +171,7 @@ def test_model_update(clean_client_with_models: "Client"):
 
     result = runner.invoke(
         update_command,
-        args=[NAME, "-d", "bar", "-r", "a", "-t", "b"],
+        args=[NAME, "-d", "bar", "-r", "a", "-t", "b", "-s", "false"],
     )
     assert result.exit_code == 0, result.stderr
 
@@ -172,6 +179,7 @@ def test_model_update(clean_client_with_models: "Client"):
     assert model.trade_offs == "foo"
     assert {t.name for t in model.tags} == {"b"}
     assert model.description == "bar"
+    assert not model.save_models_to_registry
 
 
 def test_model_create_without_required_fails(


### PR DESCRIPTION
## Describe changes
I added `save models to registry` setting of a model to CLI methods.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to control saving model artifacts to the registry directly from the CLI and client interfaces.

- **Tests**
	- Enhanced CLI tests with a new flag to save models to the registry.
	- Improved test coverage to verify the new `save_models_to_registry` attribute functionality under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->