### PR TITLE
[docs] Add missing redirects

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -184,15 +184,15 @@ redirects:
   docs/getting-started/installation: getting-started/installation.md
   docs/getting-started/core-concepts: getting-started/core-concepts.md
   docs/getting-started/system-architectures: getting-started/system-architectures.md
-  docs/getting-started/deploying-zenml/README: getting-started/deploying-zenml/README.md
-  docs/getting-started/zenml-pro/README: getting-started/zenml-pro/README.md
-  docs/user-guide/starter-guide/README: user-guide/starter-guide/README.md
-  docs/user-guide/production-guide/README: user-guide/production-guide/README.md
-  docs/user-guide/llmops-guide/README: user-guide/llmops-guide/README.md
+  docs/getting-started/deploying-zenml/: getting-started/deploying-zenml/README.md
+  docs/getting-started/zenml-pro/: getting-started/zenml-pro/README.md
+  docs/user-guide/starter-guide/: user-guide/starter-guide/README.md
+  docs/user-guide/production-guide/: user-guide/production-guide/README.md
+  docs/user-guide/llmops-guide/: user-guide/llmops-guide/README.md
   docs/how-to/interact-with-secrets: how-to/interact-with-secrets.md
   docs/how-to/debug-and-solve-issues: how-to/debug-and-solve-issues.md
-  docs/how-to/contribute-to-zenml/README: how-to/contribute-to-zenml/README.md
-  docs/component-guide/README: component-guide/README.md
+  docs/how-to/contribute-to-zenml/: how-to/contribute-to-zenml/README.md
+  docs/component-guide/: component-guide/README.md
   docs/reference/python-client: reference/python-client.md
   docs/reference/global-settings: reference/global-settings.md
   docs/reference/environment-variables: reference/environment-variables.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -19,6 +19,13 @@ redirects:
   getting-started/zenml-pro/system-architectures: getting-started/system-architectures.md
   how-to/build-pipelines/name-your-pipeline-and-runs: how-to/pipeline-development/build-pipelines/name-your-pipeline-runs.md
 
+  # ZenML Pro
+  getting-started/zenml-pro/user-management: getting-started/zenml-pro/core-concepts.md
+  getting-started/zenml-pro/zenml-cloud: getting-started/zenml-pro/README.md
+
+  # Redirects for cases that have `docs` in the path
+  docs/getting-started/zenml-pro/core-concepts/tenants: getting-started/zenml-pro/tenants.md
+
   # Project Setup redirects
   how-to/setting-up-a-project-repository/: how-to/project-setup-and-management/setting-up-a-project-repository/README.md
   how-to/setting-up-a-project-repository/set-up-repository: how-to/project-setup-and-management/setting-up-a-project-repository/set-up-repository.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -23,9 +23,6 @@ redirects:
   getting-started/zenml-pro/user-management: getting-started/zenml-pro/core-concepts.md
   getting-started/zenml-pro/zenml-cloud: getting-started/zenml-pro/README.md
 
-  # Redirects for cases that have `docs` in the path
-  docs/getting-started/zenml-pro/core-concepts/tenants: getting-started/zenml-pro/tenants.md
-
   # Project Setup redirects
   how-to/setting-up-a-project-repository/: how-to/project-setup-and-management/setting-up-a-project-repository/README.md
   how-to/setting-up-a-project-repository/set-up-repository: how-to/project-setup-and-management/setting-up-a-project-repository/set-up-repository.md
@@ -180,3 +177,23 @@ redirects:
   how-to/control-logging/set-logging-verbosity: how-to/advanced-topics/control-logging/set-logging-verbosity.md
   how-to/control-logging/disable-rich-traceback: how-to/advanced-topics/control-logging/disable-rich-traceback.md
   how-to/control-logging/disable-colorful-logging: how-to/advanced-topics/control-logging/disable-colorful-logging.md
+
+  # Redirects for cases that have `docs` in the path
+  docs/getting-started/zenml-pro/core-concepts/tenants: getting-started/zenml-pro/tenants.md
+  docs/introduction: introduction.md
+  docs/getting-started/installation: getting-started/installation.md
+  docs/getting-started/core-concepts: getting-started/core-concepts.md
+  docs/getting-started/system-architectures: getting-started/system-architectures.md
+  docs/getting-started/deploying-zenml/README: getting-started/deploying-zenml/README.md
+  docs/getting-started/zenml-pro/README: getting-started/zenml-pro/README.md
+  docs/user-guide/starter-guide/README: user-guide/starter-guide/README.md
+  docs/user-guide/production-guide/README: user-guide/production-guide/README.md
+  docs/user-guide/llmops-guide/README: user-guide/llmops-guide/README.md
+  docs/how-to/interact-with-secrets: how-to/interact-with-secrets.md
+  docs/how-to/debug-and-solve-issues: how-to/debug-and-solve-issues.md
+  docs/how-to/contribute-to-zenml/README: how-to/contribute-to-zenml/README.md
+  docs/component-guide/README: component-guide/README.md
+  docs/reference/python-client: reference/python-client.md
+  docs/reference/global-settings: reference/global-settings.md
+  docs/reference/environment-variables: reference/environment-variables.md
+  docs/reference/

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -196,4 +196,7 @@ redirects:
   docs/reference/python-client: reference/python-client.md
   docs/reference/global-settings: reference/global-settings.md
   docs/reference/environment-variables: reference/environment-variables.md
-  docs/reference/
+  docs/reference/api-reference: reference/api-reference.md
+  docs/reference/how-do-i: reference/how-do-i.md
+  docs/reference/community-and-content: reference/community-and-content.md
+  docs/reference/faq: reference/faq.md


### PR DESCRIPTION
## Describe changes
I added some missing redirects (for the ZenML Pro) section and also added one for testing the case where we have an additional `docs` in the path (arising from a spaces experiment we did on GitBook).

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

