### PR TITLE
Return up-to-date `PipelineRunResponse` from pipeline run

### DIFF
--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -758,8 +758,9 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             deploy_pipeline(
                 deployment=deployment_model, stack=stack, placeholder_run=run
             )
-
-            return Client().get_pipeline_run(run.id)
+            if run:
+                return Client().get_pipeline_run(run.id)
+            return None
 
     @staticmethod
     def log_pipeline_deployment_metadata(

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -759,7 +759,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 deployment=deployment_model, stack=stack, placeholder_run=run
             )
 
-            return run
+            return Client().get_pipeline_run(run.id)
 
     @staticmethod
     def log_pipeline_deployment_metadata(

--- a/tests/integration/functional/pipelines/test_pipeline_run.py
+++ b/tests/integration/functional/pipelines/test_pipeline_run.py
@@ -1,0 +1,20 @@
+from zenml import pipeline, step
+
+
+@step(enable_cache=False)
+def constant_int_output_test_step() -> int:
+    return 42
+
+
+def test_pipeline_run_returns_up_to_date_run_info():
+    @pipeline
+    def _pipeline():
+        constant_int_output_test_step()
+
+    pipeline_run_info = _pipeline()
+
+    assert "constant_int_output_test_step" in pipeline_run_info.steps
+    assert (
+        pipeline_run_info.steps["constant_int_output_test_step"].status
+        == "completed"
+    )


### PR DESCRIPTION
## Describe changes
I fixed the returned object from `pipeline._run`, since we introduced Placeholder Runs it was returning outdated placeholder, not the latest state after the run finished.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

