### PR TITLE
Added some visualizations for the HF dataset

### DIFF
--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -42,18 +42,18 @@ if TYPE_CHECKING:
 DEFAULT_DATASET_DIR = "hf_datasets"
 
 
-def extract_repo_url(checksum_str: str) -> Optional[str]:
-    """Extracts the repo url from the checksum URL.
+def extract_repo_name(checksum_str: str) -> Optional[str]:
+    """Extracts the repo name from the checksum string.
 
     An example of a checksum_str is:
     "hf://datasets/nyu-mll/glue@bcdcba79d07bc864c1c254ccfcedcce55bcc9a8c/mrpc/train-00000-of-00001.parquet"
     and the expected output is "nyu-mll/glue".
 
     Args:
-        checksum_str: The checksum_str to extract the dataset name from.
+        checksum_str: The checksum_str to extract the repo name from.
 
     Returns:
-        Optional[str]: The extracted dataset name.
+        str: The extracted repo name.
     """
     dataset = None
     try:
@@ -163,7 +163,7 @@ class HFDatasetMaterializer(BaseMaterializer):
 
         for name, dataset in datasets.items():
             # Generate a unique identifier for the dataset
-            dataset_id = extract_repo_url(
+            dataset_id = extract_repo_name(
                 [x for x in dataset.info.download_checksums.keys()][0]
             )
             if dataset_id:

--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -71,9 +71,9 @@ class HFDatasetMaterializer(BaseMaterializer):
     """Materializer to read data to and from huggingface datasets."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Dataset, DatasetDict)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[
-        ArtifactType
-    ] = ArtifactType.DATA_ANALYSIS
+    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = (
+        ArtifactType.DATA_ANALYSIS
+    )
 
     def load(
         self, data_type: Union[Type[Dataset], Type[DatasetDict]]
@@ -148,7 +148,7 @@ class HFDatasetMaterializer(BaseMaterializer):
 
         Returns:
             A dictionary mapping visualization paths to their types.
-            
+
         Raises:
             ValueError: If the given object is not a `Dataset` or `DatasetDict`.
         """

--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -42,24 +42,28 @@ if TYPE_CHECKING:
 DEFAULT_DATASET_DIR = "hf_datasets"
 
 
-def extract_dataset_name(input_string) -> Optional[str]:
-    """Extracts the dataset name from the input string.
+def extract_repo_url(checksum_str: str) -> Optional[str]:
+    """Extracts the repo url from the checksum URL.
+
+    An example of a checksum_str is:
+    "hf://datasets/nyu-mll/glue@bcdcba79d07bc864c1c254ccfcedcce55bcc9a8c/mrpc/train-00000-of-00001.parquet"
+    and the expected output is "nyu-mll/glue".
 
     Args:
-        input_string: The input string to extract the dataset name from.
+        checksum_str: The checksum_str to extract the dataset name from.
 
     Returns:
         Optional[str]: The extracted dataset name.
     """
     dataset = None
     try:
-        parts = input_string.split("/")
+        parts = checksum_str.split("/")
         if len(parts) >= 4:
             # Case: nyu-mll/glue
             dataset = f"{parts[3]}/{parts[4].split('@')[0]}"
-    except Exception: # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         pass
-        
+
     return dataset
 
 
@@ -144,6 +148,9 @@ class HFDatasetMaterializer(BaseMaterializer):
 
         Returns:
             A dictionary mapping visualization paths to their types.
+            
+        Raises:
+            ValueError: If the given object is not a `Dataset` or `DatasetDict`.
         """
         visualizations = {}
 
@@ -156,7 +163,7 @@ class HFDatasetMaterializer(BaseMaterializer):
 
         for name, dataset in datasets.items():
             # Generate a unique identifier for the dataset
-            dataset_id = extract_dataset_name(
+            dataset_id = extract_repo_url(
                 [x for x in dataset.info.download_checksums.keys()][0]
             )
             if dataset_id:

--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -71,9 +71,9 @@ class HFDatasetMaterializer(BaseMaterializer):
     """Materializer to read data to and from huggingface datasets."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Dataset, DatasetDict)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[
-        ArtifactType
-    ] = ArtifactType.DATA_ANALYSIS
+    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = (
+        ArtifactType.DATA_ANALYSIS
+    )
 
     def load(
         self, data_type: Union[Type[Dataset], Type[DatasetDict]]

--- a/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_datasets_materializer.py
@@ -71,9 +71,9 @@ class HFDatasetMaterializer(BaseMaterializer):
     """Materializer to read data to and from huggingface datasets."""
 
     ASSOCIATED_TYPES: ClassVar[Tuple[Type[Any], ...]] = (Dataset, DatasetDict)
-    ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = (
-        ArtifactType.DATA_ANALYSIS
-    )
+    ASSOCIATED_ARTIFACT_TYPE: ClassVar[
+        ArtifactType
+    ] = ArtifactType.DATA_ANALYSIS
 
     def load(
         self, data_type: Union[Type[Dataset], Type[DatasetDict]]
@@ -163,27 +163,28 @@ class HFDatasetMaterializer(BaseMaterializer):
 
         for name, dataset in datasets.items():
             # Generate a unique identifier for the dataset
-            dataset_id = extract_repo_name(
-                [x for x in dataset.info.download_checksums.keys()][0]
-            )
-            if dataset_id:
-                # Create the iframe HTML
-                html = f"""
-                <iframe
-                src="https://huggingface.co/datasets/{dataset_id}/embed/viewer"
-                frameborder="0"
-                width="100%"
-                height="560px"
-                ></iframe>
-                """
-
-                # Save the HTML to a file
-                visualization_path = os.path.join(
-                    self.uri, f"{name}_viewer.html"
+            if dataset.info.download_checksums:
+                dataset_id = extract_repo_name(
+                    [x for x in dataset.info.download_checksums.keys()][0]
                 )
-                with fileio.open(visualization_path, "w") as f:
-                    f.write(html)
+                if dataset_id:
+                    # Create the iframe HTML
+                    html = f"""
+                    <iframe
+                    src="https://huggingface.co/datasets/{dataset_id}/embed/viewer"
+                    frameborder="0"
+                    width="100%"
+                    height="560px"
+                    ></iframe>
+                    """
 
-                visualizations[visualization_path] = VisualizationType.HTML
+                    # Save the HTML to a file
+                    visualization_path = os.path.join(
+                        self.uri, f"{name}_viewer.html"
+                    )
+                    with fileio.open(visualization_path, "w") as f:
+                        f.write(html)
+
+                    visualizations[visualization_path] = VisualizationType.HTML
 
         return visualizations

--- a/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
+++ b/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
@@ -18,7 +18,7 @@ from datasets import Dataset
 from tests.unit.test_general import _test_materializer
 from zenml.integrations.huggingface.materializers.huggingface_datasets_materializer import (
     HFDatasetMaterializer,
-    extract_repo_url,
+    extract_repo_name,
 )
 
 
@@ -38,61 +38,61 @@ def test_huggingface_datasets_materializer(clean_client):
     assert [1, 2, 3] in data.values()
 
 
-def test_extract_repo_url():
-    """Tests whether the extract_repo_url function works correctly."""
+def test_extract_repo_name():
+    """Tests whether the extract_repo_name function works correctly."""
     # Test valid URL
     url = "hf://datasets/nyu-mll/glue@bcdcba79d07bc864c1c254ccfcedcce55bcc9a8c/mrpc/train-00000-of-00001.parquet"
-    assert extract_repo_url(url) == "nyu-mll/glue"
+    assert extract_repo_name(url) == "nyu-mll/glue"
 
     # Test valid URL with different dataset
     url = "hf://datasets/huggingface/dataset-name@123456/subset/file.parquet"
-    assert extract_repo_url(url) == "huggingface/dataset-name"
+    assert extract_repo_name(url) == "huggingface/dataset-name"
 
     # Test URL without file
     url = "hf://datasets/org/repo@commit"
-    assert extract_repo_url(url) == "org/repo"
+    assert extract_repo_name(url) == "org/repo"
 
     # Test URL with extra parts
     url = "hf://datasets/org/repo/extra/parts@commit/file.parquet"
-    assert extract_repo_url(url) == "org/repo"
+    assert extract_repo_name(url) == "org/repo"
 
     # Test invalid URL (too short)
     url = "hf://datasets/org"
-    assert extract_repo_url(url) is None
+    assert extract_repo_name(url) is None
 
     # Test invalid URL format
     url = "https://huggingface.co/datasets/org/repo"
-    assert extract_repo_url(url) is None
+    assert extract_repo_name(url) is None
 
     # Test empty string
-    assert extract_repo_url("") is None
+    assert extract_repo_name("") is None
 
     # Test None input
-    assert extract_repo_url(None) is None
+    assert extract_repo_name(None) is None
 
 
-def test_extract_repo_url_edge_cases():
-    """Tests edge cases for the extract_repo_url function."""
+def test_extract_repo_name_edge_cases():
+    """Tests edge cases for the extract_repo_name function."""
     # Test URL with no '@' symbol
     url = "hf://datasets/org/repo/file.parquet"
-    assert extract_repo_url(url) == "org/repo"
+    assert extract_repo_name(url) == "org/repo"
 
     # Test URL with multiple '@' symbols
     url = "hf://datasets/org/repo@commit@extra/file.parquet"
-    assert extract_repo_url(url) == "org/repo"
+    assert extract_repo_name(url) == "org/repo"
 
     # Test URL with special characters in repo name
     url = "hf://datasets/org-name/repo_name-123@commit/file.parquet"
-    assert extract_repo_url(url) == "org-name/repo_name-123"
+    assert extract_repo_name(url) == "org-name/repo_name-123"
 
 
-def test_extract_repo_url_exceptions():
-    """Tests exception handling in the extract_repo_url function."""
+def test_extract_repo_name_exceptions():
+    """Tests exception handling in the extract_repo_name function."""
     # Test with non-string input
-    assert extract_repo_url(123) is None
+    assert extract_repo_name(123) is None
 
     # Test with list input
-    assert extract_repo_url(["not", "a", "string"]) is None
+    assert extract_repo_name(["not", "a", "string"]) is None
 
     # Test with dict input
-    assert extract_repo_url({"not": "a string"}) is None
+    assert extract_repo_name({"not": "a string"}) is None

--- a/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
+++ b/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
@@ -18,6 +18,7 @@ from datasets import Dataset
 from tests.unit.test_general import _test_materializer
 from zenml.integrations.huggingface.materializers.huggingface_datasets_materializer import (
     HFDatasetMaterializer,
+    extract_repo_url,
 )
 
 
@@ -35,3 +36,63 @@ def test_huggingface_datasets_materializer(clean_client):
     data = dataset.data.to_pydict()
     assert "0" in data.keys()
     assert [1, 2, 3] in data.values()
+
+
+def test_extract_repo_url():
+    """Tests whether the extract_repo_url function works correctly."""
+    # Test valid URL
+    url = "hf://datasets/nyu-mll/glue@bcdcba79d07bc864c1c254ccfcedcce55bcc9a8c/mrpc/train-00000-of-00001.parquet"
+    assert extract_repo_url(url) == "nyu-mll/glue"
+
+    # Test valid URL with different dataset
+    url = "hf://datasets/huggingface/dataset-name@123456/subset/file.parquet"
+    assert extract_repo_url(url) == "huggingface/dataset-name"
+
+    # Test URL without file
+    url = "hf://datasets/org/repo@commit"
+    assert extract_repo_url(url) == "org/repo"
+
+    # Test URL with extra parts
+    url = "hf://datasets/org/repo/extra/parts@commit/file.parquet"
+    assert extract_repo_url(url) == "org/repo"
+
+    # Test invalid URL (too short)
+    url = "hf://datasets/org"
+    assert extract_repo_url(url) is None
+
+    # Test invalid URL format
+    url = "https://huggingface.co/datasets/org/repo"
+    assert extract_repo_url(url) is None
+
+    # Test empty string
+    assert extract_repo_url("") is None
+
+    # Test None input
+    assert extract_repo_url(None) is None
+
+
+def test_extract_repo_url_edge_cases():
+    """Tests edge cases for the extract_repo_url function."""
+    # Test URL with no '@' symbol
+    url = "hf://datasets/org/repo/file.parquet"
+    assert extract_repo_url(url) == "org/repo"
+
+    # Test URL with multiple '@' symbols
+    url = "hf://datasets/org/repo@commit@extra/file.parquet"
+    assert extract_repo_url(url) == "org/repo"
+
+    # Test URL with special characters in repo name
+    url = "hf://datasets/org-name/repo_name-123@commit/file.parquet"
+    assert extract_repo_url(url) == "org-name/repo_name-123"
+
+
+def test_extract_repo_url_exceptions():
+    """Tests exception handling in the extract_repo_url function."""
+    # Test with non-string input
+    assert extract_repo_url(123) is None
+
+    # Test with list input
+    assert extract_repo_url(["not", "a", "string"]) is None
+
+    # Test with dict input
+    assert extract_repo_url({"not": "a string"}) is None

--- a/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
+++ b/tests/integration/integrations/huggingface/materializers/test_huggingface_datasets_materializer.py
@@ -60,10 +60,6 @@ def test_extract_repo_name():
     url = "hf://datasets/org"
     assert extract_repo_name(url) is None
 
-    # Test invalid URL format
-    url = "https://huggingface.co/datasets/org/repo"
-    assert extract_repo_name(url) is None
-
     # Test empty string
     assert extract_repo_name("") is None
 


### PR DESCRIPTION
## Describe changes
With the ability to embed any Huggingface dataset, this feature adds the visualization the ZenML dashboard, in case one returns a HF dataset.

![image](https://github.com/user-attachments/assets/30362d52-e98d-4078-9dec-d9d9c74e45c5)


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

