### PR TITLE
Fix RBAC in combination with lazy loaders

### DIFF
--- a/examples/e2e_nlp/config.yaml
+++ b/examples/e2e_nlp/config.yaml
@@ -17,6 +17,8 @@
 
 settings:
   docker:
+    python_package_installer: uv
+    install_stack_requirements: False
     required_integrations:
       - aws
       - skypilot_aws

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -103,7 +103,9 @@ def dehydrate_response_model(
         )
 
     dehydrated_values = {}
-    for key, value in dict(model).items():
+    # See `get_subresources_for_model(...)` for a detailed explanation why we
+    # need to use `model.__iter__()` here
+    for key, value in model.__iter__():
         dehydrated_values[key] = _dehydrate_value(
             value, permissions=permissions
         )
@@ -484,7 +486,13 @@ def get_subresources_for_model(
     """
     resources = set()
 
-    for value in dict(model).values():
+    # We don't want to use `model.model_dump()` here as that recursively
+    # converts models to dicts, but we want to preserve those classes for
+    # the recursive `_get_subresources_for_value` calls.
+    # We previously used `dict(model)` here, but that lead to issues with
+    # models overwriting `__getattr__`, this `model.__iter__()` has the same
+    # results though.
+    for _, value in model.__iter__():
         resources.update(_get_subresources_for_value(value))
 
     return resources

--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -117,7 +117,8 @@ def create_run_step(
     pipeline_run = zen_store().get_run(step.pipeline_run_id)
     verify_permission_for_model(pipeline_run, action=Action.UPDATE)
 
-    return zen_store().create_run_step(step_run=step)
+    step = zen_store().create_run_step(step_run=step)
+    return dehydrate_response_model(step)
 
 
 @router.get(


### PR DESCRIPTION
## Describe changes

Our `ClientLazyLoader` class implements the `__getattr__` method to allow accessing any non-existent attribute on it.
This messed with the python `dict(...)` function that we used to convert a pydantic model to a dictionary in some RBAC utility functions. The `dict` function tries to first call the `keys()` method of an object to see if it is convertible to a dictionary in a certain way. This would fail with our lazy loaders as they returned a value when `lazy_loader.keys()` was called.

I updated the RBAC utility functions to instead use `model.__iter__()` instead which avoids this issue.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

