### PR TITLE
Remove wrongly set Model.was_created_in_this_run attribute

### DIFF
--- a/docs/book/how-to/use-configuration-files/autogenerate-a-template-yaml-file.md
+++ b/docs/book/how-to/use-configuration-files/autogenerate-a-template-yaml-file.md
@@ -44,7 +44,6 @@ model:
   trade_offs: Optional[str]
   use_cases: Optional[str]
   version: Union[ModelStages, int, str, NoneType]
-  was_created_in_this_run: bool
 parameters: Optional[Mapping[str, Any]]
 run_name: Optional[str]
 schedule:
@@ -108,7 +107,6 @@ steps:
       trade_offs: Optional[str]
       use_cases: Optional[str]
       version: Union[ModelStages, int, str, NoneType]
-      was_created_in_this_run: bool
     name: Optional[str]
     outputs:
       output:
@@ -175,7 +173,6 @@ steps:
       trade_offs: Optional[str]
       use_cases: Optional[str]
       version: Union[ModelStages, int, str, NoneType]
-      was_created_in_this_run: bool
     name: Optional[str]
     outputs: {}
     parameters: {}

--- a/src/zenml/model/model.py
+++ b/src/zenml/model/model.py
@@ -85,7 +85,6 @@ class Model(BaseModel):
     # technical attributes
     model_version_id: Optional[UUID] = None
     suppress_class_validation_warnings: bool = False
-    was_created_in_this_run: bool = False
     _model_id: UUID = PrivateAttr(None)
     _number: Optional[int] = PrivateAttr(None)
     _created_model_version: bool = PrivateAttr(False)
@@ -691,42 +690,6 @@ class Model(BaseModel):
         )
         mv_request = ModelVersionRequest.model_validate(model_version_request)
         try:
-            if not self.version:
-                try:
-                    from zenml import get_step_context
-
-                    context = get_step_context()
-                except RuntimeError:
-                    pass
-                else:
-                    # if inside a step context we loop over all
-                    # model version configuration to find, if the
-                    # model version for current model was already
-                    # created in the current run, not to create
-                    # new model versions
-                    pipeline_mv = context.pipeline_run.config.model
-                    if (
-                        pipeline_mv
-                        and pipeline_mv.was_created_in_this_run
-                        and pipeline_mv.name == self.name
-                        and pipeline_mv.version is not None
-                    ):
-                        self.version = pipeline_mv.version
-                        self.model_version_id = pipeline_mv.model_version_id
-                    else:
-                        for step in context.pipeline_run.steps.values():
-                            step_mv = step.config.model
-                            if (
-                                step_mv
-                                and step_mv.was_created_in_this_run
-                                and step_mv.name == self.name
-                                and step_mv.version is not None
-                            ):
-                                self.version = step_mv.version
-                                self.model_version_id = (
-                                    step_mv.model_version_id
-                                )
-                                break
             if self.version or self.model_version_id:
                 model_version = self._get_model_version()
             else:
@@ -783,7 +746,6 @@ class Model(BaseModel):
                     time.sleep(sleep)
                     retries_made += 1
             self.version = model_version.name
-            self.was_created_in_this_run = True
             self._created_model_version = True
 
             logger.info(

--- a/src/zenml/models/v2/core/model_version.py
+++ b/src/zenml/models/v2/core/model_version.py
@@ -325,14 +325,11 @@ class ModelVersionResponse(
     # Helper functions
     def to_model_class(
         self,
-        was_created_in_this_run: bool = False,
         suppress_class_validation_warnings: bool = True,
     ) -> "Model":
         """Convert response model to Model object.
 
         Args:
-            was_created_in_this_run: Whether model version was created during
-                the current run.
             suppress_class_validation_warnings: internally used to suppress
                 repeated warnings.
 
@@ -352,7 +349,6 @@ class ModelVersionResponse(
             ethics=self.model.ethics,
             tags=[t.name for t in self.tags],
             version=self.name,
-            was_created_in_this_run=was_created_in_this_run,
             suppress_class_validation_warnings=suppress_class_validation_warnings,
             model_version_id=self.id,
         )


### PR DESCRIPTION
## Describe changes
Since we're not updating the `Model` in the pipeline/step configurations in the DB anymore, this attribute was incorrectly set all the time and not used in any useful way.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

