### PR TITLE
assign value to component_name in preset stack registration

### DIFF
--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -408,6 +408,7 @@ def register_stack(
                     component_type, preset_name
                 )
                 component_info = component_response.id
+                component_name = component_response.name
             else:
                 if isinstance(service_connector, UUID):
                     # find existing components under same connector


### PR DESCRIPTION
## Describe changes
Fixed `UnboundLocalError: cannot access local variable 'component_name' where it is not associated with a value` when running `zenml stack register` with preset components.

e.g.
```bash
# SETUP
zenml service-connector register my-service-connector \
  --type aws \
  --auth-method implicit \
  --auto-configure
zenml orchestrator register my-orchestrator \
  --flavor vm_aws \
  --connector my-service-connector
zenml artifact-store register my-artifact-store \
  --flavor s3 \
  --path "s3://my-store/zenml" \
  --connector my-service-connector
zenml container-registry register my-container-registry \
  --flavor aws \
  --uri "1234567890.dkr.ecr.us-east-1.amazonaws.com" \
  --connector my-service-connector

# THROWS UnboundLocalError
zenml stack register my-stack \
  --connector my-service-connector \
  --orchestrator my-orchestrator \
  --artifact-store my-artifact-store \
  --container_registry my-container-registry \
  --set
```

## Pre-requisites
Please ensure you have done the following:
- [Y] I have read the **CONTRIBUTING.md** document.
- [N/A] If my change requires a change to docs, I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [Y] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [N/A] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

