### PR TITLE
Unpin `requests` dependency

### DIFF
--- a/examples/e2e_nlp/config.yaml
+++ b/examples/e2e_nlp/config.yaml
@@ -17,6 +17,8 @@
 
 settings:
   docker:
+    python_package_installer: uv
+    install_stack_requirements: False
     required_integrations:
       - aws
       - skypilot_aws

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pyparsing = ">=2.4.0"
 python = ">=3.8,<3.12"
 python-dateutil = "^2.8.1"
 pyyaml = ">=6.0.1"
-requests = "<2.32.0" # TODO: remove after https://github.com/docker/docker-py/issues/3256
+requests = "!=2.32.0"
 rich = { extras = ["jupyter"], version = ">=12.0.0" }
 secure = "~0.3.0"
 sqlalchemy = "^2.0.0"


### PR DESCRIPTION
We pinned requests on account of this: https://github.com/docker/docker-py/issues/3256

New versions have been released which fix this, so I just remove the restriction on requests since it's such a fundamental library and it was blocking other dependency upgrades / usage.