### PR TITLE
Leverage warm pools for AWS Sagemaker

### DIFF
--- a/docs/book/component-guide/orchestrators/sagemaker.md
+++ b/docs/book/component-guide/orchestrators/sagemaker.md
@@ -229,7 +229,7 @@ By default, the SageMaker orchestrator uses Training Steps where possible, which
 
 ```python
 sagemaker_orchestrator_settings = SagemakerOrchestratorSettings(
-    use_training_steps_where_possible = False
+    use_training_step = False
 )
 ```
 

--- a/docs/book/component-guide/orchestrators/sagemaker.md
+++ b/docs/book/component-guide/orchestrators/sagemaker.md
@@ -197,7 +197,7 @@ They can then be applied to a step as follows:
 @step(settings={"orchestrator": sagemaker_orchestrator_settings})
 ```
 
-For example, if your ZenML component is configured to use `ml.c5.xlarge` with 400GB additional storage by default, all steps will use it except for the step above, which will use `ml.t3.medium` with 30GB additional storage.
+For example, if your ZenML component is configured to use `ml.c5.xlarge` with 400GB additional storage by default, all steps will use it except for the step above, which will use `ml.t3.medium` (for Processing Steps) or `ml.m5.xlarge` (for Training Steps) with 30GB additional storage. See the next section for details on how ZenML decides which Sagemaker Step type to use.
 
 Check out [this docs page](../../how-to/use-configuration-files/runtime-configuration.md) for more information on how to specify settings in general.
 
@@ -297,6 +297,10 @@ sagemaker_orchestrator_settings = SagemakerOrchestratorSettings(
     }
 )
 ```
+
+{% hint style="warning" %}
+Using multichannel output or output mode except `EndOfJob` will make it impossible to use TrainingStep and also Warm Pools. See corresponding section of this document for details.
+{% endhint %}
 
 ### Enabling CUDA for GPU-backed hardware
 

--- a/docs/book/component-guide/orchestrators/sagemaker.md
+++ b/docs/book/component-guide/orchestrators/sagemaker.md
@@ -203,6 +203,38 @@ Check out [this docs page](../../how-to/use-configuration-files/runtime-configur
 
 For more information and a full list of configurable attributes of the Sagemaker orchestrator, check out the [SDK Docs](https://sdkdocs.zenml.io/latest/integration\_code\_docs/integrations-aws/#zenml.integrations.aws.orchestrators.sagemaker\_orchestrator.SagemakerOrchestrator) .
 
+### Using Warm Pools for your pipelines
+
+[Warm Pools in SageMaker](https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html) can significantly reduce the startup time of your pipeline steps, leading to faster iterations and improved development efficiency. This feature keeps compute instances in a "warm" state, ready to quickly start new jobs.
+
+To enable Warm Pools, use the `SagemakerOrchestratorSettings` class:
+
+```python
+sagemaker_orchestrator_settings = SagemakerOrchestratorSettings(
+    keep_alive_period_in_seconds = 300, # 5 minutes, default value
+)
+```
+
+This configuration keeps instances warm for 5 minutes after each job completes, allowing subsequent jobs to start faster if initiated within this timeframe. The reduced startup time can be particularly beneficial for iterative development processes or frequently run pipelines.
+
+If you prefer not to use Warm Pools, you can explicitly disable them:
+
+```python
+sagemaker_orchestrator_settings = SagemakerOrchestratorSettings(
+    keep_alive_period_in_seconds = None,
+)
+```
+
+By default, the SageMaker orchestrator uses Training Steps where possible, which can offer performance benefits and better integration with SageMaker's training capabilities. To disable this behavior:
+
+```python
+sagemaker_orchestrator_settings = SagemakerOrchestratorSettings(
+    use_training_steps_where_possible = False
+)
+```
+
+These settings allow you to fine-tune your SageMaker orchestrator configuration, balancing between faster startup times with Warm Pools and more control over resource usage. By optimizing these settings, you can potentially reduce overall pipeline runtime and improve your development workflow efficiency.
+
 #### S3 data access in ZenML steps
 
 In Sagemaker jobs, it is possible to [access data that is located in S3](https://docs.aws.amazon.com/sagemaker/latest/dg/model-access-training-data.html). Similarly, it is possible to write data from a job to a bucket. The ZenML Sagemaker orchestrator supports this via the `SagemakerOrchestratorSettings` and hence at component, pipeline, and step levels.

--- a/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
@@ -102,7 +102,7 @@ class SagemakerOrchestratorSettings(BaseSettings):
     max_runtime_in_seconds: int = 86400
     tags: Dict[str, str] = {}
     keep_alive_period_in_seconds: Optional[int] = 300  # 5 minutes
-    use_training_step: bool = True
+    use_training_step: Optional[bool] = None
 
     processor_args: Dict[str, Any] = {}
     estimator_args: Dict[str, Any] = {}

--- a/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
@@ -30,6 +30,9 @@ from zenml.utils.secret_utils import SecretField
 if TYPE_CHECKING:
     from zenml.integrations.aws.orchestrators import SagemakerOrchestrator
 
+DEFAULT_TRAINING_INSTANCE_TYPE = "ml.m5.xlarge"
+DEFAULT_PROCESSING_INSTANCE_TYPE = "ml.t3.medium"
+
 
 class SagemakerOrchestratorSettings(BaseSettings):
     """Settings for the Sagemaker orchestrator.
@@ -42,6 +45,13 @@ class SagemakerOrchestratorSettings(BaseSettings):
         max_runtime_in_seconds: The maximum runtime in seconds for the
             processing job.
         processor_tags: Tags to apply to the Processor assigned to the step.
+        keep_alive_period_in_seconds: The time in seconds after which the
+            provisioned instance will be terminated if not used. This is only
+            applicable for TrainingStep type and it is not possible to use
+            TrainingStep type if the `output_data_s3_uri` is set to Dict[str, str].
+        use_training_steps_where_possible: Whether to use the TrainingStep
+            type if possible. It is not possible to use TrainingStep type
+            if the `output_data_s3_uri` is set to Dict[str, str].
         processor_args: Arguments that are directly passed to the SageMaker
             Processor for a specific step, allowing for overriding the default
             settings provided when configuring the component. See
@@ -74,11 +84,13 @@ class SagemakerOrchestratorSettings(BaseSettings):
                     Data must be available locally in /opt/ml/processing/output/data/<ChannelName>.
     """
 
-    instance_type: str = "ml.t3.medium"
+    instance_type: Optional[str] = None
     processor_role: Optional[str] = None
     volume_size_in_gb: int = 30
     max_runtime_in_seconds: int = 86400
     processor_tags: Dict[str, str] = {}
+    keep_alive_period_in_seconds: Optional[int] = 300  # 5 minutes
+    use_training_steps_where_possible: bool = True
 
     processor_args: Dict[str, Any] = {}
     input_data_s3_mode: str = "File"

--- a/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
+++ b/src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
@@ -120,7 +120,7 @@ class SagemakerOrchestratorSettings(BaseSettings):
     processor_role: Optional[str] = None
     processor_tags: Dict[str, str] = {}
     _deprecation_validator = deprecation_utils.deprecate_pydantic_attributes(
-        "processor_role", "processor_tags"
+        ("processor_role", "execution_role"), ("processor_tags", "tags")
     )
 
     @model_validator(mode="before")

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -25,7 +25,7 @@ from sagemaker.network import NetworkConfig
 from sagemaker.processing import ProcessingInput, ProcessingOutput
 from sagemaker.workflow.execution_variables import ExecutionVariables
 from sagemaker.workflow.pipeline import Pipeline
-from sagemaker.workflow.steps import ProcessingStep
+from sagemaker.workflow.steps import ProcessingStep, TrainingStep
 
 from zenml.config.base_settings import BaseSettings
 from zenml.constants import (
@@ -33,6 +33,8 @@ from zenml.constants import (
 )
 from zenml.enums import StackComponentType
 from zenml.integrations.aws.flavors.sagemaker_orchestrator_flavor import (
+    DEFAULT_PROCESSING_INSTANCE_TYPE,
+    DEFAULT_TRAINING_INSTANCE_TYPE,
     SagemakerOrchestratorConfig,
     SagemakerOrchestratorSettings,
 )
@@ -239,46 +241,43 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             )
 
             # Retrieve Processor arguments provided in the Step settings.
-            processor_args_for_step = step_settings.processor_args or {}
+            args_for_step_executor = step_settings.processor_args or {}
 
             # Set default values from configured orchestrator Component to arguments
             # to be used when they are not present in processor_args.
-            processor_args_for_step.setdefault(
-                "instance_type", step_settings.instance_type
-            )
-            processor_args_for_step.setdefault(
+            args_for_step_executor.setdefault(
                 "role",
                 step_settings.processor_role or self.config.execution_role,
             )
-            processor_args_for_step.setdefault(
+            args_for_step_executor.setdefault(
                 "volume_size_in_gb", step_settings.volume_size_in_gb
             )
-            processor_args_for_step.setdefault(
+            args_for_step_executor.setdefault(
                 "max_runtime_in_seconds", step_settings.max_runtime_in_seconds
             )
-            processor_args_for_step.setdefault(
+            args_for_step_executor.setdefault(
                 "tags",
-                [
-                    {"Key": key, "Value": value}
-                    for key, value in step_settings.processor_tags.items()
-                ]
-                if step_settings.processor_tags
-                else None,
+                (
+                    [
+                        {"Key": key, "Value": value}
+                        for key, value in step_settings.processor_tags.items()
+                    ]
+                    if step_settings.processor_tags
+                    else None
+                ),
             )
 
             # Set values that cannot be overwritten
-            processor_args_for_step["image_uri"] = image
-            processor_args_for_step["instance_count"] = 1
-            processor_args_for_step["sagemaker_session"] = session
-            processor_args_for_step["entrypoint"] = entrypoint
-            processor_args_for_step["base_job_name"] = orchestrator_run_name
-            processor_args_for_step["env"] = environment
+            args_for_step_executor["image_uri"] = image
+            args_for_step_executor["instance_count"] = 1
+            args_for_step_executor["sagemaker_session"] = session
+            args_for_step_executor["base_job_name"] = orchestrator_run_name
 
             # Convert network_config to sagemaker.network.NetworkConfig if present
-            network_config = processor_args_for_step.get("network_config")
+            network_config = args_for_step_executor.get("network_config")
             if network_config and isinstance(network_config, dict):
                 try:
-                    processor_args_for_step["network_config"] = NetworkConfig(
+                    args_for_step_executor["network_config"] = NetworkConfig(
                         **network_config
                     )
                 except TypeError:
@@ -316,8 +315,9 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                     )
 
             # Construct S3 outputs from container for step
+            only_processing_step_possible = False
             outputs = None
-
+            output_path = None
             if step_settings.output_data_s3_uri is None:
                 pass
             elif isinstance(step_settings.output_data_s3_uri, str):
@@ -328,7 +328,9 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                         s3_upload_mode=step_settings.output_data_s3_mode,
                     )
                 ]
+                output_path = step_settings.output_data_s3_uri
             elif isinstance(step_settings.output_data_s3_uri, dict):
+                only_processing_step_possible = True
                 outputs = []
                 for (
                     channel,
@@ -342,17 +344,44 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                         )
                     )
 
-            # Create Processor and ProcessingStep
-            processor = sagemaker.processing.Processor(
-                **processor_args_for_step
-            )
-            sagemaker_step = ProcessingStep(
-                name=step_name,
-                processor=processor,
-                depends_on=step.spec.upstream_steps,
-                inputs=inputs,
-                outputs=outputs,
-            )
+            if (
+                only_processing_step_possible
+                or not step_settings.use_training_steps_where_possible
+            ):
+                # Create Processor and ProcessingStep
+                processor = sagemaker.processing.Processor(
+                    entrypoint=entrypoint,
+                    env=environment,
+                    instance_type=step_settings.instance_type
+                    or DEFAULT_PROCESSING_INSTANCE_TYPE,
+                    **args_for_step_executor,
+                )
+
+                sagemaker_step = ProcessingStep(
+                    name=step_name,
+                    processor=processor,
+                    depends_on=step.spec.upstream_steps,
+                    inputs=inputs,
+                    outputs=outputs,
+                )
+            else:
+                # Create Estimator and TrainingStep
+                estimator = sagemaker.estimator.Estimator(
+                    keep_alive_period_in_seconds=step_settings.keep_alive_period_in_seconds,
+                    output_path=output_path,
+                    environment=environment,
+                    container_entry_point=entrypoint,
+                    instance_type=step_settings.instance_type
+                    or DEFAULT_TRAINING_INSTANCE_TYPE,
+                    **args_for_step_executor,
+                )
+                sagemaker_step = TrainingStep(
+                    name=step_name,
+                    depends_on=step.spec.upstream_steps,
+                    inputs=inputs,
+                    estimator=estimator,
+                )
+
             sagemaker_steps.append(sagemaker_step)
 
         # construct the pipeline from the sagemaker_steps

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -362,21 +362,6 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                     )
 
             if use_train_step:
-                # Create Processor and ProcessingStep
-                processor = sagemaker.processing.Processor(
-                    entrypoint=entrypoint,
-                    env=environment,
-                    **args_for_step_executor,
-                )
-
-                sagemaker_step = ProcessingStep(
-                    name=step_name,
-                    processor=processor,
-                    depends_on=step.spec.upstream_steps,
-                    inputs=inputs,
-                    outputs=outputs,
-                )
-            else:
                 # Create Estimator and TrainingStep
                 estimator = sagemaker.estimator.Estimator(
                     keep_alive_period_in_seconds=step_settings.keep_alive_period_in_seconds,
@@ -390,6 +375,21 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                     depends_on=step.spec.upstream_steps,
                     inputs=inputs,
                     estimator=estimator,
+                )
+            else:
+                # Create Processor and ProcessingStep
+                processor = sagemaker.processing.Processor(
+                    entrypoint=entrypoint,
+                    env=environment,
+                    **args_for_step_executor,
+                )
+
+                sagemaker_step = ProcessingStep(
+                    name=step_name,
+                    processor=processor,
+                    depends_on=step.spec.upstream_steps,
+                    inputs=inputs,
+                    outputs=outputs,
                 )
 
             sagemaker_steps.append(sagemaker_step)

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -241,9 +241,11 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             use_training_step = (
                 step_settings.use_training_step
                 if step_settings.use_training_step is not None
-                else self.config.use_training_step
-                if self.config.use_training_step is not None
-                else True
+                else (
+                    self.config.use_training_step
+                    if self.config.use_training_step is not None
+                    else True
+                )
             )
 
             # Retrieve Executor arguments provided in the Step settings.
@@ -256,10 +258,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             # to be used when they are not present in processor_args.
             args_for_step_executor.setdefault(
                 "role",
-                step_settings.execution_role
-                or step_settings.processor_role
-                or self.config.execution_role
-                or self.config.processor_role,
+                step_settings.execution_role or self.config.execution_role,
             )
             args_for_step_executor.setdefault(
                 "volume_size_in_gb", step_settings.volume_size_in_gb
@@ -267,7 +266,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             args_for_step_executor.setdefault(
                 "max_runtime_in_seconds", step_settings.max_runtime_in_seconds
             )
-            tags = step_settings.tags or step_settings.processor_tags
+            tags = step_settings.tags
             args_for_step_executor.setdefault(
                 "tags",
                 (
@@ -401,9 +400,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             sagemaker_session=session,
         )
 
-        pipeline.create(
-            role_arn=self.config.execution_role or self.config.processor_role
-        )
+        pipeline.create(role_arn=self.config.execution_role)
         pipeline_execution = pipeline.start()
         logger.warning(
             "Steps can take 5-15 minutes to start running "

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -238,16 +238,16 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                 ExecutionVariables.PIPELINE_EXECUTION_ARN
             )
 
-            use_training_step_in_step = step_settings.model_dump(
-                exclude_unset=True
-            ).get("use_training_step", None)
-            if use_training_step_in_step is not None:
-                use_train_step = use_training_step_in_step
-            else:
-                use_train_step = self.config.use_training_step
+            use_training_step = (
+                step_settings.use_training_step
+                if step_settings.use_training_step is not None
+                else self.config.use_training_step
+                if self.config.use_training_step is not None
+                else True
+            )
 
             # Retrieve Executor arguments provided in the Step settings.
-            if use_train_step:
+            if use_training_step:
                 args_for_step_executor = step_settings.estimator_args or {}
             else:
                 args_for_step_executor = step_settings.processor_args or {}
@@ -337,7 +337,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             if step_settings.output_data_s3_uri is None:
                 pass
             elif isinstance(step_settings.output_data_s3_uri, str):
-                if use_train_step:
+                if use_training_step:
                     output_path = step_settings.output_data_s3_uri
                 else:
                     outputs = [
@@ -361,7 +361,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                         )
                     )
 
-            if use_train_step:
+            if use_training_step:
                 # Create Estimator and TrainingStep
                 estimator = sagemaker.estimator.Estimator(
                     keep_alive_period_in_seconds=step_settings.keep_alive_period_in_seconds,


### PR DESCRIPTION
## Describe changes
I implemented support for [Sagemaker Warm Pools](https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html) to improve the runtime of the Sagemaker orchestrator.
Observed speed-up can be estimated as up to 45% for the step to be provisioned and started. The exact start-up time heavily depends on the base Docker image being used, instance types, and the composition of the steps.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

