### PR TITLE
Fix wandb mypy error

### DIFF
--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -126,7 +126,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
             info: Info about the step that was executed.
             step_failed: Whether the step failed or not.
         """
-        wandb.finish(exit_code=1) if step_failed else wandb.finish()
+        wandb.finish(exit_code=1) if step_failed else wandb.finish()  # type: ignore
         os.environ.pop(WANDB_API_KEY, None)
 
     def _initialize_wandb(


### PR DESCRIPTION
Nothing seems to have [changed on the `wandb` side](https://github.com/wandb/wandb/releases/tag/v0.17.8) with the 0.17.8 release, but this error only starts showing up with 0.17.8 (released today).