### PR TITLE
Automatically populate GCP/azure path when using wizard from the frontend

### DIFF
--- a/src/zenml/service_connectors/service_connector_utils.py
+++ b/src/zenml/service_connectors/service_connector_utils.py
@@ -290,7 +290,8 @@ def get_resources_options_from_resource_model_for_full_stack(
                             resource_ids=each.resource_ids,
                             stack_component_type=StackComponentType.ARTIFACT_STORE,
                             flavor="gcp",
-                            required_configuration={},
+                            required_configuration={"path": "Path"},
+                            use_resource_value_as_fixed_config=True,
                             flavor_display_name="GCS Bucket",
                         )
                     )
@@ -350,7 +351,8 @@ def get_resources_options_from_resource_model_for_full_stack(
                             resource_ids=each.resource_ids,
                             stack_component_type=StackComponentType.ARTIFACT_STORE,
                             flavor="azure",
-                            required_configuration={},
+                            required_configuration={"path": "Path"},
+                            use_resource_value_as_fixed_config=True,
                             flavor_display_name="Blob container",
                         )
                     )


### PR DESCRIPTION
## Describe changes
Fixes a bug with the GCP and Azure wizards which created unusable artifact stores.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

