### PR TITLE
Disable notebook error for Kubernetes orchestrator

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -338,15 +338,15 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
             RuntimeError: If trying to run from a Jupyter notebook.
         """
         # First check whether the code is running in a notebook.
-        if Environment.in_notebook():
-            raise RuntimeError(
-                "The Kubernetes orchestrator cannot run pipelines in a notebook "
-                "environment. The reason is that it is non-trivial to create "
-                "a Docker image of a notebook. Please consider refactoring "
-                "your notebook cells into separate scripts in a Python module "
-                "and run the code outside of a notebook when using this "
-                "orchestrator."
-            )
+        # if Environment.in_notebook():
+        #     raise RuntimeError(
+        #         "The Kubernetes orchestrator cannot run pipelines in a notebook "
+        #         "environment. The reason is that it is non-trivial to create "
+        #         "a Docker image of a notebook. Please consider refactoring "
+        #         "your notebook cells into separate scripts in a Python module "
+        #         "and run the code outside of a notebook when using this "
+        #         "orchestrator."
+        #     )
 
         for step_name, step in deployment.step_configurations.items():
             if self.requires_resources_in_orchestration_environment(step):

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -337,6 +337,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
         Raises:
             RuntimeError: If trying to run from a Jupyter notebook.
         """
+        # TODO: consider making this a warning instead
         # First check whether the code is running in a notebook.
         # if Environment.in_notebook():
         #     raise RuntimeError(


### PR DESCRIPTION
Disables an error from getting raised when running pipelines in the Kubernetes orchestrator from within a notebook.