### PR TITLE
Adding a `logo_url` and the of the `integration` to component responses

### DIFF
--- a/src/zenml/models/v2/core/component.py
+++ b/src/zenml/models/v2/core/component.py
@@ -191,6 +191,17 @@ class ComponentResponseBody(WorkspaceScopedResponseBody):
         title="The flavor of the stack component.",
         max_length=STR_FIELD_MAX_LENGTH,
     )
+    integration: Optional[str] = Field(
+        default=None,
+        title="The name of the integration that the component's flavor "
+        "belongs to.",
+        max_length=STR_FIELD_MAX_LENGTH,
+    )
+    logo_url: Optional[str] = Field(
+        default=None,
+        title="Optionally, a url pointing to a png,"
+        "svg or jpg can be attached.",
+    )
 
 
 class ComponentResponseMetadata(WorkspaceScopedResponseMetadata):
@@ -284,6 +295,24 @@ class ComponentResponse(
             the value of the property.
         """
         return self.get_body().flavor
+
+    @property
+    def integration(self) -> Optional[str]:
+        """The `integration` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().integration
+
+    @property
+    def logo_url(self) -> str:
+        """The `logo_url` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().logo_url
 
     @property
     def configuration(self) -> Dict[str, Any]:

--- a/src/zenml/models/v2/core/component.py
+++ b/src/zenml/models/v2/core/component.py
@@ -306,7 +306,7 @@ class ComponentResponse(
         return self.get_body().integration
 
     @property
-    def logo_url(self) -> str:
+    def logo_url(self) -> Optional[str]:
         """The `logo_url` property.
 
         Returns:

--- a/src/zenml/zen_stores/schemas/component_schemas.py
+++ b/src/zenml/zen_stores/schemas/component_schemas.py
@@ -38,6 +38,7 @@ from zenml.zen_stores.schemas.user_schemas import UserSchema
 from zenml.zen_stores.schemas.workspace_schemas import WorkspaceSchema
 
 if TYPE_CHECKING:
+    from zenml.zen_stores.schemas.flavor_schemas import FlavorSchema
     from zenml.zen_stores.schemas.logs_schemas import LogsSchema
     from zenml.zen_stores.schemas.run_metadata_schemas import RunMetadataSchema
     from zenml.zen_stores.schemas.schedule_schema import ScheduleSchema
@@ -84,6 +85,13 @@ class StackComponentSchema(NamedSchema, table=True):
 
     run_metadata: List["RunMetadataSchema"] = Relationship(
         back_populates="stack_component",
+    )
+    flavor_schema: Optional["FlavorSchema"] = Relationship(
+        sa_relationship_kwargs={
+            "primaryjoin": "and_(foreign(StackComponentSchema.flavor) == FlavorSchema.name, foreign(StackComponentSchema.type) == FlavorSchema.type)",
+            "lazy": "joined",
+            "uselist": False,
+        },
     )
 
     run_or_step_logs: List["LogsSchema"] = Relationship(
@@ -161,6 +169,12 @@ class StackComponentSchema(NamedSchema, table=True):
             user=self.user.to_model() if self.user else None,
             created=self.created,
             updated=self.updated,
+            logo_url=self.flavor_schema.logo_url
+            if self.flavor_schema
+            else None,
+            integration=self.flavor_schema.integration
+            if self.flavor_schema
+            else None,
         )
         metadata = None
         if include_metadata:


### PR DESCRIPTION
## Describe changes

I added `logo_url` and `integration` as new attributes to the components' response bodies. Unfortunately, the component schema was not directly related to a flavor schema so I had to create a new relationship where we match the flavor by name and type.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [X] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

