### PR TITLE
Tell users where they can import `DockerSettings` from

### DIFF
--- a/docs/book/how-to/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
+++ b/docs/book/how-to/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
@@ -6,6 +6,8 @@ The configuration for specifying pip and apt dependencies only works in the remo
 
 When a [pipeline is run with a remote orchestrator](../configure-python-environments/README.md) a [Dockerfile](https://docs.docker.com/engine/reference/builder/) is dynamically generated at runtime. It is then used to build the Docker image using the [image builder](../configure-python-environments/README.md#-configure-python-environments) component of your stack.
 
+For all of examples on this page, note that `DockerSettings` can be imported using `from zenml.config import DockerSettings`.
+
 By default, ZenML automatically installs all packages required by your active ZenML stack. However, you can specify additional packages to be installed in various ways:
 
 * Install all the packages in your local Python environment (This will use the `pip` or `poetry` package manager to get a list of your local packages):
@@ -23,6 +25,8 @@ def my_pipeline(...):
 If required, a custom command can be provided. This command must output a list of requirements following the format of the [requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/):
 
 ```python
+from zenml.config import DockerSettings
+
 docker_settings = DockerSettings(replicate_local_python_environment=[
     "poetry",
     "export",


### PR DESCRIPTION
We didn't mention where to import `DockerSettings` from on the page even though it was filled with examples of how to use it. Probably a product of the docs refactoring we did last time around.