### PR TITLE
Allow running a single step from the same cell it was defined in

### DIFF
--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -601,6 +601,15 @@ class BaseStep(metaclass=BaseStepMeta):
             if run_without_stack:
                 return self.call_entrypoint(*args, **kwargs)
             else:
+                from zenml import constants
+
+                if constants.SHOULD_PREVENT_PIPELINE_EXECUTION:
+                    logger.info(
+                        "Preventing execution of step '%s' during importing.",
+                        self.name,
+                    )
+                    return
+
                 return run_as_single_step_pipeline(self, *args, **kwargs)
 
         (


### PR DESCRIPTION
## Describe changes

If a step was defined and called in the same notebook cell, it would fail to execute as a remote one step pipeline. The reason for this was the notebook cell code being imported in the container, which would start code to run the step which would then internally fail. We just stop this early by using the environment variable that is set to prevent the same thing happening for module-level pipeline calls.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

