### PR TITLE
Add links to `uv` new PyTorch documentation

### DIFF
--- a/docs/book/component-guide/README.md
+++ b/docs/book/component-guide/README.md
@@ -70,9 +70,13 @@ You can run `zenml integration --help` to see a full list of CLI commands that Z
 
 Note, that you can also install your dependencies directly, but please note that there is no guarantee that ZenML internals with work with any arbitrary version of any external library.
 
-#### Experimental: Use `uv` for package installation
+#### Use `uv` for package installation
 
-You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstallations. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`. We will monitor how this performs and update as `uv` becomes more stable.
+You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstallations. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`.
+
+Full documentation for how it works with PyTorch can be found on Astral's docs
+website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers
+some of the particular gotchas and details you might need to know.
 
 ### Upgrade ZenML integrations
 

--- a/docs/book/component-guide/README.md
+++ b/docs/book/component-guide/README.md
@@ -72,7 +72,7 @@ Note, that you can also install your dependencies directly, but please note that
 
 #### Use `uv` for package installation
 
-You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstallations. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`.
+You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstalls. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`.
 
 Full documentation for how it works with PyTorch can be found on Astral's docs
 website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers

--- a/docs/book/component-guide/integration-overview.md
+++ b/docs/book/component-guide/integration-overview.md
@@ -44,7 +44,7 @@ Note, that you can also install your dependencies directly, but please note that
 
 You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstallations. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`. We will monitor how this performs and update as `uv` becomes more stable.
 
-Full documentation for how it works with PyTorch can be found on Astral's docs
+Full documentation for how it works with PyTorch can be found on Astral Docs
 website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers
 some of the particular gotchas and details you might need to know.
 

--- a/docs/book/component-guide/integration-overview.md
+++ b/docs/book/component-guide/integration-overview.md
@@ -40,9 +40,13 @@ You can run `zenml integration --help` to see a full list of CLI commands that Z
 
 Note, that you can also install your dependencies directly, but please note that there is no guarantee that ZenML internals with work with any arbitrary version of any external library.
 
-### Experimental: Use `uv` for package installation
+### Use `uv` for package installation
 
 You can use [`uv`](https://github.com/astral-sh/uv) as a package manager if you want. Simply pass the `--uv` flag to the `zenml integration ...` command and it'll use `uv` for installation, upgrades and uninstallations. Note that `uv` must be installed for this to work. This is an experimental option that we've added for users wishing to use `uv` but given that it is relatively new as an option there might be certain packages that don't work well with `uv`. We will monitor how this performs and update as `uv` becomes more stable.
+
+Full documentation for how it works with PyTorch can be found on Astral's docs
+website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers
+some of the particular gotchas and details you might need to know.
 
 ## Upgrade ZenML integrations
 

--- a/docs/book/how-to/infrastructure-deployment/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
+++ b/docs/book/how-to/infrastructure-deployment/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
@@ -134,7 +134,7 @@ def my_pipeline(...):
 `uv` is a relatively new project and not as stable as `pip` yet, which might lead to errors during package installation. If this happens, try switching the installer back to `pip` and see if that solves the issue.
 {% endhint %}
 
-Full documentation for how `uv` works with PyTorch can be found on Astral's docs
+Full documentation for how `uv` works with PyTorch can be found on Astral Docs
 website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers
 some of the particular gotchas and details you might need to know.
 

--- a/docs/book/how-to/infrastructure-deployment/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
+++ b/docs/book/how-to/infrastructure-deployment/customize-docker-builds/specify-pip-dependencies-and-apt-packages.md
@@ -134,4 +134,8 @@ def my_pipeline(...):
 `uv` is a relatively new project and not as stable as `pip` yet, which might lead to errors during package installation. If this happens, try switching the installer back to `pip` and see if that solves the issue.
 {% endhint %}
 
+Full documentation for how `uv` works with PyTorch can be found on Astral's docs
+website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers
+some of the particular gotchas and details you might need to know.
+
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>


### PR DESCRIPTION
Covers some common issues people have with uv and PyTorch so I added it to our docs.