### PR TITLE
Allow env variable placeholders in configurations

### DIFF
--- a/docs/book/how-to/build-pipelines/reference-environment-variables-in-configurations.md
+++ b/docs/book/how-to/build-pipelines/reference-environment-variables-in-configurations.md
@@ -1,0 +1,24 @@
+# Reference environment variables in configurations
+
+To make your configurations in code as well as in configuration files more flexible, ZenML allows you to reference environment variables
+by using the following placeholder syntax in your configuration: `${ENV_VARIABLE_NAME}`
+
+## In-code
+
+```python
+from zenml import step
+
+@step(extra={"value_from_environment": "${ENV_VAR}"})
+def my_step() -> None:
+    ...
+```
+
+# In a configuration file
+
+```yaml
+extra:
+  value_from_environment: ${ENV_VAR}
+  combined_value: prefix_${ENV_VAR}_suffix
+```
+
+<figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -71,6 +71,7 @@
 * [⛓️ Build a pipeline](how-to/build-pipelines/README.md)
   * [Use pipeline/step parameters](how-to/build-pipelines/use-pipeline-step-parameters.md)
   * [Configuring a pipeline at runtime](how-to/build-pipelines/configuring-a-pipeline-at-runtime.md)
+  * [Reference environment variables in configurations](how-to/build-pipelines/reference-environment-variables-in-configurations.md)
   * [Step output typing and annotation](how-to/build-pipelines/step-output-typing-and-annotation.md)
   * [Control caching behavior](how-to/build-pipelines/control-caching-behavior.md)
   * [Schedule a pipeline](how-to/build-pipelines/schedule-a-pipeline.md)

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -137,7 +137,6 @@ class ArtifactConfiguration(PartialArtifactConfiguration):
 class StepConfigurationUpdate(StrictBaseModel):
     """Class for step configuration updates."""
 
-    name: Optional[str] = None
     enable_cache: Optional[bool] = None
     enable_artifact_metadata: Optional[bool] = None
     enable_artifact_visualization: Optional[bool] = None
@@ -153,10 +152,6 @@ class StepConfigurationUpdate(StrictBaseModel):
     retry: Optional[StepRetryConfig] = None
 
     outputs: Mapping[str, PartialArtifactConfiguration] = {}
-
-    _deprecation_validator = deprecation_utils.deprecate_pydantic_attributes(
-        "name"
-    )
 
 
 class PartialStepConfiguration(StepConfigurationUpdate):

--- a/src/zenml/new/pipelines/pipeline.py
+++ b/src/zenml/new/pipelines/pipeline.py
@@ -84,6 +84,7 @@ from zenml.utils import (
     code_utils,
     dashboard_utils,
     dict_utils,
+    env_utils,
     pydantic_utils,
     settings_utils,
     source_utils,
@@ -1030,12 +1031,14 @@ To avoid this consider setting pipeline parameters only in one place (config or 
 
         # Update with the values in code so they take precedence
         run_config = pydantic_utils.update_model(run_config, update=update)
+        run_config = env_utils.substitute_env_variable_placeholders(run_config)
 
         deployment = Compiler().compile(
             pipeline=self,
             stack=Client().active_stack,
             run_configuration=run_config,
         )
+        deployment = env_utils.substitute_env_variable_placeholders(deployment)
 
         return deployment, run_config.schedule, run_config.build
 
@@ -1252,6 +1255,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         if config_path:
             with open(config_path, "r") as f:
                 _from_config_file = yaml.load(f, Loader=yaml.SafeLoader)
+
             _from_config_file = dict_utils.remove_none_values(
                 {k: v for k, v in _from_config_file.items() if k in matcher}
             )

--- a/src/zenml/utils/env_utils.py
+++ b/src/zenml/utils/env_utils.py
@@ -15,7 +15,7 @@
 
 import os
 import re
-from typing import Any, Dict, List, Optional, TypeVar, cast
+from typing import Any, Dict, List, Match, Optional, TypeVar, cast
 
 from zenml.logger import get_logger
 from zenml.utils import string_utils
@@ -120,7 +120,7 @@ def substitute_env_variable_placeholders(value: V) -> V:
         The object with placeholders substituted.
     """
 
-    def _replace_with_env_variable_value(match: re.Match) -> str:
+    def _replace_with_env_variable_value(match: Match[str]) -> str:
         key = match.group(1)
         if value := os.getenv(key):
             return value

--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -193,7 +193,7 @@ def substitute_string(value: V, substitution_func: Callable[[str], str]) -> V:
     if isinstance(value, BaseModel):
         model_values = {}
 
-        for k, v in dict(value).items():
+        for k, v in value.__iter__():
             new_value = substitute_(v)
 
             if k not in value.model_fields_set and new_value == getattr(

--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -18,7 +18,7 @@ import datetime
 import functools
 import random
 import string
-from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar
+from typing import Any, Callable, Dict, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -194,12 +194,14 @@ def substitute_string(value: V, substitution_func: Callable[[str], str]) -> V:
         model_values = {
             k: substitute_(v) for k, v in value.model_dump(mode="json").items()
         }
-        return type(value).model_validate(model_values)
+        return cast(V, type(value).model_validate(model_values))
     elif isinstance(value, Dict):
-        return {substitute_(k): substitute_(v) for k, v in value.items()}
-    elif isinstance(value, (List, Set, Tuple)):
-        return type(value)(substitute_(v) for v in value)
+        return cast(
+            V, {substitute_(k): substitute_(v) for k, v in value.items()}
+        )
+    elif isinstance(value, (list, set, tuple)):
+        return cast(V, type(value)(substitute_(v) for v in value))
     elif isinstance(value, str):
-        return substitution_func(value)
+        return cast(V, substitution_func(value))
 
     return value

--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -174,7 +174,7 @@ def format_name_template(
 
 
 def substitute_string(value: V, substitution_func: Callable[[str], str]) -> V:
-    """Recursively substitue strings in objects.
+    """Recursively substitute strings in objects.
 
     Args:
         value: An object in which the strings should be recursively substituted.

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import os
 from contextlib import ExitStack as does_not_raise
 from unittest.mock import ANY, patch
 from uuid import uuid4
@@ -1064,3 +1065,13 @@ def test_running_scheduled_pipeline_does_not_create_placeholder_run(
     mock_create_run.assert_called_once()
     run_request = mock_create_run.call_args[0][0]  # First arg
     assert not is_placeholder_request(run_request)
+
+
+def test_env_var_substitution(mocker, clean_client, empty_pipeline):
+    """Test env var substituion in pipeline config."""
+    mocker.patch.dict(os.environ, {"A": "1"})
+
+    empty_pipeline.configure(extra={"key": "${A}_suffix"})
+    run = empty_pipeline()
+
+    assert run.config.extra["key"] == "1_suffix"

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import os
 from contextlib import ExitStack as does_not_raise
 from unittest.mock import ANY, patch
 from uuid import uuid4
@@ -1066,11 +1067,10 @@ def test_running_scheduled_pipeline_does_not_create_placeholder_run(
     assert not is_placeholder_request(run_request)
 
 
-# def test_env_var_substitution(mocker, clean_client, empty_pipeline):  # noqa: F811
-#     """Test env var substitution in pipeline config."""
-#     mocker.patch.dict(os.environ, {"A": "1"})
+def test_env_var_substitution(clean_client, empty_pipeline):  # noqa: F811
+    """Test env var substitution in pipeline config."""
+    with patch.dict(os.environ, {"A": "1"}):
+        empty_pipeline.configure(extra={"key": "${A}_suffix"})
+        run = empty_pipeline()
 
-#     empty_pipeline.configure(extra={"key": "${A}_suffix"})
-#     run = empty_pipeline()
-
-#     assert run.config.extra["key"] == "1_suffix"
+        assert run.config.extra["key"] == "1_suffix"

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-import os
 from contextlib import ExitStack as does_not_raise
 from unittest.mock import ANY, patch
 from uuid import uuid4
@@ -1067,11 +1066,11 @@ def test_running_scheduled_pipeline_does_not_create_placeholder_run(
     assert not is_placeholder_request(run_request)
 
 
-def test_env_var_substitution(mocker, clean_client, empty_pipeline):  # noqa: F811
-    """Test env var substitution in pipeline config."""
-    mocker.patch.dict(os.environ, {"A": "1"})
+# def test_env_var_substitution(mocker, clean_client, empty_pipeline):  # noqa: F811
+#     """Test env var substitution in pipeline config."""
+#     mocker.patch.dict(os.environ, {"A": "1"})
 
-    empty_pipeline.configure(extra={"key": "${A}_suffix"})
-    run = empty_pipeline()
+#     empty_pipeline.configure(extra={"key": "${A}_suffix"})
+#     run = empty_pipeline()
 
-    assert run.config.extra["key"] == "1_suffix"
+#     assert run.config.extra["key"] == "1_suffix"

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -1067,8 +1067,8 @@ def test_running_scheduled_pipeline_does_not_create_placeholder_run(
     assert not is_placeholder_request(run_request)
 
 
-def test_env_var_substitution(mocker, clean_client, empty_pipeline):
-    """Test env var substituion in pipeline config."""
+def test_env_var_substitution(mocker, clean_client, empty_pipeline):  # noqa: F811
+    """Test env var substitution in pipeline config."""
     mocker.patch.dict(os.environ, {"A": "1"})
 
     empty_pipeline.configure(extra={"key": "${A}_suffix"})

--- a/tests/unit/utils/test_env_utils.py
+++ b/tests/unit/utils/test_env_utils.py
@@ -86,9 +86,18 @@ def test_env_var_substitution(mocker):
         substitute_env_variable_placeholders("prefix_${A}_suffix")
         == "prefix_1_suffix"
     )
+
+    # Non existent -> Raise when configured
+    with pytest.raises(KeyError):
+        substitute_env_variable_placeholders(
+            "prefix_${B}_suffix", raise_when_missing=True
+        )
+
     # Non existent -> empty string
     assert (
-        substitute_env_variable_placeholders("prefix_${B}_suffix")
+        substitute_env_variable_placeholders(
+            "prefix_${B}_suffix", raise_when_missing=False
+        )
         == "prefix__suffix"
     )
 

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -14,6 +14,8 @@
 
 from typing import List
 
+from pydantic import BaseModel
+
 from zenml.utils import string_utils
 
 
@@ -44,3 +46,71 @@ def test_random_str_is_random() -> None:
         new_str = string_utils.random_str(16)
         assert new_str not in lst
         lst.append(new_str)
+
+
+def test_string_substitution() -> None:
+    """Test string substitution."""
+
+    class ModelClass(BaseModel):
+        string_attribute: str
+        int_attribute: int
+
+    model = ModelClass(string_attribute="string_value", int_attribute=1)
+    model_sub = ModelClass(
+        string_attribute="string_value_suffix", int_attribute=1
+    )
+    substitution_func = lambda s: s + "_suffix"
+
+    assert (
+        string_utils.substitute_string(1, substitution_func=substitution_func)
+        == 1
+    )
+    assert (
+        string_utils.substitute_string(
+            0.1, substitution_func=substitution_func
+        )
+        == 0.1
+    )
+    assert (
+        string_utils.substitute_string(
+            None, substitution_func=substitution_func
+        )
+        == None
+    )
+    assert string_utils.substitute_string(
+        ["a", "b", 1], substitution_func=substitution_func
+    ) == ["a_suffix", "b_suffix", 1]
+    assert string_utils.substitute_string(
+        ("a", "b", 1), substitution_func=substitution_func
+    ) == ("a_suffix", "b_suffix", 1)
+    assert string_utils.substitute_string(
+        set(["a", "b", 1]), substitution_func=substitution_func
+    ) == set(["a_suffix", "b_suffix", 1])
+    assert string_utils.substitute_string(
+        {"key": "value"}, substitution_func=substitution_func
+    ) == {"key_suffix": "value_suffix"}
+    assert (
+        string_utils.substitute_string(
+            model, substitution_func=substitution_func
+        )
+        == model_sub
+    )
+
+    combined = [
+        2,
+        0.2,
+        None,
+        "string",
+        {3: "value", "key": model},
+        set(["set_value", 4]),
+    ]
+    assert string_utils.substitute_string(
+        combined, substitution_func=substitution_func
+    ) == [
+        2,
+        0.2,
+        None,
+        "string_suffix",
+        {3: "value_suffix", "key_suffix": model_sub},
+        set(["set_value_suffix", 4]),
+    ]

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -59,6 +59,7 @@ def test_string_substitution() -> None:
     model_sub = ModelClass(
         string_attribute="string_value_suffix", int_attribute=1
     )
+
     def substitution_func(s):
         return s + "_suffix"
 

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -59,7 +59,8 @@ def test_string_substitution() -> None:
     model_sub = ModelClass(
         string_attribute="string_value_suffix", int_attribute=1
     )
-    substitution_func = lambda s: s + "_suffix"
+    def substitution_func(s):
+        return s + "_suffix"
 
     assert (
         string_utils.substitute_string(1, substitution_func=substitution_func)
@@ -75,7 +76,7 @@ def test_string_substitution() -> None:
         string_utils.substitute_string(
             None, substitution_func=substitution_func
         )
-        == None
+        is None
     )
     assert string_utils.substitute_string(
         ["a", "b", 1], substitution_func=substitution_func


### PR DESCRIPTION
## Describe changes

Allows environment variables placeholders in the pipeline/step configurations in code as well as in config files.
The format will be `${ENV_VARIABLE_NAME}` and will be replaced at compilation time. This makes sure it is only happening client side and can't be used to read server environment variables when running a pipeline from the server.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

