### PR TITLE
Use a generic OAuth2 client credentials flow to login to the Cloud API

### DIFF
--- a/src/zenml/zen_server/cloud_utils.py
+++ b/src/zenml/zen_server/cloud_utils.py
@@ -22,6 +22,7 @@ class ZenMLCloudConfiguration(BaseModel):
     api_url: str
     oauth2_client_id: str
     oauth2_client_secret: str
+    oauth2_audience: str
 
     @field_validator("api_url")
     @classmethod
@@ -213,6 +214,7 @@ class ZenMLCloudConnection:
         payload = {
             "client_id": self._config.oauth2_client_id,
             "client_secret": self._config.oauth2_client_secret,
+            "audience": self._config.oauth2_audience,
             "grant_type": "client_credentials",
         }
         try:


### PR DESCRIPTION
## Describe changes
Currently, the ZenML Pro tenants are hard-coded to using Auth0 to fetch the M2M tokens needed to access the ZenML Pro API. This PR changes that and makes the implementation generic, allowing ZenML Pro tenants to connect to any authentication server that supports the OAuth2 client credentials grant, not just Auth0.

This allows ZenML Pro tenants to connect straight to the ZenML Pro API itself to fetch M2M tokens through the client credentials grant instead of Auth0.

This is paired with https://github.com/zenml-io/zenml-cloud-api/pull/223 which adds OAuth2 client credentials grant support to the ZenML Pro API. 

Note: no configuration changes are needed from the ZenML Pro deployments themselves, because they will be using the same client ID and client secret to connect to the ZenML PRo API. However, as a future security hardening measure, each tenant will be given its own client ID (probably the same as the tenant ID) and client secret.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

