### PR TITLE
Do not tag model via `Model` class on creation

### DIFF
--- a/docs/book/how-to/handle-data-artifacts/tagging.md
+++ b/docs/book/how-to/handle-data-artifacts/tagging.md
@@ -54,15 +54,19 @@ Note that [ZenML Pro](https://zenml.io/pro) users can tag artifacts directly in 
 
 Just like artifacts, you can also tag your models to organize them semantically. Here's how to use tags with models in the ZenML Python SDK and CLI (or in the [ZenML Pro Dashboard directly](https://zenml.io/pro)).
 
-When creating a model using the `Model` object, you can specify tags as key-value pairs that will be attached to the model upon creation:
+When creating a model version using the `Model` object, you can specify tags as key-value pairs that will be attached to the model version upon creation.
+{% hint style="warning" %}
+During pipeline run a model can be also implicitly created (if not exists), in such cases it will not get the `tags` from the `Model` class.
+You can manipulate the model tags using SDK (see below) or the ZenML Pro UI.
+{% endhint %}
 
 ```python
 from zenml.models import Model
 
-# Define tags to be added to the model
+# Define tags to be added to the model version
 tags = ["experiment", "v1", "classification-task"]
 
-# Create a model with tags
+# Create a model version with tags
 model = Model(
     name="iris_classifier",
     version="1.0.0",

--- a/src/zenml/model/model.py
+++ b/src/zenml/model/model.py
@@ -569,7 +569,6 @@ class Model(BaseModel):
                     limitations=self.limitations,
                     trade_offs=self.trade_offs,
                     ethics=self.ethics,
-                    tags=self.tags,
                     user=zenml_client.active_user.id,
                     workspace=zenml_client.active_workspace.id,
                     save_models_to_registry=self.save_models_to_registry,

--- a/src/zenml/models/v2/core/model.py
+++ b/src/zenml/models/v2/core/model.py
@@ -82,6 +82,7 @@ class ModelRequest(WorkspaceScopedRequest):
     )
     tags: Optional[List[str]] = Field(
         title="Tags associated with the model",
+        default=None,
     )
     save_models_to_registry: bool = Field(
         title="Whether to save all ModelArtifacts to Model Registry",

--- a/tests/integration/functional/model/test_model_version.py
+++ b/tests/integration/functional/model/test_model_version.py
@@ -198,7 +198,7 @@ class TestModel:
             assert mv.name == str(mv.number)
             assert mv.model.name == mdl_name
             assert {t.name for t in mv.tags} == {"tag1", "tag2"}
-            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
+            assert len(mv.model.tags) == 0
 
     def test_create_model_version_makes_proper_tagging(self):
         """Test if model versions get unique tags."""
@@ -208,14 +208,14 @@ class TestModel:
             assert mv.name == str(mv.number)
             assert mv.model.name == mdl_name
             assert {t.name for t in mv.tags} == {"tag1", "tag2"}
-            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
+            assert len(mv.model.tags) == 0
 
             mv = Model(name=mdl_name, tags=["tag3", "tag4"])
             mv = mv._get_or_create_model_version()
             assert mv.name == str(mv.number)
             assert mv.model.name == mdl_name
             assert {t.name for t in mv.tags} == {"tag3", "tag4"}
-            assert {t.name for t in mv.model.tags} == {"tag1", "tag2"}
+            assert len(mv.model.tags) == 0
 
     def test_model_fetch_model_and_version_by_number(self):
         """Test model and model version retrieval by exact version number."""
@@ -301,15 +301,17 @@ class TestModel:
 
                     # run 2 times to first create, next get
                     for _ in range(2):
-                        model = mv._get_or_create_model()
+                        model_version = mv._get_or_create_model_version()
 
-                        assert len(model.tags) == 2
-                        assert {t.name for t in model.tags} == {
+                        assert len(model_version.tags) == 2
+                        assert {t.name for t in model_version.tags} == {
                             green_tag,
                             new_tag,
                         }
                         assert {
-                            t.color for t in model.tags if t.name == green_tag
+                            t.color
+                            for t in model_version.tags
+                            if t.name == green_tag
                         } == {"green"}
 
     def test_tags_properly_updated(self):
@@ -324,10 +326,8 @@ class TestModel:
 
             client.update_model(model_id, add_tags=["tag1", "tag2"])
             model = mv._get_or_create_model()
-            assert len(model.tags) == 4
+            assert len(model.tags) == 2
             assert {t.name for t in model.tags} == {
-                "foo",
-                "bar",
                 "tag1",
                 "tag2",
             }
@@ -346,8 +346,7 @@ class TestModel:
 
             client.update_model(model_id, remove_tags=["tag1", "tag2"])
             model = mv._get_or_create_model()
-            assert len(model.tags) == 2
-            assert {t.name for t in model.tags} == {"foo", "bar"}
+            assert len(model.tags) == 0
 
             client.update_model_version(
                 model_id, "1", remove_tags=["tag3", "tag4"]


### PR DESCRIPTION
## Describe changes
I removed the tagging of the Model entity if it gets created implicitly via the `Model` class. (e.g. set in `@pipeline`).

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] If my change requires a change to docs, I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

