### PR TITLE
Use `uv pip compile` for environment setup in CI

### DIFF
--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -27,8 +27,12 @@ install_zenml() {
     touch zenml_requirements.txt
     echo "-e .[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]" >> zenml_requirements.txt
 
-    pip install -r zenml_requirements.txt
+    cp zenml_requirements.txt zenml_requirements.in
+    uv pip compile zenml_requirements.in -o zenml_requirements-compiled.txt
+
+    pip install -r zenml_requirements-compiled.txt
     rm zenml_requirements.txt
+    rm zenml_requirements.in
 }
 
 install_integrations() {

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -87,7 +87,7 @@ export ZENML_ANALYTICS_OPT_IN=false
 
 parse_args "$@"
 
-python -m pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade pip setuptools wheel uv
 
 install_zenml
 

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -73,9 +73,6 @@ install_integrations() {
     rm integration-requirements.txt
     rm integration-requirements.in
     rm integration-requirements-compiled.txt
-
-    # install langchain separately
-    zenml integration install -y langchain
 }
 
 
@@ -94,7 +91,4 @@ install_zenml
 # install integrations, if requested
 if [ "$INTEGRATIONS" = yes ]; then
     install_integrations
-
-    # refresh the ZenML installation after installing integrations
-    install_zenml
 fi

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -6,7 +6,7 @@ parse_args () {
     while [ $# -gt 0 ]; do
         case $1 in
             -i|--integrations)
-                INTEGRATIONS="yes"
+                INTEGRATIONS="$2"
                 shift # past argument
                 shift # past value
                 ;;
@@ -22,6 +22,8 @@ parse_args () {
 }
 
 install_zenml() {
+    # install ZenML in editable mode
+
     touch zenml_requirements.txt
     echo "-e .[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]" >> zenml_requirements.txt
 
@@ -31,24 +33,32 @@ install_zenml() {
     pip install -r zenml_requirements-compiled.txt
     rm zenml_requirements.txt
     rm zenml_requirements.in
-    rm zenml_requirements-compiled.txt # Ensure this file is also removed after installation
 }
 
 install_integrations() {
+
+    # figure out the python version
     python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 
     ignore_integrations="feast label_studio bentoml seldon kserve pycaret skypilot_aws skypilot_gcp skypilot_azure"
+    # if python version is 3.11, exclude all integrations depending on kfp
+    # because they are not yet compatible with python 3.11
     if [ "$python_version" = "3.11" ]; then
         ignore_integrations="$ignore_integrations kubeflow tekton gcp"
     fi
 
+    # turn the ignore integrations into a list of --ignore-integration args
     ignore_integrations_args=""
     for integration in $ignore_integrations; do
         ignore_integrations_args="$ignore_integrations_args --ignore-integration $integration"
     done
 
-    zenml integration export-requirements --output-file integration-requirements.txt $ignore_integrations_args
+    # install basic ZenML integrations
+    zenml integration export-requirements \
+        --output-file integration-requirements.txt \
+        $ignore_integrations_args
 
+    # pin pyyaml>=6.0.1
     echo "" >> integration-requirements.txt
     echo "pyyaml>=6.0.1" >> integration-requirements.txt
     echo "pyopenssl" >> integration-requirements.txt
@@ -65,6 +75,7 @@ install_integrations() {
     rm integration-requirements-compiled.txt
 }
 
+
 set -x
 set -e
 
@@ -75,9 +86,9 @@ parse_args "$@"
 
 python -m pip install --upgrade pip setuptools wheel uv
 
-# Conditionally install ZenML or ZenML with integrations
-if [ "$INTEGRATIONS" = "yes" ]; then
+install_zenml
+
+# install integrations, if requested
+if [ "$INTEGRATIONS" = yes ]; then
     install_integrations
-else
-    install_zenml
 fi

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -6,7 +6,7 @@ parse_args () {
     while [ $# -gt 0 ]; do
         case $1 in
             -i|--integrations)
-                INTEGRATIONS="$2"
+                INTEGRATIONS="yes"
                 shift # past argument
                 shift # past value
                 ;;
@@ -22,8 +22,6 @@ parse_args () {
 }
 
 install_zenml() {
-    # install ZenML in editable mode
-
     touch zenml_requirements.txt
     echo "-e .[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]" >> zenml_requirements.txt
 
@@ -33,32 +31,24 @@ install_zenml() {
     pip install -r zenml_requirements-compiled.txt
     rm zenml_requirements.txt
     rm zenml_requirements.in
+    rm zenml_requirements-compiled.txt # Ensure this file is also removed after installation
 }
 
 install_integrations() {
-
-    # figure out the python version
     python_version=$(python -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 
     ignore_integrations="feast label_studio bentoml seldon kserve pycaret skypilot_aws skypilot_gcp skypilot_azure"
-    # if python version is 3.11, exclude all integrations depending on kfp
-    # because they are not yet compatible with python 3.11
     if [ "$python_version" = "3.11" ]; then
         ignore_integrations="$ignore_integrations kubeflow tekton gcp"
     fi
 
-    # turn the ignore integrations into a list of --ignore-integration args
     ignore_integrations_args=""
     for integration in $ignore_integrations; do
         ignore_integrations_args="$ignore_integrations_args --ignore-integration $integration"
     done
 
-    # install basic ZenML integrations
-    zenml integration export-requirements \
-        --output-file integration-requirements.txt \
-        $ignore_integrations_args
+    zenml integration export-requirements --output-file integration-requirements.txt $ignore_integrations_args
 
-    # pin pyyaml>=6.0.1
     echo "" >> integration-requirements.txt
     echo "pyyaml>=6.0.1" >> integration-requirements.txt
     echo "pyopenssl" >> integration-requirements.txt
@@ -75,7 +65,6 @@ install_integrations() {
     rm integration-requirements-compiled.txt
 }
 
-
 set -x
 set -e
 
@@ -86,9 +75,9 @@ parse_args "$@"
 
 python -m pip install --upgrade pip setuptools wheel uv
 
-install_zenml
-
-# install integrations, if requested
-if [ "$INTEGRATIONS" = yes ]; then
+# Conditionally install ZenML or ZenML with integrations
+if [ "$INTEGRATIONS" = "yes" ]; then
     install_integrations
+else
+    install_zenml
 fi

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -38,8 +38,6 @@ class MlflowIntegration(Integration):
         "mlflow>=2.1.1,<=2.10.2",
         "mlserver>=1.3.3",
         "mlserver-mlflow>=1.3.3",
-        # TODO: remove this requirement once rapidjson is fixed
-        "python-rapidjson<1.15",
     ]
 
     @classmethod

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -38,6 +38,8 @@ class MlflowIntegration(Integration):
         "mlflow>=2.1.1,<=2.10.2",
         "mlserver>=1.3.3",
         "mlserver-mlflow>=1.3.3",
+        # TODO: remove this requirement once rapidjson is fixed
+        "python-rapidjson<1.15",
     ]
 
     @classmethod


### PR DESCRIPTION
We now use `uv pip compile` to resolve all our installations on runners for testing in setup.

This allows our CI to install everything, but has the downside that we're starting to depart a bit from the tooling that users would / do use to install zenml (i.e. `pip`). On the other side of that is the fact that previously as per the original setup behaviour, we actually install zenml in a way that no user would -- i.e. almost all integrations in the same environment, and the same with all extras -- but probably for the moment the tradeoff of this update / change.

We're also now installing zenml as well as langchain during the integration installation function, so I removed the duplicate installation steps for both.