### PR TITLE
Fix materializer type compatibility check during loading

### DIFF
--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -176,7 +176,7 @@ def save_artifact(
 
     # Save the artifact to the artifact store
     data_type = type(data)
-    materializer_object.validate_type_compatibility(data_type)
+    materializer_object.validate_save_type_compatibility(data_type)
     materializer_object.save(data)
 
     # Save visualizations of the artifact

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -229,35 +229,65 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
     # ================
     # Internal Methods
     # ================
-
-    def validate_type_compatibility(self, data_type: Type[Any]) -> None:
-        """Checks whether the materializer can read/write the given type.
+    def validate_save_type_compatibility(self, data_type: Type[Any]) -> None:
+        """Checks whether the materializer can save the given type.
 
         Args:
             data_type: The type to check.
 
         Raises:
-            TypeError: If the materializer cannot read/write the given type.
+            TypeError: If the materializer cannot save the given type.
         """
-        if not self.can_handle_type(data_type):
+        if not self.can_save_type(data_type):
             raise TypeError(
-                f"Unable to handle type {data_type}. {self.__class__.__name__} "
-                f"can only read/write artifacts of the following types: "
+                f"Unable to save type {data_type}. {self.__class__.__name__} "
+                f"can only save artifacts of the following types: "
+                f"{self.ASSOCIATED_TYPES}."
+            )
+
+    def validate_load_type_compatibility(self, data_type: Type[Any]) -> None:
+        """Checks whether the materializer can load the given type.
+
+        Args:
+            data_type: The type to check.
+
+        Raises:
+            TypeError: If the materializer cannot load the given type.
+        """
+        if not self.can_load_type(data_type):
+            raise TypeError(
+                f"Unable to load type {data_type}. {self.__class__.__name__} "
+                f"can only load artifacts of the following types: "
                 f"{self.ASSOCIATED_TYPES}."
             )
 
     @classmethod
-    def can_handle_type(cls, data_type: Type[Any]) -> bool:
-        """Whether the materializer can read/write a certain type.
+    def can_save_type(cls, data_type: Type[Any]) -> bool:
+        """Whether the materializer can save a certain type.
 
         Args:
             data_type: The type to check.
 
         Returns:
-            Whether the materializer can read/write the given type.
+            Whether the materializer can save the given type.
         """
         return any(
             issubclass(data_type, associated_type)
+            for associated_type in cls.ASSOCIATED_TYPES
+        )
+
+    @classmethod
+    def can_load_type(cls, data_type: Type[Any]) -> bool:
+        """Whether the materializer can load an artifact as the given type.
+
+        Args:
+            data_type: The type to check.
+
+        Returns:
+            Whether the materializer can load an artifact as the given type.
+        """
+        return any(
+            issubclass(associated_type, data_type)
             for associated_type in cls.ASSOCIATED_TYPES
         )
 

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -290,7 +290,7 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
             issubclass(associated_type, data_type)
             # This next condition is not always correct, but better to have a
             # false positive here instead of failing for cases where it would
-            # have worked. 
+            # have worked.
             or issubclass(data_type, associated_type)
             for associated_type in cls.ASSOCIATED_TYPES
         )

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -288,6 +288,10 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
         """
         return any(
             issubclass(associated_type, data_type)
+            # This next condition is not always correct, but better to have a
+            # false positive here instead of failing for cases where it would
+            # have worked. 
+            or issubclass(data_type, associated_type)
             for associated_type in cls.ASSOCIATED_TYPES
         )
 

--- a/src/zenml/materializers/built_in_materializer.py
+++ b/src/zenml/materializers/built_in_materializer.py
@@ -403,7 +403,7 @@ class BuiltInContainerMaterializer(BaseMaterializer):
             yaml_utils.write_json(self.metadata_path, metadata)
             # Materialize each element.
             for element, materializer in zip(data, materializers):
-                materializer.validate_type_compatibility(type(element))
+                materializer.validate_save_type_compatibility(type(element))
                 materializer.save(element)
         # If an error occurs, delete all created files.
         except Exception as e:

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -412,7 +412,7 @@ class StepRunner:
             materializer: BaseMaterializer = materializer_class(
                 uri=artifact.uri, artifact_store=target_artifact_store
             )
-            materializer.validate_type_compatibility(data_type)
+            materializer.validate_load_type_compatibility(data_type)
             return materializer.load(data_type=data_type)
 
     def _validate_outputs(

--- a/src/zenml/utils/materializer_utils.py
+++ b/src/zenml/utils/materializer_utils.py
@@ -41,7 +41,7 @@ def select_materializer(
         for materializer_class in materializer_classes:
             if class_ in materializer_class.ASSOCIATED_TYPES:
                 return materializer_class
-            elif not fallback and materializer_class.can_handle_type(class_):
+            elif not fallback and materializer_class.can_save_type(class_):
                 fallback = materializer_class
 
     if fallback:

--- a/tests/unit/materializers/test_base_materializer.py
+++ b/tests/unit/materializers/test_base_materializer.py
@@ -21,9 +21,20 @@ from zenml.exceptions import MaterializerInterfaceError
 from zenml.materializers.base_materializer import BaseMaterializer
 
 
-class TestMaterializer(BaseMaterializer):
-    __test__ = False
-    ASSOCIATED_TYPES = (int,)
+class Parent:
+    pass
+
+
+class Child(Parent):
+    pass
+
+
+class ParentMaterializer(BaseMaterializer):
+    ASSOCIATED_TYPES = (Parent,)
+
+
+class ChildMaterializer(BaseMaterializer):
+    ASSOCIATED_TYPES = (Child,)
 
 
 def test_materializer_raises_an_exception_if_associated_types_are_no_classes():
@@ -54,9 +65,31 @@ def test_materializer_raises_an_exception_if_associated_artifact_type_wrong():
             ASSOCIATED_ARTIFACT_TYPE = "not_an_artifact_type"
 
 
-def test_validate_type_compatibility():
-    """Unit test for `BaseMaterializer.validate_type_compatibility`."""
-    materializer = TestMaterializer(uri="")
+def test_validate_save_type_compatibility():
+    child_materializer = ChildMaterializer(uri="")
+    parent_materializer = ParentMaterializer(uri="")
 
     with pytest.raises(TypeError):
-        materializer.validate_type_compatibility(data_type=str)
+        child_materializer.validate_save_type_compatibility(data_type=Parent)
+
+    with does_not_raise():
+        child_materializer.validate_save_type_compatibility(data_type=Child)
+
+    with does_not_raise():
+        parent_materializer.validate_save_type_compatibility(data_type=Parent)
+        parent_materializer.validate_save_type_compatibility(data_type=Child)
+
+
+def test_validate_load_type_compatibility():
+    child_materializer = ChildMaterializer(uri="")
+    parent_materializer = ParentMaterializer(uri="")
+
+    with does_not_raise():
+        child_materializer.validate_load_type_compatibility(data_type=Parent)
+        child_materializer.validate_load_type_compatibility(data_type=Child)
+
+    with does_not_raise():
+        parent_materializer.validate_load_type_compatibility(data_type=Parent)
+
+    with pytest.raises(TypeError):
+        parent_materializer.validate_load_type_compatibility(data_type=Child)

--- a/tests/unit/materializers/test_base_materializer.py
+++ b/tests/unit/materializers/test_base_materializer.py
@@ -87,9 +87,5 @@ def test_validate_load_type_compatibility():
     with does_not_raise():
         child_materializer.validate_load_type_compatibility(data_type=Parent)
         child_materializer.validate_load_type_compatibility(data_type=Child)
-
-    with does_not_raise():
         parent_materializer.validate_load_type_compatibility(data_type=Parent)
-
-    with pytest.raises(TypeError):
         parent_materializer.validate_load_type_compatibility(data_type=Child)


### PR DESCRIPTION
## Describe changes

The `issubclass(...)` checks in `BaseMaterializer.can_handle_type` were only correct when saving artifacts and not when loading them.
- A materializer can save any artifact that is an associated type or a subclass of an associated type.
- A user can specify a superclass of an associated type as step input and the materializer can be used to load this artifact
```python
class Parent:
  value: int

class Child(Parent):
  another_value: int

class ChildMaterializer(BaseMaterializer):
  ASSOCIATED_TYPES = (Child,)
  
  ...

@step
def producer() -> Child:
  return Child(value=1, another_value=2)

@step
def consumer(parent: Parent) -> None:
  pass

@pipeline
def test():
  consumer(producer())
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

