### PR TITLE
Instances of the `FeatureService`s are now used instead of only the names of the FeatureServices. 

### DIFF
--- a/src/zenml/integrations/feast/__init__.py
+++ b/src/zenml/integrations/feast/__init__.py
@@ -31,7 +31,7 @@ class FeastIntegration(Integration):
 
     NAME = FEAST
     # click is added to keep the feast click version in sync with ZenML's click
-    REQUIREMENTS = ["feast", "click>=8.0.1,<8.1.4"]
+    REQUIREMENTS = ["feast>=0.12.0", "click>=8.0.1,<8.1.4"]
     REQUIREMENTS_IGNORED_ON_UNINSTALL = ["click", "pandas"]
 
     @classmethod

--- a/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
+++ b/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
@@ -43,14 +43,14 @@ class FeastFeatureStore(BaseFeatureStore):
     def get_historical_features(
         self,
         entity_df: Union[pd.DataFrame, str],
-        features: List[str],
+        features: Union[List[str], FeatureService],
         full_feature_names: bool = False,
     ) -> pd.DataFrame:
         """Returns the historical features for training or batch scoring.
 
         Args:
             entity_df: The entity DataFrame or entity name.
-            features: The features to retrieve.
+            features: The features to retrieve or a FeatureService.
             full_feature_names: Whether to return the full feature names.
 
         Raise:
@@ -70,14 +70,14 @@ class FeastFeatureStore(BaseFeatureStore):
     def get_online_features(
         self,
         entity_rows: List[Dict[str, Any]],
-        features: List[str],
+        features: Union[List[str], FeatureService],
         full_feature_names: bool = False,
     ) -> Dict[str, Any]:
         """Returns the latest online feature data.
 
         Args:
             entity_rows: The entity rows to retrieve.
-            features: The features to retrieve.
+            features: The features to retrieve or a FeatureService.
             full_feature_names: Whether to return the full feature names.
 
         Raise:

--- a/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
+++ b/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
@@ -128,7 +128,11 @@ class FeastFeatureStore(BaseFeatureStore):
             The feature services.
         """
         fs = FeatureStore(repo_path=self.config.feast_repo)
-        return fs.list_feature_services()
+        feature_services: List[FeatureService] = list(
+            fs.list_feature_services()
+        )
+
+        return feature_services
 
     def get_feature_views(self) -> List[str]:
         """Returns the feature view names.

--- a/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
+++ b/src/zenml/integrations/feast/feature_stores/feast_feature_store.py
@@ -16,7 +16,7 @@
 from typing import Any, Dict, List, Union, cast
 
 import pandas as pd
-from feast import FeatureStore  # type: ignore
+from feast import FeatureService, FeatureStore  # type: ignore
 from feast.infra.registry.base_registry import BaseRegistry  # type: ignore
 
 from zenml.feature_stores.base_feature_store import BaseFeatureStore
@@ -118,17 +118,17 @@ class FeastFeatureStore(BaseFeatureStore):
         fs = FeatureStore(repo_path=self.config.feast_repo)
         return [ds.name for ds in fs.list_entities()]
 
-    def get_feature_services(self) -> List[str]:
-        """Returns the feature service names.
+    def get_feature_services(self) -> List[FeatureService]:
+        """Returns the feature services.
 
         Raise:
             ConnectionError: If the online component (Redis) is not available.
 
         Returns:
-            The feature service names.
+            The feature services.
         """
         fs = FeatureStore(repo_path=self.config.feast_repo)
-        return [ds.name for ds in fs.list_feature_services()]
+        return fs.list_feature_services()
 
     def get_feature_views(self) -> List[str]:
         """Returns the feature view names.


### PR DESCRIPTION
## Describe changes
I have adapted the `get_feature_services` function so that it returns instances of the `FeaturesService` class and not just a list of feature service names. In addition, the functions `get_online_features` and `get_historical_features` of the integration can now be used with a list of features / feature views as well as with a `FeatureService` instance. 
This brings the implementation of the feast integration closer to the feast API. 

I have also set the minimum version of feast to 0.12.0 to ensure that the necessary Pythom API is available from feast. 

This PR closes #3180.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (add details above)

