### PR TITLE
Disable methods for local case

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -188,6 +188,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 AnyResponse = TypeVar("AnyResponse", bound=BaseIdentifiedResponse)  # type: ignore[type-arg]
+T = TypeVar("T")
 
 
 class ClientConfiguration(FileSyncModel):
@@ -365,7 +366,7 @@ class Client(metaclass=ClientMetaClass):
         cls._global_client = client
 
     @staticmethod
-    def _fail_for_sql_zen_store(method):
+    def _fail_for_sql_zen_store(method: Callable[..., T]) -> Callable[..., T]:
         """Decorator for all methods, that are disallowed when the client is not connected through REST API.
 
         Args:
@@ -376,7 +377,7 @@ class Client(metaclass=ClientMetaClass):
         """
 
         @functools.wraps(method)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(self: "Client", *args: Any, **kwargs: Any) -> Any:
             # No isinstance check to avoid importing ZenStore implementations
             if self.zen_store.__class__.__name__ == "SqlZenStore":
                 raise TypeError(

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -12,7 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """Client implementation."""
-
+import functools
 import json
 import os
 from abc import ABCMeta
@@ -364,16 +364,29 @@ class Client(metaclass=ClientMetaClass):
         """
         cls._global_client = client
 
-    def _fail_for_sql_zen_store(self):
-        def decorator(func):
-            def inner(*args, **kwargs):
-                # No isinstance check to avoid importing ZenStore implementations
-                if self.zen_store.__class__.__name__ == 'SqlZenStore':
-                    raise TypeError("This method is not allowed when not connected "
-                                    "to a ZenML Server through the API interface..")
-                return func(*args, **kwargs)
-            return inner
-        return decorator
+    @staticmethod
+    def _fail_for_sql_zen_store(method):
+        """Decorator for all methods, that are disallowed when the client is not connected through REST API.
+
+        Args:
+            method: The method
+
+        Returns:
+            The decorated method.
+        """
+
+        @functools.wraps(method)
+        def wrapper(self, *args, **kwargs):
+            # No isinstance check to avoid importing ZenStore implementations
+            breakpoint()
+            if self.zen_store.__class__.__name__ == "SqlZenStore":
+                raise TypeError(
+                    "This method is not allowed when not connected "
+                    "to a ZenML Server through the API interface.."
+                )
+            return method(*args, **kwargs)
+
+        return wrapper
 
     def _set_active_root(self, root: Optional[Path] = None) -> None:
         """Set the supplied path as the repository root.

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -381,7 +381,7 @@ class Client(metaclass=ClientMetaClass):
             if self.zen_store.__class__.__name__ == "SqlZenStore":
                 raise TypeError(
                     "This method is not allowed when not connected "
-                    "to a ZenML Server through the API interface.."
+                    "to a ZenML Server through the API interface."
                 )
             return method(self, *args, **kwargs)
 

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -378,13 +378,12 @@ class Client(metaclass=ClientMetaClass):
         @functools.wraps(method)
         def wrapper(self, *args, **kwargs):
             # No isinstance check to avoid importing ZenStore implementations
-            breakpoint()
             if self.zen_store.__class__.__name__ == "SqlZenStore":
                 raise TypeError(
                     "This method is not allowed when not connected "
                     "to a ZenML Server through the API interface.."
                 )
-            return method(*args, **kwargs)
+            return method(self, *args, **kwargs)
 
         return wrapper
 

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -364,6 +364,17 @@ class Client(metaclass=ClientMetaClass):
         """
         cls._global_client = client
 
+    def _fail_for_sql_zen_store(self):
+        def decorator(func):
+            def inner(*args, **kwargs):
+                # No isinstance check to avoid importing ZenStore implementations
+                if self.zen_store.__class__.__name__ == 'SqlZenStore':
+                    raise TypeError("This method is not allowed when not connected "
+                                    "to a ZenML Server through the API interface..")
+                return func(*args, **kwargs)
+            return inner
+        return decorator
+
     def _set_active_root(self, root: Optional[Path] = None) -> None:
         """Set the supplied path as the repository root.
 
@@ -2212,6 +2223,7 @@ class Client(metaclass=ClientMetaClass):
 
     # --------------------------------- Event Sources -------------------------
 
+    @_fail_for_sql_zen_store
     def create_event_source(
         self,
         name: str,
@@ -2245,6 +2257,7 @@ class Client(metaclass=ClientMetaClass):
 
         return self.zen_store.create_event_source(event_source=event_source)
 
+    @_fail_for_sql_zen_store
     def get_event_source(
         self,
         name_id_or_prefix: Union[UUID, str],
@@ -2326,6 +2339,7 @@ class Client(metaclass=ClientMetaClass):
             event_source_filter_model, hydrate=hydrate
         )
 
+    @_fail_for_sql_zen_store
     def update_event_source(
         self,
         name_id_or_prefix: Union[UUID, str],
@@ -2380,6 +2394,7 @@ class Client(metaclass=ClientMetaClass):
         )
         return updated_event_source
 
+    @_fail_for_sql_zen_store
     def delete_event_source(self, name_id_or_prefix: Union[str, UUID]) -> None:
         """Deletes an event_source.
 
@@ -2396,6 +2411,7 @@ class Client(metaclass=ClientMetaClass):
 
     # --------------------------------- Triggers -------------------------
 
+    @_fail_for_sql_zen_store
     def create_trigger(
         self,
         name: str,
@@ -2434,6 +2450,7 @@ class Client(metaclass=ClientMetaClass):
 
         return self.zen_store.create_trigger(trigger=trigger)
 
+    @_fail_for_sql_zen_store
     def get_trigger(
         self,
         name_id_or_prefix: Union[UUID, str],
@@ -2459,6 +2476,7 @@ class Client(metaclass=ClientMetaClass):
             hydrate=hydrate,
         )
 
+    @_fail_for_sql_zen_store
     def list_triggers(
         self,
         sort_by: str = "created",
@@ -2512,6 +2530,7 @@ class Client(metaclass=ClientMetaClass):
             trigger_filter_model, hydrate=hydrate
         )
 
+    @_fail_for_sql_zen_store
     def update_trigger(
         self,
         name_id_or_prefix: Union[UUID, str],
@@ -2565,6 +2584,7 @@ class Client(metaclass=ClientMetaClass):
         )
         return updated_trigger
 
+    @_fail_for_sql_zen_store
     def delete_trigger(self, name_id_or_prefix: Union[str, UUID]) -> None:
         """Deletes an trigger.
 


### PR DESCRIPTION
## Describe changes
Some methods should not be allowed for the fully local setup where the client is directly connected to the SqlZenStore. This is because there is some custom logic, that is only run in the layer between endpoint and database:

Client -> RestZenStore -> Server-Endpoint -> Custom handler -> SqlZenStore

This custom layer would be bypassed in the local setup:

Client -> SqlZenStore

For this reason the relevant methods are disallowed.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

