### PR TITLE
Mount zenml config path as empty dir

### DIFF
--- a/src/zenml/zen_server/deploy/helm/templates/server-db-job.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-db-job.yaml
@@ -32,9 +32,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-
-      {{- if eq .Values.zenml.database.backupStrategy "dump-file" }}
       volumes:
+        - name: zenml-config
+          emptyDir: {}
+      {{- if eq .Values.zenml.database.backupStrategy "dump-file" }}
         # define a volume that will hold a backup of the database
         - name: db-backup
         # if a storage PVC is configured, then use it
@@ -55,8 +56,10 @@ spec:
           imagePullPolicy: {{ .Values.zenml.image.pullPolicy }}
           args: ["migrate-database"]
           command: ['zenml']
-          {{- if eq .Values.zenml.database.backupStrategy "dump-file" }}
           volumeMounts:
+            - name: zenml-config
+              mountPath: /zenml/.zenconfig
+          {{- if eq .Values.zenml.database.backupStrategy "dump-file" }}
             - name: db-backup
               mountPath: /backups
           {{- end }}

--- a/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
@@ -32,12 +32,18 @@ spec:
       serviceAccountName: {{ include "zenml.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: zenml-config
+          emptyDir: {}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.zenml.image.repository }}:{{ .Values.zenml.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.zenml.image.pullPolicy }}
+          volumeMounts:
+            - name: zenml-config
+              mountPath: /zenml/.zenconfig
           env:
             {{- if .Values.zenml.debug }}
             - name: ZENML_LOGGING_VERBOSITY


### PR DESCRIPTION
## Describe changes
To make the helm chart by default compatible with more restrictive cluster security policies that prevent containers from writing to paths that are not mounted as volumes.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

