### PR TITLE
Remove log versions from versioned buckets in S3

### DIFF
--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -475,6 +475,17 @@ class BaseArtifactStore(StackComponent):
 
         default_filesystem_registry.register(filesystem_class)
 
+    def _keep_only_latest_file_version(self, path: PathType) -> None:
+        """Keep only the latest file version in the given path.
+
+        Method is useful for logs stored in versioned file systems
+        like AWS S3.
+
+        Args:
+            path: The path to the file.
+        """
+        return
+
 
 class BaseArtifactStoreFlavor(Flavor):
     """Base class for artifact store flavors."""

--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -475,8 +475,8 @@ class BaseArtifactStore(StackComponent):
 
         default_filesystem_registry.register(filesystem_class)
 
-    def _keep_only_latest_file_version(self, path: PathType) -> None:
-        """Keep only the latest file version in the given path.
+    def _remove_previous_file_versions(self, path: PathType) -> None:
+        """Remove all file versions but the latest in the given path.
 
         Method is useful for logs stored in versioned file systems
         like AWS S3.

--- a/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
+++ b/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Implementation of the S3 Artifact Store."""
 
-import os
 from typing import (
     Any,
     Callable,
@@ -34,6 +33,7 @@ from zenml.artifact_stores import BaseArtifactStore
 from zenml.integrations.s3.flavors.s3_artifact_store_flavor import (
     S3ArtifactStoreConfig,
 )
+from zenml.integrations.s3.utils import split_s3_path
 from zenml.io.fileio import convert_to_str
 from zenml.logger import get_logger
 from zenml.secret.schemas import AWSSecretSchema
@@ -466,7 +466,7 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         if self.is_versioned:
             if isinstance(path, bytes):
                 path = path.decode()
-            prefix = os.path.join(*os.path.normpath(path).split("/")[2:])
+            _, prefix = split_s3_path(path)
             s3 = boto3.resource("s3")
             bucket = s3.Bucket(self.config.bucket)
             for version in bucket.object_versions.filter(Prefix=prefix):

--- a/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
+++ b/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Amazon S3 artifact store flavor."""
 
+import os
 import re
 from typing import (
     TYPE_CHECKING,
@@ -31,6 +32,7 @@ from zenml.artifact_stores import (
     BaseArtifactStoreFlavor,
 )
 from zenml.integrations.s3 import S3_ARTIFACT_STORE_FLAVOR
+from zenml.logger import get_logger
 from zenml.models import ServiceConnectorRequirements
 from zenml.stack.authentication_mixin import AuthenticationConfigMixin
 from zenml.utils.networking_utils import (
@@ -40,6 +42,8 @@ from zenml.utils.secret_utils import SecretField
 
 if TYPE_CHECKING:
     from zenml.integrations.s3.artifact_stores import S3ArtifactStore
+
+logger = get_logger(__name__)
 
 
 class S3ArtifactStoreConfig(
@@ -69,6 +73,8 @@ class S3ArtifactStoreConfig(
     client_kwargs: Optional[Dict[str, Any]] = None
     config_kwargs: Optional[Dict[str, Any]] = None
     s3_additional_kwargs: Optional[Dict[str, Any]] = None
+
+    _is_versioned: Optional[bool] = None
 
     @field_validator("client_kwargs")
     @classmethod
@@ -105,6 +111,38 @@ class S3ArtifactStoreConfig(
                 url
             )
         return value
+
+    @property
+    def bucket(self) -> str:
+        """The bucket name of the artifact store.
+
+        Returns:
+            The bucket name of the artifact store.
+        """
+        return os.path.normpath(self.path).split(os.sep)[1]
+
+    @property
+    def is_versioned(self) -> bool:
+        """Whether the artifact store is versioned or not.
+
+        Returns:
+            Whether the artifact store is versioned or not.
+        """
+        if self._is_versioned is None:
+            import boto3
+
+            c = boto3.client("s3")
+            if (
+                c.get_bucket_versioning(Bucket=self.bucket).get("Status")
+                == "Enabled"
+            ):
+                self._is_versioned = True
+                logger.warning(
+                    "The artifact store is versioned, this may slow down logging process significantly."
+                )
+            else:
+                self._is_versioned = False
+        return self._is_versioned
 
 
 class S3ArtifactStoreFlavor(BaseArtifactStoreFlavor):

--- a/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
+++ b/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Amazon S3 artifact store flavor."""
 
-import os
 import re
 from typing import (
     TYPE_CHECKING,
@@ -32,6 +31,7 @@ from zenml.artifact_stores import (
     BaseArtifactStoreFlavor,
 )
 from zenml.integrations.s3 import S3_ARTIFACT_STORE_FLAVOR
+from zenml.integrations.s3.utils import split_s3_path
 from zenml.models import ServiceConnectorRequirements
 from zenml.stack.authentication_mixin import AuthenticationConfigMixin
 from zenml.utils.networking_utils import (
@@ -117,7 +117,7 @@ class S3ArtifactStoreConfig(
             The bucket name of the artifact store.
         """
         if self._bucket is None:
-            self._bucket = os.path.normpath(self.path).split("/")[1]
+            self._bucket, _ = split_s3_path(self.path)
         return self._bucket
 
 

--- a/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
+++ b/src/zenml/integrations/s3/flavors/s3_artifact_store_flavor.py
@@ -75,6 +75,7 @@ class S3ArtifactStoreConfig(
     s3_additional_kwargs: Optional[Dict[str, Any]] = None
 
     _is_versioned: Optional[bool] = None
+    _bucket: Optional[str] = None
 
     @field_validator("client_kwargs")
     @classmethod
@@ -119,7 +120,9 @@ class S3ArtifactStoreConfig(
         Returns:
             The bucket name of the artifact store.
         """
-        return os.path.normpath(self.path).split(os.sep)[1]
+        if self._bucket is None:
+            self._bucket = os.path.normpath(self.path).split(os.sep)[1]
+        return self._bucket
 
     @property
     def is_versioned(self) -> bool:

--- a/src/zenml/integrations/s3/utils.py
+++ b/src/zenml/integrations/s3/utils.py
@@ -1,0 +1,40 @@
+#  Copyright (c) ZenML GmbH 2022. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Utility methods for S3."""
+
+from typing import Tuple
+
+
+def split_s3_path(s3_path: str) -> Tuple[str, str]:
+    """Split S3 URI into bucket and key.
+
+    Args:
+        s3_path: S3 URI (e.g. "s3://bucket/path")
+
+    Returns:
+        A tuple of bucket and key, for "s3://bucket/path/path2"
+            it will return ("bucket","path/path2")
+
+    Raises:
+        ValueError: if the S3 URI is invalid
+    """
+    if not s3_path.startswith("s3://"):
+        raise ValueError(
+            f"Invalid S3 URI given: {s3_path}. "
+            "It should start with `s3://`."
+        )
+    path_parts = s3_path.replace("s3://", "").split("/")
+    bucket = path_parts.pop(0)
+    key = "/".join(path_parts)
+    return bucket, key

--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -330,7 +330,7 @@ class StepLogsStorage:
                                 file.write(
                                     f"[{timestamp} UTC] {remove_ansi_escape_codes(message)}\n"
                                 )
-                        self.artifact_store._keep_only_latest_file_version(
+                        self.artifact_store._remove_previous_file_versions(
                             self.logs_uri
                         )
 

--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -330,6 +330,9 @@ class StepLogsStorage:
                                 file.write(
                                     f"[{timestamp} UTC] {remove_ansi_escape_codes(message)}\n"
                                 )
+                        self.artifact_store._keep_only_latest_file_version(
+                            self.logs_uri
+                        )
 
             except (OSError, IOError) as e:
                 # This exception can be raised if there are issues with the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Generator, Tuple
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -448,17 +449,18 @@ def s3_artifact_store():
         S3ArtifactStoreConfig,
     )
 
-    return S3ArtifactStore(
-        name="",
-        id=uuid4(),
-        config=S3ArtifactStoreConfig(path="s3://tmp"),
-        flavor="s3",
-        type=StackComponentType.ARTIFACT_STORE,
-        user=uuid4(),
-        workspace=uuid4(),
-        created=datetime.now(),
-        updated=datetime.now(),
-    )
+    with patch("boto3.resource", MagicMock()):
+        return S3ArtifactStore(
+            name="",
+            id=uuid4(),
+            config=S3ArtifactStoreConfig(path="s3://tmp"),
+            flavor="s3",
+            type=StackComponentType.ARTIFACT_STORE,
+            user=uuid4(),
+            workspace=uuid4(),
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
 
 
 @pytest.fixture

--- a/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
+++ b/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
@@ -14,6 +14,7 @@
 
 
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -30,28 +31,55 @@ from zenml.integrations.s3.flavors.s3_artifact_store_flavor import (
 
 def test_s3_artifact_store_attributes():
     """Tests that the basic attributes of the s3 artifact store are set correctly."""
-    artifact_store = S3ArtifactStore(
-        name="",
-        id=uuid4(),
-        config=S3ArtifactStoreConfig(path="s3://tmp"),
-        flavor="s3",
-        type=StackComponentType.ARTIFACT_STORE,
-        user=uuid4(),
-        workspace=uuid4(),
-        created=datetime.now(),
-        updated=datetime.now(),
-    )
+    with patch("boto3.resource", MagicMock()):
+        artifact_store = S3ArtifactStore(
+            name="",
+            id=uuid4(),
+            config=S3ArtifactStoreConfig(path="s3://tmp"),
+            flavor="s3",
+            type=StackComponentType.ARTIFACT_STORE,
+            user=uuid4(),
+            workspace=uuid4(),
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
     assert artifact_store.type == StackComponentType.ARTIFACT_STORE
     assert artifact_store.flavor == "s3"
 
 
 def test_must_be_s3_path():
     """Checks that a s3 artifact store can only be initialized with a s3 path."""
-    with pytest.raises(ArtifactStoreInterfaceError):
-        S3ArtifactStore(
+    with patch("boto3.resource", MagicMock()):
+        with pytest.raises(ArtifactStoreInterfaceError):
+            S3ArtifactStore(
+                name="",
+                id=uuid4(),
+                config=S3ArtifactStoreConfig(path="/local/path"),
+                flavor="s3",
+                type=StackComponentType.ARTIFACT_STORE,
+                user=uuid4(),
+                workspace=uuid4(),
+                created=datetime.now(),
+                updated=datetime.now(),
+            )
+
+        with pytest.raises(ArtifactStoreInterfaceError):
+            S3ArtifactStore(
+                name="",
+                id=uuid4(),
+                config=S3ArtifactStoreConfig(path="gs://mybucket"),
+                flavor="s3",
+                type=StackComponentType.ARTIFACT_STORE,
+                user=uuid4(),
+                workspace=uuid4(),
+                created=datetime.now(),
+                updated=datetime.now(),
+            )
+
+        artifact_store = S3ArtifactStore(
             name="",
             id=uuid4(),
-            config=S3ArtifactStoreConfig(path="/local/path"),
+            config=S3ArtifactStoreConfig(path="s3://mybucket"),
             flavor="s3",
             type=StackComponentType.ARTIFACT_STORE,
             user=uuid4(),
@@ -59,29 +87,4 @@ def test_must_be_s3_path():
             created=datetime.now(),
             updated=datetime.now(),
         )
-
-    with pytest.raises(ArtifactStoreInterfaceError):
-        S3ArtifactStore(
-            name="",
-            id=uuid4(),
-            config=S3ArtifactStoreConfig(path="gs://mybucket"),
-            flavor="s3",
-            type=StackComponentType.ARTIFACT_STORE,
-            user=uuid4(),
-            workspace=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
-
-    artifact_store = S3ArtifactStore(
-        name="",
-        id=uuid4(),
-        config=S3ArtifactStoreConfig(path="s3://mybucket"),
-        flavor="s3",
-        type=StackComponentType.ARTIFACT_STORE,
-        user=uuid4(),
-        workspace=uuid4(),
-        created=datetime.now(),
-        updated=datetime.now(),
-    )
     assert artifact_store.path == "s3://mybucket"

--- a/tests/integration/integrations/s3/test_utils.py
+++ b/tests/integration/integrations/s3/test_utils.py
@@ -1,0 +1,53 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from typing import Tuple
+
+import pytest
+
+from zenml.integrations.s3.utils import split_s3_path
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ["s3://bucket/path", ("bucket", "path")],
+        ["s3://bucket2/path/path2", ("bucket2", "path/path2")],
+        [
+            "s3://bucket3/path/path2/random.file",
+            ("bucket3", "path/path2/random.file"),
+        ],
+        ["s3://bucket/", ("bucket", "")],
+        ["s3://bucket2", ("bucket2", "")],
+    ],
+)
+def test_split_s3_path_on_good_paths(
+    path: str, expected: Tuple[str, str]
+) -> None:
+    """Test that paths are correctly parsed."""
+    assert split_s3_path(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "s3:/bucket",
+        "bucket2/path/path2",
+        "s2://bucket/",
+    ],
+)
+def test_split_s3_path_on_bad_paths(path: str) -> None:
+    """Test that exception is raised for badly formatted paths."""
+    with pytest.raises(ValueError):
+        split_s3_path(path)


### PR DESCRIPTION
## Describe changes
I implemented the removal of versions for log files in S3 versioned bucket scenarios to prevent storage requirements from blowing up. It is still not advised to use versioning here, but if this is required for artifacts, then the logging at least would not be an issue.
Users have to bear in mind the performance impact of this since the versions would be looked up and deleted, which takes some time still.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

