### PR TITLE
Updating the `sagemaker` dependency in the AWS integration

### DIFF
--- a/examples/quickstart/requirements_aws.txt
+++ b/examples/quickstart/requirements_aws.txt
@@ -7,7 +7,7 @@ transformers[torch]
 torch
 sentencepiece
 protobuf
-sagemaker>=2.117.0
+sagemaker>=2.203.0
 s3
 s3fs
 aws-profile-manager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ azure-mgmt-resource = { version = ">=21.0.0", optional = true }
 s3fs = { version = ">=2022.11.0", optional = true }
 
 # Optional dependencies for the Sagemaker orchestrator
-sagemaker = { version = ">=2.117.0", optional = true }
+sagemaker = { version = ">=2.203.0", optional = true }
 
 # Optional dependencies for the GCS artifact store
 gcsfs = { version = ">=2022.11.0", optional = true }

--- a/src/zenml/integrations/aws/__init__.py
+++ b/src/zenml/integrations/aws/__init__.py
@@ -34,12 +34,13 @@ AWS_CONNECTOR_TYPE = "aws"
 AWS_RESOURCE_TYPE = "aws-generic"
 S3_RESOURCE_TYPE = "s3-bucket"
 
+
 class AWSIntegration(Integration):
     """Definition of AWS integration for ZenML."""
 
     NAME = AWS
     REQUIREMENTS = [
-        "sagemaker>=2.117.0",
+        "sagemaker>=2.203.0",
         "kubernetes",
         "aws-profile-manager",
     ]

--- a/src/zenml/integrations/huggingface/__init__.py
+++ b/src/zenml/integrations/huggingface/__init__.py
@@ -55,8 +55,8 @@ class HuggingfaceIntegration(Integration):
             # temporary fix for CI issue similar to:
             # - https://github.com/huggingface/datasets/issues/6737
             # - https://github.com/huggingface/datasets/issues/6697
-            # TODO try relaxing it back going forward
-            "fsspec<=2023.12.0",
+            # TODO: try relaxing it back going forward. DONE: I did it :)
+            "fsspec",
             "transformers",
         ]
 


### PR DESCRIPTION
## Describe changes

Following [the PR here](https://github.com/aws/sagemaker-python-sdk/pull/4327), `sagemaker` changed how they handled tags in their pipeline interface. In order to be compatible with it, we have to update our `sagemaker` dependency to the version `>=v2.203.0`, released on 2023-12-28, where this change eventually got released.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

