### PR TITLE
Race condition on creating new users allows duplicate usernames

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5156,7 +5156,8 @@ class SqlZenStore(BaseZenStore):
             # exists
             service_accounts = session.execute(
                 select(UserSchema).where(
-                    UserSchema.name == service_account.name
+                    UserSchema.name == service_account.name,
+                    UserSchema.is_service_account.is_(True),  # type: ignore[attr-defined]
                 )
             ).fetchall()
             if len(service_accounts) == 1:
@@ -7354,7 +7355,10 @@ class SqlZenStore(BaseZenStore):
 
             # Check if a user account with the given name already exists
             users = session.execute(
-                select(UserSchema).where(UserSchema.name == user.name)
+                select(UserSchema).where(
+                    UserSchema.name == user.name,
+                    UserSchema.is_service_account.is_(False),  # type: ignore[attr-defined]
+                )
             ).fetchall()
             if len(users) == 1:
                 session.commit()

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -12,11 +12,11 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import os
-import threading
 import time
 import uuid
 from contextlib import ExitStack as does_not_raise
 from datetime import datetime
+from threading import Thread
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
@@ -416,6 +416,10 @@ def test_creating_users_in_parallel_do_not_duplicate_fails(
     """Tests creating a user with an existing username fails in parallel mode."""
 
     def silent_create_user(user_request: UserRequest):
+        """This function attempts to create a user and silently passes
+        if a duplicate user exists. This is used to simulate race
+        conditions in parallel user creation.
+        """
         try:
             clean_client.zen_store.create_user(user_request)
         except EntityExistsError:
@@ -425,9 +429,9 @@ def test_creating_users_in_parallel_do_not_duplicate_fails(
     password = "P@ssw0rd"
     count = 100
 
-    threads: List[threading.Thread] = []
+    threads: List[Thread] = []
     for _ in range(count):
-        t = threading.Thread(
+        t = Thread(
             target=silent_create_user,
             args=(UserRequest(name=user_name, password=password),),
         )
@@ -451,6 +455,10 @@ def test_creating_service_accounts_in_parallel_do_not_duplicate_fails(
     def silent_create_service_account(
         service_account_request: ServiceAccountRequest,
     ):
+        """This function attempts to create a service account and silently
+        passes if a duplicate user exists. This is used to simulate race
+        conditions in parallel user creation.
+        """
         try:
             clean_client.zen_store.create_service_account(
                 service_account_request
@@ -461,9 +469,9 @@ def test_creating_service_accounts_in_parallel_do_not_duplicate_fails(
     user_name = "test_user"
     count = 100
 
-    threads: List[threading.Thread] = []
+    threads: List[Thread] = []
     for _ in range(count):
-        t = threading.Thread(
+        t = Thread(
             target=silent_create_service_account,
             args=(ServiceAccountRequest(name=user_name, active=True),),
         )


### PR DESCRIPTION
## Describe changes
I fixed the conditional check for new users/service account creation under heavy race conditions (e.g. 100 simultaneous request to create new user).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling and creation process of entities within the system to prevent duplication and enhance error management.
- **Tests**
	- Added tests to ensure users and service accounts can be created in parallel without duplication, enhancing system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->