### PR TITLE
Cleanup materializer temporary directories after step execution

### DIFF
--- a/docs/book/how-to/data-artifact-management/handle-data-artifacts/handle-custom-data-types.md
+++ b/docs/book/how-to/data-artifact-management/handle-data-artifacts/handle-custom-data-types.md
@@ -258,6 +258,14 @@ The `load()` and `save()` methods define the serialization and deserialization o
 
 You will need to override these methods according to how you plan to serialize your objects. E.g., if you have custom PyTorch classes as `ASSOCIATED_TYPES`, then you might want to use `torch.save()` and `torch.load()` here.
 
+{% hint style="info" %}
+If you need a temporary directory in your custom materializer, it is best to use the helper method `get_temporary_directory(...)` on the materializer class in order to have the directory cleaned up correctly:
+```python
+with self.get_temporary_directory(...) as temp_dir:
+    ...
+```
+{% endhint %}
+
 #### (Optional) How to Visualize the Artifact
 
 Optionally, you can override the `save_visualizations()` method to automatically save visualizations for all artifacts saved by your materializer. These visualizations are then shown next to your artifacts in the dashboard:

--- a/src/zenml/artifacts/load_directory_materializer.py
+++ b/src/zenml/artifacts/load_directory_materializer.py
@@ -47,6 +47,7 @@ class PreexistingDataMaterializer(BaseMaterializer):
             Path to the local directory that contains the artifact files.
         """
         directory = tempfile.mkdtemp(prefix="zenml-artifact")
+        self.register_local_directory_cleanup(directory)
         if fileio.isdir(self.uri):
             self._copy_directory(src=self.uri, dst=directory)
             return Path(directory)

--- a/src/zenml/artifacts/preexisting_data_materializer.py
+++ b/src/zenml/artifacts/preexisting_data_materializer.py
@@ -46,7 +46,6 @@ class PreexistingDataMaterializer(BaseMaterializer):
             Path to the local directory that contains the artifact files.
         """
         with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
-            self.register_local_directory_for_cleanup(temp_dir)
             if fileio.isdir(self.uri):
                 self._copy_directory(src=self.uri, dst=temp_dir)
                 return Path(temp_dir)

--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -33,7 +33,7 @@ from typing import (
 from uuid import UUID, uuid4
 
 from zenml.artifacts.artifact_config import ArtifactConfig
-from zenml.artifacts.load_directory_materializer import (
+from zenml.artifacts.preexisting_data_materializer import (
     PreexistingDataMaterializer,
 )
 from zenml.client import Client

--- a/src/zenml/integrations/bentoml/materializers/bentoml_bento_materializer.py
+++ b/src/zenml/integrations/bentoml/materializers/bentoml_bento_materializer.py
@@ -48,14 +48,12 @@ class BentoMaterializer(BaseMaterializer):
             An bento.Bento object.
         """
         with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
-            self.register_local_directory_for_cleanup(temp_dir)
-
             # Copy from artifact store to temporary directory
-            io_utils.copy_dir(self.uri, temp_dir.name)
+            io_utils.copy_dir(self.uri, temp_dir)
 
             # Load the Bento from the temporary directory
             imported_bento = Bento.import_from(
-                os.path.join(temp_dir.name, DEFAULT_BENTO_FILENAME)
+                os.path.join(temp_dir, DEFAULT_BENTO_FILENAME)
             )
 
             # Try save the Bento to the local BentoML store
@@ -72,11 +70,9 @@ class BentoMaterializer(BaseMaterializer):
             bento: An bento.Bento object.
         """
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
-            temp_bento_path = os.path.join(
-                temp_dir.name, DEFAULT_BENTO_FILENAME
-            )
+            temp_bento_path = os.path.join(temp_dir, DEFAULT_BENTO_FILENAME)
             bentoml.export_bento(bento.tag, temp_bento_path)
-            io_utils.copy_dir(temp_dir.name, self.uri)
+            io_utils.copy_dir(temp_dir, self.uri)
 
     def extract_metadata(
         self, bento: bento.Bento

--- a/src/zenml/integrations/huggingface/materializers/huggingface_pt_model_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_pt_model_materializer.py
@@ -15,7 +15,6 @@
 
 import importlib
 import os
-from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Dict, Tuple, Type
 
 from transformers import (
@@ -46,17 +45,17 @@ class HFPTModelMaterializer(BaseMaterializer):
         Returns:
             The model read from the specified dir.
         """
-        temp_dir = TemporaryDirectory()
-        io_utils.copy_dir(
-            os.path.join(self.uri, DEFAULT_PT_MODEL_DIR), temp_dir.name
-        )
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            io_utils.copy_dir(
+                os.path.join(self.uri, DEFAULT_PT_MODEL_DIR), temp_dir
+            )
 
-        config = AutoConfig.from_pretrained(temp_dir.name)
-        architecture = config.architectures[0]
-        model_cls = getattr(
-            importlib.import_module("transformers"), architecture
-        )
-        return model_cls.from_pretrained(temp_dir.name)
+            config = AutoConfig.from_pretrained(temp_dir)
+            architecture = config.architectures[0]
+            model_cls = getattr(
+                importlib.import_module("transformers"), architecture
+            )
+            return model_cls.from_pretrained(temp_dir)
 
     def save(self, model: PreTrainedModel) -> None:
         """Writes a Model to the specified dir.
@@ -64,12 +63,12 @@ class HFPTModelMaterializer(BaseMaterializer):
         Args:
             model: The Torch Model to write.
         """
-        temp_dir = TemporaryDirectory()
-        model.save_pretrained(temp_dir.name)
-        io_utils.copy_dir(
-            temp_dir.name,
-            os.path.join(self.uri, DEFAULT_PT_MODEL_DIR),
-        )
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            model.save_pretrained(temp_dir)
+            io_utils.copy_dir(
+                temp_dir,
+                os.path.join(self.uri, DEFAULT_PT_MODEL_DIR),
+            )
 
     def extract_metadata(
         self, model: PreTrainedModel

--- a/src/zenml/integrations/huggingface/materializers/huggingface_t5_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_t5_materializer.py
@@ -14,7 +14,6 @@
 """Implementation of the Huggingface t5 materializer."""
 
 import os
-import tempfile
 from typing import Any, ClassVar, Type, Union
 
 from transformers import (
@@ -52,8 +51,7 @@ class HFT5Materializer(BaseMaterializer):
             ValueError: Unsupported data type used
         """
         filepath = self.uri
-
-        with tempfile.TemporaryDirectory(prefix="zenml-temp-") as temp_dir:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             # Copy files from artifact store to temporary directory
             for file in fileio.listdir(filepath):
                 src = os.path.join(filepath, file)
@@ -86,8 +84,7 @@ class HFT5Materializer(BaseMaterializer):
         Args:
             obj: A T5ForConditionalGeneration model or T5Tokenizer.
         """
-        # Create a temporary directory
-        with tempfile.TemporaryDirectory(prefix="zenml-temp-") as temp_dir:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             # Save the model or tokenizer
             obj.save_pretrained(temp_dir)
 

--- a/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
@@ -63,7 +63,7 @@ class HFTFModelMaterializer(BaseMaterializer):
         Args:
             model: The TF Model to write.
         """
-        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             model.save_pretrained(temp_dir)
             io_utils.copy_dir(
                 temp_dir,

--- a/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_tf_model_materializer.py
@@ -15,7 +15,6 @@
 
 import importlib
 import os
-from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Dict, Tuple, Type
 
 from transformers import (
@@ -46,17 +45,17 @@ class HFTFModelMaterializer(BaseMaterializer):
         Returns:
             The model read from the specified dir.
         """
-        temp_dir = TemporaryDirectory()
-        io_utils.copy_dir(
-            os.path.join(self.uri, DEFAULT_TF_MODEL_DIR), temp_dir.name
-        )
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            io_utils.copy_dir(
+                os.path.join(self.uri, DEFAULT_TF_MODEL_DIR), temp_dir
+            )
 
-        config = AutoConfig.from_pretrained(temp_dir.name)
-        architecture = "TF" + config.architectures[0]
-        model_cls = getattr(
-            importlib.import_module("transformers"), architecture
-        )
-        return model_cls.from_pretrained(temp_dir.name)
+            config = AutoConfig.from_pretrained(temp_dir)
+            architecture = "TF" + config.architectures[0]
+            model_cls = getattr(
+                importlib.import_module("transformers"), architecture
+            )
+            return model_cls.from_pretrained(temp_dir)
 
     def save(self, model: TFPreTrainedModel) -> None:
         """Writes a Model to the specified dir.
@@ -64,12 +63,12 @@ class HFTFModelMaterializer(BaseMaterializer):
         Args:
             model: The TF Model to write.
         """
-        temp_dir = TemporaryDirectory()
-        model.save_pretrained(temp_dir.name)
-        io_utils.copy_dir(
-            temp_dir.name,
-            os.path.join(self.uri, DEFAULT_TF_MODEL_DIR),
-        )
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            model.save_pretrained(temp_dir)
+            io_utils.copy_dir(
+                temp_dir,
+                os.path.join(self.uri, DEFAULT_TF_MODEL_DIR),
+            )
 
     def extract_metadata(
         self, model: TFPreTrainedModel

--- a/src/zenml/integrations/huggingface/materializers/huggingface_tokenizer_materializer.py
+++ b/src/zenml/integrations/huggingface/materializers/huggingface_tokenizer_materializer.py
@@ -14,7 +14,6 @@
 """Implementation of the Huggingface tokenizer materializer."""
 
 import os
-from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, Tuple, Type
 
 from transformers import AutoTokenizer
@@ -46,7 +45,7 @@ class HFTokenizerMaterializer(BaseMaterializer):
         Returns:
             The tokenizer read from the specified dir.
         """
-        with TemporaryDirectory() as temp_dir:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             io_utils.copy_dir(
                 os.path.join(self.uri, DEFAULT_TOKENIZER_DIR), temp_dir
             )
@@ -58,7 +57,7 @@ class HFTokenizerMaterializer(BaseMaterializer):
         Args:
             tokenizer: The HFTokenizer to write.
         """
-        with TemporaryDirectory() as temp_dir:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             tokenizer.save_pretrained(temp_dir)
             io_utils.copy_dir(
                 temp_dir,

--- a/src/zenml/integrations/pycaret/materializers/model_materializer.py
+++ b/src/zenml/integrations/pycaret/materializers/model_materializer.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """PyCaret materializer."""
 
-import tempfile
 from typing import (
     Any,
     Type,
@@ -65,7 +64,6 @@ from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 from xgboost import XGBClassifier, XGBRegressor
 
 from zenml.enums import ArtifactType
-from zenml.io import fileio
 from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.utils import io_utils
 
@@ -133,19 +131,10 @@ class PyCaretMaterializer(BaseMaterializer):
         Returns:
             A PyCaret model.
         """
-        # Create a temporary directory to store the model
-        temp_dir = tempfile.TemporaryDirectory()
-
-        # Copy from artifact store to temporary directory
-        io_utils.copy_dir(self.uri, temp_dir.name)
-
-        # Load the model from the temporary directory
-        model = load_model(temp_dir.name)
-
-        # Cleanup and return
-        fileio.rmtree(temp_dir.name)
-
-        return model
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            io_utils.copy_dir(self.uri, temp_dir)
+            model = load_model(temp_dir)
+            return model
 
     def save(self, model: Any) -> None:
         """Writes a PyCaret model to the artifact store.
@@ -153,10 +142,6 @@ class PyCaretMaterializer(BaseMaterializer):
         Args:
             model: Any of the supported models.
         """
-        # Create a temporary directory to store the model
-        temp_dir = tempfile.TemporaryDirectory()
-        save_model(model, temp_dir.name)
-        io_utils.copy_dir(temp_dir.name, self.uri)
-
-        # Remove the temporary directory
-        fileio.rmtree(temp_dir.name)
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            save_model(model, temp_dir.name)
+            io_utils.copy_dir(temp_dir.name, self.uri)

--- a/src/zenml/integrations/pycaret/materializers/model_materializer.py
+++ b/src/zenml/integrations/pycaret/materializers/model_materializer.py
@@ -143,5 +143,5 @@ class PyCaretMaterializer(BaseMaterializer):
             model: Any of the supported models.
         """
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
-            save_model(model, temp_dir.name)
-            io_utils.copy_dir(temp_dir.name, self.uri)
+            save_model(model, temp_dir)
+            io_utils.copy_dir(temp_dir, self.uri)

--- a/src/zenml/integrations/tensorflow/materializers/tf_dataset_materializer.py
+++ b/src/zenml/integrations/tensorflow/materializers/tf_dataset_materializer.py
@@ -14,13 +14,11 @@
 """Implementation of the TensorFlow dataset materializer."""
 
 import os
-import tempfile
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Tuple, Type
 
 import tensorflow as tf
 
 from zenml.enums import ArtifactType
-from zenml.io import fileio
 from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.utils import io_utils
 
@@ -45,13 +43,11 @@ class TensorflowDatasetMaterializer(BaseMaterializer):
         Returns:
             A tf.data.Dataset object.
         """
-        temp_dir = tempfile.mkdtemp()
-        io_utils.copy_dir(self.uri, temp_dir)
-        path = os.path.join(temp_dir, DEFAULT_FILENAME)
-        dataset = tf.data.Dataset.load(path)
-        # Don't delete the temporary directory here as the dataset is lazily
-        # loaded and needs to read it when the object gets used
-        return dataset
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            io_utils.copy_dir(self.uri, temp_dir)
+            path = os.path.join(temp_dir, DEFAULT_FILENAME)
+            dataset = tf.data.Dataset.load(path)
+            return dataset
 
     def save(self, dataset: tf.data.Dataset) -> None:
         """Persists a tf.data.Dataset object.
@@ -59,15 +55,12 @@ class TensorflowDatasetMaterializer(BaseMaterializer):
         Args:
             dataset: The dataset to persist.
         """
-        temp_dir = tempfile.TemporaryDirectory()
-        path = os.path.join(temp_dir.name, DEFAULT_FILENAME)
-        try:
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            path = os.path.join(temp_dir, DEFAULT_FILENAME)
             tf.data.Dataset.save(
                 dataset, path, compression=None, shard_func=None
             )
-            io_utils.copy_dir(temp_dir.name, self.uri)
-        finally:
-            fileio.rmtree(temp_dir.name)
+            io_utils.copy_dir(temp_dir, self.uri)
 
     def extract_metadata(
         self, dataset: tf.data.Dataset

--- a/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
+++ b/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
@@ -14,7 +14,6 @@
 """Implementation of an XGBoost booster materializer."""
 
 import os
-import tempfile
 from typing import Any, ClassVar, Tuple, Type
 
 import xgboost as xgb
@@ -43,18 +42,15 @@ class XgboostBoosterMaterializer(BaseMaterializer):
         """
         filepath = os.path.join(self.uri, DEFAULT_FILENAME)
 
-        # Create a temporary folder
-        temp_dir = tempfile.mkdtemp(prefix="zenml-temp-")
-        temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
 
-        # Copy from artifact store to temporary file
-        fileio.copy(filepath, temp_file)
-        booster = xgb.Booster()
-        booster.load_model(temp_file)
+            # Copy from artifact store to temporary file
+            fileio.copy(filepath, temp_file)
+            booster = xgb.Booster()
+            booster.load_model(temp_file)
 
-        # Cleanup and return
-        fileio.rmtree(temp_dir)
-        return booster
+            return booster
 
     def save(self, booster: xgb.Booster) -> None:
         """Creates a JSON serialization for a xgboost Booster model.
@@ -64,14 +60,9 @@ class XgboostBoosterMaterializer(BaseMaterializer):
         """
         filepath = os.path.join(self.uri, DEFAULT_FILENAME)
 
-        # Make a temporary phantom artifact
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as f:
-            booster.save_model(f.name)
-            # Copy it into artifact store
-            fileio.copy(f.name, filepath)
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
+            with open(temp_file, "w") as f:
+                booster.save_model(f)
 
-        # Close and remove the temporary file
-        f.close()
-        fileio.remove(f.name)
+            fileio.copy(f, filepath)

--- a/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
+++ b/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
@@ -62,7 +62,7 @@ class XgboostBoosterMaterializer(BaseMaterializer):
 
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
-            with open(temp_file, "w") as f:
-                booster.save_model(f)
+            with open(temp_file, "w"):
+                booster.save_model(temp_file)
 
-            fileio.copy(f, filepath)
+            fileio.copy(temp_file, filepath)

--- a/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
+++ b/src/zenml/integrations/xgboost/materializers/xgboost_booster_materializer.py
@@ -62,7 +62,5 @@ class XgboostBoosterMaterializer(BaseMaterializer):
 
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
-            with open(temp_file, "w"):
-                booster.save_model(temp_file)
-
+            booster.save_model(temp_file)
             fileio.copy(temp_file, filepath)

--- a/src/zenml/integrations/xgboost/materializers/xgboost_dmatrix_materializer.py
+++ b/src/zenml/integrations/xgboost/materializers/xgboost_dmatrix_materializer.py
@@ -65,10 +65,10 @@ class XgboostDMatrixMaterializer(BaseMaterializer):
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
 
-            with open(temp_file, "wb") as f:
-                matrix.save_binary(f)
+            with open(temp_file, "wb"):
+                matrix.save_binary(temp_file)
 
-            fileio.copy(f, filepath)
+            fileio.copy(temp_file, filepath)
 
     def extract_metadata(
         self, dataset: xgb.DMatrix

--- a/src/zenml/integrations/xgboost/materializers/xgboost_dmatrix_materializer.py
+++ b/src/zenml/integrations/xgboost/materializers/xgboost_dmatrix_materializer.py
@@ -64,10 +64,7 @@ class XgboostDMatrixMaterializer(BaseMaterializer):
 
         with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
             temp_file = os.path.join(str(temp_dir), DEFAULT_FILENAME)
-
-            with open(temp_file, "wb"):
-                matrix.save_binary(temp_file)
-
+            matrix.save_binary(temp_file)
             fileio.copy(temp_file, filepath)
 
     def extract_metadata(

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -390,6 +390,6 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
 
         def _callback() -> None:
             shutil.rmtree(directory)
-            logger.warning("Cleaned up materializer directory %s", directory)
+            logger.debug("Cleaned up materializer directory %s", directory)
 
         step_context._cleanup_registry.register_callback(_callback)

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -345,7 +345,7 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
                 this is set to True, the temporary directory will be deleted
                 after the step finished executing. If a materializer is being
                 used outside of the context of a step execution, the temporary
-                directory will not be deleted and the user is reponsible for
+                directory will not be deleted and the user is responsible for
                 deleting it themselves.
 
         Yields:

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -163,6 +163,10 @@ class StepRunner:
                 },
             )
 
+            from zenml.materializers import base_materializer
+            base_materializer._ACTIVE_CLEANUP_REGISTRY = base_materializer.CleanupRegistry()
+
+
             # Parse the inputs for the entrypoint function.
             function_params = self._parse_inputs(
                 args=spec.args,
@@ -246,6 +250,8 @@ class StepRunner:
                                 model_version=model_version,
                             )
                 finally:
+                    base_materializer._ACTIVE_CLEANUP_REGISTRY.cleanup()
+                    base_materializer._ACTIVE_CLEANUP_REGISTRY = None
                     StepContext._clear()  # Remove the step context singleton
 
             # Update the status and output artifacts of the step run.

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -164,8 +164,10 @@ class StepRunner:
             )
 
             from zenml.materializers import base_materializer
-            base_materializer._ACTIVE_CLEANUP_REGISTRY = base_materializer.CleanupRegistry()
 
+            base_materializer._ACTIVE_CLEANUP_REGISTRY = (
+                base_materializer.CleanupRegistry()
+            )
 
             # Parse the inputs for the entrypoint function.
             function_params = self._parse_inputs(

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -153,7 +153,7 @@ class StepRunner:
 
             # Initialize the step context singleton
             StepContext._clear()
-            StepContext(
+            step_context = StepContext(
                 pipeline_run=pipeline_run,
                 step_run=step_run,
                 output_materializers=output_materializers,
@@ -246,7 +246,7 @@ class StepRunner:
                                 model_version=model_version,
                             )
                 finally:
-                    StepContext()._cleanup_registry.execute_callbacks(
+                    step_context._cleanup_registry.execute_callbacks(
                         raise_on_exception=False
                     )
                     StepContext._clear()  # Remove the step context singleton

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -163,12 +163,6 @@ class StepRunner:
                 },
             )
 
-            from zenml.materializers import base_materializer
-
-            base_materializer._ACTIVE_CLEANUP_REGISTRY = (
-                base_materializer.CleanupRegistry()
-            )
-
             # Parse the inputs for the entrypoint function.
             function_params = self._parse_inputs(
                 args=spec.args,
@@ -252,8 +246,9 @@ class StepRunner:
                                 model_version=model_version,
                             )
                 finally:
-                    base_materializer._ACTIVE_CLEANUP_REGISTRY.cleanup()
-                    base_materializer._ACTIVE_CLEANUP_REGISTRY = None
+                    StepContext()._cleanup_registry.execute_callbacks(
+                        raise_on_exception=False
+                    )
                     StepContext._clear()  # Remove the step context singleton
 
             # Update the status and output artifacts of the step run.

--- a/src/zenml/steps/step_context.py
+++ b/src/zenml/steps/step_context.py
@@ -26,6 +26,7 @@ from typing import (
 
 from zenml.exceptions import StepContextError
 from zenml.logger import get_logger
+from zenml.utils.callback_registry import CallbackRegistry
 from zenml.utils.singleton import SingletonMetaClass
 
 if TYPE_CHECKING:
@@ -145,6 +146,7 @@ class StepContext(metaclass=SingletonMetaClass):
             )
             for key in output_materializers.keys()
         }
+        self._cleanup_registry = CallbackRegistry()
 
     @property
     def pipeline(self) -> "PipelineResponse":

--- a/src/zenml/utils/callback_registry.py
+++ b/src/zenml/utils/callback_registry.py
@@ -30,7 +30,7 @@ class CallbackRegistry:
     def __init__(self) -> None:
         """Initializes the callback registry."""
         self._callbacks: List[
-            Tuple[Callable[P, Any]], Tuple[Any], Dict[str, Any]
+            Tuple[Callable[P, Any], Tuple[Any], Dict[str, Any]]
         ] = []
 
     def register_callback(
@@ -43,7 +43,7 @@ class CallbackRegistry:
             *args: Arguments to call the callback with.
             **kwargs: Keyword arguments to call the callback with.
         """
-        self._callbacks.append((callback, args, kwargs))
+        self._callbacks.append((callback, args, kwargs))  # type: ignore[arg-type]
 
     def reset(self) -> None:
         """Reset the callbacks."""

--- a/src/zenml/utils/callback_registry.py
+++ b/src/zenml/utils/callback_registry.py
@@ -1,0 +1,71 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Callback registry implementation."""
+
+from typing import Any, Callable, Dict, List, Tuple
+
+from typing_extensions import ParamSpec
+
+from zenml.logger import get_logger
+
+P = ParamSpec("P")
+
+logger = get_logger(__name__)
+
+
+class CallbackRegistry:
+    """Callback registry class."""
+
+    def __init__(self) -> None:
+        """Initializes the callback registry."""
+        self._callbacks: List[
+            Tuple[Callable[P, Any]], Tuple[Any], Dict[str, Any]
+        ] = []
+
+    def register_callback(
+        self, callback: Callable[P, Any], *args: P.args, **kwargs: P.kwargs
+    ) -> None:
+        """Register a callback.
+
+        Args:
+            callback: The callback to register.
+            *args: Arguments to call the callback with.
+            **kwargs: Keyword arguments to call the callback with.
+        """
+        self._callbacks.append((callback, args, kwargs))
+
+    def reset(self) -> None:
+        """Reset the callbacks."""
+        self._callbacks = []
+
+    def execute_callbacks(self, raise_on_exception: bool) -> None:
+        """Execute all registered callbacks.
+
+        Args:
+            raise_on_exception: If True, exceptions raised during the execution
+                of the callbacks will be raised. If False, a warning with the
+                exception will be logged instead.
+
+        Raises:
+            Exception: Exceptions raised in any of the callbacks if
+                `raise_on_exception` is set to True.
+        """
+        for callback, args, kwargs in self._callbacks:
+            try:
+                callback(*args, **kwargs)
+            except Exception as e:
+                if raise_on_exception:
+                    raise e
+                else:
+                    logger.warning("Failed to run callback: %s", str(e))

--- a/tests/integration/functional/materializers/__init__.py
+++ b/tests/integration/functional/materializers/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/integration/functional/materializers/test_base_materializer.py
+++ b/tests/integration/functional/materializers/test_base_materializer.py
@@ -1,0 +1,129 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+import os
+
+from zenml import pipeline, step
+from zenml.materializers.base_materializer import BaseMaterializer
+
+IMMEDIATE_CLEANUP_SAVE_DIR = None
+IMMEDIATE_CLEANUP_LOAD_DIR = None
+DELAYED_CLEANUP_SAVE_DIR = None
+DELAYED_CLEANUP_LOAD_DIR = None
+
+
+class CustomType:
+    pass
+
+
+class ImmediateCleanupMaterializer(BaseMaterializer):
+    ASSOCIATED_TYPES = (CustomType,)
+
+    def load(self, data_type):
+        global IMMEDIATE_CLEANUP_LOAD_DIR
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            IMMEDIATE_CLEANUP_LOAD_DIR = temp_dir
+            return CustomType()
+
+    def save(self, data):
+        global IMMEDIATE_CLEANUP_SAVE_DIR
+        with self.get_temporary_directory(delete_at_exit=True) as temp_dir:
+            IMMEDIATE_CLEANUP_SAVE_DIR = temp_dir
+
+
+class DelayedCleanupMaterializer(BaseMaterializer):
+    ASSOCIATED_TYPES = (CustomType,)
+
+    def load(self, data_type):
+        global DELAYED_CLEANUP_LOAD_DIR
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            DELAYED_CLEANUP_LOAD_DIR = temp_dir
+            return CustomType()
+
+    def save(self, data):
+        global DELAYED_CLEANUP_SAVE_DIR
+        with self.get_temporary_directory(delete_at_exit=False) as temp_dir:
+            DELAYED_CLEANUP_SAVE_DIR = temp_dir
+
+
+@step
+def step_with_custom_type_output() -> CustomType:
+    return CustomType()
+
+
+@step
+def verify_immediate_delete_step(input_: CustomType) -> None:
+    assert not os.path.exists(IMMEDIATE_CLEANUP_SAVE_DIR)
+    assert not os.path.exists(IMMEDIATE_CLEANUP_LOAD_DIR)
+
+
+@step
+def verify_delayed_delete_step(input_: CustomType) -> None:
+    # The save from previous step does not exist anymore
+    assert not os.path.exists(DELAYED_CLEANUP_SAVE_DIR)
+    # The load directory exists during the step execution
+    assert os.path.exists(DELAYED_CLEANUP_LOAD_DIR)
+
+
+def test_immediate_temporary_directory_cleanup_inside_step(clean_client):
+    global IMMEDIATE_CLEANUP_SAVE_DIR, IMMEDIATE_CLEANUP_LOAD_DIR
+    IMMEDIATE_CLEANUP_SAVE_DIR = None
+    IMMEDIATE_CLEANUP_LOAD_DIR = None
+
+    @pipeline
+    def test_pipeline():
+        artifact = step_with_custom_type_output.with_options(
+            output_materializers=ImmediateCleanupMaterializer
+        )()
+        verify_immediate_delete_step(artifact)
+
+    test_pipeline()
+
+    # Gets cleaned up after step execution
+    assert not os.path.exists(IMMEDIATE_CLEANUP_SAVE_DIR)
+    assert not os.path.exists(IMMEDIATE_CLEANUP_LOAD_DIR)
+
+
+def test_delayed_temporary_directory_cleanup_inside_step(clean_client):
+    global DELAYED_CLEANUP_LOAD_DIR, DELAYED_CLEANUP_SAVE_DIR
+    DELAYED_CLEANUP_SAVE_DIR = None
+    DELAYED_CLEANUP_LOAD_DIR = None
+
+    @pipeline
+    def test_pipeline():
+        artifact = step_with_custom_type_output.with_options(
+            output_materializers=DelayedCleanupMaterializer
+        )()
+        verify_delayed_delete_step(artifact)
+
+    test_pipeline()
+
+    # Gets cleaned up after step execution
+    assert not os.path.exists(DELAYED_CLEANUP_LOAD_DIR)
+    assert not os.path.exists(DELAYED_CLEANUP_SAVE_DIR)
+
+
+def test_materializer_temporary_directory_cleanup_outside_step():
+    global IMMEDIATE_CLEANUP_LOAD_DIR, DELAYED_CLEANUP_LOAD_DIR
+    IMMEDIATE_CLEANUP_LOAD_DIR = None
+    materializer = ImmediateCleanupMaterializer(uri=".")
+    materializer.load(CustomType)
+    # Gets cleaned up immediately
+    assert not os.path.exists(IMMEDIATE_CLEANUP_LOAD_DIR)
+
+    DELAYED_CLEANUP_LOAD_DIR = None
+    materializer = DelayedCleanupMaterializer(uri=".")
+    materializer.load(CustomType)
+    # Does not get cleaned up because not running inside a step
+    assert os.path.exists(DELAYED_CLEANUP_LOAD_DIR)


### PR DESCRIPTION
## Describe changes
The temporary directory cleanup in our materializer was all over the place. This PR refactors it to use a common helper method. This helper method either
- cleans up the directory immediately after the context manager finishes
- cleans up the directory after the current step execution finishes. This is useful for materializers that copy data into a local directory and need it to stay on disk for lazy loading. Once the step execution finishes however, the data is not needed anymore as the step function ended.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

