### PR TITLE
Fix hook type definition and improve code completion for pipeline decorator

### DIFF
--- a/src/zenml/hooks/hook_validators.py
+++ b/src/zenml/hooks/hook_validators.py
@@ -14,14 +14,13 @@
 """Validation functions for hooks."""
 
 import inspect
-from types import FunctionType
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from zenml.config.source import Source
 from zenml.utils import source_utils
 
 if TYPE_CHECKING:
-    HookSpecification = Union[str, Source, FunctionType]
+    from zenml.types import HookSpecification
 
 
 def resolve_and_validate_hook(hook: "HookSpecification") -> Source:

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -19,7 +19,6 @@ import inspect
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -98,11 +97,11 @@ if TYPE_CHECKING:
     from zenml.config.source import Source
     from zenml.model.lazy_load import ModelVersionDataLazyLoader
     from zenml.model.model import Model
+    from zenml.types import HookSpecification
 
     StepConfigurationUpdateOrDict = Union[
         Dict[str, Any], StepConfigurationUpdate
     ]
-    HookSpecification = Union[str, "Source", FunctionType]
 
 logger = get_logger(__name__)
 

--- a/src/zenml/new/pipelines/pipeline_decorator.py
+++ b/src/zenml/new/pipelines/pipeline_decorator.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """ZenML pipeline decorator definition."""
 
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -31,8 +30,8 @@ if TYPE_CHECKING:
     from zenml.config.base_settings import SettingsOrDict
     from zenml.model.model import Model
     from zenml.new.pipelines.pipeline import Pipeline
+    from zenml.types import HookSpecification
 
-    HookSpecification = Union[str, FunctionType]
     F = TypeVar("F", bound=Callable[..., None])
 
 logger = get_logger(__name__)

--- a/src/zenml/new/pipelines/run_utils.py
+++ b/src/zenml/new/pipelines/run_utils.py
@@ -3,16 +3,7 @@
 import time
 from collections import defaultdict
 from datetime import datetime
-from types import FunctionType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Tuple, Union
 from uuid import UUID
 
 from zenml import constants
@@ -36,13 +27,11 @@ from zenml.utils import cloud_utils
 from zenml.zen_stores.base_zen_store import BaseZenStore
 
 if TYPE_CHECKING:
-    from zenml.config.source import Source
     from zenml.model.model import Model
 
     StepConfigurationUpdateOrDict = Union[
         Dict[str, Any], StepConfigurationUpdate
     ]
-    HookSpecification = Union[str, "Source", FunctionType]
 
 logger = get_logger(__name__)
 

--- a/src/zenml/new/steps/step_decorator.py
+++ b/src/zenml/new/steps/step_decorator.py
@@ -30,17 +30,16 @@ from typing import (
 from zenml.logger import get_logger
 
 if TYPE_CHECKING:
-    from types import FunctionType
-
     from zenml.config.base_settings import SettingsOrDict
     from zenml.config.retry_config import StepRetryConfig
     from zenml.config.source import Source
     from zenml.materializers.base_materializer import BaseMaterializer
     from zenml.model.model import Model
     from zenml.steps import BaseStep
+    from zenml.types import HookSpecification
 
     MaterializerClassOrSource = Union[str, Source, Type[BaseMaterializer]]
-    HookSpecification = Union[str, Source, FunctionType]
+
     OutputMaterializersSpecification = Union[
         MaterializerClassOrSource,
         Sequence[MaterializerClassOrSource],

--- a/src/zenml/pipelines/base_pipeline.py
+++ b/src/zenml/pipelines/base_pipeline.py
@@ -15,7 +15,6 @@
 
 import inspect
 from abc import ABC, abstractmethod
-from types import FunctionType
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Mapping, Optional, Union
 from uuid import UUID
 
@@ -35,7 +34,6 @@ if TYPE_CHECKING:
     StepConfigurationUpdateOrDict = Union[
         Dict[str, Any], StepConfigurationUpdate
     ]
-    HookSpecification = Union[str, FunctionType]
 
 logger = get_logger(__name__)
 

--- a/src/zenml/pipelines/pipeline_decorator.py
+++ b/src/zenml/pipelines/pipeline_decorator.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Legacy ZenML pipeline decorator definition."""
 
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,8 +45,8 @@ from zenml.pipelines.base_pipeline import (
 
 if TYPE_CHECKING:
     from zenml.config.base_settings import SettingsOrDict
+    from zenml.types import HookSpecification
 
-    HookSpecification = Union[str, FunctionType]
 
 logger = get_logger(__name__)
 

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -18,7 +18,6 @@ import hashlib
 import inspect
 from abc import abstractmethod
 from collections import defaultdict
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -76,10 +75,10 @@ if TYPE_CHECKING:
     )
     from zenml.model.lazy_load import ModelVersionDataLazyLoader
     from zenml.model.model import Model
+    from zenml.types import HookSpecification
 
     ParametersOrDict = Union["BaseParameters", Dict[str, Any]]
     MaterializerClassOrSource = Union[str, Source, Type["BaseMaterializer"]]
-    HookSpecification = Union[str, Source, FunctionType]
     OutputMaterializersSpecification = Union[
         "MaterializerClassOrSource",
         Sequence["MaterializerClassOrSource"],

--- a/src/zenml/steps/step_decorator.py
+++ b/src/zenml/steps/step_decorator.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Step decorator function."""
 
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -37,9 +36,9 @@ if TYPE_CHECKING:
     from zenml.config.source import Source
     from zenml.materializers.base_materializer import BaseMaterializer
     from zenml.model.model import Model
+    from zenml.types import HookSpecification
 
     MaterializerClassOrSource = Union[str, "Source", Type["BaseMaterializer"]]
-    HookSpecification = Union[str, "Source", FunctionType]
     OutputMaterializersSpecification = Union[
         "MaterializerClassOrSource",
         Sequence["MaterializerClassOrSource"],

--- a/src/zenml/types.py
+++ b/src/zenml/types.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Custom types that are used to indicate how to handle data."""
+"""Custom ZenML types."""
 
 from typing import TYPE_CHECKING, Callable, Union
 

--- a/src/zenml/types.py
+++ b/src/zenml/types.py
@@ -13,6 +13,15 @@
 #  permissions and limitations under the License.
 """Custom types that are used to indicate how to handle data."""
 
+from typing import TYPE_CHECKING, Callable, Union
+
+if TYPE_CHECKING:
+    from types import FunctionType
+
+    from zenml.config.source import Source
+
+    HookSpecification = Union[str, Source, FunctionType, Callable[..., None]]
+
 
 class HTMLString(str):
     """Special string class to indicate an HTML string."""


### PR DESCRIPTION
## Describe changes

Our current `HookSpecification` did not allow `Callables`, only `FunctionType`. I fixed that by allowing specifications of `Callable`, and also added some additional type hints to the pipeline decorator overload to enable better code completion. 



## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

