### PR TITLE
Allow running docker-orchestrators on default config

### DIFF
--- a/examples/quickstart/configs/training_local.yaml
+++ b/examples/quickstart/configs/training_local.yaml
@@ -1,3 +1,8 @@
+# Environment configuration
+settings:
+  docker:
+    requirements: requirements.txt
+
 # Model Control Plane configuration
 model:
   name: YeOldeEnglishTranslator


### PR DESCRIPTION
## Describe changes
This allows running `python run.py` with remote orchestrators 


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

