### PR TITLE
Make a clear separation between server and dashboard API in the server configuration

### DIFF
--- a/.github/actions/setup_environment/action.yml
+++ b/.github/actions/setup_environment/action.yml
@@ -117,7 +117,7 @@ runs:
     - name: Install ZenML and dependencies
       shell: bash
       run: |
-        scripts/install-zenml-dev.sh --integrations ${{ inputs.install_integrations }}
+        scripts/install-zenml-dev.sh --system --integrations ${{ inputs.install_integrations }}
     - name: Check Python environment
       shell: bash
       run: |-

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -24,7 +24,7 @@ parse_args () {
 install_zenml() {
     # install ZenML in editable mode
 
-    uv pip install --system -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]"
+    uv pip install -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]"
 }
 
 install_integrations() {
@@ -61,7 +61,7 @@ install_integrations() {
     # https://github.com/pytorch/pytorch/issues/124897
     echo "torch<2.3.0" >> integration-requirements.txt
 
-    uv pip install --system -r integration-requirements.txt
+    uv pip install -r integration-requirements.txt
     rm integration-requirements.txt
 }
 

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 
 INTEGRATIONS=no
+PIP_ARGS=
 
 parse_args () {
     while [ $# -gt 0 ]; do
@@ -9,6 +10,10 @@ parse_args () {
                 INTEGRATIONS="$2"
                 shift # past argument
                 shift # past value
+                ;;
+            -s|--system)
+                PIP_ARGS="--system"
+                shift # past argument
                 ;;
             -*|--*)
                 echo "Unknown option $1"
@@ -24,7 +29,7 @@ parse_args () {
 install_zenml() {
     # install ZenML in editable mode
 
-    uv pip install -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]"
+    uv pip install $PIP_ARGS -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]"
 }
 
 install_integrations() {
@@ -61,7 +66,7 @@ install_integrations() {
     # https://github.com/pytorch/pytorch/issues/124897
     echo "torch<2.3.0" >> integration-requirements.txt
 
-    uv pip install -r integration-requirements.txt
+    uv pip install $PIP_ARGS -r integration-requirements.txt
     rm integration-requirements.txt
 }
 

--- a/src/zenml/cli/web_login.py
+++ b/src/zenml/cli/web_login.py
@@ -128,6 +128,7 @@ def web_login(url: str, verify_ssl: Union[str, bool]) -> str:
         auth_response.verification_uri_complete
         or auth_response.verification_uri
     )
+    breakpoint()
     if verification_uri.startswith("/"):
         # If the verification URI is a relative path, we need to add the base
         # URL to it

--- a/src/zenml/cli/web_login.py
+++ b/src/zenml/cli/web_login.py
@@ -128,7 +128,6 @@ def web_login(url: str, verify_ssl: Union[str, bool]) -> str:
         auth_response.verification_uri_complete
         or auth_response.verification_uri
     )
-    breakpoint()
     if verification_uri.startswith("/"):
         # If the verification URI is a relative path, we need to add the base
         # URL to it

--- a/src/zenml/config/server_config.py
+++ b/src/zenml/config/server_config.py
@@ -65,8 +65,16 @@ class ServerConfiguration(BaseModel):
 
     Attributes:
         deployment_type: The type of ZenML server deployment that is running.
-        base_url: The base URL of the ZenML server.
-        root_url_path: The root URL path of the ZenML server.
+        server_url: The URL where the ZenML server API is reachable. Must be
+            configured for features that involve triggering workloads from the
+            ZenML dashboard (e.g., running pipelines). If not specified, the
+            clients will use the same URL used to connect them to the ZenML
+            server.
+        dashboard_url: The URL where the ZenML dashboard is reachable.
+            If not specified, the `server_url` value is used. This should be
+            configured if the dashboard is served from a different URL than the
+            ZenML server.
+        root_url_path: The root URL path for the ZenML API and dashboard.
         auth_scheme: The authentication scheme used by the ZenML server.
         jwt_token_algorithm: The algorithm used to sign and verify JWT tokens.
         jwt_token_issuer: The issuer of the JWT tokens. If not specified, the
@@ -93,10 +101,6 @@ class ServerConfiguration(BaseModel):
             2.0 device authorization request expires.
         device_auth_polling_interval: The polling interval in seconds used to
             poll the OAuth 2.0 device authorization endpoint.
-        dashboard_url: The URL where the ZenML dashboard is hosted. Used to
-            construct the OAuth 2.0 device authorization endpoint. If not set,
-            a partial URL is returned to the client which is used to construct
-            the full URL based on the server's root URL path.
         device_expiration_minutes: The time in minutes that an OAuth 2.0 device is
             allowed to be used to authenticate with the ZenML server. If not
             set or if `jwt_token_expire_minutes` is not set, the devices are
@@ -204,7 +208,7 @@ class ServerConfiguration(BaseModel):
             of the reserved values `enabled`, `yes`, `true`, `on`, the
             `Permissions-Policy` header will be set to the default value
             (`accelerometer=(), camera=(), geolocation=(), gyroscope=(),
-              magnetometer=(), microphone=(), payment=(), usb=()`). If set to
+            magnetometer=(), microphone=(), payment=(), usb=()`). If set to
             one of the reserved values `disabled`, `no`, `none`, `false`, `off`
             or to an empty string, the `Permissions-Policy` header will not be
             included in responses.
@@ -225,7 +229,8 @@ class ServerConfiguration(BaseModel):
     """
 
     deployment_type: ServerDeploymentType = ServerDeploymentType.OTHER
-    base_url: str = ""
+    server_url: Optional[str] = None
+    dashboard_url: Optional[str] = None
     root_url_path: str = ""
     metadata: Dict[str, Any] = {}
     auth_scheme: AuthScheme = AuthScheme.OAUTH2_PASSWORD_BEARER
@@ -245,7 +250,6 @@ class ServerConfiguration(BaseModel):
     device_auth_polling_interval: int = (
         DEFAULT_ZENML_SERVER_DEVICE_AUTH_POLLING
     )
-    dashboard_url: Optional[str] = None
     device_expiration_minutes: Optional[int] = None
     trusted_device_expiration_minutes: Optional[int] = None
 

--- a/src/zenml/models/v2/misc/server_models.py
+++ b/src/zenml/models/v2/misc/server_models.py
@@ -78,11 +78,17 @@ class ServerModel(BaseModel):
     auth_scheme: AuthScheme = Field(
         title="The authentication scheme that the server is using.",
     )
-    base_url: str = Field(
+    server_url: str = Field(
         "",
-        title="The Base URL of the server.",
+        title="The URL where the ZenML server API is reachable. If not "
+        "specified, the clients will use the same URL used to connect them to "
+        "the ZenML server.",
     )
-
+    dashboard_url: str = Field(
+        "",
+        title="The URL where the ZenML dashboard is reachable. If "
+        "not specified, the `server_url` value will be used instead.",
+    )
     analytics_enabled: bool = Field(
         default=True,  # We set a default for migrations from < 0.57.0
         title="Enable server-side analytics.",

--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -42,8 +42,7 @@ def is_cloud_server(server_info: ServerModel) -> bool:
     """
     return (
         "organization_id" in server_info.metadata
-        and server_info.base_url is not None
-        and "cloud.zenml.io" in server_info.base_url
+        and "cloud.zenml.io" in server_info.server_url
     )
 
 
@@ -59,7 +58,7 @@ def get_cloud_dashboard_url() -> Optional[str]:
         server_info = client.zen_store.get_store_info()
 
         if is_cloud_server(server_info):
-            return server_info.base_url
+            return server_info.dashboard_url
 
     return None
 
@@ -80,11 +79,8 @@ def get_server_dashboard_url() -> Tuple[Optional[str], bool]:
         else:
             suffix = ""
 
-        if server_info.base_url and not is_cloud_server(server_info):
-            # For cloud the base URL is set to the cloud dashboard, but in this
-            # function we want the URL of the dashboard provided by the server
-            # deployment, which for cloud is just the ZenStore URL
-            url = server_info.base_url
+        if server_info.server_url:
+            url = server_info.server_url
         else:
             url = client.zen_store.url
 

--- a/src/zenml/zen_server/deploy/helm/templates/_environment.tpl
+++ b/src/zenml/zen_server/deploy/helm/templates/_environment.tpl
@@ -58,9 +58,6 @@ device_auth_timeout: {{ .ZenML.auth.deviceAuthTimeout | quote }}
 {{- if .ZenML.auth.deviceAuthPollingInterval }}
 device_auth_polling_interval: {{ .ZenML.auth.deviceAuthPollingInterval | quote }}
 {{- end }}
-{{- if .ZenML.auth.dashboardURL }}
-dashboard_url: {{ .ZenML.auth.dashboardURL | quote }}
-{{- end }}
 {{- if .ZenML.auth.deviceExpirationMinutes }}
 device_expiration_minutes: {{ .ZenML.auth.deviceExpirationMinutes | quote }}
 {{- end }}
@@ -82,8 +79,11 @@ external_server_id: {{ .ZenML.auth.externalServerID | quote }}
 {{- if .ZenML.rootUrlPath }}
 root_url_path: {{ .ZenML.rootUrlPath | quote }}
 {{- end }}
-{{- if .ZenML.baseURL }}
-base_url: {{ .ZenML.baseURL | quote }}
+{{- if .ZenML.serverURL }}
+server_url: {{ .ZenML.serverURL | quote }}
+{{- end }}
+{{- if .ZenML.dashboardURL }}
+dashboard_url: {{ .ZenML.dashboardURL | quote }}
 {{- end }}
 {{- if .ZenML.auth.rbacImplementationSource }}
 rbac_implementation_source: {{ .ZenML.auth.rbacImplementationSource | quote }}

--- a/src/zenml/zen_server/deploy/helm/values.yaml
+++ b/src/zenml/zen_server/deploy/helm/values.yaml
@@ -16,9 +16,19 @@ zenml:
     # Overrides the image tag whose default is the chart appVersion.
     tag:
 
-  # The URL of the ZenML server. This is used to direct users to the correct
-  # address in log messages when running a pipeline and for other similar tasks.
-  baseURL:
+  # The URL where the ZenML server API is reachable. If not specified, the
+  # clients will use the same URL used to connect them to the ZenML server.
+  serverURL:
+
+  # The URL where the ZenML dashboard is reachable.
+  # If not specified, the `serverURL` value is used. This should be
+  # configured if the dashboard is served from a different URL than the
+  # ZenML server.
+  #
+  # This is value is used to compute the dashboard URLs during the web login
+  # authentication workflow, to print dashboard URLs in log messages when
+  # running a pipeline and for other similar tasks.
+  dashboardURL:
 
   debug: true
 
@@ -111,12 +121,6 @@ zenml:
     # device authorization endpoint for the status of a pending device
     # authorization request.
     deviceAuthPollingInterval: 5
-
-    # The URL where the ZenML dashboard is hosted. Used to construct the OAuth
-    # 2.0 device authorization endpoint. If not set, a partial URL is returned
-    # to the client which is used to construct the full URL based on the
-    # server's root URL path.
-    dashboardURL:
 
     # The time in minutes that an OAuth 2.0 device is allowed to be used to
     # authenticate with the ZenML server. If not set or if

--- a/src/zenml/zen_server/pipeline_deployment/utils.py
+++ b/src/zenml/zen_server/pipeline_deployment/utils.py
@@ -58,6 +58,7 @@ def run_pipeline(
     Raises:
         ValueError: If the deployment does not have an associated stack or
             build.
+        RuntimeError: If the server URL is not set in the server configuration.
 
     Returns:
         ID of the new pipeline run.
@@ -87,8 +88,11 @@ def run_pipeline(
         assert auth_context.access_token
         api_token = auth_context.access_token.encode()
 
-    server_url = server_config().dashboard_url
-    assert server_url
+    server_url = server_config().server_url
+    if not server_url:
+        raise RuntimeError(
+            "The server URL is not set in the server configuration"
+        )
     assert build.zenml_version
     zenml_version = build.zenml_version
 

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -458,10 +458,10 @@ def device_authorization(
             ),
         )
 
-    if config.dashboard_url:
-        verification_uri = (
-            config.dashboard_url.lstrip("/") + DEVICES + DEVICE_VERIFY
-        )
+    dashboard_url = config.dashboard_url or config.server_url
+
+    if dashboard_url:
+        verification_uri = dashboard_url.lstrip("/") + DEVICES + DEVICE_VERIFY
     else:
         verification_uri = DEVICES + DEVICE_VERIFY
 

--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -375,7 +375,6 @@ class BaseZenStore(
         server_config = ServerConfiguration.get_server_config()
         deployment_type = server_config.deployment_type
         auth_scheme = server_config.auth_scheme
-        base_url = server_config.base_url
         metadata = server_config.metadata
         secrets_store_type = SecretsStoreType.NONE
         if isinstance(self, SqlZenStore) and self.config.secrets_store:
@@ -390,7 +389,8 @@ class BaseZenStore(
             debug=IS_DEBUG_ENV,
             secrets_store_type=secrets_store_type,
             auth_scheme=auth_scheme,
-            base_url=base_url,
+            server_url=server_config.server_url or "",
+            dashboard_url=server_config.dashboard_url or "",
             analytics_enabled=GlobalConfiguration().analytics_opt_in,
             metadata=metadata,
             use_legacy_dashboard=use_legacy_dashboard,


### PR DESCRIPTION
## Describe changes
There was some confusion and overlap between the `base_url` and `dashboard_url` ZenML server configuration values. This PR makes a clear separation between these configurations and includes them both in the server info and using them properly throughout:

* `server_url` replaces `base_url` - this is where the ZenML server itself is running / served.
* `dashboard_url` - this is where the ZenML dashboard is served. Can be different than `server_url`

Both values will always be set for ZenML Cloud tenants. Neither needs to be set for self-hosted servers.

## Side-changes

* change to the authorized device web login workflow code to use the dashboard URL instead of the server URL
* a change to the script used to install ZenML in a development environment is made to parameterize the installation of system-wide packages. System-wide mode is turned off by default to preserve the behavior used to install ZenML in a local python environment.

## Backwards compatibility

* OSS: these options were never used with the self-hosted ZenML server versions
* ZenML Cloud: ensured by https://github.com/zenml-io/zenml-cloud-infra/pull/39 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

