### PR TITLE
Fix service connector creation in full stack endpoint

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -7086,12 +7086,16 @@ class SqlZenStore(BaseZenStore):
                             )
                             is not False
                         ):
+                            connector_config = (
+                                existing_service_connector.configuration
+                            )
+                            connector_config["generate_temporary_tokens"] = (
+                                False
+                            )
                             self.update_service_connector(
                                 existing_service_connector.id,
                                 ServiceConnectorUpdate(
-                                    configuration=existing_service_connector.configuration.update(
-                                        {"generate_temporary_tokens": False}
-                                    )
+                                    configuration=connector_config
                                 ),
                             )
                     service_connectors.append(
@@ -7100,17 +7104,18 @@ class SqlZenStore(BaseZenStore):
                 # Create a new service connector
                 else:
                     connector_name = full_stack.name
+                    connector_config = connector_id_or_info.configuration
+                    connector_config[
+                        "generate_temporary_tokens"
+                    ] = not need_to_generate_permanent_tokens
+
                     while True:
                         try:
                             service_connector_request = ServiceConnectorRequest(
                                 name=connector_name,
                                 connector_type=connector_id_or_info.type,
                                 auth_method=connector_id_or_info.auth_method,
-                                configuration=connector_id_or_info.configuration.update(
-                                    {
-                                        "generate_temporary_tokens": not need_to_generate_permanent_tokens
-                                    }
-                                ),
+                                configuration=connector_config,
                                 user=full_stack.user,
                                 workspace=full_stack.workspace,
                                 labels={


### PR DESCRIPTION
## Describe changes
The `dict.update(...)` method returns `None` and was used incorrectly which means the service connector request was invalid due to a `None` config.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

