### PR TITLE
Workflow to create JIRA tickets when Github Issues are created

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,21 @@
+---
+name: Jira Sync
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+  issue_comment:
+    types: [created]
+jobs:
+  sync:
+    name: Sync Items
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync
+        uses: mheap/github-action-issue-to-jira@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          jiraHost: ${{ secrets.JIRA_HOST }}
+          jiraUsername: ${{ secrets.JIRA_USERNAME }}
+          jiraPassword: ${{ secrets.JIRA_PASSWORD }}  # See https://id.atlassian.com/manage/api-tokens
+          project: OSSK


### PR DESCRIPTION
Added this following our discussion earlier today in DIscord. I think this will only start working when it reaches `main`.

Any new GH issue will create a JIRA ticket. I'm not sure exactly where it'll get created, so we'll have to see when that happens. No way to set that with the GH action we'll use.