### PR TITLE
Fix `Model` imports in docs

### DIFF
--- a/docs/book/how-to/use-the-model-control-plane/associate-a-pipeline-with-a-model.md
+++ b/docs/book/how-to/use-the-model-control-plane/associate-a-pipeline-with-a-model.md
@@ -3,7 +3,7 @@
 The most common use-case for a Model is to associate it with a pipeline.
 
 <pre class="language-python"><code class="lang-python"><strong>from zenml import pipeline
-</strong>from zenml.model.model import Model
+</strong>from zenml import Model
 
 <strong>@pipeline(
 </strong><strong>    model=Model(
@@ -21,7 +21,7 @@ In case you want to attach the pipeline to an existing model version, specify th
 
 ```python
 from zenml import pipeline
-from zenml.model.model import Model
+from zenml import Model
 from zenml.enums import ModelStages
 
 @pipeline(


### PR DESCRIPTION
Uses the easiest way to import the `Model` (i.e. via `zenml` and not via `zenml.model.model`).