### PR TITLE
Fix bug in HyperAI orchestrator depends_on parallelism

### DIFF
--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -230,17 +230,23 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
 
             # Add dependency on upstream steps if applicable
             upstream_steps = step.spec.upstream_steps
-            for upstream_step_name in upstream_steps:
-                upstream_container_name = (
-                    f"{deployment_id}-{upstream_step_name}"
-                )
+
+            if len(upstream_steps) > 0:
                 compose_definition["services"][container_name][
                     "depends_on"
-                ] = {
-                    upstream_container_name: {
-                        "condition": "service_completed_successfully"
-                    }
-                }
+                ] = {}
+
+                for upstream_step_name in upstream_steps:
+                    upstream_container_name = (
+                        f"{deployment_id}-{upstream_step_name}"
+                    )
+                    compose_definition["services"][container_name][
+                        "depends_on"
+                    ].update({
+                        upstream_container_name: {
+                            "condition": "service_completed_successfully"
+                        }
+                    })
 
         # Convert into yaml
         logger.info("Finalizing Docker Compose definition.")

--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -224,9 +224,9 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
                     ".env"
                 ]
 
-            compose_definition["services"][container_name][
-                "environment"
-            ] = environment
+            compose_definition["services"][container_name]["environment"] = (
+                environment
+            )
 
             # Add dependency on upstream steps if applicable
             upstream_steps = step.spec.upstream_steps

--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -224,9 +224,9 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
                     ".env"
                 ]
 
-            compose_definition["services"][container_name]["environment"] = (
-                environment
-            )
+            compose_definition["services"][container_name][
+                "environment"
+            ] = environment
 
             # Add dependency on upstream steps if applicable
             upstream_steps = step.spec.upstream_steps
@@ -242,11 +242,13 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
                     )
                     compose_definition["services"][container_name][
                         "depends_on"
-                    ].update({
-                        upstream_container_name: {
-                            "condition": "service_completed_successfully"
+                    ].update(
+                        {
+                            upstream_container_name: {
+                                "condition": "service_completed_successfully"
+                            }
                         }
-                    })
+                    )
 
         # Convert into yaml
         logger.info("Finalizing Docker Compose definition.")


### PR DESCRIPTION
## Describe changes
There is a newly discovered issue with the HyperAI orchestrator which leads to unexpected behavior when a step depends on multiple previous steps. Upon investigation a bug was identified as currently the `depends_on` dict that eventually leads to the Docker Compose file is overwritten for every step a downstream one is dependent on. This PR fixes the issue by first initializing the dict to an empty one if it discovers that a step is dependent on others; then adds them one by one by updating it. I have just tested locally with the following Compose file, and multi-container dependency works nicely, so the fix also works Docker side.


```
version: '3.8'
services:
  hello-world:
    image: busybox
    command: /bin/sh -c "sleep 30"
  hello-world2:
    image: hello-world
  hello-world3:
    image: hello-world
    depends_on:
      hello-world:
        condition: service_completed_successfully
      hello-world2:
        condition: service_completed_successfully
```

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

