### PR TITLE
[Cloud] Use legacy url for stacks and stack components

### DIFF
--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 from zenml import constants
 from zenml.client import Client
+from zenml.config.server_config import ServerConfiguration
 from zenml.enums import EnvironmentType, StoreType
 from zenml.environment import get_environment
 from zenml.logger import get_logger
@@ -65,6 +66,15 @@ def get_stack_url(stack: StackResponse) -> Optional[str]:
         the URL to the stack if the dashboard is available, else None.
     """
     base_url = get_base_url()
+
+    # the cloud dashboard doesn't support stacks yet
+    # use the legacy URL for now
+    server_config = ServerConfiguration()
+    legacy_url = server_config.dashboard_url
+
+    if legacy_url:
+        return legacy_url + f"{constants.STACKS}/{stack.id}/configuration"
+
     if base_url:
         return base_url + f"{constants.STACKS}/{stack.id}/configuration"
     return None
@@ -80,6 +90,18 @@ def get_component_url(component: ComponentResponse) -> Optional[str]:
         the URL to the component if the dashboard is available, else None.
     """
     base_url = get_base_url()
+
+    # the cloud dashboard doesn't support components yet
+    # use the legacy URL for now
+    server_config = ServerConfiguration()
+    legacy_url = server_config.dashboard_url
+
+    if legacy_url:
+        return (
+            legacy_url
+            + f"{constants.STACK_COMPONENTS}/{component.type.value}/{component.id}/configuration"
+        )
+
     if base_url:
         return (
             base_url


### PR DESCRIPTION
## Describe changes
I fixed the stack URL to use the legacy dashboard until the page is ready on the new dashboard. The `dashboard_url` property of the server config has the value for the legacy dashboard.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

