### PR TITLE
Update pyparsing version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ passlib = { extras = ["bcrypt"], version = "~1.7.4" }
 psutil = ">=5.0.0"
 pydantic = "<1.11, >=1.9.0"
 pymysql = { version = "~1.0.2" }
-pyparsing = "<3,>=2.4.0"
+pyparsing = ">=2.4.0"
 python = ">=3.8,<3.12"
 python-dateutil = "^2.8.1"
 pyyaml = ">=6.0.1"


### PR DESCRIPTION
Unpins the version of pyparsing (originally made in #426).

Might need / want some manual testing, but I think the fact that it passes all our tests is a really good sign.

This came from a user in Slack who mentioned:

> "Conflicts with the moto mocking library https://github.com/getmoto/moto which requires pyparsing>=3.0.7 in the latest version and the first version to work with pyparsing < 3 is some years-old version."