### PR TITLE
Prevent templates update from formatting the whole codebase

### DIFF
--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -70,7 +70,7 @@ jobs:
           mkdir -p examples/e2e
           printf 'info@zenml.io' | zenml init --path examples/e2e --template e2e_batch --template-with-defaults
           pip install yamlfix
-          bash scripts/format.sh
+          bash scripts/format.sh examples/e2e
       - name: Check for changes
         id: check_changes
         run: |
@@ -141,7 +141,7 @@ jobs:
           mkdir -p examples/e2e_nlp
           printf 'info@zenml.io' | zenml init --path examples/e2e_nlp --template nlp --template-with-defaults
           pip install yamlfix
-          bash scripts/format.sh
+          bash scripts/format.sh examples/e2e_nlp
       - name: Check for changes
         id: check_changes
         run: |
@@ -214,7 +214,7 @@ jobs:
           mkdir -p examples/quickstart
           printf 'info@zenml.io' | zenml init --path examples/quickstart --template starter --template-with-defaults
           pip install yamlfix
-          bash scripts/format.sh
+          bash scripts/format.sh examples/quickstart
       - name: Check for changes
         id: check_changes
         run: |


### PR DESCRIPTION
## Describe changes
Currently on template update a `bash scripts/format.sh`, which formats all the code in the repo. This PR limits such calls only to template directories.

Misuse example: https://github.com/zenml-io/zenml/pull/2312/commits/24f30a751b265cc5b4a062ba627f4deb4e89ab5e

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

