### PR TITLE
Fix Lightning Orchestrator (remove -y from pip install)

### DIFF
--- a/src/zenml/integrations/lightning/orchestrators/lightning_orchestrator.py
+++ b/src/zenml/integrations/lightning/orchestrators/lightning_orchestrator.py
@@ -399,7 +399,7 @@ class LightningOrchestrator(WheeledOrchestrator):
                 f"Installing requirements: {pipeline_requirements_to_string}"
             )
             studio.run(f"uv pip install {pipeline_requirements_to_string}")
-            studio.run("pip install zenml -y")
+            studio.run("pip install zenml")
 
             for custom_command in settings.custom_commands or []:
                 studio.run(
@@ -493,7 +493,7 @@ class LightningOrchestrator(WheeledOrchestrator):
             )
             studio.run("pip install uv")
             studio.run(f"uv pip install {requirements}")
-            studio.run("pip install zenml -y")
+            studio.run("pip install zenml")
             # studio.run(f"pip install {wheel_path.rsplit('/', 1)[-1]}")
             for command in settings.custom_commands or []:
                 output = studio.run(
@@ -566,7 +566,7 @@ class LightningOrchestrator(WheeledOrchestrator):
         )
         studio.run("pip install uv")
         studio.run(f"uv pip install {details['requirements']}")
-        studio.run("pip install zenml -y")
+        studio.run("pip install zenml")
         # studio.run(f"pip install {wheel_path.rsplit('/', 1)[-1]}")
         for command in custom_commands or []:
             output = studio.run(

--- a/src/zenml/integrations/lightning/orchestrators/lightning_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/lightning/orchestrators/lightning_orchestrator_entrypoint.py
@@ -166,7 +166,7 @@ def main() -> None:
         f"uv pip install {pipeline_requirements_to_string}"
     )
     logger.info(output)
-    output = main_studio.run("pip install zenml -y")
+    output = main_studio.run("pip install zenml")
     logger.info(output)
 
     for command in pipeline_settings.custom_commands or []:
@@ -248,7 +248,7 @@ def main() -> None:
                     f"uv pip install {step_requirements_to_string}"
                 )
                 logger.info(output)
-                output = studio.run("pip install zenml -y")
+                output = studio.run("pip install zenml")
                 logger.info(output)
                 for command in step_settings.custom_commands or []:
                     output = studio.run(


### PR DESCRIPTION
## Describe changes
I fixed the lightning orchestrator by removing the `-y` flag from the pip install commands as this flag doesn't exist and breaks the pipeline run.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

