### PR TITLE
Fix pipeline and model URLs for ZenML Pro on-prem deployments

### DIFF
--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -24,26 +24,11 @@ from zenml.logger import get_logger
 from zenml.models import (
     ComponentResponse,
     PipelineRunResponse,
-    ServerModel,
+    ServerDeploymentType,
     StackResponse,
 )
 
 logger = get_logger(__name__)
-
-
-def is_cloud_server(server_info: ServerModel) -> bool:
-    """Checks whether the server info refers to a ZenML Pro server.
-
-    Args:
-        server_info: Info of the server.
-
-    Returns:
-        Whether the server info refers to a ZenML Pro server.
-    """
-    return (
-        "organization_id" in server_info.metadata
-        and "cloud.zenml.io" in server_info.dashboard_url
-    )
 
 
 def get_cloud_dashboard_url() -> Optional[str]:
@@ -57,7 +42,7 @@ def get_cloud_dashboard_url() -> Optional[str]:
     if client.zen_store.type == StoreType.REST:
         server_info = client.zen_store.get_store_info()
 
-        if is_cloud_server(server_info):
+        if server_info.deployment_type == ServerDeploymentType.CLOUD:
             return server_info.dashboard_url
 
     return None
@@ -167,9 +152,9 @@ def get_model_version_url(model_version_id: UUID) -> Optional[str]:
     Returns:
         the URL to the model version if the dashboard is available, else None.
     """
-    base_url = get_cloud_dashboard_url()
-    if base_url:
-        return f"{base_url}/model-versions/{str(model_version_id)}"
+    cloud_url = get_cloud_dashboard_url()
+    if cloud_url:
+        return f"{cloud_url}/model-versions/{str(model_version_id)}"
 
     return None
 

--- a/src/zenml/zen_server/feature_gate/zenml_cloud_feature_gate.py
+++ b/src/zenml/zen_server/feature_gate/zenml_cloud_feature_gate.py
@@ -110,7 +110,7 @@ class ZenMLCloudFeatureGateInterface(FeatureGateInterface):
             feature=resource,
             total=1 if not is_decrement else -1,
             metadata={
-                "tenant_id": str(server_config.external_server_id),
+                "tenant_id": str(server_config.get_external_server_id()),
                 "resource_id": str(resource_id),
             },
         ).model_dump()


### PR DESCRIPTION
## Describe changes
When connected to an on-prem installation of ZenML Pro, the pipeline and model URLs printed by the ZenML client still point to the legacy dashboard.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

