### PR TITLE
Use HTTP forwarded headers to detect the real origin of client devices

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -35,4 +35,4 @@ RUN mkdir -p /zenml/.zenconfig/local_stores/default_zen_store && chown -R $USER_
 ENV PATH="$PATH:/home/$USERNAME/.local/bin"
 
 ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "debug"]
-CMD ["--proxy-headers", "--port", "8080", "--host",  "0.0.0.0"]
+CMD ["--port", "8080", "--host",  "0.0.0.0"]

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -43,4 +43,4 @@ ENV ZENML_CONFIG_PATH=/zenml/.zenconfig \
     ZENML_ANALYTICS_OPT_IN=false
 
 ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "debug"]
-CMD ["--proxy-headers", "--port", "8080", "--host",  "0.0.0.0"]
+CMD ["--port", "8080", "--host",  "0.0.0.0"]

--- a/docker/zenml-server-hf-spaces.Dockerfile
+++ b/docker/zenml-server-hf-spaces.Dockerfile
@@ -60,4 +60,4 @@ ENV ZENML_SERVER_DEPLOYMENT_TYPE="hf_spaces"
 # ENV ZENML_SECRETS_STORE_MAX_VERSIONS=""
 
 ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app",  "--log-level", "debug"]
-CMD ["--proxy-headers", "--port", "8080", "--host",  "0.0.0.0"]
+CMD ["--port", "8080", "--host",  "0.0.0.0"]

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -406,8 +406,14 @@ def device_authorization(
     # Fetch the IP address of the client
     ip_address: str = ""
     city, region, country = "", "", ""
-    if request.client and request.client.host:
+    forwarded = request.headers.get("X-Forwarded-For")
+
+    if forwarded:
+        ip_address = forwarded.split(",")[0].strip()
+    elif request.client and request.client.host:
         ip_address = request.client.host
+
+    if ip_address:
         city, region, country = get_ip_location(ip_address)
 
     # Check if a device is already registered for the same client ID.


### PR DESCRIPTION
## Describe changes
When the zenml server is deployed behind a proxy, the source IP of requests is actually the IP address of the proxy. We use `X-Forwarded-For` HTTP headers set by the proxy to extract the real source IP of the client.

Based on the official uvicorn documentation, `--proxy-headers` is set by default, so there's no need to enable it explicitly in the Dockerfiles.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

