### PR TITLE
Fix broken / unparseable md docs file

### DIFF
--- a/docs/book/how-to/run-remote-pipelines-from-notebooks/README.md
+++ b/docs/book/how-to/run-remote-pipelines-from-notebooks/README.md
@@ -8,7 +8,7 @@ ZenML steps and pipelines can be defined in a Jupyter notebook and executed remo
 
 Learn more about it in the following sections:
 
-<table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Define steps in notebook cells</td><td></td><td></td><td><a href="define-steps-in-notebook-cells.md">define-steps-in-notebook-cells.md</a></td></tr><tr><td>Configure the notebook path</td><td></td></tbody></table>
+<table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Define steps in notebook cells</td><td></td><td></td><td><a href="define-steps-in-notebook-cells.md">define-steps-in-notebook-cells.md</a></td></tr><tr><td>Configure the notebook path</td><td></td><td></td><td></td></tr></tbody></table>
 
 <!-- For scarf -->
 <figure><img alt="ZenML Scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" /></figure>


### PR DESCRIPTION
![CleanShot 2024-08-08 at 07 18 07@2x](https://github.com/user-attachments/assets/859b5c04-f524-431a-b864-f5311a36e23f)

Gitbook currently fails to parse our docs on 'bleeding edge' on account of this markdown parsing error. I fixed the error (though the table feels incomplete?). I think after this is merged probably worth checking that the gitbook sync proceeds as expected for 'bleeding edge'.