### PR TITLE
Add Discord Alerter into TOC

### DIFF
--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -157,6 +157,7 @@
     * [Spark](stacks-and-components/component-guide/step-operators/spark-kubernetes.md)
     * [Develop a Custom Step Operator](stacks-and-components/component-guide/step-operators/custom.md)
   * [Alerters](stacks-and-components/component-guide/alerters/alerters.md)
+    * [Discord Alerter](stacks-and-components/component-guide/alerters/discord.md)
     * [Slack Alerter](stacks-and-components/component-guide/alerters/slack.md)
     * [Develop a Custom Alerter](stacks-and-components/component-guide/alerters/custom.md)
   * [Feature Stores](stacks-and-components/component-guide/feature-stores/feature-stores.md)


### PR DESCRIPTION
This pull request adds the Discord Alerter documentation to the Table of Contents (TOC) in the component guide. The Discord Alerter is a recently-added alerter that allows users to receive alerts in Discord. This addition enhances the documentation by providing information on how to use the Discord Alerter and integrate it into the existing alerting system.