### PR TITLE
Fix config file in starter guide

### DIFF
--- a/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
+++ b/docs/book/user-guide/starter-guide/create-an-ml-pipeline.md
@@ -260,10 +260,8 @@ check them into git history.
 A simple version of such a YAML file could be:
 
 ```yaml
-steps:
-  svc_trainer:
-    parameters:
-      gamma: 0.01
+parameters:
+    gamma: 0.01
 ```
 
 Please note that this would take precedence over any parameters passed in the code.


### PR DESCRIPTION
## Describe changes
The current configuration lead to an error as the `gamma` value was supplied both in code (passed from the pipeline paramter) as well as in the config file. I changed the config file to supply a pipeline paramter instead of a step paramter to fix this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

