### PR TITLE
Telemetry guarding for CI & editable installs

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v5.0.0
         with:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -30,6 +30,9 @@ jobs:
         run: bash scripts/docstring.sh
   sqlite-db-migration-testing:
     runs-on: ubuntu-dind-runners
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      ZENML_DEBUG: true
     # if team member commented, not a draft, on a PR, using /fulltest
     if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ubuntu-dind-runners
     steps:
       - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v5.0.0
         with:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -54,6 +54,9 @@ jobs:
   sqlite-db-migration-testing:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      ZENML_DEBUG: true
     runs-on: ubuntu-dind-runners
     steps:
       - uses: actions/checkout@v4.1.1
@@ -63,9 +66,6 @@ jobs:
           python-version: '3.9'
       - name: Test migrations across versions
         run: bash scripts/test-migrations-mysql.sh sqlite
-        env:
-          ZENML_ANALYTICS_OPT_IN: false
-          ZENML_DEBUG: true
   small-checks:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -63,6 +63,9 @@ jobs:
           python-version: '3.9'
       - name: Test migrations across versions
         run: bash scripts/test-migrations-mysql.sh sqlite
+        env:
+          ZENML_ANALYTICS_OPT_IN: false
+          ZENML_DEBUG: true
   small-checks:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
         run: pip check
   mysql-db-migration-testing:
     runs-on: ubuntu-dind-runners
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
@@ -41,6 +44,9 @@ jobs:
         run: bash scripts/test-migrations-mysql.sh mysql
   sqlite-db-migration-testing:
     runs-on: ubuntu-dind-runners
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
@@ -52,6 +58,9 @@ jobs:
         run: bash scripts/test-migrations-mysql.sh sqlite
   mariadb-db-migration-testing:
     runs-on: ubuntu-dind-runners
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v5.0.0
         with:
@@ -50,6 +52,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v5.0.0
         with:
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Set up Python 3.9
         uses: actions/setup-python@v4.8.0
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Run unit tests
         run: |
           bash scripts/test-coverage-xml.sh unit
+        env:
+          ZENML_ANALYTICS_OPT_IN: false
+          ZENML_DEBUG: true
 
       # - name: Upload coverage
       #  # only do it for python 3.8, we don't need to do it for every version

--- a/scripts/test-migrations-mariadb.sh
+++ b/scripts/test-migrations-mariadb.sh
@@ -33,6 +33,10 @@ function run_tests_for_version() {
 }
 
 echo "===== Testing MariaDB ====="
+
+export ZENML_ANALYTICS_OPT_IN=false
+export ZENML_DEBUG=true
+
 # run a mariadb instance in docker
 docker run --name mariadb -d -p 3306:3306 -e MYSQL_ROOT_PASSWORD=password mariadb:10.6
 # mariadb takes a while to start up
@@ -54,6 +58,9 @@ do
     # Install the specific version
     pip3 install -U pip setuptools wheel
     pip3 install "zenml[templates,server]==$VERSION"
+
+    export ZENML_ANALYTICS_OPT_IN=false
+    export ZENML_DEBUG=true
 
     zenml connect --url mysql://127.0.0.1/zenml --username root --password password
 

--- a/scripts/test-migrations-mariadb.sh
+++ b/scripts/test-migrations-mariadb.sh
@@ -57,7 +57,9 @@ do
 
     # Install the specific version
     pip3 install -U pip setuptools wheel
-    pip3 install "zenml[templates,server]==$VERSION"
+    
+    git checkout release/$VERSION
+    pip3 install -e ".[templates,server]"
 
     export ZENML_ANALYTICS_OPT_IN=false
     export ZENML_DEBUG=true

--- a/scripts/test-migrations-mysql.sh
+++ b/scripts/test-migrations-mysql.sh
@@ -3,6 +3,9 @@
 DB="sqlite"
 DB_STARTUP_DELAY=30 # Time in seconds to wait for the database container to start
 
+export ZENML_ANALYTICS_OPT_IN=false
+export ZENML_DEBUG=true
+
 if [ -z "$1" ]; then
   echo "No argument passed, using default: $DB"
 else

--- a/scripts/test-migrations-mysql.sh
+++ b/scripts/test-migrations-mysql.sh
@@ -75,7 +75,9 @@ do
 
     # Install the specific version
     pip3 install -U pip setuptools wheel
-    pip3 install "zenml[templates,server]==$VERSION"
+
+    git checkout release/$VERSION
+    pip3 install -e ".[templates,server]"
     # handles unpinned sqlmodel dependency in older versions
     pip3 install "sqlmodel==0.0.8" "bcrypt==4.0.1"
 


### PR DESCRIPTION
This pull request adds extra telemetry guarding to the codebase. It also includes environment variables `ZENML_ANALYTICS_OPT_IN` and `ZENML_DEBUG` with their respective values set to `false` and `true`. This applies to the CI systems in action.

Also uses editable installs for DB testing (was installing from PyPI previously).