### PR TITLE
Small improvements and bug fixes

### DIFF
--- a/src/zenml/cli/artifact.py
+++ b/src/zenml/cli/artifact.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """CLI functionality to interact with artifacts."""
 
-from functools import partial
 from typing import Any, Dict, List, Optional
 
 import click
@@ -258,7 +257,7 @@ def prune_artifacts(
     """
     client = Client()
     unused_artifact_versions = depaginate(
-        partial(client.list_artifact_versions, only_unused=True)
+        client.list_artifact_versions, only_unused=True
     )
 
     if not unused_artifact_versions:

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -19,7 +19,6 @@ import os
 from abc import ABCMeta
 from collections import Counter
 from datetime import datetime
-from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -2439,9 +2438,7 @@ class Client(metaclass=ClientMetaClass):
                 )
 
             for pipeline in depaginate(
-                functools.partial(
-                    Client().list_pipelines, name=name_id_or_prefix
-                )
+                Client().list_pipelines, name=name_id_or_prefix
             ):
                 Client().delete_pipeline(pipeline.id)
         else:
@@ -2579,11 +2576,9 @@ class Client(metaclass=ClientMetaClass):
                 )
 
             builds = depaginate(
-                partial(
-                    self.list_builds,
-                    pipeline_id=pipeline.id,
-                    stack_id=stack.id if stack else None,
-                )
+                self.list_builds,
+                pipeline_id=pipeline.id,
+                stack_id=stack.id if stack else None,
             )
 
             for build in builds:
@@ -3942,7 +3937,7 @@ class Client(metaclass=ClientMetaClass):
         """
         if delete_from_artifact_store:
             unused_artifact_versions = depaginate(
-                partial(self.list_artifact_versions, only_unused=True)
+                self.list_artifact_versions, only_unused=True
             )
             for unused_artifact_version in unused_artifact_versions:
                 self._delete_artifact_from_artifact_store(
@@ -4151,7 +4146,7 @@ class Client(metaclass=ClientMetaClass):
             ValueError: If the artifact version is still used in any runs.
         """
         if artifact_version not in depaginate(
-            partial(self.list_artifact_versions, only_unused=True)
+            self.list_artifact_versions, only_unused=True
         ):
             raise ValueError(
                 "The metadata of artifact versions that are used in runs "

--- a/src/zenml/event_hub/event_hub.py
+++ b/src/zenml/event_hub/event_hub.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Base class for all the Event Hub."""
 
-from functools import partial
 from typing import List
 
 from pydantic import ValidationError
@@ -125,13 +124,11 @@ class InternalEventHub(BaseEventHub):
         """
         # get all event sources configured for this flavor
         triggers: List[TriggerResponse] = depaginate(
-            partial(
-                self.zen_store.list_triggers,
-                trigger_filter_model=TriggerFilter(
-                    event_source_id=event_source.id, is_active=True
-                ),
-                hydrate=True,
-            )
+            self.zen_store.list_triggers,
+            trigger_filter_model=TriggerFilter(
+                event_source_id=event_source.id, is_active=True
+            ),
+            hydrate=True,
         )
 
         trigger_list: List[TriggerResponse] = []

--- a/src/zenml/models/v2/core/model.py
+++ b/src/zenml/models/v2/core/model.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Models representing models."""
 
-from functools import partial
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Union
 from uuid import UUID
 
@@ -303,7 +302,7 @@ class ModelResponse(
 
         client = Client()
         model_versions = depaginate(
-            partial(client.list_model_versions, model_name_or_id=self.id)
+            client.list_model_versions, model_name_or_id=self.id
         )
         return [
             mv.to_model_class(suppress_class_validation_warnings=True)

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -281,7 +281,7 @@ class Pipeline:
         raise RuntimeError(
             f"Cannot get the model of pipeline '{self.name}' because it has "
             f"not been registered yet. Please ensure that the pipeline has "
-            f"been run and that at least one step has been executed."
+            f"been run or built and try again."
         )
 
     @contextmanager

--- a/src/zenml/orchestrators/input_utils.py
+++ b/src/zenml/orchestrators/input_utils.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Utilities for inputs."""
 
-import functools
 from typing import TYPE_CHECKING, Dict, List, Tuple
 from uuid import UUID
 
@@ -48,13 +47,11 @@ def resolve_step_inputs(
     """
     from zenml.models import ArtifactVersionResponse, RunMetadataResponse
 
-    list_run_steps = functools.partial(
-        Client().list_run_steps, pipeline_run_id=run_id
-    )
-
     current_run_steps = {
         run_step.name: run_step
-        for run_step in pagination_utils.depaginate(list_run_steps)
+        for run_step in pagination_utils.depaginate(
+            Client().list_run_steps, pipeline_run_id=run_id
+        )
     }
 
     input_artifacts: Dict[str, "ArtifactVersionResponse"] = {}

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Implementation of the ZenML Stack class."""
 
-import functools
 import itertools
 import json
 import os
@@ -155,11 +154,9 @@ class Stack:
 
         # Run a hydrated list call once to avoid one request per component
         component_models = pagination_utils.depaginate(
-            list_method=functools.partial(
-                Client().list_stack_components,
-                stack_id=stack_model.id,
-                hydrate=True,
-            )
+            Client().list_stack_components,
+            stack_id=stack_model.id,
+            hydrate=True,
         )
 
         stack_components = {

--- a/src/zenml/utils/pagination_utils.py
+++ b/src/zenml/utils/pagination_utils.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Pagination utilities."""
 
-from typing import Callable, List, TypeVar
+from typing import Any, Callable, List, TypeVar
 
 from zenml.models import BaseIdentifiedResponse, Page
 
@@ -21,20 +21,22 @@ AnyResponse = TypeVar("AnyResponse", bound=BaseIdentifiedResponse)  # type: igno
 
 
 def depaginate(
-    list_method: Callable[..., Page[AnyResponse]],
+    list_method: Callable[..., Page[AnyResponse]], **kwargs: Any
 ) -> List[AnyResponse]:
     """Depaginate the results from a client or store method that returns pages.
 
     Args:
-        list_method: The list method to wrap around.
+        list_method: The list method to depaginate.
+        **kwargs: Arguments for the list method.
 
     Returns:
         A list of the corresponding Response Models.
     """
-    page = list_method()
+    page = list_method(**kwargs)
     items = list(page.items)
     while page.index < page.total_pages:
-        page = list_method(page=page.index + 1)
+        kwargs["page"] = page.index + 1
+        page = list_method(**kwargs)
         items += list(page.items)
 
     return items

--- a/src/zenml/utils/pydantic_utils.py
+++ b/src/zenml/utils/pydantic_utils.py
@@ -45,7 +45,7 @@ def update_model(
     original: M,
     update: Union["BaseModel", Dict[str, Any]],
     recursive: bool = True,
-    exclude_none: bool = True,
+    exclude_none: bool = False,
 ) -> M:
     """Updates a pydantic model.
 
@@ -53,8 +53,7 @@ def update_model(
         original: The model to update.
         update: The update values.
         recursive: If `True`, dictionary values will be updated recursively.
-        exclude_none: If `True`, `None` values in the update dictionary
-            will be removed.
+        exclude_none: If `True`, `None` values in the update will be removed.
 
     Returns:
         The updated model.
@@ -67,7 +66,9 @@ def update_model(
         else:
             update_dict = update
     else:
-        update_dict = update.model_dump(exclude_unset=True)
+        update_dict = update.model_dump(
+            exclude_unset=True, exclude_none=exclude_none
+        )
 
     original_dict = original.model_dump(exclude_unset=True)
     if recursive:
@@ -75,7 +76,7 @@ def update_model(
     else:
         values = {**original_dict, **update_dict}
 
-    return original.__class__(**values)
+    return original.__class__.model_validate(values)
 
 
 class TemplateGenerator:

--- a/src/zenml/zen_server/pipeline_deployment/utils.py
+++ b/src/zenml/zen_server/pipeline_deployment/utils.py
@@ -357,8 +357,12 @@ def apply_run_config(
         step_config = StepConfiguration.model_validate(step_config_dict)
 
         if update := run_config.steps.get(invocation_id):
+            update_dict = update.model_dump()
+            # Get rid of deprecated name to prevent overriding the step name
+            # with `None`.
+            update_dict.pop("name", None)
             step_config = pydantic_utils.update_model(
-                step_config, update=update
+                step_config, update=update_dict
             )
         steps[invocation_id] = Step(spec=step.spec, config=step_config)
 

--- a/tests/harness/model/requirements.py
+++ b/tests/harness/model/requirements.py
@@ -17,7 +17,6 @@ import logging
 import platform
 import shutil
 from enum import Enum
-from functools import partial
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -94,12 +93,10 @@ class StackRequirement(BaseTestConfigModel):
             The stack component or None if no component was found.
         """
         components = depaginate(
-            partial(
-                client.list_stack_components,
-                name=self.name or None,
-                type=self.type,
-                flavor=self.flavor,
-            )
+            client.list_stack_components,
+            name=self.name or None,
+            type=self.type,
+            flavor=self.flavor,
         )
 
         mandatory_components: List[UUID] = []

--- a/tests/unit/utils/test_pydantic_utils.py
+++ b/tests/unit/utils/test_pydantic_utils.py
@@ -75,8 +75,8 @@ def test_update_model_works_recursively():
     assert updated.b["c"]["d"] == "f"
 
 
-def test_update_model_works_with_none_exclusion():
-    """'None' values in the update dictionary don't get removed.'"""
+def test_update_model_works_with_dict_none_exclusion():
+    """'None' values in the update dictionary get removed if specified."""
 
     class TestModel(BaseModel):
         a: int
@@ -92,6 +92,30 @@ def test_update_model_works_with_none_exclusion():
     # Case: when exclude_none is False
     original2 = TestModel(a=1, b=2)
     update2 = {"a": 3, "b": None}
+    updated2 = pydantic_utils.update_model(
+        original2, update2, exclude_none=False
+    )
+    assert updated2.a == 3
+    assert updated2.b is None
+
+
+def test_update_model_works_with_model_none_exclusion():
+    """'None' values in the update model get removed if specified"""
+
+    class TestModel(BaseModel):
+        a: int
+        b: Optional[int] = None
+
+    # Case: when exclude_none is True
+    original = TestModel(a=1, b=2)
+    update = TestModel(a=3, b=None)
+    updated = pydantic_utils.update_model(original, update, exclude_none=True)
+    assert updated.a == 3
+    assert updated.b == 2
+
+    # Case: when exclude_none is False
+    original2 = TestModel(a=1, b=2)
+    update2 = TestModel(a=3, b=None)
     updated2 = pydantic_utils.update_model(
         original2, update2, exclude_none=False
     )


### PR DESCRIPTION
## Describe changes
This PR contains a number of small fixes and improvements:
- The `pagination_utils.depaginate(...)` function now allows passing keyword arguments that will be used when calling the list function. This means we don't have to use `functools.partial(...)` to apply those arguments to the function before passing it to the depagination.
- The `model` property of a pipeline had a wrong error message that was adjusted.
- When running a pipeline from the server, the deprecated `name` property of the `StepConfigurationUpdate` led to an issue in some cases. That property is now explicitly removed from the update dict.
- The `exclude_none` argument of the `pydantic_utils.update_model(...)` function was not working when the update was a pydantic model, only if it was a dict. There is not a single place in our code where this function is being called with a dictionary however. I fixed the bug and updated the default value for `exclude_none` to `False` to keep the existing behaviour.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

