### PR TITLE
Restoring the env var order in the helm chart to avoid helm patch conflicts 

### DIFF
--- a/src/zenml/zen_server/deploy/helm/templates/_environment.tpl
+++ b/src/zenml/zen_server/deploy/helm/templates/_environment.tpl
@@ -58,6 +58,9 @@ device_auth_timeout: {{ .ZenML.auth.deviceAuthTimeout | quote }}
 {{- if .ZenML.auth.deviceAuthPollingInterval }}
 device_auth_polling_interval: {{ .ZenML.auth.deviceAuthPollingInterval | quote }}
 {{- end }}
+{{- if .ZenML.dashboardURL }}
+dashboard_url: {{ .ZenML.dashboardURL | quote }}
+{{- end }}
 {{- if .ZenML.auth.deviceExpirationMinutes }}
 device_expiration_minutes: {{ .ZenML.auth.deviceExpirationMinutes | quote }}
 {{- end }}
@@ -81,9 +84,6 @@ root_url_path: {{ .ZenML.rootUrlPath | quote }}
 {{- end }}
 {{- if .ZenML.serverURL }}
 server_url: {{ .ZenML.serverURL | quote }}
-{{- end }}
-{{- if .ZenML.dashboardURL }}
-dashboard_url: {{ .ZenML.dashboardURL | quote }}
 {{- end }}
 {{- if .ZenML.auth.rbacImplementationSource }}
 rbac_implementation_source: {{ .ZenML.auth.rbacImplementationSource | quote }}


### PR DESCRIPTION
## Describe changes
Restoring the env var order in the helm chart to avoid helm patch conflicts.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

