### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/book/getting-started/deploying-zenml/deploy-with-docker.md
+++ b/docs/book/getting-started/deploying-zenml/deploy-with-docker.md
@@ -54,7 +54,7 @@ Unless explicitly disabled or configured otherwise, the ZenML server will use th
 > **Important:** If you are updating the configuration of your ZenML Server container to use a different secrets store back-end or location, you should follow [the documented secrets migration strategy](secret-management.md#secrets-migration-strategy) to minimize downtime and to ensure that existing secrets are also properly migrated.
 
 {% tabs %}
-{% tab title="undefined" %}
+{% tab title="Default" %}
 The SQL database is used as the default secret store location. You only need to configure these options if you want to change the default behavior.
 
 It is particularly recommended to enable encryption at rest for the SQL database if you plan on using it as a secrets store backend. You'll have to configure the secret key used to encrypt the secret values. If not set, encryption will not be used and passwords will be stored unencrypted in the database.


### PR DESCRIPTION
This reads as "undefined" in our docs currently: https://docs.zenml.io/getting-started/deploying-zenml/deploy-with-docker#secret-store-environment-variables
