### PR TITLE
Don't write the global config to file on server

### DIFF
--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -304,6 +304,16 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
 
     def _write_config(self) -> None:
         """Writes the global configuration options to disk."""
+        # We never write the configuration file in a ZenML server environment
+        # because this is a long-running process and the global configuration
+        # variables are supplied via environment variables.
+        if ENV_ZENML_SERVER in os.environ:
+            logger.info(
+                "Not writing the global configuration to disk in a ZenML "
+                "server environment."
+            )
+            return
+
         config_file = self._config_file
         yaml_dict = json.loads(self.json(exclude_none=True))
         logger.debug(f"Writing config to {config_file}")

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -39,7 +39,7 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import SecretStr, root_validator, validator
+from pydantic import Field, SecretStr, root_validator, validator
 from sqlalchemy import asc, desc, func
 from sqlalchemy.engine import URL, Engine, make_url
 from sqlalchemy.exc import (
@@ -384,9 +384,11 @@ class SqlZenStoreConfiguration(StoreConfiguration):
 
     backup_strategy: DatabaseBackupStrategy = DatabaseBackupStrategy.IN_MEMORY
     # database backup directory
-    backup_directory: str = os.path.join(
-        GlobalConfiguration().config_directory,
-        SQL_STORE_BACKUP_DIRECTORY_NAME,
+    backup_directory: str = Field(
+        default_factory=lambda: os.path.join(
+            GlobalConfiguration().config_directory,
+            SQL_STORE_BACKUP_DIRECTORY_NAME,
+        )
     )
     backup_database: Optional[str] = None
 


### PR DESCRIPTION
## Describe changes
To prevent accidentally leaking sensitive configuration information by exposing the global configuration file, the ZenML server doesn't dump any of its configuration to disk anymore.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

