### PR TITLE
Send workflow dispatch event to Cloud Plugins repo on release

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -51,7 +51,7 @@ jobs:
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
               workflow_id: 'main_image_builder.yml',
-              ref: 'feature/automate-image-building-on-zenml-tag-push',
+              ref: 'cloud/send-workflow-dispatch-on-release',
               inputs: {
                 tag: '0.56.3',
               }

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -8,7 +8,6 @@ on:
         required: false
         type: string
         default: release-cloudbuild.yaml
-
 jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub
@@ -37,7 +36,6 @@ jobs:
             --quiet \
             --config=${{inputs.config_file}} \
             --substitutions=TAG_NAME=${{github.ref_name}} .
-
     wait-for-package-release:
       runs-on: arc-runner-set
       needs: publish_to_docker
@@ -50,12 +48,12 @@ jobs:
     dispatch_to_cloud_plugins_repo:
       runs-on: ubuntu-latest
       needs: wait-for-package-release
-      steps:  
+      steps:
         - name: Trigger ZenML Cloud server image creation
           uses: actions/github-script@v7
           with:
             github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
-            script: |
+            script: |-
               await github.rest.actions.createWorkflowDispatch({
                 owner: 'zenml-io',
                 repo: 'zenml-cloud-plugins',

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Trigger ZenML Cloud server image creation
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CLOUD_BE_REPO_PAT }}
+          github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'zenml-io',

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -8,56 +8,54 @@ on:
         required: false
         type: string
         default: release-cloudbuild.yaml
-  push:
-    branches:
-      - cloud/send-workflow-dispatch-on-release
 
 jobs:
-  # publish_to_docker:
-  #   name: Publish Docker 🐋 image 🖼️ to Dockerhub
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     ZENML_DEBUG: 1
-  #     ZENML_ANALYTICS_OPT_IN: false
-  #     PYTHONIOENCODING: utf-8
-  #   steps:
-  #     - uses: actions/checkout@v4.1.1
-  #     - name: Get the version from the github tag ref
-  #       id: get_version
-  #       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+  publish_to_docker:
+    name: Publish Docker 🐋 image 🖼️ to Dockerhub
+    runs-on: ubuntu-latest
+    env:
+      ZENML_DEBUG: 1
+      ZENML_ANALYTICS_OPT_IN: false
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Get the version from the github tag ref
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-  #     # Setup gcloud CLI
-  #     - uses: google-github-actions/setup-gcloud@v0
-  #       with:
-  #         service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
-  #         service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
-  #         project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
+          service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
+          project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
 
-  #     # Cloudbuild
-  #     - name: Build docker images
-  #       run: |-
-  #         gcloud builds submit \
-  #           --quiet \
-  #           --config=${{inputs.config_file}} \
-  #           --substitutions=TAG_NAME=${{github.ref_name}} .
-  # wait-for-package-release:
-  #   runs-on: arc-runner-set
-  #   needs: publish_to_docker
-  #   steps:
-  #     - name: Sleep for 4 minutes
-  #       run: sleep 240
-  #       shell: bash
-
+      # Cloudbuild
+      - name: Build docker images
+        run: |-
+          gcloud builds submit \
+            --quiet \
+            --config=${{inputs.config_file}} \
+            --substitutions=TAG_NAME=${{github.ref_name}} .
+  wait-for-package-release:
+    runs-on: arc-runner-set
+    needs: publish_to_docker
+    steps:
+      - name: Sleep for 4 minutes
+        run: sleep 240
+        shell: bash
   # create a tag on the ZenML cloud plugins repo
   create_tag_on_cloud_plugins_repo:
     runs-on: ubuntu-latest
-    permissions: write-all
-    # needs: wait-for-package-release
+    needs: wait-for-package-release
     steps:
       - name: Get the sha of the latest commit on plugins/main
         id: get_sha
         run: |
           echo "::set-output name=sha::$(curl -s -H "Authorization: token ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}" https://api.github.com/repos/zenml-io/zenml-cloud-plugins/commits/main | jq -r '.sha')"
+      - name: Get the version from the github tag ref
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       - name: Create a tag on ZenML Cloud plugins repo
         uses: actions/github-script@v7
         with:
@@ -66,6 +64,6 @@ jobs:
             await github.rest.git.createRef({
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
-              ref: 'refs/tags/testtag',
+              ref: 'refs/tags/${{ steps.get_version.outputs.VERSION }}',
               sha: '${{ steps.get_sha.outputs.sha }}'
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -44,6 +44,7 @@ jobs:
       # Create a workflow dispatch to the ZenML Cloud API repository
       - name: Trigger ZenML Cloud server image creation
         uses: actions/github-script@v7
+        github-token: ${{ secrets.CLOUD_BE_REPO_PAT }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -49,7 +49,7 @@ jobs:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'zenml-io',
-              repo: 'zenml-cloud-api',
+              repo: 'zenml-cloud-plugins',
               workflow_id: 'main_image_builder.yml',
               ref: 'feature/automate-image-building-on-zenml-tag-push',
               inputs: {

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -51,6 +51,7 @@ jobs:
   # create a tag on the ZenML cloud plugins repo
   create_tag_on_cloud_plugins_repo:
     runs-on: ubuntu-latest
+    permissions: write-all
     # needs: wait-for-package-release
     steps:
       - name: Create a tag on ZenML Cloud plugins repo

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -13,54 +13,54 @@ on:
       - cloud/send-workflow-dispatch-on-release
 
 jobs:
-  publish_to_docker:
-    name: Publish Docker 🐋 image 🖼️ to Dockerhub
-    runs-on: ubuntu-latest
-    env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
-      PYTHONIOENCODING: utf-8
+  # publish_to_docker:
+  #   name: Publish Docker 🐋 image 🖼️ to Dockerhub
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     ZENML_DEBUG: 1
+  #     ZENML_ANALYTICS_OPT_IN: false
+  #     PYTHONIOENCODING: utf-8
+  #   steps:
+  #     - uses: actions/checkout@v4.1.1
+  #     - name: Get the version from the github tag ref
+  #       id: get_version
+  #       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+  #     # Setup gcloud CLI
+  #     - uses: google-github-actions/setup-gcloud@v0
+  #       with:
+  #         service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
+  #         service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
+  #         project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
+
+  #     # Cloudbuild
+  #     - name: Build docker images
+  #       run: |-
+  #         gcloud builds submit \
+  #           --quiet \
+  #           --config=${{inputs.config_file}} \
+  #           --substitutions=TAG_NAME=${{github.ref_name}} .
+  wait-for-package-release:
+    runs-on: arc-runner-set
+    needs: publish_to_docker
     steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Get the version from the github tag ref
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Sleep for 4 minutes
+        run: sleep 240
+        shell: bash
 
-      # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v0
+  # create a tag on the ZenML cloud plugins repo
+  create_tag_on_cloud_plugins_repo:
+    runs-on: ubuntu-latest
+    needs: wait-for-package-release
+    steps:
+      - name: Create a tag on ZenML Cloud plugins repo
+        uses: actions/github-script@v7
         with:
-          service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
-          service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
-          project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
-
-      # Cloudbuild
-      - name: Build docker images
-        run: |-
-          gcloud builds submit \
-            --quiet \
-            --config=${{inputs.config_file}} \
-            --substitutions=TAG_NAME=${{github.ref_name}} .
-    wait-for-package-release:
-      runs-on: arc-runner-set
-      needs: publish_to_docker
-      steps:
-        - name: Sleep for 4 minutes
-          run: sleep 240
-          shell: bash
-
-    # create a tag on the ZenML cloud plugins repo
-    create_tag_on_cloud_plugins_repo:
-      runs-on: ubuntu-latest
-      needs: wait-for-package-release
-      steps:
-        - name: Create a tag on ZenML Cloud plugins repo
-          uses: actions/github-script@v7
-          with:
-            github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
-            script: |-
-              await github.rest.git.createRef({
-                owner: 'zenml-io',
-                repo: 'zenml-cloud-plugins',
-                ref: 'refs/tags/testtag',
-                sha: '${{github.sha}}'
-              })
+          github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+          script: |-
+            await github.rest.git.createRef({
+              owner: 'zenml-io',
+              repo: 'zenml-cloud-plugins',
+              ref: 'refs/tags/testtag',
+              sha: '${{github.sha}}'
+            })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: release-cloudbuild.yaml
+  push:
+    branches:
+      - cloud/send-workflow-dispatch-on-release
+
 jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub
@@ -18,24 +22,24 @@ jobs:
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@v4.1.1
-      - name: Get the version from the github tag ref
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      # - name: Get the version from the github tag ref
+      #   id: get_version
+      #   run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-      # Setup gcloud CLI
-      - uses: google-github-actions/setup-gcloud@v0
-        with:
-          service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
-          service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
-          project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
+      # # Setup gcloud CLI
+      # - uses: google-github-actions/setup-gcloud@v0
+      #   with:
+      #     service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
+      #     service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
+      #     project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
 
-      # Cloudbuild
-      - name: Build docker images
-        run: |-
-          gcloud builds submit \
-            --quiet \
-            --config=${{inputs.config_file}} \
-            --substitutions=TAG_NAME=${{github.ref_name}} .
+      # # Cloudbuild
+      # - name: Build docker images
+      #   run: |-
+      #     gcloud builds submit \
+      #       --quiet \
+      #       --config=${{inputs.config_file}} \
+      #       --substitutions=TAG_NAME=${{github.ref_name}} .
 
       # Create a workflow dispatch to the ZenML Cloud API repository
       - name: Trigger ZenML Cloud server image creation
@@ -46,8 +50,8 @@ jobs:
               owner: 'zenml-io',
               repo: 'zenml-cloud-api',
               workflow_id: 'main_image_builder.yml',
-              ref: 'main',
+              ref: 'feature/automate-image-building-on-zenml-tag-push',
               inputs: {
-                tag: '${{github.ref_name}}',
+                tag: '0.56.3',
               }
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -41,7 +41,7 @@ jobs:
       #       --config=${{inputs.config_file}} \
       #       --substitutions=TAG_NAME=${{github.ref_name}} .
 
-      # Create a workflow dispatch to the ZenML Cloud API repository
+      # Create a workflow dispatch to the ZenML Cloud API repo
       - name: Trigger ZenML Cloud server image creation
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -61,6 +61,6 @@ jobs:
             await github.rest.git.createRef({
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
-              ref: 'refs/tags/testtag',
+              ref: 'refs/heads/testtag',
               sha: '${{github.sha}}'
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: string
         default: release-cloudbuild.yaml
-  push:
-    branches:
-      - cloud/send-workflow-dispatch-on-release
 
 jobs:
   publish_to_docker:
@@ -22,26 +19,26 @@ jobs:
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@v4.1.1
-      # - name: Get the version from the github tag ref
-      #   id: get_version
-      #   run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Get the version from the github tag ref
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-      # # Setup gcloud CLI
-      # - uses: google-github-actions/setup-gcloud@v0
-      #   with:
-      #     service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
-      #     service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
-      #     project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_email: ${{ secrets.GCP_CLOUDBUILD_EMAIL }}
+          service_account_key: ${{ secrets.GCP_CLOUDBUILD_KEY }}
+          project_id: ${{ secrets.GCP_CLOUDBUILD_PROJECT }}
 
-      # # Cloudbuild
-      # - name: Build docker images
-      #   run: |-
-      #     gcloud builds submit \
-      #       --quiet \
-      #       --config=${{inputs.config_file}} \
-      #       --substitutions=TAG_NAME=${{github.ref_name}} .
+      # Cloudbuild
+      - name: Build docker images
+        run: |-
+          gcloud builds submit \
+            --quiet \
+            --config=${{inputs.config_file}} \
+            --substitutions=TAG_NAME=${{github.ref_name}} .
 
-      # Create a workflow dispatch to the ZenML Cloud API repo
+      # Create a workflow dispatch to the ZenML Cloud API repository
       - name: Trigger ZenML Cloud server image creation
         uses: actions/github-script@v7
         with:
@@ -53,6 +50,6 @@ jobs:
               workflow_id: 'main_image_builder.yml',
               ref: 'main',
               inputs: {
-                tag: '0.56.3',
+                tag: '${{github.ref_name}}',
               }
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -54,6 +54,10 @@ jobs:
     permissions: write-all
     # needs: wait-for-package-release
     steps:
+      - name: Get the sha of the latest commit on plugins/main
+        id: get_sha
+        run: |
+          echo "::set-output name=sha::$(curl -s -H "Authorization: token ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}" https://api.github.com/repos/zenml-io/zenml-cloud-plugins/commits/main | jq -r '.sha')"
       - name: Create a tag on ZenML Cloud plugins repo
         uses: actions/github-script@v7
         with:
@@ -63,5 +67,5 @@ jobs:
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
               ref: 'refs/tags/testtag',
-              sha: '${{github.sha}}'
+              sha: '${{ steps.get_sha.outputs.sha }}'
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -36,3 +36,18 @@ jobs:
             --quiet \
             --config=${{inputs.config_file}} \
             --substitutions=TAG_NAME=${{github.ref_name}} .
+
+      # Create a workflow dispatch to the ZenML Cloud API repository
+      - name: Trigger ZenML Cloud server image creation
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'zenml-io',
+              repo: 'zenml-cloud-api',
+              workflow_id: 'main_image_builder.yml',
+              ref: 'main',
+              inputs: {
+                tag: '${{github.ref_name}}',
+              }
+            })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -44,8 +44,8 @@ jobs:
       # Create a workflow dispatch to the ZenML Cloud API repository
       - name: Trigger ZenML Cloud server image creation
         uses: actions/github-script@v7
-        github-token: ${{ secrets.CLOUD_BE_REPO_PAT }}
         with:
+          github-token: ${{ secrets.CLOUD_BE_REPO_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'zenml-io',

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -38,18 +38,30 @@ jobs:
             --config=${{inputs.config_file}} \
             --substitutions=TAG_NAME=${{github.ref_name}} .
 
-      # Create a workflow dispatch to the ZenML Cloud API repository
-      - name: Trigger ZenML Cloud server image creation
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'zenml-io',
-              repo: 'zenml-cloud-plugins',
-              workflow_id: 'main_image_builder.yml',
-              ref: 'main',
-              inputs: {
-                tag: '${{github.ref_name}}',
-              }
-            })
+    wait-for-package-release:
+      runs-on: arc-runner-set
+      needs: publish_to_docker
+      steps:
+        - name: Sleep for 4 minutes
+          run: sleep 240
+          shell: bash
+
+    # Create a workflow dispatch to the ZenML Cloud API repository
+    dispatch_to_cloud_plugins_repo:
+      runs-on: ubuntu-latest
+      needs: wait-for-package-release
+      steps:  
+        - name: Trigger ZenML Cloud server image creation
+          uses: actions/github-script@v7
+          with:
+            github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+            script: |
+              await github.rest.actions.createWorkflowDispatch({
+                owner: 'zenml-io',
+                repo: 'zenml-cloud-plugins',
+                workflow_id: 'main_image_builder.yml',
+                ref: 'main',
+                inputs: {
+                  tag: '${{github.ref_name}}',
+                }
+              })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -62,6 +62,6 @@ jobs:
             await github.rest.git.createRef({
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
-              ref: 'refs/heads/testtag',
+              ref: 'refs/tags/testtag',
               sha: '${{github.sha}}'
             })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         default: release-cloudbuild.yaml
+  push:
+    branches:
+      - cloud/send-workflow-dispatch-on-release
+
 jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub
@@ -44,22 +48,19 @@ jobs:
           run: sleep 240
           shell: bash
 
-    # Create a workflow dispatch to the ZenML Cloud API repository
-    dispatch_to_cloud_plugins_repo:
+    # create a tag on the ZenML cloud plugins repo
+    create_tag_on_cloud_plugins_repo:
       runs-on: ubuntu-latest
       needs: wait-for-package-release
       steps:
-        - name: Trigger ZenML Cloud server image creation
+        - name: Create a tag on ZenML Cloud plugins repo
           uses: actions/github-script@v7
           with:
             github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
             script: |-
-              await github.rest.actions.createWorkflowDispatch({
+              await github.rest.git.createRef({
                 owner: 'zenml-io',
                 repo: 'zenml-cloud-plugins',
-                workflow_id: 'main_image_builder.yml',
-                ref: 'main',
-                inputs: {
-                  tag: '${{github.ref_name}}',
-                }
+                ref: 'refs/tags/testtag',
+                sha: '${{github.sha}}'
               })

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -51,7 +51,7 @@ jobs:
               owner: 'zenml-io',
               repo: 'zenml-cloud-plugins',
               workflow_id: 'main_image_builder.yml',
-              ref: 'cloud/send-workflow-dispatch-on-release',
+              ref: 'main',
               inputs: {
                 tag: '0.56.3',
               }

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -40,18 +40,18 @@ jobs:
   #           --quiet \
   #           --config=${{inputs.config_file}} \
   #           --substitutions=TAG_NAME=${{github.ref_name}} .
-  wait-for-package-release:
-    runs-on: arc-runner-set
-    needs: publish_to_docker
-    steps:
-      - name: Sleep for 4 minutes
-        run: sleep 240
-        shell: bash
+  # wait-for-package-release:
+  #   runs-on: arc-runner-set
+  #   needs: publish_to_docker
+  #   steps:
+  #     - name: Sleep for 4 minutes
+  #       run: sleep 240
+  #       shell: bash
 
   # create a tag on the ZenML cloud plugins repo
   create_tag_on_cloud_plugins_repo:
     runs-on: ubuntu-latest
-    needs: wait-for-package-release
+    # needs: wait-for-package-release
     steps:
       - name: Create a tag on ZenML Cloud plugins repo
         uses: actions/github-script@v7

--- a/examples/e2e/.copier-answers.yml
+++ b/examples/e2e/.copier-answers.yml
@@ -2,7 +2,7 @@
 _commit: 2024.04.05
 _src_path: gh:zenml-io/template-e2e-batch
 data_quality_checks: true
-email: ''
+email: info@zenml.io
 full_name: ZenML GmbH
 hyperparameters_tuning: true
 metric_compare_promotion: true

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -9,7 +9,7 @@ with the following properties:
 - Project name: ZenML E2E project
 - Technical Name: e2e_use_case
 - Version: `0.0.1`
-- Licensed with apache to ZenML GmbH<>
+- Licensed with apache to ZenML GmbH<info@zenml.io>
 - Deployment environment: `staging`
 
 Settings of your project are:

--- a/examples/e2e_nlp/.copier-answers.yml
+++ b/examples/e2e_nlp/.copier-answers.yml
@@ -7,7 +7,7 @@ dataset: airline_reviews
 deploy_locally: true
 deploy_to_huggingface: true
 deploy_to_skypilot: true
-email: ''
+email: info@zenml.io
 full_name: ZenML GmbH
 metric_compare_promotion: true
 model: distilbert-base-uncased

--- a/examples/e2e_nlp/README.md
+++ b/examples/e2e_nlp/README.md
@@ -12,7 +12,7 @@ with the following properties:
 - Project name: ZenML NLP project
 - Technical Name: nlp_use_case
 - Version: `0.0.1`
-- Licensed with apache to ZenML GmbH<>
+- Licensed with apache to ZenML GmbH<info@zenml.io>
 - Deployment environment: `staging`
 
 Settings of your project are:

--- a/examples/quickstart/.copier-answers.yml
+++ b/examples/quickstart/.copier-answers.yml
@@ -1,7 +1,7 @@
 # Changes here will be overwritten by Copier
 _commit: 2024.04.03
 _src_path: gh:zenml-io/template-starter
-email: ''
+email: info@zenml.io
 full_name: ZenML GmbH
 open_source_license: apache
 project_name: ZenML Starter


### PR DESCRIPTION
## Describe changes
I implemented an addition to the Docker image building workflow to send an event to the `zenml-io/zenml-cloud-plugins` repo when zenml server images are built.

This allows us to build new `zenml-cloud-server` images based on top of the latest zenml server images.

## Testing

I have tested this to send an event to the plugins repo.
- action on this repo: https://github.com/zenml-io/zenml/actions/runs/8833520859
- action on the plugins repo: https://github.com/zenml-io/zenml-cloud-plugins/actions/runs/8833523496/job/24253038897


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

