### PR TITLE
Fix broken links in code examples

### DIFF
--- a/docs/book/user-guide/llmops-guide/evaluation/evaluation-in-65-loc.md
+++ b/docs/book/user-guide/llmops-guide/evaluation/evaluation-in-65-loc.md
@@ -7,14 +7,14 @@ implement a basic RAG pipeline in just 85 lines of code. In this section, we'll
 build on that example to show how you can evaluate the performance of your RAG
 pipeline in just 65 lines. For the full code, please visit the project
 repository
-[here](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/most_basic_eval.py).
+[here](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/most_basic_eval.py).
 The code that follows requires the functions from the earlier RAG pipeline code
 to work.
 
 
 ```python
 # ...previous RAG pipeline code here...
-# see https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/most_basic_rag_pipeline.py
+# see https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/most_basic_rag_pipeline.py
 
 eval_data = [
     {

--- a/docs/book/user-guide/llmops-guide/evaluation/evaluation-in-practice.md
+++ b/docs/book/user-guide/llmops-guide/evaluation/evaluation-in-practice.md
@@ -60,7 +60,7 @@ practice and you can of course then play with and modify the evaluation code.
 To run the evaluation pipeline, first clone the project repository:
 
 ```bash
-git clone -b feature/evaluation-llm-complete-guide https://github.com/zenml-io/zenml-projects.git
+git clone https://github.com/zenml-io/zenml-projects.git
 ```
 
 Then navigate to the `llm-complete-guide` directory and follow the instructions

--- a/docs/book/user-guide/llmops-guide/evaluation/generation.md
+++ b/docs/book/user-guide/llmops-guide/evaluation/generation.md
@@ -34,7 +34,7 @@ orchestrator in ZenML?' you would expect that the answer would include the word
 'local', so we can make a test case to confirm that.
 
 You can view our starter set of these tests
-[here](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/steps/eval_e2e.py#L28-L55).
+[here](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/steps/eval_e2e.py#L28-L55).
 It's better to start with something small and simple and then expand as is
 needed. There's no need for complicated harnesses or frameworks at this stage.
 
@@ -388,7 +388,7 @@ improves as we make changes to the retrieval and generation components.
 ## Code Example
 
 To explore the full code, visit the [Complete
-Guide](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/)
-repository and for this section, particularly [the `eval_e2e.py` file](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/steps/eval_e2e.py).
+Guide](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/)
+repository and for this section, particularly [the `eval_e2e.py` file](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/steps/eval_e2e.py).
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/user-guide/llmops-guide/evaluation/retrieval.md
+++ b/docs/book/user-guide/llmops-guide/evaluation/retrieval.md
@@ -340,8 +340,8 @@ reliable question-answering system.
 ## Code Example
 
 To explore the full code, visit the [Complete
-Guide](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/)
+Guide](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/)
 repository and for this section, particularly [the `eval_retrieval.py`
-file](https://github.com/zenml-io/zenml-projects/blob/feature/evaluation-llm-complete-guide/llm-complete-guide/steps/eval_retrieval.py).
+file](https://github.com/zenml-io/zenml-projects/blob/main/llm-complete-guide/steps/eval_retrieval.py).
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>


### PR DESCRIPTION
This pull request fixes broken links in the code examples of the ZenML Complete Guide. The links were pointing to the wrong branch in the GitHub repository. This PR updates the links to point to the main branch instead.