### PR TITLE
Fix intermittent timeout issues with service connector sessions

### DIFF
--- a/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
+++ b/src/zenml/integrations/aws/service_connectors/aws_service_connector.py
@@ -71,6 +71,7 @@ logger = get_logger(__name__)
 EKS_KUBE_API_TOKEN_EXPIRATION = 15  # 15 minutes
 DEFAULT_IAM_ROLE_TOKEN_EXPIRATION = 3600  # 1 hour
 DEFAULT_STS_TOKEN_EXPIRATION = 43200  # 12 hours
+BOTO3_SESSION_EXPIRATION_BUFFER = 15  # 15 minutes
 
 
 class AWSSecretKey(AuthenticationConfig):
@@ -713,8 +714,10 @@ class AWSServiceConnector(ServiceConnector):
             # Refresh expired sessions
             now = datetime.datetime.now(datetime.timezone.utc)
             expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
-            # check if the token expires in the next 5 minutes
-            if expires_at > now + datetime.timedelta(minutes=5):
+            # check if the token expires in the near future
+            if expires_at > now + datetime.timedelta(
+                minutes=BOTO3_SESSION_EXPIRATION_BUFFER
+            ):
                 return session, expires_at
 
         logger.debug(

--- a/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
+++ b/src/zenml/integrations/azure/service_connectors/azure_service_connector.py
@@ -62,6 +62,7 @@ logger = get_logger(__name__)
 
 AZURE_MANAGEMENT_TOKEN_SCOPE = "https://management.azure.com/.default"
 AZURE_SESSION_TOKEN_DEFAULT_EXPIRATION_TIME = 60 * 60  # 1 hour
+AZURE_SESSION_EXPIRATION_BUFFER = 15  # 15 minutes
 
 
 class AzureBaseConfig(AuthenticationConfig):
@@ -600,7 +601,11 @@ class AzureServiceConnector(ServiceConnector):
             # Refresh expired sessions
             now = datetime.datetime.now(datetime.timezone.utc)
             expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
-            if expires_at > now:
+
+            # check if the token expires in the near future
+            if expires_at > now + datetime.timedelta(
+                minutes=AZURE_SESSION_EXPIRATION_BUFFER
+            ):
                 return session, expires_at
 
         logger.debug(

--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -79,6 +79,7 @@ logger = get_logger(__name__)
 
 GKE_KUBE_API_TOKEN_EXPIRATION = 60
 DEFAULT_IMPERSONATE_TOKEN_EXPIRATION = 3600  # 1 hour
+GCP_SESSION_EXPIRATION_BUFFER = 15  # 15 minutes
 
 
 class GCPUserAccountCredentials(AuthenticationConfig):
@@ -859,7 +860,10 @@ class GCPServiceConnector(ServiceConnector):
             # Refresh expired sessions
             now = datetime.datetime.now(datetime.timezone.utc)
             expires_at = expires_at.replace(tzinfo=datetime.timezone.utc)
-            if expires_at > now:
+            # check if the token expires in the near future
+            if expires_at > now + datetime.timedelta(
+                minutes=GCP_SESSION_EXPIRATION_BUFFER
+            ):
                 return session, expires_at
 
         logger.debug(


### PR DESCRIPTION
## Describe changes
AWS, GCP and Azure service connectors use a cache of sessions to avoid the overhead of authenticating with the cloud APIs on every call. These sessions are set to expire based on the validity of the attached credentials, but what was missing was a time buffer to catch corner cases in which credentials are just about to expire before being used.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

