### PR TITLE
Fix AWS service connector resource ID regexp

### DIFF
--- a/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
+++ b/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
@@ -1132,19 +1132,19 @@ class AWSServiceConnector(ServiceConnector):
         # We need to extract the bucket name from the provided resource ID
         bucket_name: Optional[str] = None
         if re.match(
-            r"^arn:aws:s3:::[a-z0-9-]+(/.*)*$",
+            r"^arn:aws:s3:::[a-z0-9][a-z0-9\-\.]{1,61}[a-z0-9](/.*)*$",
             resource_id,
         ):
             # The resource ID is an S3 bucket ARN
             bucket_name = resource_id.split(":")[-1].split("/")[0]
         elif re.match(
-            r"^s3://[a-z0-9-]+(/.*)*$",
+            r"^s3://[a-z0-9][a-z0-9\-\.]{1,61}[a-z0-9](/.*)*$",
             resource_id,
         ):
             # The resource ID is an S3 bucket URI
             bucket_name = resource_id.split("/")[2]
         elif re.match(
-            r"^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$",
+            r"^[a-z0-9][a-z0-9\-\.]{1,61}[a-z0-9]$",
             resource_id,
         ):
             # The resource ID is the S3 bucket name
@@ -1243,14 +1243,14 @@ class AWSServiceConnector(ServiceConnector):
         cluster_name: Optional[str] = None
         region_id: Optional[str] = None
         if re.match(
-            r"^arn:aws:eks:[a-z0-9-]+:\d{12}:cluster/.+$",
+            r"^arn:aws:eks:[a-z0-9-]+:\d{12}:cluster/[0-9A-Za-z][A-Za-z0-9\-_]*$",
             resource_id,
         ):
             # The resource ID is an EKS cluster ARN
             cluster_name = resource_id.split("/")[-1]
             region_id = resource_id.split(":")[3]
         elif re.match(
-            r"^[a-z0-9]+[a-z0-9_-]*$",
+            r"^[0-9A-Za-z][A-Za-z0-9\-_]*$",
             resource_id,
         ):
             # Assume the resource ID is an EKS cluster name


### PR DESCRIPTION
## Describe changes
The regular expressions used to detect AWS S3 bucket names and AWS EKS cluster names in the AWS Service Connector were inaccurate (some characters were not allowed even though AWS didn't prevent them from being used).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

