### PR TITLE
Allow deleting all versions of a pipeline using the Client/CLI

### DIFF
--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -1672,8 +1672,14 @@ occasionally want to delete a pipeline, which you can do via:
 zenml pipeline delete <PIPELINE_NAME>
 ```
 
-This will delete the pipeline and change all corresponding pipeline runs to
-become unlisted (not linked to any pipeline).
+This will delete the latest pipeline version and change all corresponding
+pipeline runs to become unlisted (not linked to any pipeline).
+
+If you want to delete all versions of a pipeline, you can do so as follows:
+
+```bash
+zenml pipeline delete <PIPELINE_NAME> --all-versions
+```
 
 To list all pipeline runs that you have executed, use:
 

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """CLI functionality to interact with pipelines."""
 
-import functools
 import json
 import os
 from typing import Any, Dict, Optional, Union
@@ -35,7 +34,7 @@ from zenml.models import (
     ScheduleFilter,
 )
 from zenml.new.pipelines.pipeline import Pipeline
-from zenml.utils import pagination_utils, source_utils, uuid_utils
+from zenml.utils import source_utils, uuid_utils
 from zenml.utils.yaml_utils import write_yaml
 
 logger = get_logger(__name__)
@@ -370,17 +369,11 @@ def delete_pipeline(
             return
 
     try:
-        if all_versions:
-            for pipeline in pagination_utils.depaginate(
-                functools.partial(
-                    Client().list_pipelines, name=pipeline_name_or_id
-                )
-            ):
-                Client().delete_pipeline(pipeline.id)
-        else:
-            Client().delete_pipeline(
-                name_id_or_prefix=pipeline_name_or_id, version=version
-            )
+        Client().delete_pipeline(
+            name_id_or_prefix=pipeline_name_or_id,
+            version=version,
+            all_versions=all_versions,
+        )
     except KeyError as e:
         cli_utils.error(str(e))
     else:

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -2415,6 +2415,7 @@ class Client(metaclass=ClientMetaClass):
         self,
         name_id_or_prefix: Union[str, UUID],
         version: Optional[str] = None,
+        all_versions: bool = False,
     ) -> None:
         """Delete a pipeline.
 
@@ -2422,11 +2423,30 @@ class Client(metaclass=ClientMetaClass):
             name_id_or_prefix: The name, ID or ID prefix of the pipeline.
             version: The pipeline version. If left empty, will delete
                 the latest version.
+            all_versions: If `True`, delete all versions of the pipeline.
+
+        Raises:
+            ValueError: If an ID is supplied when trying to delete all versions
+                of a pipeline.
         """
-        pipeline = self.get_pipeline(
-            name_id_or_prefix=name_id_or_prefix, version=version
-        )
-        self.zen_store.delete_pipeline(pipeline_id=pipeline.id)
+        if all_versions:
+            if is_valid_uuid(name_id_or_prefix):
+                raise ValueError(
+                    "You need to supply a name (not an ID) when trying to "
+                    "delete all versions of a pipeline."
+                )
+
+            for pipeline in depaginate(
+                functools.partial(
+                    Client().list_pipelines, name=name_id_or_prefix
+                )
+            ):
+                Client().delete_pipeline(pipeline.id)
+        else:
+            pipeline = self.get_pipeline(
+                name_id_or_prefix=name_id_or_prefix, version=version
+            )
+            self.zen_store.delete_pipeline(pipeline_id=pipeline.id)
 
     # -------------------------------- Builds ----------------------------------
 


### PR DESCRIPTION
## Describe changes
Adds a flag to delete all versions of a pipeline via the Client/CLI.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

