### PR TITLE
Don't initialize client during flavor sync

### DIFF
--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -16,6 +16,7 @@
 from abc import abstractmethod
 from typing import Any, Dict, Optional, Type, cast
 
+from zenml.client import Client
 from zenml.enums import StackComponentType
 from zenml.models import (
     FlavorRequest,
@@ -146,9 +147,6 @@ class Flavor:
         Returns:
             The model.
         """
-        from zenml.client import Client
-
-        client = Client()
         connector_requirements = self.service_connector_requirements
         connector_type = (
             connector_requirements.connector_type
@@ -165,10 +163,16 @@ class Flavor:
             if connector_requirements
             else None
         )
+        user = None
+        workspace = None
+        if is_custom:
+            user = Client().active_user.id
+            workspace = Client().active_workspace.id
+
         model_class = FlavorRequest if is_custom else InternalFlavorRequest
         model = model_class(
-            user=client.active_user.id if is_custom else None,
-            workspace=client.active_workspace.id if is_custom else None,
+            user=user,
+            workspace=workspace,
             name=self.name,
             type=self.type,
             source=source_utils.resolve(self.__class__).import_path,


### PR DESCRIPTION
## Describe changes

This PR fixes another loop that happens during the flavor sync:
- `GlobalConfig.zen_store` gets accessed, which starts the flavor sync
- During the flavor sync, `Flavor.to_model(...)` gets called which initializes the `Client`
- If a `.zen` repository exists, the client tries to sanitize it's config, which in turn calls `GlobalConfig.zen_store`
-> This second access of `GlobalConfig.zen_store` now tries to create the default stack and fails because the flavors are not in the database yet

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

