### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/book/user-guide/production-guide/cloud-orchestration.md
+++ b/docs/book/user-guide/production-guide/cloud-orchestration.md
@@ -8,8 +8,8 @@ Until now, we've only run pipelines locally. The next step is to get free from o
 
 In order to do this, we need to get familiar with two more stack components: 
 
-- The [orchestrator](../../stacks-and-components/component-guide/orchestrators) manages the workflow and execution of your pipelines.
-- The [container registry](../../stacks-and-components/component-guide/container-registries) is a storage and content delivery system that holds your Docker container images.
+- The [orchestrator](../../stacks-and-components/component-guide/orchestrators/orchestrators.md) manages the workflow and execution of your pipelines.
+- The [container registry](../../stacks-and-components/component-guide/container-registries/container-registries.md) is a storage and content delivery system that holds your Docker container images.
 
 These, along with [remote storage](remote-storage.md), complete a basic cloud stack where our pipeline is entirely running on the cloud. 
 
@@ -48,7 +48,7 @@ Before we start registering any components, there is another step that we have
 to execute. As we [explained in the previous section](./remote-storage.md#configuring-permissions-with-your-first-service-connector), 
 components such as orchestrators and container registries often require you to 
 set up the right permissions. In ZenML, this process is simplified with the 
-use of [Service Connectors](../../stacks-and-components/auth-management). 
+use of [Service Connectors](../../stacks-and-components/auth-managemen/auth-management.md). 
 For this example, we need to use the [IAM role authentication method 
 of our AWS service connector](../../stacks-and-components/auth-management/aws-service-connector.md#aws-iam-role):
 
@@ -88,7 +88,7 @@ Before we start registering any components, there is another step that we have
 to execute. As we [explained in the previous section](./remote-storage.md#configuring-permissions-with-your-first-service-connector), 
 components such as orchestrators and container registries often require you to 
 set up the right permissions. In ZenML, this process is simplified with the 
-use of [Service Connectors](../../stacks-and-components/auth-management). 
+use of [Service Connectors](../../stacks-and-components/auth-management/auth-management.md). 
 For this example, we need to use the [Service Account authentication feature 
 of our GCP service connector](../../stacks-and-components/auth-management/gcp-service-connector.md#gcp-service-account):
 
@@ -128,7 +128,7 @@ Before we start registering any components, there is another step that we have
 to execute. As we [explained in the previous section](./remote-storage.md#configuring-permissions-with-your-first-service-connector), 
 components such as orchestrators and container registries often require you to 
 set up the right permissions. In ZenML, this process is simplified with the 
-use of [Service Connectors](../../stacks-and-components/auth-management). 
+use of [Service Connectors](../../stacks-and-components/auth-management/auth-management.md). 
 For this example, we will need to use the [Service Principal authentication 
 feature of our Azure service connector](../../stacks-and-components/auth-management/azure-service-connector.md#azure-service-principal):
 
@@ -159,7 +159,7 @@ For more information, you can always check the [dedicated Skypilot orchestrator 
 {% endtabs %}
 
 {% hint style="info" %}
-Having trouble with setting up infrastructure? Try reading the [stack deployment](../../stacks-and-components/stack-deployment) section of the docs to gain more insight. If that still doesn't work, join the [ZenML community](https://zenml.io/slack) and ask!
+Having trouble with setting up infrastructure? Try reading the [stack deployment](../../stacks-and-components/stack-deployment/stack-deployment.md) section of the docs to gain more insight. If that still doesn't work, join the [ZenML community](https://zenml.io/slack) and ask!
 {% endhint %}
 
 ## Running a pipeline on a cloud stack

--- a/docs/book/user-guide/production-guide/cloud-orchestration.md
+++ b/docs/book/user-guide/production-guide/cloud-orchestration.md
@@ -8,8 +8,8 @@ Until now, we've only run pipelines locally. The next step is to get free from o
 
 In order to do this, we need to get familiar with two more stack components: 
 
-- The [orchestrator](../../stacks-and-components/component-guide/orchestrators/) manages the workflow and execution of your pipelines.
-- The [container registry](../../stacks-and-components/component-guide/container-registries/) is a storage and content delivery system that holds your Docker container images.
+- The [orchestrator](../../stacks-and-components/component-guide/orchestrators) manages the workflow and execution of your pipelines.
+- The [container registry](../../stacks-and-components/component-guide/container-registries) is a storage and content delivery system that holds your Docker container images.
 
 These, along with [remote storage](remote-storage.md), complete a basic cloud stack where our pipeline is entirely running on the cloud. 
 
@@ -159,7 +159,7 @@ For more information, you can always check the [dedicated Skypilot orchestrator 
 {% endtabs %}
 
 {% hint style="info" %}
-Having trouble with setting up infrastructure? Try reading the [stack deployment](../../stacks-and-components/stack-deployment/) section of the docs to gain more insight. If that still doesn't work, join the [ZenML community](https://zenml.io/slack) and ask!
+Having trouble with setting up infrastructure? Try reading the [stack deployment](../../stacks-and-components/stack-deployment) section of the docs to gain more insight. If that still doesn't work, join the [ZenML community](https://zenml.io/slack) and ask!
 {% endhint %}
 
 ## Running a pipeline on a cloud stack
@@ -192,7 +192,7 @@ python run.py --training-pipeline
  
 You will notice this time your pipeline behaves differently. After it has built the Docker image with all your code, it will push that image, and run a VM on the cloud. Here is where your pipeline will execute, and the logs will be streamed back to you. So with a few commands, we were able to ship our entire code to the cloud!
 
-Curious to see what other stacks you can create? The [Component Guide](../../stacks-and-components/component-guide/) has an exhaustive list of various artifact stores, container registries, and orchestrators that are integrated with ZenML. Try playing around with more stack components to see how easy it is to switch between MLOps stacks with ZenML.
+Curious to see what other stacks you can create? The [Component Guide](../../stacks-and-components/component-guide/component-guide.md) has an exhaustive list of various artifact stores, container registries, and orchestrators that are integrated with ZenML. Try playing around with more stack components to see how easy it is to switch between MLOps stacks with ZenML.
 
 <!-- For scarf -->
 <figure><img alt="ZenML Scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" /></figure>


### PR DESCRIPTION
As per Slack message:

> "FYI, several documentation links are referencing non-existing README files from the repo, for example https://docs.zenml.io/user-guide/production-guide/cloud-orchestration has a link to https://github.com/zenml-io/zenml/blob/release/0.55.3/docs/book/stacks-and-components/component-guide/orchestrators/README.md which does not exist (I've seen more examples like this)"