### PR TITLE
Raise error if Dockerfile does not exist

### DIFF
--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -119,6 +119,7 @@ class PipelineDockerImageBuilder:
             ValueError: If no Dockerfile and/or custom parent image is
                 specified and the Docker configuration doesn't require an
                 image build.
+            ValueError: If the specified Dockerfile does not exist.
         """
         requirements: Optional[str] = None
         dockerfile: Optional[str] = None
@@ -173,6 +174,12 @@ class PipelineDockerImageBuilder:
         )
 
         if docker_settings.dockerfile:
+            if not os.path.isfile(docker_settings.dockerfile):
+                raise ValueError(
+                    "Dockerfile at path "
+                    f"{os.path.abspath(docker_settings.dockerfile)} not found."
+                )
+
             if parent_image != DEFAULT_DOCKER_PARENT_IMAGE:
                 logger.warning(
                     "You've specified both a Dockerfile and a custom parent "

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -134,6 +134,14 @@ class PipelineDockerImageBuilder:
             # pipeline?
             return docker_settings.parent_image, dockerfile, requirements
 
+        if docker_settings.dockerfile and not os.path.isfile(
+            docker_settings.dockerfile
+        ):
+            raise ValueError(
+                "Dockerfile at path "
+                f"{os.path.abspath(docker_settings.dockerfile)} not found."
+            )
+
         stack.validate()
         image_builder = stack.image_builder
         if not image_builder:
@@ -174,12 +182,6 @@ class PipelineDockerImageBuilder:
         )
 
         if docker_settings.dockerfile:
-            if not os.path.isfile(docker_settings.dockerfile):
-                raise ValueError(
-                    "Dockerfile at path "
-                    f"{os.path.abspath(docker_settings.dockerfile)} not found."
-                )
-
             if parent_image != DEFAULT_DOCKER_PARENT_IMAGE:
                 logger.warning(
                     "You've specified both a Dockerfile and a custom parent "

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -14,6 +14,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from zenml.client import Client
 from zenml.config import DockerSettings
 from zenml.integrations.sklearn import SKLEARN, SklearnIntegration
@@ -170,3 +172,20 @@ def test_python_package_installer_args():
         "RUN pip install --no-cache-dir --default-timeout=99 --other-arg=value --option"
         in generated_dockerfile
     )
+
+
+def test_dockerfile_needs_to_exist():
+    """Tests that an error gets raised if the Dockerfile specified in the
+    DockerSettings does not exist."""
+    docker_settings = DockerSettings(
+        dockerfile="/a/file/that/does/not/exist.random"
+    )
+
+    with pytest.raises(ValueError):
+        PipelineDockerImageBuilder().build_docker_image(
+            docker_settings=docker_settings,
+            tag="tag",
+            stack=Client().active_stack,
+            include_files=True,
+            download_files=False,
+        )


### PR DESCRIPTION
## Describe changes
Currently, when users specify an invalid path to a Dockerfile, we instead treat the invalid path string as the contents of the Dockerfile, which leads to unexpected behaviour. This PR adds an additional check that the file exists to avoid this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

