### PR TITLE
Fix Kubeflow v2 integration 

### DIFF
--- a/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubeflow/flavors/kubeflow_orchestrator_flavor.py
@@ -149,7 +149,7 @@ class KubeflowOrchestratorConfig(
 
     kubeflow_hostname: Optional[str] = None
     kubeflow_namespace: str = "kubeflow"
-    kubernetes_context: Optional[str]  # TODO: Potential setting
+    kubernetes_context: Optional[str] = None # TODO: Potential setting
 
     @model_validator(mode="before")
     @classmethod

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -433,7 +433,6 @@ class KubeflowOrchestrator(ContainerizedOrchestrator):
             The dynamic container component.
         """
 
-        @dsl.container_component  # type: ignore[misc]
         def dynamic_container_component() -> dsl.ContainerSpec:
             """Dynamic container component.
 


### PR DESCRIPTION
## Describe changes
This PR:
- makes `kubernetes_context` optional because we don't need it set when using a service connector.
- fixed the pipeline creation step for kfp, by not using the decorator, as it converts the function to a ContainerComponent object.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

