### PR TITLE
Bump mlflow to version 2.11.1

### DIFF
--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -35,7 +35,7 @@ class MlflowIntegration(Integration):
     # does not pin it. They fixed this in a later version, so we can probably
     # remove this once we update the mlflow version.
     REQUIREMENTS = [
-        "mlflow>=2.1.1,<=2.10.2",
+        "mlflow>=2.1.1,<=2.11.1",
         "mlserver>=1.3.3",
         "mlserver-mlflow>=1.3.3",
         # TODO: remove this requirement once rapidjson is fixed


### PR DESCRIPTION
## Describe changes
This PR bumps `mlflow` to version `2.11.1`.

I just ran the same test pipeline we're always running when bumping `mlflow` and it completed successfully including writing all metrics and artifacts to our MLFlow instance.

![image](https://github.com/zenml-io/zenml/assets/6450612/acc7363e-7975-4b06-99ed-b08cc047a678)

![image](https://github.com/zenml-io/zenml/assets/6450612/10e955fd-826f-4df8-bd33-7336466fd700)



## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

