### PR TITLE
Allow specifying python package installer args

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -105,6 +105,8 @@ ENV \
   PYTHONFAULTHANDLER=1 \
   # Use a random seed for random number generators
   PYTHONHASHSEED=random \
+  # Set environment variable to point to the active virtual env
+  VIRTUAL_ENV=$VIRTUAL_ENV \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1
 
@@ -136,6 +138,8 @@ ENV \
   PYTHONFAULTHANDLER=1 \
   # Use a random seed for random number generators
   PYTHONHASHSEED=random \
+  # Set environment variable to point to the active virtual env
+  VIRTUAL_ENV=$VIRTUAL_ENV \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
   # Set the ZenML global configuration path

--- a/docker/zenml-dev.Dockerfile
+++ b/docker/zenml-dev.Dockerfile
@@ -85,6 +85,8 @@ ENV \
   PYTHONFAULTHANDLER=1 \
   # Use a random seed for random number generators
   PYTHONHASHSEED=random \
+  # Set environment variable to point to the active virtual env
+  VIRTUAL_ENV=$VIRTUAL_ENV \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
   # Set ZenML debug mode to true

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -78,6 +78,8 @@ ENV \
   PYTHONFAULTHANDLER=1 \
   # Use a random seed for random number generators
   PYTHONHASHSEED=random \
+  # Set environment variable to point to the active virtual env
+  VIRTUAL_ENV=$VIRTUAL_ENV \
   # Set the ZenML global configuration path
   ZENML_CONFIG_PATH=/zenml/.zenconfig \
   # Signal to ZenML that it is running in a container

--- a/docs/book/user-guide/advanced-guide/infrastructure-management/containerize-your-pipeline.md
+++ b/docs/book/user-guide/advanced-guide/infrastructure-management/containerize-your-pipeline.md
@@ -261,6 +261,16 @@ Depending on the options specified in your Docker settings, ZenML installs the r
 * The packages installed in your local Python environment
 * The packages specified via the `requirements` attribute (step level overwrites pipeline level)
 * The packages specified via the `required_integrations` and potentially stack requirements
+* You can specify additional arguments for the installer used to install your Python packages as follows:
+```python
+# This will result in a `pip install --timeout=1000 ...` call when installing packages in the
+# Docker image
+docker_settings = DockerSettings(python_package_installer_args={"timeout": 1000})
+
+@pipeline(settings={"docker": docker_settings})
+def my_pipeline(...):
+    ...
+```
 
 * **Experimental**: If you want to use [`uv`](https://github.com/astral-sh/uv) for faster resolving and installation of your Python packages, you can use by it as follows:
 

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -128,6 +128,8 @@ class DockerSettings(BaseSettings):
             therefore **not** include any registry.
         python_package_installer: The package installer to use for python
             packages.
+        python_package_installer_args: Arguments to pass to the python package
+            installer.
         replicate_local_python_environment: If not `None`, ZenML will use the
             specified method to generate a requirements file that replicates
             the packages installed in the currently running python environment.
@@ -185,6 +187,7 @@ class DockerSettings(BaseSettings):
     python_package_installer: PythonPackageInstaller = (
         PythonPackageInstaller.PIP
     )
+    python_package_installer_args: Dict[str, Any] = {}
     replicate_local_python_environment: Optional[
         Union[List[str], PythonEnvironmentExportMethod]
     ] = None

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -20,6 +20,7 @@ import sys
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
+    Any,
     DefaultDict,
     Dict,
     List,
@@ -645,7 +646,7 @@ class PipelineDockerImageBuilder:
             == PythonPackageInstaller.PIP
         ):
             install_command = "pip install"
-            default_installer_args = PIP_DEFAULT_ARGS
+            default_installer_args: Dict[str, Any] = PIP_DEFAULT_ARGS
         elif (
             docker_settings.python_package_installer
             == PythonPackageInstaller.UV

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -146,7 +146,8 @@ def test_build_skipping():
     assert image_digest
 
 
-def test_installer_args():
+def test_python_package_installer_args():
+    """Tests that the python package installer args get passed correctly."""
     docker_settings = DockerSettings(
         python_package_installer_args={
             "default-timeout": 99,

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -144,3 +144,28 @@ def test_build_skipping():
         download_files=False,
     )
     assert image_digest
+
+
+def test_installer_args():
+    docker_settings = DockerSettings(
+        python_package_installer_args={
+            "default-timeout": 99,
+            "other-arg": "value",
+            "option": None,
+        }
+    )
+
+    requirements_files = [("requirements.txt", "numpy", [])]
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag",
+            docker_settings,
+            download_files=False,
+            requirements_files=requirements_files,
+        )
+    )
+
+    assert (
+        "RUN pip install --no-cache-dir --default-timeout=99 --other-arg=value --option"
+        in generated_dockerfile
+    )


### PR DESCRIPTION
## Describe changes
This PR adds the option to specify arguments for the python package installer when building Docker images.

For `uv` to work without the `--system` option, I also had to set the `VIRTUAL_ENV` variable in our Docker images so `uv` correctly picks up that the current python interpreter is from a virtual environment and not the system interpreter.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

