### PR TITLE
Prevent extra attributes in component configs

### DIFF
--- a/src/zenml/stack/utils.py
+++ b/src/zenml/stack/utils.py
@@ -75,7 +75,16 @@ def validate_stack_component_config(
             return None
         raise
 
-    configuration = flavor_class.config_class(**configuration_dict)
+    config_class = flavor_class.config_class
+    # Make sure extras are forbidden for the config class. Due to inhertance
+    # order, some config classes allow extras by accident which we patch here.
+    validation_config_class = type(
+        config_class.__name__,
+        (config_class,),
+        {"model_config": {"extra": "forbid"}},
+    )
+    configuration = validation_config_class(**configuration_dict)
+
     if not configuration.is_valid:
         raise ValueError(
             f"Invalid stack component configuration. Please verify "

--- a/src/zenml/stack/utils.py
+++ b/src/zenml/stack/utils.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Util functions for handling stacks, components, and flavors."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
 from zenml.client import Client
 from zenml.enums import StackComponentType, StoreType
@@ -78,7 +78,7 @@ def validate_stack_component_config(
     config_class = flavor_class.config_class
     # Make sure extras are forbidden for the config class. Due to inheritance
     # order, some config classes allow extras by accident which we patch here.
-    validation_config_class = type(
+    validation_config_class: Type[StackComponentConfig] = type(
         config_class.__name__,
         (config_class,),
         {"model_config": {"extra": "forbid"}},

--- a/src/zenml/stack/utils.py
+++ b/src/zenml/stack/utils.py
@@ -76,7 +76,7 @@ def validate_stack_component_config(
         raise
 
     config_class = flavor_class.config_class
-    # Make sure extras are forbidden for the config class. Due to inhertance
+    # Make sure extras are forbidden for the config class. Due to inheritance
     # order, some config classes allow extras by accident which we patch here.
     validation_config_class = type(
         config_class.__name__,

--- a/tests/unit/stack/test_utils.py
+++ b/tests/unit/stack/test_utils.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/unit/stack/test_utils.py
+++ b/tests/unit/stack/test_utils.py
@@ -1,0 +1,40 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from contextlib import ExitStack as does_not_raise
+
+import pytest
+from pydantic import ValidationError
+
+from tests.unit.conftest_new import empty_pipeline  # noqa
+from zenml.enums import StackComponentType
+from zenml.orchestrators.local_docker.local_docker_orchestrator import (
+    LocalDockerOrchestratorConfig,
+)
+from zenml.stack.utils import validate_stack_component_config
+
+
+def test_stack_component_validation_prevents_extras():
+    """Tests that stack component validation prevents extra attributes."""
+    config_dict = {"not_a_valid_component_attribute": False}
+
+    with does_not_raise():
+        LocalDockerOrchestratorConfig(**config_dict)
+
+    with pytest.raises(ValidationError):
+        validate_stack_component_config(
+            config_dict,
+            flavor_name="local_docker",
+            component_type=StackComponentType.ORCHESTRATOR,
+        )


### PR DESCRIPTION
## Describe changes
Prevent extra attributes in the config classes of our stack components. Previously, this was defined in the `StackComponentConfig` parent class, but due to the inheritance order lots of our stack components allowed extra attributes. This PR fixes that by making sure extras are not allowed during stack component config validation.
- I also thought about changing the inheritance order of all config classes. However I think it is very unreliable and might lead to newly created stack components having the same issues again. It would also lead to crashes for existing stack components that were registered with a "faulty" config, which my solution does not. It will only fail if users now try to update such a faulty component, at which point they will have to remove the extra attributes.
- Potential issues with my implementation: If some stack component would require `extra="allow"` in their configuration for some reason, this would now be ignored and extras will not be allowed. I can't think of any case where this would be necessary though.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

