### PR TITLE
Add VS Code extension to README / docs (#2568)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
     🎉 Version 0.56.2 is out. Check out the release notes
     <a href="https://github.com/zenml-io/zenml/releases">here</a>.
     <br />
+    🖥️ Download our VS Code Extension <a href="https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode">here</a>.
     <br />
   </p>
 </div>
@@ -222,6 +223,21 @@ For inspiration, here are some other examples and use cases:
 2. [Basic NLP with BERT](examples/e2e_nlp/): Feature engineering, training, and inference focused on NLP.
 3. [LLM RAG Pipeline with Langchain and OpenAI](https://github.com/zenml-io/zenml-projects/tree/main/llm-agents): Using Langchain to create a simple RAG pipeline.
 4. [Huggingface Model to Sagemaker Endpoint](https://github.com/zenml-io/zenml-projects/tree/main/huggingface-sagemaker): Automated MLOps on Amazon Sagemaker and HuggingFace.
+
+# Use ZenML with VS Code
+
+ZenML has a [VS Code
+extension](https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode)
+that allows you to inspect your stacks and pipeline runs directly from your
+editor. The extension also allows you to switch your stacks without needing to
+type any CLI commands.
+
+<details>
+  <summary>🖥️ VS Code Extension in Action!</summary>
+  <div align="center">
+  <img width="60%" src="/docs/book/.gitbook/assets/zenml-extension-shortened.gif" alt="ZenML Extension">
+</div>
+</details>
 
 # 🗺 Roadmap
 

--- a/docs/book/getting-started/core-concepts.md
+++ b/docs/book/getting-started/core-concepts.md
@@ -161,12 +161,18 @@ With a deployed **ZenML Server**, users have the ability to create their own tea
 
 The **ZenML Dashboard** also communicates with **the ZenML Server** to visualize your _pipelines_, _stacks_, and _stack components_. The dashboard serves as a visual interface to showcase collaboration with ZenML. You can invite _users_, and share your stacks with them.
 
-When you start working with ZenML, you'll start with a local ZenML setup, and when you want to transition you will need to [deploy ZenML](../deploying-zenml/zenml-self-hosted/zenml-self-hosted.md). Don't worry though, there is a one-click way to do it which we'll learn about later.
+When you start working with ZenML, you'll start with a local ZenML setup, and
+when you want to transition you will need to [deploy
+ZenML](../deploying-zenml/zenml-self-hosted/zenml-self-hosted.md). Don't worry
+though, there is a one-click way to do it which we'll learn about later.
 
-#### ZenML Hub
+#### VS Code Extension
 
-The **ZenML Hub** is a central platform that enables our users to search, share and discover community-contributed code, such as flavors, materializers, and steps, that can be used across organizations. The goal is to allow our users to extend their ZenML experience by leveraging the community's diverse range of implementations.
-
-The ZenML Hub revolves around the concept of **plugins**, which can be made up of one or multiple ZenML entities, including flavors, materializers, and steps. Aside from the implementation of these entities, every plugin in the hub is also equipped with
+ZenML also provides a [VS Code
+extension](https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode)
+that allows you to interact with your ZenML stacks, runs and server directly
+from your VS Code editor. If you're working on code in your editor, you can
+easily switch and inspect the
+stacks you're using, delete and inspect pipelines as well as even switch stacks.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/user-guide/production-guide/understand-stacks.md
+++ b/docs/book/user-guide/production-guide/understand-stacks.md
@@ -251,4 +251,13 @@ To run a pipeline using the new stack:
 
 Keep this code handy as we'll be using it in the next chapters!
 
+### Switch stacks with our VS Code extension
+
+![GIF of our VS code extension, showing some of the uses of the sidebar](/docs/book/.gitbook/assets/zenml-extension-shortened.gif)
+
+If you are using [our VS Code extension](https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode), you can easily view and switch your
+stacks by opening the sidebar (click on the ZenML icon). You can then click on
+the stack you want to switch to as well as view the stack components it's made
+up of.
+
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/user-guide/starter-guide/fetching-pipelines.md
+++ b/docs/book/user-guide/starter-guide/fetching-pipelines.md
@@ -171,6 +171,17 @@ step = run.steps["first_step"]
 If you're only calling each step once inside your pipeline, the **invocation ID** will be the same as the name of your step. For more complex pipelines, check out [this page](../advanced-guide/pipelining-features/managing-steps.md#using-a-custom-step-invocation-id) to learn more about the invocation ID.
 {% endhint %}
 
+### Inspect pipeline runs with our VS Code extension
+
+![GIF of our VS code extension, showing some of the uses of the sidebar](/docs/book/.gitbook/assets/zenml-extension-shortened.gif)
+
+If you are using [our VS Code
+extension](https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode),
+you can easily view your pipeline runs by opening the sidebar (click on the
+ZenML icon). You can then click on any particular pipeline run to see its status
+and some other metadata. If you want to delete a run, you can also do so from
+the same sidebar view.
+
 ### Step information
 
 Similar to the run, you can use the `step` object to access a variety of useful information:


### PR DESCRIPTION
* add VS Code extension to our readme

* update docs

* update following PR comments

* add tiny preview section

* improve spacing

(cherry picked from commit 22c53b01b0064e076ea478bc0d562dc655b6bbfa)

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

