### PR TITLE
Allow resetting server and user metadata

### DIFF
--- a/src/zenml/zen_stores/schemas/server_settings_schemas.py
+++ b/src/zenml/zen_stores/schemas/server_settings_schemas.py
@@ -58,7 +58,7 @@ class ServerSettingsSchema(SQLModel, table=True):
         """
         for field, value in settings_update.dict(exclude_unset=True).items():
             if field == "onboarding_state":
-                if value:
+                if value is not None:
                     self.onboarding_state = json.dumps(value)
             elif hasattr(self, field):
                 setattr(self, field, value)

--- a/src/zenml/zen_stores/schemas/user_schemas.py
+++ b/src/zenml/zen_stores/schemas/user_schemas.py
@@ -221,7 +221,7 @@ class UserSchema(NamedSchema, table=True):
                     self, field, user_update.create_hashed_activation_token()
                 )
             elif field == "user_metadata":
-                if value:
+                if value is not None:
                     self.user_metadata = json.dumps(value)
             else:
                 setattr(self, field, value)


### PR DESCRIPTION
## Describe changes
This PR adds an option to set the user/server metadata to an empty dictionary.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

