### PR TITLE
Fix the one-click AWS and GCP stack deployments

### DIFF
--- a/infra/aws/aws-ecr-s3-sagemaker.yaml
+++ b/infra/aws/aws-ecr-s3-sagemaker.yaml
@@ -235,7 +235,7 @@ Resources:
                     send_response(event, context, 'SUCCESS', {'Message': 'Resource updated successfully'})
                     return
 
-                url = os.environ['ZENML_SERVER_URL'].lstrip('/')+'/api/v1/workspaces/default/full-stack'
+                url = os.environ['ZENML_SERVER_URL'].lstrip('/')+'/api/v1/workspaces/default/stacks'
                 api_token = os.environ['ZENML_SERVER_API_TOKEN']
                 payload = event['ResourceProperties']['Payload']
 
@@ -303,31 +303,31 @@ Resources:
             }
           ],
           "components": {
-            "artifact_store": {
+            "artifact_store": [{
               "flavor": "s3",
               "service_connector_index": 0,
               "configuration": {
                 "path": "s3://${S3Bucket}"
               }
-            },
-            "container_registry":{
+            }],
+            "container_registry":[{
               "flavor": "aws",
               "service_connector_index": 0,
               "configuration": {
                 "uri": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com",
                 "default_repository": "${ECRRepository}"
               }
-            },
-            "orchestrator": {
+            }],
+            "orchestrator": [{
               "flavor": "sagemaker",
               "service_connector_index": 0,
               "configuration": {
                 "execution_role": "${SageMakerRuntimeRole.Arn}"
               }
-            },
-            "image_builder": {
+            }],
+            "image_builder": [{
               "flavor": "local"
-            }
+            }]
           }
         }
 
@@ -375,30 +375,30 @@ Outputs:
           }
         ],
         "components": {
-          "artifact_store": {
+          "artifact_store": [{
             "flavor": "s3",
             "service_connector_index": 0,
             "configuration": {
               "path": "s3://${S3Bucket}"
             }
-          },
-          "container_registry":{
+          }],
+          "container_registry":[{
             "flavor": "aws",
             "service_connector_index": 0,
             "configuration": {
               "uri": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com",
               "default_repository": "${ECRRepository}"
             }
-          },
-          "orchestrator": {
+          }],
+          "orchestrator": [{
             "flavor": "sagemaker",
             "service_connector_index": 0,
             "configuration": {
               "execution_role": "${SageMakerRuntimeRole.Arn}"
             }
-          },
-          "image_builder": {
+          }],
+          "image_builder": [{
             "flavor": "local"
-          }
+          }]
         }
       }

--- a/infra/gcp/gcp-gar-gcs-vertex-deploy.sh
+++ b/infra/gcp/gcp-gar-gcs-vertex-deploy.sh
@@ -159,7 +159,7 @@ echo
 
 set +e
 # Register the ZenML stack with the ZenML server
-curl -X POST "$ZENML_SERVER_URL/api/v1/workspaces/default/full-stack" \
+curl -X POST "$ZENML_SERVER_URL/api/v1/workspaces/default/stacks" \
     -H "Authorization: Bearer $ZENML_SERVER_API_TOKEN" \
     -H "Content-Type: application/json" \
     -d "$zenml_stack_json"

--- a/infra/gcp/gcp-gar-gcs-vertex.jinja
+++ b/infra/gcp/gcp-gar-gcs-vertex.jinja
@@ -30,32 +30,32 @@
     }
   ],
   "components": {
-    "artifact_store": {
+    "artifact_store": [{
       "flavor": "gcp",
       "service_connector_index": 0,
       "configuration": {
         "path": "gs://zenml-{{ project_number }}-{{ resourceNameSuffix }}"
       }
-    },
-    "container_registry":{
+    }],
+    "container_registry":[{
       "flavor": "gcp",
       "service_connector_index": 0,
       "configuration": {
         "uri": "{{ region }}-docker.pkg.dev/{{ project }}/zenml-{{ resourceNameSuffix }}"
       }
-    },
-    "orchestrator": {
+    }],
+    "orchestrator": [{
       "flavor": "vertex",
       "service_connector_index": 0,
       "configuration": {
         "location": "{{ region }}",
         "workload_service_account": "zenml-{{ resourceNameSuffix }}@{{ project }}.iam.gserviceaccount.com"
       }
-    },
-    "image_builder": {
+    }],
+    "image_builder": [{
       "flavor": "gcp",
       "service_connector_index": 0
-    }
+    }]
   }
 }
 {%- endmacro -%}


### PR DESCRIPTION
## Describe changes
The 0.65.0 release removed the full stack registration endpoint. The one-click deployment templates now have to call a different endpoint and use a slightly different format.

NOTE: this PR needs to be back-ported to 0.65.0 as well.

## Breaking change
This is a breaking change. AWS and GCP one-click stack deployments will stop working for ZenML versions prior to 0.65.0.

Due to the inflexible nature of AWS Cloud Formation and GCP Deployment Manager templates, it is quite difficult to provide backwards compatibility by looking at the zenml version, as we do it in the ZenML Terraform stack deployment modules.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

