### PR TITLE
Adjust docs url for flavors

### DIFF
--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -26,6 +26,7 @@ from zenml.models import (
 from zenml.models.v2.core.flavor import InternalFlavorRequest
 from zenml.stack.stack_component import StackComponent, StackComponentConfig
 from zenml.utils import source_utils
+from zenml.utils.package_utils import is_latest_zenml_version
 
 
 class Flavor:
@@ -187,15 +188,11 @@ class Flavor:
         )
         return model
 
-    def generate_default_docs_url(self, component_name: str = "") -> str:
+    def generate_default_docs_url(self) -> str:
         """Generate the doc urls for all inbuilt and integration flavors.
 
         Note that this method is not going to be useful for custom flavors,
         which do not have any docs in the main zenml docs.
-
-        Args:
-            component_name: The name of the component for docs generation. Used
-                for legacy documentation before ZenML v0.34.0.
 
         Returns:
             The complete url to the zenml documentation
@@ -204,11 +201,18 @@ class Flavor:
 
         component_type = self.type.plural.replace("_", "-")
         name = self.name.replace("_", "-")
-        docs_component_name = component_name or name
-        base = f"https://docs.zenml.io/v/{__version__}"
-        return (
-            f"{base}/stack-components/{component_type}/{docs_component_name}"
-        )
+
+        try:
+            is_latest = is_latest_zenml_version()
+        except RuntimeError:
+            # We assume in error cases that we are on the latest version
+            is_latest = True
+
+        if is_latest:
+            base = f"https://zenml-io.gitbook.io/zenml-legacy-documentation/v/{__version__}"
+        else:
+            base = "https://docs.zenml.io/"
+        return f"{base}/stack-components/{component_type}/{name}"
 
     def generate_default_sdk_docs_url(self) -> str:
         """Generate SDK docs url for a flavor.

--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -209,9 +209,9 @@ class Flavor:
             is_latest = True
 
         if is_latest:
-            base = f"https://zenml-io.gitbook.io/zenml-legacy-documentation/v/{__version__}"
-        else:
             base = "https://docs.zenml.io/"
+        else:
+            base = f"https://zenml-io.gitbook.io/zenml-legacy-documentation/v/{__version__}"
         return f"{base}/stack-components/{component_type}/{name}"
 
     def generate_default_sdk_docs_url(self) -> str:

--- a/src/zenml/utils/package_utils.py
+++ b/src/zenml/utils/package_utils.py
@@ -12,6 +12,7 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """Utility functions for the package."""
+
 import requests
 from packaging import version
 
@@ -41,7 +42,9 @@ def is_latest_zenml_version() -> bool:
         )
 
     # Compare versions
-    if version.parse(latest_published_version) > version.parse(current_local_version):
+    if version.parse(latest_published_version) > version.parse(
+        current_local_version
+    ):
         return False
     else:
         return True

--- a/src/zenml/utils/package_utils.py
+++ b/src/zenml/utils/package_utils.py
@@ -28,20 +28,20 @@ def is_latest_zenml_version() -> bool:
     from zenml import __version__
 
     # Get the current version of the package
-    current_version = __version__
+    current_local_version = __version__
 
     # Get the latest version from PyPI
     try:
         response = requests.get("https://pypi.org/pypi/zenml/json")
         response.raise_for_status()
-        latest_version = response.json()["info"]["version"]
+        latest_published_version = response.json()["info"]["version"]
     except Exception as e:
         raise RuntimeError(
             f"Failed to fetch the latest version from PyPI: {e}"
         )
 
     # Compare versions
-    if version.parse(latest_version) > version.parse(current_version):
+    if version.parse(latest_published_version) > version.parse(current_local_version):
         return False
     else:
         return True

--- a/src/zenml/utils/package_utils.py
+++ b/src/zenml/utils/package_utils.py
@@ -1,0 +1,47 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Utility functions for the package."""
+import requests
+from packaging import version
+
+
+def is_latest_zenml_version() -> bool:
+    """Checks if the currently running ZenML package is on the latest version.
+
+    Returns:
+        True in case the current running zenml code is the latest available version on PYPI, otherwise False.
+
+    Raises:
+        RuntimeError: In case something goe wrong
+    """
+    from zenml import __version__
+
+    # Get the current version of the package
+    current_version = __version__
+
+    # Get the latest version from PyPI
+    try:
+        response = requests.get("https://pypi.org/pypi/zenml/json")
+        response.raise_for_status()
+        latest_version = response.json()["info"]["version"]
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to fetch the latest version from PyPI: {e}"
+        )
+
+    # Compare versions
+    if version.parse(latest_version) > version.parse(current_version):
+        return False
+    else:
+        return True


### PR DESCRIPTION
## Describe changes
Stack component flavors have a "docs_url" property which is used in the frontend and CLI to point users in the right direction to get more context. With the recent changes to legacy docs, the package needs to return a different URL for the latest zenml version vs. all older versions.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

