### PR TITLE
Fix Kaniko image builder service account passing

### DIFF
--- a/examples/e2e/.copier-answers.yml
+++ b/examples/e2e/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2024.10.09-2-g429e445
+_commit: 2024.10.10
 _src_path: gh:zenml-io/template-e2e-batch
 data_quality_checks: true
 email: info@zenml.io

--- a/examples/llm_finetuning/.copier-answers.yml
+++ b/examples/llm_finetuning/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2024.08.29-1-ge25e9e0
+_commit: 2024.09.24
 _src_path: gh:zenml-io/template-llm-finetuning
 bf16: true
 cuda_version: cuda11.8

--- a/examples/mlops_starter/.copier-answers.yml
+++ b/examples/mlops_starter/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2024.09.23-1-g9128c4b
+_commit: 2024.09.24
 _src_path: gh:zenml-io/template-starter
 email: info@zenml.io
 full_name: ZenML GmbH

--- a/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
+++ b/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
@@ -199,9 +199,9 @@ class KanikoImageBuilder(BaseImageBuilder):
             "--image-name-with-digest-file=/dev/termination-log",
         ] + self.config.executor_args
 
-        optional_container_args: Dict[str, Any] = {}
+        optional_spec_args: Dict[str, Any] = {}
         if self.config.service_account_name:
-            optional_container_args["serviceAccountName"] = (
+            optional_spec_args["serviceAccountName"] = (
                 self.config.service_account_name
             )
 
@@ -218,10 +218,10 @@ class KanikoImageBuilder(BaseImageBuilder):
                         "env": self.config.env,
                         "envFrom": self.config.env_from,
                         "volumeMounts": self.config.volume_mounts,
-                        **optional_container_args,
                     }
                 ],
                 "volumes": self.config.volumes,
+                **optional_spec_args,
             },
         }
 


### PR DESCRIPTION
## Describe changes

The service account was incorrectly being passed to the `container` instead of the `pod spec`.
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

