### PR TITLE
Catch assertion in GH library

### DIFF
--- a/src/zenml/integrations/github/code_repositories/github_code_repository.py
+++ b/src/zenml/integrations/github/code_repositories/github_code_repository.py
@@ -164,7 +164,7 @@ class GitHubCodeRepository(BaseCodeRepository):
                 try:
                     with open(local_path, "wb") as f:
                         f.write(content.decoded_content)
-                except (GithubException, IOError) as e:
+                except (GithubException, IOError, AssertionError) as e:
                     logger.error("Error processing %s: %s", content.path, e)
 
     def get_local_context(self, path: str) -> Optional[LocalRepositoryContext]:


### PR DESCRIPTION
## Describe changes
Some files fail to download from GH with an assertion, which stops the step execution. We now catch that error and try to run the step without that file.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

