### PR TITLE
Make `secure` an optional import

### DIFF
--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
-          ref-template: '2024-04-05'  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
+          ref-template: 2024.04.05  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
       - name: Clean-up
         run: |
           rm -rf ./local_checkout
@@ -122,7 +122,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
-          ref-template: '2024-04-05'  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
+          ref-template: 2024.04.05  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
       - name: Clean-up
         run: |
           rm -rf ./local_checkout
@@ -266,7 +266,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           stack-name: local
           ref-zenml: ${{ github.ref }}
-          ref-template: '2024-04-05'  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
+          ref-template: 2024.04.05  # Make sure it is aligned with ZENML_PROJECT_TEMPLATES from src/zenml/cli/base.py
       - name: Clean-up
         run: |
           rm -rf ./local_checkout

--- a/examples/e2e/.copier-answers.yml
+++ b/examples/e2e/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2024.01.22-3-g71dbb60
+_commit: 2024.01.22-5-ga8559f4
 _src_path: gh:zenml-io/template-e2e-batch
 data_quality_checks: true
 email: ''

--- a/examples/e2e_nlp/.copier-answers.yml
+++ b/examples/e2e_nlp/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2024.01.12-3-g84c410d
+_commit: 2024.01.12-5-gb5f35d0
 _src_path: gh:zenml-io/template-nlp
 accelerator: cpu
 cloud_of_choice: aws

--- a/examples/llm_finetuning/.copier-answers.yml
+++ b/examples/llm_finetuning/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: '2024-04-05'
+_commit: 2024.03.18-6-g7831e8b
 _src_path: gh:zenml-io/template-llm-finetuning
 cuda_version: cuda11.8
 email: ''

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -73,7 +73,7 @@ class ZenMLProjectTemplateLocation(BaseModel):
 ZENML_PROJECT_TEMPLATES = dict(
     e2e_batch=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-e2e-batch",
-        github_tag="2024-04-05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
+        github_tag="2024.04.05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
     ),
     starter=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-starter",
@@ -81,11 +81,11 @@ ZENML_PROJECT_TEMPLATES = dict(
     ),
     nlp=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-nlp",
-        github_tag="2024-04-05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
+        github_tag="2024.04.05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
     ),
     llm_finetuning=ZenMLProjectTemplateLocation(
         github_url="zenml-io/template-llm-finetuning",
-        github_tag="2024-04-05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
+        github_tag="2024.04.05",  # Make sure it is aligned with .github/workflows/update-templates-to-examples.yml
     ),
 )
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -17,6 +17,7 @@ import inspect
 import os
 from functools import wraps
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
@@ -27,7 +28,6 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-import secure
 from pydantic import BaseModel, ValidationError
 
 from zenml.config.global_config import GlobalConfiguration
@@ -53,6 +53,9 @@ from zenml.zen_server.pipeline_deployment.workload_manager_interface import (
 from zenml.zen_server.rbac.rbac_interface import RBACInterface
 from zenml.zen_stores.sql_zen_store import SqlZenStore
 
+if TYPE_CHECKING:
+    import secure
+
 logger = get_logger(__name__)
 
 _zen_store: Optional["SqlZenStore"] = None
@@ -60,7 +63,7 @@ _rbac: Optional[RBACInterface] = None
 _feature_gate: Optional[FeatureGateInterface] = None
 _workload_manager: Optional[WorkloadManagerInterface] = None
 _plugin_flavor_registry: Optional[PluginFlavorRegistry] = None
-_secure_headers: Optional[secure.Secure] = None
+_secure_headers: Optional["secure.Secure"] = None
 
 
 def zen_store() -> "SqlZenStore":
@@ -216,7 +219,7 @@ def initialize_zen_store() -> None:
     _zen_store = zen_store_
 
 
-def secure_headers() -> secure.Secure:
+def secure_headers() -> "secure.Secure":
     """Return the secure headers component.
 
     Returns:
@@ -233,6 +236,8 @@ def secure_headers() -> secure.Secure:
 
 def initialize_secure_headers() -> None:
     """Initialize the secure headers component."""
+    import secure
+
     global _secure_headers
 
     config = server_config()


### PR DESCRIPTION
## Describe changes
Given that `secure` is an optional ZenML server extra, it should not be required as an import when the server extras are not installed.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

