### PR TITLE
Allow functional `run_with_accelerate`

### DIFF
--- a/src/zenml/config/source.py
+++ b/src/zenml/config/source.py
@@ -69,6 +69,9 @@ class Source(BaseModel):
     attribute: Optional[str] = None
     type: SourceType
 
+    dynamic_decorator: Optional["Source"] = None
+    dynamic_decorator_kwargs: Optional[Dict[str, Any]] = {}
+
     @classmethod
     def from_import_path(
         cls, import_path: str, is_module_path: bool = False

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -501,3 +501,8 @@ ZENML_PRO_CONNECTION_ISSUES_SUSPENDED_PAUSED_TENANT_HINT = (
     "Organization page. If the tenant is PAUSED you can `Resume` it via UI "
     "and try again."
 )
+
+# Step decorators common objects used in setattr/getattr calls
+STEP_DECO_ORIGINAL_ENTRYPOINT = "undecorated_entrypoint"
+STEP_DECO_DECORATOR_FUNCTION = "dynamic_decorator"
+STEP_DECO_DECORATOR_KWARGS = "dynamic_decorator_kwargs"

--- a/src/zenml/new/steps/decorated_step.py
+++ b/src/zenml/new/steps/decorated_step.py
@@ -16,6 +16,10 @@
 from typing import Any
 
 from zenml.config.source import Source
+from zenml.constants import (
+    STEP_DECO_DECORATOR_FUNCTION,
+    STEP_DECO_DECORATOR_KWARGS,
+)
 from zenml.steps import BaseStep
 
 
@@ -39,4 +43,16 @@ class _DecoratedStep(BaseStep):
         """
         from zenml.utils import source_utils
 
-        return source_utils.resolve(self.entrypoint, skip_validation=True)
+        source = source_utils.resolve(self.entrypoint, skip_validation=True)
+
+        if dynamic_decorator := getattr(
+            self, STEP_DECO_DECORATOR_FUNCTION, None
+        ):
+            source.dynamic_decorator = source_utils.resolve(
+                dynamic_decorator, skip_validation=True
+            )
+            source.dynamic_decorator_kwargs = getattr(
+                self, STEP_DECO_DECORATOR_KWARGS, {}
+            )
+
+        return source

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -279,6 +279,15 @@ class BaseStep(metaclass=BaseStepMeta):
         """
         obj = source_utils.load(source)
 
+        if isinstance(source, Source):
+            # apply the chain of decorators applied in the pipeline context directly
+            source_ = source
+            while source_.dynamic_decorator:
+                obj = source_utils.load(source_.dynamic_decorator)(
+                    obj, **source_.dynamic_decorator_kwargs
+                )
+                source_ = source_.dynamic_decorator
+
         if isinstance(obj, BaseStep):
             return obj
         elif isinstance(obj, type) and issubclass(obj, BaseStep):

--- a/src/zenml/utils/function_utils.py
+++ b/src/zenml/utils/function_utils.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Iterator, List, Tuple, TypeVar, Union
 
 import click
 
+from zenml.constants import STEP_DECO_ORIGINAL_ENTRYPOINT
 from zenml.logger import get_logger
 from zenml.utils.string_utils import random_str
 
@@ -28,19 +29,21 @@ F = TypeVar("F", bound=Callable[..., None])
 
 logger = get_logger(__name__)
 
-_CLI_WRAPPED_SCRIPT_TEMPLATE_HEADER = """
+_CLI_WRAPPED_SCRIPT_TEMPLATE_HEADER = (
+    """
 from zenml.utils.function_utils import _cli_wrapped_function
 
 import sys
 sys.path.append(r"{func_path}")
 
 from {func_module} import {func_name} as step_function
-
-if unwrapped_entrypoint:=getattr(step_function, "unwrapped_entrypoint", None):
-    func = _cli_wrapped_function(unwrapped_entrypoint)
+"""
+    + f"""if {STEP_DECO_ORIGINAL_ENTRYPOINT}:=getattr(step_function, "{STEP_DECO_ORIGINAL_ENTRYPOINT}", None):
+    func = _cli_wrapped_function({STEP_DECO_ORIGINAL_ENTRYPOINT})
 else:
     func = _cli_wrapped_function(step_function.entrypoint)
 """
+)
 _CLI_WRAPPED_MAINS = {
     "accelerate": """
 if __name__=="__main__":


### PR DESCRIPTION
## Describe changes
This PR updates the structure we use in BaseStep and Source to allow for dynamic decorating of the steps in pipelines with specially backed decorators. Decoration with any deco is still not supported, just with specific ones.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

