### PR TITLE
[HELM] Remove extra environment variable assignment

### DIFF
--- a/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
+++ b/src/zenml/zen_server/deploy/helm/templates/server-deployment.yaml
@@ -91,10 +91,6 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.zenml.baseURL }}
-            - name: ZENML_SERVER_BASE_URL
-              value: {{ .Values.zenml.baseURL | quote }}
-            {{- end }}
           envFrom:
           - secretRef:
               name: {{ include "zenml.fullname" . }}


### PR DESCRIPTION
## Describe changes
I fixed the helm chart to no longer assign the `ZENML_SERVER_BASE_URL` variable twice, which leads to errors when upgrading.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

