### PR TITLE
Ensure extra flags aren't passed into `uv` integration install command

### DIFF
--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -1047,10 +1047,9 @@ def install_packages(
 
     if not IS_DEBUG_ENV:
         quiet_flag = "-q" if use_uv else "-qqq"
-        command += [
-            quiet_flag,
-            "--no-warn-conflicts",
-        ]
+        command.append(quiet_flag)
+        if not use_uv:
+            command.append("--no-warn-conflicts")
 
     try:
         subprocess.check_call(command)


### PR DESCRIPTION
Since `uv` doesn't allow the `--no-warn-conflicts` flag to be passed.

This pull request refactors the install_packages function to handle the quiet flag and warn conflicts option. The function now checks if the environment is in debug mode and sets the quiet flag accordingly. Additionally, the `--no-warn-conflicts` option is only added if the `use_uv` flag is False. This improves the functionality and readability of the code.