### PR TITLE
Add permissions to workflow to enable assuming AWS role

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -17,6 +17,9 @@ jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     env:
       ZENML_DEBUG: 1
       ZENML_ANALYTICS_OPT_IN: false


### PR DESCRIPTION
## Describe changes
Pushing the AWS quickstart image to ECR failed in our release process because it wasn't able to assume the AWS role. This PR adds permissions to the job that hopefully fixes this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

