### PR TITLE
Fix incorrect method name in Pigeon docs

### DIFF
--- a/docs/book/component-guide/annotators/pigeon.md
+++ b/docs/book/component-guide/annotators/pigeon.md
@@ -55,7 +55,7 @@ from zenml.client import Client
 
 annotator = Client().active_stack.annotator
 
-annotations = annotator.launch(
+annotations = annotator.annotate(
     data=[
         'I love this movie',
         'I was really disappointed by the book'
@@ -75,7 +75,7 @@ from IPython.display import display, Image
 
 annotator = Client().active_stack.annotator
 
-annotations = annotator.launch(
+annotations = annotator.annotate(
     data=[
         '/path/to/image1.png',
         '/path/to/image2.png'


### PR DESCRIPTION
I fixed the part of the Pigeon docs where I specified that users should use the 'launch' method when it should have been the 'annotate' method. They should use `.annotate`.