### PR TITLE
Linking registered models in MLflow with the corresponding MLflow run

### DIFF
--- a/src/zenml/integrations/mlflow/steps/mlflow_registry.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_registry.py
@@ -146,9 +146,8 @@ def mlflow_register_model_step(
         metadata.zenml_pipeline_run_uuid = pipeline_run_uuid
     if metadata.zenml_workspace is None:
         metadata.zenml_workspace = zenml_workspace
-    if metadata.model_extra:
-        if metadata.model_extra.get("mlflow_run_id", None) is None:
-            metadata.model_extra["mlflow_run_id"] = mlflow_run_id
+    if metadata.model_extra.get("mlflow_run_id", None) is None:
+        metadata.model_extra["mlflow_run_id"] = mlflow_run_id
 
     # Register model version
     model_version = model_registry.register_model_version(

--- a/src/zenml/integrations/mlflow/steps/mlflow_registry.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_registry.py
@@ -146,11 +146,9 @@ def mlflow_register_model_step(
         metadata.zenml_pipeline_run_uuid = pipeline_run_uuid
     if metadata.zenml_workspace is None:
         metadata.zenml_workspace = zenml_workspace
-    if metadata.model_extra and "mlflow_run_id" in metadata.model_extra:
-        if metadata.model_extra["mlflow_run_id"] is None:
+    if metadata.model_extra:
+        if metadata.model_extra.get("mlflow_run_id", None) is None:
             metadata.model_extra["mlflow_run_id"] = mlflow_run_id
-        else:
-            metadata.model_extra.update({"mlflow_run_id": mlflow_run_id})
 
     # Register model version
     model_version = model_registry.register_model_version(

--- a/src/zenml/integrations/mlflow/steps/mlflow_registry.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_registry.py
@@ -146,6 +146,11 @@ def mlflow_register_model_step(
         metadata.zenml_pipeline_run_uuid = pipeline_run_uuid
     if metadata.zenml_workspace is None:
         metadata.zenml_workspace = zenml_workspace
+    if metadata.model_extra and "mlflow_run_id" in metadata.model_extra:
+        if metadata.model_extra["mlflow_run_id"] is None:
+            metadata.model_extra["mlflow_run_id"] = mlflow_run_id
+        else:
+            metadata.model_extra.update({"mlflow_run_id": mlflow_run_id})
 
     # Register model version
     model_version = model_registry.register_model_version(


### PR DESCRIPTION
## Describe changes

To link a registered model in MLflow with the corresponding MLflow run, the parameter `mlflow_run_id` must be included in the metadata argument of the `mlflow_register_model_step`. 

The MLflow run can be traced back to a ZenML pipeline run. This is not a necessary change. However, it is more convenient to have a reference to the MLflow run for the registered models as well, as this makes it possible to view parameters or metrics, for example.

I have adjusted the `mlflow_register_model_step` so that the `mlflow_run_id` is added by default if it is not already present in the metadata. 

The following screenshots show the effects in the MLFlow user interface. 
<img width="1089" alt="Bildschirmfoto 2024-09-17 um 17 19 31" src="https://github.com/user-attachments/assets/40045b78-2ccd-4e33-9d88-f9c5d2f57959">
<img width="1439" alt="Bildschirmfoto 2024-09-17 um 17 19 55" src="https://github.com/user-attachments/assets/d5600686-b5a5-4045-9be3-96069fcf4a86">


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

