### PR TITLE
Avoid exposure of tracking uri to metadata

### DIFF
--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -161,13 +161,20 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
             os.makedirs(local_mlflow_tracking_uri)
         return "file:" + local_mlflow_tracking_uri
 
-    def get_tracking_uri(self) -> str:
+    def get_tracking_uri(self, as_plain_text: bool = True) -> str:
         """Returns the configured tracking URI or a local fallback.
+
+        Args:
+            as_plain_text: Whether to return the tracking URI as plain text.
 
         Returns:
             The tracking URI.
         """
-        return self.config.tracking_uri or self._local_mlflow_backend()
+        if as_plain_text:
+            tracking_uri = self.config.tracking_uri
+        else:
+            tracking_uri = self.config.dict()["tracking_uri"]
+        return tracking_uri or self._local_mlflow_backend()
 
     def prepare_step_run(self, info: "StepRunInfo") -> None:
         """Sets the MLflow tracking uri and credentials.
@@ -214,7 +221,9 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
             A dictionary of metadata.
         """
         return {
-            METADATA_EXPERIMENT_TRACKER_URL: Uri(self.get_tracking_uri()),
+            METADATA_EXPERIMENT_TRACKER_URL: Uri(
+                self.get_tracking_uri(as_plain_text=False)
+            ),
             "mlflow_run_id": mlflow.active_run().info.run_id,
             "mlflow_experiment_id": mlflow.active_run().info.experiment_id,
         }


### PR DESCRIPTION
## Describe changes
I fixed the exposure of the tracking URI of MlFlow configured as ZenML Secret to the run metadata.

Fixes https://github.com/zenml-io/zenml/issues/2443

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

