### PR TITLE
Remove default system flag in docker UV

### DIFF
--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -70,10 +70,7 @@ PIP_DEFAULT_ARGS = {
     "no-cache-dir": None,
     "default-timeout": 60,
 }
-UV_DEFAULT_ARGS = {
-    "no-cache-dir": None,
-    "system": None,
-}
+UV_DEFAULT_ARGS = {"no-cache-dir": None}
 
 
 class PipelineDockerImageBuilder:


### PR DESCRIPTION
## Describe changes
I remove the default `--system` flag from the Docker UV flags, since it is impacting how the libraries are installed in standard ZenML images. Users can still pass this flag in Docker Settings, if needed, for example, when a non-ZenML base image is used.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

