### PR TITLE
Use canonical way of checking for Docker

### DIFF
--- a/src/zenml/utils/docker_utils.py
+++ b/src/zenml/utils/docker_utils.py
@@ -28,6 +28,7 @@ from typing import (
     cast,
 )
 
+import docker
 from docker.client import DockerClient
 from docker.utils import build as docker_build_utils
 
@@ -46,7 +47,7 @@ def check_docker() -> bool:
     """
     # Try to ping Docker, to see if it's running
     try:
-        docker_client = DockerClient.from_env()
+        docker_client = docker.from_env()
         docker_client.ping()
         return True
     except Exception:
@@ -227,7 +228,7 @@ def build_image(
 
     logger.info("Building the image might take a while...")
 
-    docker_client = DockerClient.from_env()
+    docker_client = docker.from_env()
     # We use the client api directly here, so we can stream the logs
     output_stream = docker_client.images.client.api.build(
         fileobj=build_context,
@@ -258,7 +259,7 @@ def push_image(
         RuntimeError: If fetching the repository digest of the image failed.
     """
     logger.info("Pushing Docker image `%s`.", image_name)
-    docker_client = docker_client or DockerClient.from_env()
+    docker_client = docker_client or docker.from_env()
     output_stream = docker_client.images.push(image_name, stream=True)
     aux_info = _process_stream(output_stream)
     logger.info("Finished pushing Docker image.")
@@ -283,7 +284,7 @@ def tag_image(image_name: str, target: str) -> None:
         image_name: The name of the image to tag.
         target: The full target name including a tag.
     """
-    docker_client = DockerClient.from_env()
+    docker_client = docker.from_env()
     image = docker_client.images.get(image_name)
     image.tag(target)
 
@@ -298,7 +299,7 @@ def get_image_digest(image_name: str) -> Optional[str]:
         Returns the repo digest for the given image if there exists exactly one.
         If there are zero or multiple repo digests, returns `None`.
     """
-    docker_client = DockerClient.from_env()
+    docker_client = docker.from_env()
     image = docker_client.images.get(image_name)
     repo_digests = image.attrs["RepoDigests"]
     if len(repo_digests) == 1:
@@ -321,7 +322,7 @@ def is_local_image(image_name: str) -> bool:
     Returns:
         `True` if the image was pulled from a registry, `False` otherwise.
     """
-    docker_client = DockerClient.from_env()
+    docker_client = docker.from_env()
     images = docker_client.images.list(name=image_name)
     if images:
         # An image with this name is available locally -> now check whether it


### PR DESCRIPTION
I quite often find that ZenML is unable to detect the Docker daemon on my (intel) Mac. The official docs for the `docker` package suggests that this way is what they recommend to create a client instance, and for me then it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved Docker operations by optimizing the method for environment-based Docker client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->