### PR TITLE
Handle error when using `zenml info` with missing dependencies

### DIFF
--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -653,7 +653,14 @@ def info(
         cli_utils.print_user_info(user_info)
 
     if stack:
-        cli_utils.print_debug_stack()
+        try:
+            cli_utils.print_debug_stack()
+        except ModuleNotFoundError:
+            cli_utils.warning(
+                "Could not print debug stack information. Please make sure "
+                "you have the necessary dependencies and integrations "
+                "installed for all your stack components."
+            )
 
 
 @cli.command(

--- a/src/zenml/cli/base.py
+++ b/src/zenml/cli/base.py
@@ -655,12 +655,13 @@ def info(
     if stack:
         try:
             cli_utils.print_debug_stack()
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
             cli_utils.warning(
                 "Could not print debug stack information. Please make sure "
                 "you have the necessary dependencies and integrations "
                 "installed for all your stack components."
             )
+            cli_utils.warning(f"The missing package is: '{e.name}'")
 
 
 @cli.command(


### PR DESCRIPTION
When using `zenml info -s`, a `ModelNotFoundError` gets raised if your environment doesn't have all the necessary dependencies installed for the components in your stack. 

This is raised from the `Client().active_stack` property which in turn calls `Stack.from_model(self.active_stack_model)` which is where the error is raised.

This PR handles the error gracefully to log an error message instead of completely failing.