### PR TITLE
Fix imports in for `Model` in documentation

### DIFF
--- a/docs/book/user-guide/advanced-guide/data-management/model-management.md
+++ b/docs/book/user-guide/advanced-guide/data-management/model-management.md
@@ -90,7 +90,7 @@ is specified, while other fields remain optional for this task.
 
 ```python
 from zenml import pipeline
-from zenml.model import Model
+from zenml import Model
 
 @pipeline(
     enable_cache=False,
@@ -127,7 +127,7 @@ the `version` argument to the `Model` object. If you don't do this, ZenML
 will automatically generate a version number for you.
 
 ```python
-from zenml.model import Model
+from zenml import Model
 
 model= Model(
     name="my_model",
@@ -272,7 +272,7 @@ There are a few ways to link artifacts:
 The easiest way is to configure the `model` parameter on the `@pipeline` decorator or `@step` decorator:
 
 ```python
-from zenml.model import Model
+from zenml import Model
 
 model = Model(
     name="my_model",

--- a/docs/book/user-guide/starter-guide/track-ml-models.md
+++ b/docs/book/user-guide/starter-guide/track-ml-models.md
@@ -230,7 +230,7 @@ A model's versions can exist in various stages. These are meant to signify their
 {% tabs %}
 {% tab title="Python SDK" %}
 ```python
-from zenml.model import Model
+from zenml import Model
 
 # Get the latest version of a model
 model = Model(


### PR DESCRIPTION
This pull request fixes the imports in the model-management.md and track-ml-models.md files. The imports have been updated to use the `Model` class from the `zenml` module instead of importing it directly from the `zenml.model` module. This ensures consistency and improves code readability.