### PR TITLE
Make upgrade checks in formatting script optional

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,15 +6,18 @@ default_src="src/zenml tests examples docs/mkdocstrings_helper.py scripts"
 # Initialize SRC as an empty string
 SRC=""
 
-# Initialize SKIP_YAMLFIX as false
+# Initialize SKIP_YAMLFIX and SKIP_UPGRADE as false
 SKIP_YAMLFIX=false
+SKIP_UPGRADE=true
 
 # Process arguments
 for arg in "$@"
 do
-    # Check for the --no-yamlfix flag
+    # Check for the --no-yamlfix and --no-upgrade flags
     if [ "$arg" = "--no-yamlfix" ]; then
         SKIP_YAMLFIX=true
+    elif [ "$arg" = "--no-upgrade" ]; then
+        SKIP_UPGRADE=true
     else
         # If it's not the flag, treat it as a source directory
         # Append the argument to SRC, separated by space
@@ -25,6 +28,24 @@ do
         fi
     fi
 done
+
+# Check for ruff and yamlfix versions
+if [ "$SKIP_UPGRADE" = false ]; then
+    RED='\033[0;31m'
+    NC='\033[0m'
+    
+    pip install uv -q
+    uv_output=$(uv pip install ".[dev]" --dry-run --upgrade --system 2>&1 | grep "+")
+    ruff_version_change=$(echo "$uv_output" | grep "+ ruff")
+    yamlfix_version_change=$(echo "$uv_output" | grep "+ yamlfix")
+    
+    if [ -n "$ruff_version_change" ]; then
+        echo "${RED}ruff version is outdated and might lead to CI failures. Consider upgrading to ${ruff_version_change:3}.${NC}"
+    fi
+    if [ -n "$yamlfix_version_change" ]; then
+        echo "${RED}yamlfix version is outdated and might lead to CI failures. Consider upgrading to ${yamlfix_version_change:3}.${NC}"
+    fi
+fi
 
 # If no source directories were provided, use the default
 if [ -z "$SRC" ]; then

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,18 +6,15 @@ default_src="src/zenml tests examples docs/mkdocstrings_helper.py scripts"
 # Initialize SRC as an empty string
 SRC=""
 
-# Initialize SKIP_YAMLFIX and SKIP_UPGRADE as false
+# Initialize SKIP_YAMLFIX as false
 SKIP_YAMLFIX=false
-SKIP_UPGRADE=false
 
 # Process arguments
 for arg in "$@"
 do
-    # Check for the --no-yamlfix and --no-upgrade flags
+    # Check for the --no-yamlfix flag
     if [ "$arg" = "--no-yamlfix" ]; then
         SKIP_YAMLFIX=true
-    elif [ "$arg" = "--no-upgrade" ]; then
-        SKIP_UPGRADE=true
     else
         # If it's not the flag, treat it as a source directory
         # Append the argument to SRC, separated by space
@@ -28,24 +25,6 @@ do
         fi
     fi
 done
-
-# Check for ruff and yamlfix versions
-if [ "$SKIP_UPGRADE" = false ]; then
-    RED='\033[0;31m'
-    NC='\033[0m'
-    
-    pip install uv -q
-    uv_output=$(uv pip install ".[dev]" --dry-run --upgrade --system 2>&1 | grep "+")
-    ruff_version_change=$(echo "$uv_output" | grep "+ ruff")
-    yamlfix_version_change=$(echo "$uv_output" | grep "+ yamlfix")
-    
-    if [ -n "$ruff_version_change" ]; then
-        echo "${RED}ruff version is outdated and might lead to CI failures. Consider upgrading to ${ruff_version_change:3}.${NC}"
-    fi
-    if [ -n "$yamlfix_version_change" ]; then
-        echo "${RED}yamlfix version is outdated and might lead to CI failures. Consider upgrading to ${yamlfix_version_change:3}.${NC}"
-    fi
-fi
 
 # If no source directories were provided, use the default
 if [ -z "$SRC" ]; then


### PR DESCRIPTION
## Describe changes
This PR makes new Upgrade checks in `format.sh` disabled by default, as it shows issues on externally managed systems (e.g. pyenv)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

