### PR TITLE
Reverting the installation of `mlstacks` after its new release

### DIFF
--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -164,8 +164,7 @@ jobs:
         run: |
           source .venv/bin/activate
           uv pip install -e .
-          # TODO: Remove and add mlstacks back in
-          uv pip install git+https://github.com/zenml-io/mlstacks.git@feature/upgrade-python-3.12
+          uv pip install mlstacks
       - name: Check for broken dependencies
         run: |
           source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ types-psutil = { version = "^5.8.13", optional = true }
 types-passlib = { version = "^1.7.7", optional = true }
 
 # mlstacks dependencies
-mlstacks = { version = "0.9.0", optional = true }
+mlstacks = { version = "0.10.0", optional = true }
 
 [tool.poetry.extras]
 server = [

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -28,9 +28,7 @@ parse_args () {
 
 install_zenml() {
     # install ZenML in editable mode
-    uv pip install $PIP_ARGS -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev]"
-    # TODO: Remove and add the extra back in
-    uv pip install $PIP_ARGS git+https://github.com/zenml-io/mlstacks.git@feature/upgrade-python-3.12
+    uv pip install $PIP_ARGS -e ".[server,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,mlstacks]"
 }
 
 install_integrations() {


### PR DESCRIPTION
## Describe changes
I reverted the way that mlstacks is installed.

**IMPORTANT: This must be merged AFTER the next `mlstacks` release and BEFORE the next `zenml` release. (Provided that [this PR](https://github.com/zenml-io/mlstacks/pull/162) is also merged)**

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [X] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

