### PR TITLE
Allow DB backup failures if the database version is 0.56.3 or earlier

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1321,9 +1321,19 @@ class SqlZenStore(BaseZenStore):
                     # database schema. If the database is at version 0.56.3
                     # or earlier and if the backup fails, we only log the
                     # exception and leave the upgrade process to proceed.
-                    if version.parse(current_revisions[0]) <= version.parse(
-                        "0.56.3"
-                    ):
+                    allow_backup_failures = False
+                    try:
+                        if version.parse(
+                            current_revisions[0]
+                        ) <= version.parse("0.56.3"):
+                            allow_backup_failures = True
+                    except version.InvalidVersion:
+                        # This can happen if the database is not currently
+                        # stamped with an official ZenML version (e.g. in
+                        # development environments).
+                        pass
+
+                    if allow_backup_failures:
                         logger.exception(
                             "Failed to backup the database. The database "
                             "upgrade will proceed without a backup."

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1341,7 +1341,7 @@ class SqlZenStore(BaseZenStore):
                     else:
                         raise RuntimeError(
                             f"Failed to backup the database: {str(e)}. "
-                            "Please check the logs for more details."
+                            "Please check the logs for more details. "
                             "If you would like to disable the database backup "
                             "functionality, set the `backup_strategy` attribute "
                             "of the store configuration to `disabled`."


### PR DESCRIPTION
## Describe changes
The database backup and restore feature wasn't fully functional until now due to problems in the DB schema:

* table dependency loop impacting all backup strategies
* improper pagination when the database backup strategy is used

Moreover, even if the DB upgrade is successful, the database backup step will fail if the database backup strategy is used, and basically interrupt the entire upgrade process.

We want to avoid any unnecessary administrative operations to be incurred by ZenML users and thus we allow database backup failures to occur with earlier database versions. In these cases, the upgrade process will continue uninterrupted without a backup. Things will go back to normal (i.e. DB backup errors will be reported as failures and interrupt the upgrades) after ZenML is upgraded to the next release.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

