### PR TITLE
Bump MLFlow to version 2.11.2

### DIFF
--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -35,7 +35,7 @@ class MlflowIntegration(Integration):
     # does not pin it. They fixed this in a later version, so we can probably
     # remove this once we update the mlflow version.
     REQUIREMENTS = [
-        "mlflow>=2.1.1,<=2.11.1",
+        "mlflow>=2.1.1,<=2.11.2",
         "mlserver>=1.3.3",
         "mlserver-mlflow>=1.3.3",
         # TODO: remove this requirement once rapidjson is fixed


### PR DESCRIPTION
## Describe changes
This PR bumps `mlflow` to version `2.11.2`.

As usual, I ran my test pipeline and verified that everything works and ends up in MLFlow. It works nicely, but this is not unexpected given the fact that there seem to be no breaking changes.

![image](https://github.com/zenml-io/zenml/assets/6450612/06972be0-c520-415f-8bf8-93fcee99f418)

![image](https://github.com/zenml-io/zenml/assets/6450612/7de69a7a-556f-4f96-9443-d3efae3c2cb8)


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

