### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -79,7 +79,7 @@ jobs:
       == false
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
-      python-version: '3.8'
+      python-version: '3.9'
       os: ubuntu-latest
     secrets: inherit
   custom-ubuntu-setup-and-unit-test:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
+          python-version: '3.11'
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -199,7 +199,7 @@ jobs:
     strategy:
       matrix:
         os: [arc-runner-set]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
     with:
@@ -212,7 +212,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
     with:
@@ -225,14 +225,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        # Python 3.8 and 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
-          - {python-version: '3.8', os: macos-latest}
           - {python-version: '3.9', os: macos-latest}
         include:
-          - {python-version: '3.8', os: macos-13}
           - {python-version: '3.9', os: macos-13}
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
@@ -246,7 +244,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         test_environment: [default]
       fail-fast: false
     uses: ./.github/workflows/integration-test-slow.yml
@@ -261,14 +259,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-13]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        # Python 3.8 and 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
         # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
         exclude:
-          - {python-version: '3.8', os: macos-latest}
           - {python-version: '3.9', os: macos-latest}
         include:
-          - {python-version: '3.8', os: macos-13}
           - {python-version: '3.9', os: macos-13}
         test_environment: [default]
       fail-fast: false
@@ -284,25 +280,25 @@ jobs:
     strategy:
       matrix:
         os: [arc-runner-set]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         test_environment:
           - default
           - docker-server-docker-orchestrator-mysql
           - docker-server-docker-orchestrator-mariadb
         exclude:
-   # docker is time-consuming to run, so we only run it on 3.8
-          - test_environment: docker-server-docker-orchestrator-mysql
-            python-version: '3.9'
+          # docker is time-consuming to run, so we only run it on 3.9
           - test_environment: docker-server-docker-orchestrator-mysql
             python-version: '3.10'
           - test_environment: docker-server-docker-orchestrator-mysql
             python-version: '3.11'
-          - test_environment: docker-server-docker-orchestrator-mariadb
-            python-version: '3.9'
+          - test_environment: docker-server-docker-orchestrator-mysql
+            python-version: '3.12'
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.10'
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.11'
+          - test_environment: docker-server-docker-orchestrator-mariadb
+            python-version: '3.12'
       fail-fast: false
     uses: ./.github/workflows/integration-test-slow.yml
     with:

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -36,9 +36,9 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        options: ['3.9', '3.10', '3.11', '3.12']
         required: false
-        default: '3.8'
+        default: '3.9'
       test_environment:
         description: The test environment
         type: choice

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -36,9 +36,9 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        options: ['3.9', '3.10', '3.11', '3.12']
         required: false
-        default: '3.8'
+        default: '3.9'
       test_environment:
         description: The test environment
         type: choice
@@ -162,7 +162,7 @@ jobs:
       - name: Install MacOS System Dependencies
         if: runner.os=='macOS'
         run: brew install libomp
-      - name: Unbreak Python in GHA for 3.8-3.10
+      - name: Unbreak Python in GHA for 3.9-3.10
         if: runner.os=='macOS' && inputs.python-version != '3.11'
         # github actions overwrites brew's python. Force it to reassert itself, by
         # running in a separate step.

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
-      python-version: '3.8'
+      python-version: '3.9'
       git-ref: develop
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.4
         with:

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
     with:
       os: arc-runner-set
-      python-version: '3.8'
+      python-version: '3.9'
     secrets: inherit
   mlstacks-compatibility-check:
     needs: setup-and-test
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -22,9 +22,9 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        options: ['3.9', '3.10', '3.11', '3.12']
         required: false
-        default: '3.8'
+        default: '3.9'
 jobs:
   all-template-tests:
     name: all-template-tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,9 +37,9 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        options: ['3.9', '3.10', '3.11', '3.12']
         required: false
-        default: '3.8'
+        default: '3.9'
       enable_tmate:
         description: Enable tmate session for debugging
         type: choice
@@ -104,11 +104,6 @@ jobs:
         env:
           ZENML_ANALYTICS_OPT_IN: false
           ZENML_DEBUG: true
-
-      # - name: Upload coverage
-      #  # only do it for python 3.8, we don't need to do it for every version
-      #   if: ${{ inputs.os == 'arc-runner-set' && inputs.python-version == '3.8' }}
-      #   uses: codecov/codecov-action@v2
       - name: Setup tmate session after tests
         if: ${{ inputs.enable_tmate == 'always' || (inputs.enable_tmate == 'on-failure' && failure()) }}
         uses: mxschmitt/action-tmate@v3.17

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -22,9 +22,9 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        options: ['3.9', '3.10', '3.11', '3.12']
         required: false
-        default: '3.8'
+        default: '3.9'
 jobs:
   update-e2e-batch-template-to-examples:
     name: update-e2e-batch-template-to-examples

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Thank you for your support! 🌟
 ## 🤸 Quickstart
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/zenml-io/zenml/blob/main/examples/quickstart/quickstart.ipynb)
 
-[Install ZenML](https://docs.zenml.io/getting-started/installation) via [PyPI](https://pypi.org/project/zenml/). Python 3.8 - 3.11 is required:
+[Install ZenML](https://docs.zenml.io/getting-started/installation) via [PyPI](https://pypi.org/project/zenml/). Python 3.9 - 3.12 is required:
 
 ```bash
 pip install "zenml[server]" notebook

--- a/docs/book/component-guide/orchestrators/skypilot-vm.md
+++ b/docs/book/component-guide/orchestrators/skypilot-vm.md
@@ -11,7 +11,7 @@ This component is only meant to be used within the context of a [remote ZenML de
 {% endhint %}
 
 {% hint style="warning" %}
-SkyPilot VM Orchestrator is currently supported only for Python 3.8 and 3.9.
+SkyPilot VM Orchestrator is currently supported only for Python 3.9.
 {% endhint %}
 
 ## When to use it

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -11,7 +11,7 @@ pip install zenml
 ```
 
 {% hint style="warning" %}
-Note that ZenML currently supports **Python 3.8, 3.9, 3.10, and 3.11**. Please make sure that you are using a supported Python version.
+Note that ZenML currently supports **Python 3.9, 3.10, 3.11 and 3.12**. Please make sure that you are using a supported Python version.
 {% endhint %}
 
 ## Install with the dashboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -55,7 +54,7 @@ psutil = ">=5.0.0"
 pydantic = "~2.8"
 pydantic-settings = "*"
 pymysql = { version = "~1.1.0,>=1.1.1" }
-python = ">=3.8,<3.13"
+python = ">=3.9,<3.13"
 python-dateutil = "^2.8.1"
 pyyaml = ">=6.0.1"
 rich = { extras = ["jupyter"], version = ">=12.0.0" }
@@ -322,8 +321,8 @@ exclude = [
 ]
 
 src = ["src", "test"]
-# use Python 3.8 as the minimum version for autofixing
-target-version = "py38"
+# use Python 3.9 as the minimum version for autofixing
+target-version = "py39"
 
 
 [tool.ruff.format]
@@ -381,10 +380,6 @@ plugins = ["pydantic.mypy"]
 strict = true
 namespace_packages = true
 show_error_codes = true
-
-# temporary fix for python 3.8 https://github.com/apache/airflow/discussions/19006
-# remove once the issue is solved in airflow
-exclude = "airflow/"
 
 [[tool.mypy.overrides]]
 module = ["airflow.*"]

--- a/release-cloudbuild.yaml
+++ b/release-cloudbuild.yaml
@@ -1,26 +1,4 @@
 steps:
-  # build client base image - python 3.8
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - '-c'
-      - |
-        docker build \
-          --build-arg ZENML_VERSION=$TAG_NAME \
-          --build-arg PYTHON_VERSION=3.8 \
-          --target client \
-          -f docker/base.Dockerfile . \
-          -t $$USERNAME/zenml:$TAG_NAME-py3.8
-
-        # use latest tags only for official releases
-        if [[ $TAG_NAME =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-          docker tag $$USERNAME/zenml:$TAG_NAME-py3.8 $$USERNAME/zenml:py3.8
-        fi
-    id: build-base-3.8
-    waitFor: ['-']
-    entrypoint: bash
-    secretEnv:
-      - USERNAME
-
   # build client base image - python 3.9
   - name: gcr.io/cloud-builders/docker
     args:
@@ -152,7 +130,6 @@ steps:
     id: push-base
     waitFor:
       - docker-login
-      - build-base-3.8
       - build-base-3.9
       - build-base-3.10
       - build-base-3.11

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -282,15 +282,6 @@ def install(
     else:
         integration_set = set(integrations)
 
-    # TODO: remove once python 3.8 is deprecated
-    if sys.version_info.minor == 8 and "tensorflow" in integration_set:
-        warning(
-            "Python 3.8 with TensorFlow is not fully compatible with "
-            "Pydantic 2 requirements. Consider upgrading to a "
-            "higher Python version if you would like to use the "
-            "Tensorflow integration."
-        )
-
     if sys.version_info.minor == 12 and "tensorflow" in integration_set:
         warning(
             "The TensorFlow integration is not yet compatible with Python "

--- a/src/zenml/integrations/huggingface/__init__.py
+++ b/src/zenml/integrations/huggingface/__init__.py
@@ -57,13 +57,8 @@ class HuggingfaceIntegration(Integration):
             # - https://github.com/huggingface/datasets/issues/6697
             # TODO try relaxing it back going forward
             "fsspec<=2023.12.0",
+            "transformers",
         ]
-
-        # In python 3.8 higher transformers version lead to other packages breaking
-        if sys.version_info.minor > 8:
-            requirements += ["transformers"]
-        else:
-            requirements += ["transformers<=4.31"]
 
         # Add the pandas integration requirements
         from zenml.integrations.pandas import PandasIntegration

--- a/src/zenml/integrations/tensorflow/__init__.py
+++ b/src/zenml/integrations/tensorflow/__init__.py
@@ -40,15 +40,6 @@ class TensorflowIntegration(Integration):
 
         from zenml.integrations.tensorflow import materializers  # noqa
 
-        if sys.version_info.minor == 8:
-            logger.warning(
-                "Python 3.8 with TensorFlow is not fully "
-                "compatible with Pydantic 2 requirements. "
-                "Consider upgrading to a higher Python "
-                "version if you would like to use the "
-                "Tensorflow integration."
-            )
-
     @classmethod
     def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
         """Defines platform specific requirements for the integration.

--- a/src/zenml/utils/typing_utils.py
+++ b/src/zenml/utils/typing_utils.py
@@ -39,38 +39,18 @@ if hasattr(typing, "Literal"):
 
 # ----- is_none_type -----
 
-if sys.version_info[:2] == (3, 8):
 
-    def is_none_type(type_: Any) -> bool:
-        """Checks if the provided type is none type.
+def is_none_type(type_: Any) -> bool:
+    """Checks if the provided type is a none type.
 
-        Args:
-            type_: type to check.
+    Args:
+        type_: type to check.
 
-        Returns:
-            boolean indicating whether the type is none type.
-        """
-        for none_type in NONE_TYPES:
-            if type_ is none_type:
-                return True
-        # With python 3.8, specifically 3.8.10, Literal "is" checks are very
-        # flakey can change on very subtle changes like use of types in other
-        # modules, hopefully this check avoids that issue.
-        if is_literal_type(type_):  # pragma: no cover
-            return all_literal_values(type_) == (None,)
-        return False
-else:
+    Returns:
+        boolean indicating whether the type is a none type.
+    """
+    return type_ in NONE_TYPES
 
-    def is_none_type(type_: Any) -> bool:
-        """Checks if the provided type is a none type.
-
-        Args:
-            type_: type to check.
-
-        Returns:
-            boolean indicating whether the type is a none type.
-        """
-        return type_ in NONE_TYPES
 
 # ----- is_union -----
 

--- a/tests/harness/utils.py
+++ b/tests/harness/utils.py
@@ -56,9 +56,6 @@ def cleanup_folder(path: str) -> None:
                 "Skipping deletion of temp dir at teardown, due to "
                 "Windows Permission error"
             )
-            # TODO[HIGH]: Implement fixture cleanup for Windows where
-            #  shutil.rmtree fails on files that are in use on python 3.7 and
-            #  3.8
     else:
         shutil.rmtree(path)
 

--- a/tests/integration/functional/zen_stores/test_secrets_store.py
+++ b/tests/integration/functional/zen_stores/test_secrets_store.py
@@ -1114,15 +1114,16 @@ def test_list_secrets_filter():
     aria_secret_name = sample_name("arias-whiskers")
     axl_secret_name = sample_name("axls-whiskers")
 
-    with SecretContext(
-        secret_name=aria_secret_name
-    ) as secret_one, SecretContext(
-        secret_name=aria_secret_name, scope=SecretScope.USER
-    ) as secret_two, SecretContext(
-        secret_name=axl_secret_name
-    ) as secret_three, SecretContext(
-        secret_name=axl_secret_name, scope=SecretScope.USER
-    ) as secret_four:
+    with (
+        SecretContext(secret_name=aria_secret_name) as secret_one,
+        SecretContext(
+            secret_name=aria_secret_name, scope=SecretScope.USER
+        ) as secret_two,
+        SecretContext(secret_name=axl_secret_name) as secret_three,
+        SecretContext(
+            secret_name=axl_secret_name, scope=SecretScope.USER
+        ) as secret_four,
+    ):
         all_secrets = store.list_secrets(SecretFilter()).items
         assert len(all_secrets) >= 4
         assert set(
@@ -1263,17 +1264,20 @@ def test_list_secrets_pagination_and_sorting():
 
     suffix = sample_name("")
 
-    with SecretContext(
-        secret_name=f"arias-whiskers-{suffix}"
-    ) as secret_one, SecretContext(
-        secret_name=f"arias-spots-{suffix}",
-        scope=SecretScope.USER,
-    ) as secret_two, SecretContext(
-        secret_name=f"axls-whiskers-{suffix}",
-    ) as secret_three, SecretContext(
-        secret_name=f"axls-spots-{suffix}",
-        scope=SecretScope.USER,
-    ) as secret_four:
+    with (
+        SecretContext(secret_name=f"arias-whiskers-{suffix}") as secret_one,
+        SecretContext(
+            secret_name=f"arias-spots-{suffix}",
+            scope=SecretScope.USER,
+        ) as secret_two,
+        SecretContext(
+            secret_name=f"axls-whiskers-{suffix}",
+        ) as secret_three,
+        SecretContext(
+            secret_name=f"axls-spots-{suffix}",
+            scope=SecretScope.USER,
+        ) as secret_four,
+    ):
         secrets = store.list_secrets(
             SecretFilter(
                 name=f"endswith:{suffix}",

--- a/tests/integration/integrations/skypilot/orchestrators/test_skypilot_orchestrator.py
+++ b/tests/integration/integrations/skypilot/orchestrators/test_skypilot_orchestrator.py
@@ -83,7 +83,7 @@ def _get_skypilot_orchestrator(
 
 
 @pytest.mark.skip(
-    reason="SkyPilot can not be installed in Python 3.8 or 3.9",
+    reason="SkyPilot can not be installed in Python 3.9",
 )
 @pytest.mark.parametrize("provider", ["aws", "azure", "gcp"])
 def test_skypilot_orchestrator_local_stack(


### PR DESCRIPTION
Python 3.8 is EOL on October 1st, so we're removing support for it.