### PR TITLE
Fix Lightning docs

### DIFF
--- a/docs/book/component-guide/orchestrators/lightning.md
+++ b/docs/book/component-guide/orchestrators/lightning.md
@@ -1,4 +1,3 @@
-
 ---
 description: Orchestrating your pipelines to run on Lightning AI.
 ---


### PR DESCRIPTION
The extra line at the top makes it display like this:

![CleanShot 2024-09-16 at 10 15 35](https://github.com/user-attachments/assets/9f11ff9a-cd9f-4e71-8546-25ea52b73c97)
