### PR TITLE
Enable cache precomputation for run templates

### DIFF
--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -166,9 +166,8 @@ class BaseOrchestrator(StackComponent, ABC):
             environment: Environment variables to set in the orchestration
                 environment. These don't need to be set if running locally.
 
-        Returns:
-            The optional return value from this method will be returned by the
-            `pipeline_instance.run()` call when someone is running a pipeline.
+        Yields:
+            Metadata for the pipeline run.
         """
 
     def run(
@@ -176,7 +175,7 @@ class BaseOrchestrator(StackComponent, ABC):
         deployment: "PipelineDeploymentResponse",
         stack: "Stack",
         placeholder_run: Optional["PipelineRunResponse"] = None,
-    ) -> Any:
+    ) -> None:
         """Runs a pipeline on a stack.
 
         Args:

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -785,7 +785,6 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 deployment=deployment_model,
                 stack=stack,
                 placeholder_run=run,
-                cleanup_placeholder_run=True,
             )
             if run:
                 return Client().get_pipeline_run(run.id)

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -782,7 +782,10 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                     )
 
             deploy_pipeline(
-                deployment=deployment_model, stack=stack, placeholder_run=run
+                deployment=deployment_model,
+                stack=stack,
+                placeholder_run=run,
+                cleanup_placeholder_run=True,
             )
             if run:
                 return Client().get_pipeline_run(run.id)

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -810,18 +810,14 @@ class Stack:
         self,
         deployment: "PipelineDeploymentResponse",
         placeholder_run: Optional["PipelineRunResponse"] = None,
-    ) -> Any:
+    ) -> None:
         """Deploys a pipeline on this stack.
 
         Args:
             deployment: The pipeline deployment.
             placeholder_run: An optional placeholder run for the deployment.
-                This will be deleted in case the pipeline deployment failed.
-
-        Returns:
-            The return value of the call to `orchestrator.run_pipeline(...)`.
         """
-        return self.orchestrator.run(
+        self.orchestrator.run(
             deployment=deployment, stack=self, placeholder_run=placeholder_run
         )
 

--- a/src/zenml/zen_server/template_execution/runner_entrypoint_configuration.py
+++ b/src/zenml/zen_server/template_execution/runner_entrypoint_configuration.py
@@ -35,11 +35,8 @@ class RunnerEntrypointConfiguration(BaseEntrypointConfiguration):
         assert deployment.stack and stack.id == deployment.stack.id
 
         placeholder_run = get_placeholder_run(deployment_id=deployment.id)
-        # We don't want to cleanup the placeholder run here, as that contains
-        # the logs that help the user see what happened/why it might have failed
         deploy_pipeline(
             deployment=deployment,
             stack=stack,
             placeholder_run=placeholder_run,
-            cleanup_placeholder_run=False,
         )

--- a/src/zenml/zen_server/template_execution/runner_entrypoint_configuration.py
+++ b/src/zenml/zen_server/template_execution/runner_entrypoint_configuration.py
@@ -17,9 +17,7 @@ from zenml.client import Client
 from zenml.entrypoints.base_entrypoint_configuration import (
     BaseEntrypointConfiguration,
 )
-from zenml.pipelines.run_utils import (
-    deploy_pipeline,
-)
+from zenml.pipelines.run_utils import deploy_pipeline, get_placeholder_run
 
 
 class RunnerEntrypointConfiguration(BaseEntrypointConfiguration):
@@ -36,4 +34,12 @@ class RunnerEntrypointConfiguration(BaseEntrypointConfiguration):
         stack = Client().active_stack
         assert deployment.stack and stack.id == deployment.stack.id
 
-        deploy_pipeline(deployment=deployment, stack=stack)
+        placeholder_run = get_placeholder_run(deployment_id=deployment.id)
+        # We don't want to cleanup the placeholder run here, as that contains
+        # the logs that help the user see what happened/why it might have failed
+        deploy_pipeline(
+            deployment=deployment,
+            stack=stack,
+            placeholder_run=placeholder_run,
+            cleanup_placeholder_run=False,
+        )

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -605,22 +605,17 @@ def test_rerunning_deloyment_does_not_fail(
     assert runs.total == 2
 
 
-def test_failure_during_initialization_deletes_placeholder_run(
+def test_failure_during_initialization_marks_placeholder_run_as_failed(
     clean_client,
     empty_pipeline,  # noqa: F811
     mocker,
 ):
     """Tests that when a pipeline run fails during initialization, the
-    placeholder run that was created for it is deleted."""
+    placeholder run is marked as failed."""
     mock_create_run = mocker.patch.object(
         type(clean_client.zen_store),
         "create_run",
         wraps=clean_client.zen_store.create_run,
-    )
-    mock_delete_run = mocker.patch.object(
-        type(clean_client.zen_store),
-        "delete_run",
-        wraps=clean_client.zen_store.delete_run,
     )
 
     pipeline_instance = empty_pipeline
@@ -634,9 +629,10 @@ def test_failure_during_initialization_deletes_placeholder_run(
         pipeline_instance()
 
     mock_create_run.assert_called_once()
-    mock_delete_run.assert_called_once()
 
-    assert clean_client.list_pipeline_runs().total == 0
+    runs = clean_client.list_pipeline_runs()
+    assert len(runs) == 1
+    assert runs[0].status == ExecutionStatus.FAILED
 
 
 def test_running_scheduled_pipeline_does_not_create_placeholder_run(

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -160,12 +160,6 @@ def test_stack_deployment(
     components."""
     # Mock the pipeline run registering which tries (and fails) to serialize
     # our mock objects
-
-    pipeline_run_return_value = object()
-    stack_with_mock_components.orchestrator.run.return_value = (
-        pipeline_run_return_value
-    )
-
     with empty_pipeline:
         empty_pipeline.entrypoint()
     deployment = Compiler().compile(
@@ -173,19 +167,15 @@ def test_stack_deployment(
         stack=stack_with_mock_components,
         run_configuration=PipelineRunConfiguration(),
     )
-    return_value = stack_with_mock_components.deploy_pipeline(
+    stack_with_mock_components.deploy_pipeline(
         deployment=deployment,
     )
-
-    # for component in stack_with_mock_components.components.values():
-    #     component.prepare_step_run.assert_called_once()
 
     stack_with_mock_components.orchestrator.run.assert_called_once_with(
         deployment=deployment,
         stack=stack_with_mock_components,
         placeholder_run=None,
     )
-    assert return_value is pipeline_run_return_value
 
 
 def test_requires_remote_server(stack_with_mock_components, mocker):


### PR DESCRIPTION
## Describe changes

Because no placeholder run was being passed when running a template, the client-side cache computation was not being considered. This PR fixes that by passing the placeholder run, and additionally improves the placeholder run cleanup behaviour and some return types/docstrings.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

