### PR TITLE
Bump kfp version in GCP integration for pydantic2.0

### DIFF
--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -43,7 +43,7 @@ class GcpIntegration(Integration):
 
     NAME = GCP
     REQUIREMENTS = [
-        "kfp>=1.8.22",
+        "kfp>=2.6.0",
         "gcsfs",
         "google-cloud-secret-manager",
         "google-cloud-container>=2.21.0",


### PR DESCRIPTION
## Describe changes
I bumped the kfp version requirement in our GCP integration so that it doesn't install pydantic1.x when installing the integration. Tested by running a pipeline on Vertex.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

