### PR TITLE
Relax azure, gcfs and s3 dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ jinja2-time = { version = "^0.2.0", optional = true }
 python-terraform = { version = "^0.10.1", optional = true }
 
 # Optional dependencies for the AWS secrets store
-boto3 = { version = ">=1.16.0,<=1.24.59", optional = true }
+boto3 = { version = ">=1.16.0", optional = true }
 
 # Optional dependencies for the GCP secrets store
 google-cloud-secret-manager = { version = ">=2.12.5", optional = true }
@@ -112,10 +112,10 @@ azure-storage-blob = { version = ">=12.0.0", optional = true }
 azure-mgmt-resource = { version = ">=21.0.0", optional = true }
 
 # Optional dependencies for the S3 artifact store
-s3fs = { version = "2022.11.0", optional = true }
+s3fs = { version = ">=2022.11.0", optional = true }
 
 # Optional dependencies for the GCS artifact store
-gcsfs = { version = "2022.11.0", optional = true }
+gcsfs = { version = ">=2022.11.0", optional = true }
 
 # Optional dependencies for the Azure artifact store
 adlfs = { version = ">=2021.10.0", optional = true }

--- a/src/zenml/integrations/azure/__init__.py
+++ b/src/zenml/integrations/azure/__init__.py
@@ -39,7 +39,7 @@ class AzureIntegration(Integration):
 
     NAME = AZURE
     REQUIREMENTS = [
-        "adlfs==2021.10.0",
+        "adlfs>=2021.10.0",
         "azure-keyvault-keys",
         "azure-keyvault-secrets",
         "azure-identity==1.10.0",

--- a/src/zenml/integrations/huggingface/__init__.py
+++ b/src/zenml/integrations/huggingface/__init__.py
@@ -21,7 +21,11 @@ class HuggingfaceIntegration(Integration):
     """Definition of Huggingface integration for ZenML."""
 
     NAME = HUGGINGFACE
-    REQUIREMENTS = ["transformers<=4.31", "datasets"]
+    REQUIREMENTS = [
+        "transformers<=4.31",
+        "datasets",
+        "huggingface_hub>0.19.0",
+    ]
 
     @classmethod
     def activate(cls) -> None:

--- a/src/zenml/integrations/s3/__init__.py
+++ b/src/zenml/integrations/s3/__init__.py
@@ -41,8 +41,8 @@ class S3Integration(Integration):
     # The above command installs boto3==1.26.76, so we use the same version
     # here to avoid the dependency resolution overhead.
     REQUIREMENTS = [
-        "s3fs>2022.3.0,<=2023.4.0",
-        "boto3<=1.26.76",
+        "s3fs>2022.3.0",
+        "boto3",
         # The following dependencies are only required for the AWS connector.
         "aws-profile-manager",
     ]


### PR DESCRIPTION
This pull request updates the version requirements for the azure, gcfs, and s3 dependencies to allow for more flexibility in the versions used.

In particular, this would unblock https://github.com/zenml-io/zenml/pull/2376.