### PR TITLE
Limit kubernetes pod and label length

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -106,6 +106,7 @@ def sanitize_pod_name(pod_name: str) -> str:
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
     pod_name = re.sub(r"[^a-z0-9-]", "-", pod_name.lower())
     pod_name = re.sub(r"^[-]+", "", pod_name)
+    pod_name = re.sub(r"[-]+$", "", pod_name)
     pod_name = re.sub(r"[-]+", "-", pod_name)
 
     return pod_name[:253]
@@ -123,6 +124,7 @@ def sanitize_label(label: str) -> str:
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
     label = re.sub(r"[^a-z0-9-]", "-", label.lower())
     label = re.sub(r"^[-]+", "", label)
+    label = re.sub(r"[-]+$", "", label)
     label = re.sub(r"[-]+", "-", label)
 
     return label[:63]

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -94,6 +94,24 @@ def load_kube_config(
         k8s_config.load_kube_config(context=context)
 
 
+def calculate_max_pod_name_length_for_namespace(namespace: str) -> int:
+    """Calculate the max pod length for a certain namespace.
+
+    Args:
+        namespace: The namespace in which the pod will be created.
+
+    Returns:
+        The maximum pod name length.
+    """
+    # Kubernetes allows Pod names to have 253 characters. However, when
+    # creating a pod they try to create a log file which is called
+    # <NAMESPACE>_<POD_NAME>_<UUID>, which adds additional characters and
+    # runs into filesystem limitations for filename lengths (255). We therefore
+    # subtract the length of a UUID (36), the two underscores and the
+    # namespace length from the pod name.
+    return 255 - 38 - len(namespace)
+
+
 def sanitize_pod_name(pod_name: str, namespace: str) -> str:
     """Sanitize pod names so they conform to Kubernetes pod naming convention.
 
@@ -110,13 +128,9 @@ def sanitize_pod_name(pod_name: str, namespace: str) -> str:
     pod_name = re.sub(r"[-]+$", "", pod_name)
     pod_name = re.sub(r"[-]+", "-", pod_name)
 
-    # Kubernetes allows Pod names to have 253 characters. However, when
-    # creating a pod they try to create a log file which is called
-    # <NAMESPACE>_<POD_NAME>_<UUID>, which adds additional characters and
-    # runs into filesystem limitations for filename lengths. We therefore
-    # subtract the length of a UUID (36), the two underscores and the
-    # namespace length from the pod name.
-    allowed_length = 253 - 38 - len(namespace)
+    allowed_length = calculate_max_pod_name_length_for_namespace(
+        namespace=namespace
+    )
     return pod_name[:allowed_length]
 
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -103,9 +103,29 @@ def sanitize_pod_name(pod_name: str) -> str:
     Returns:
         Sanitized pod name.
     """
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
     pod_name = re.sub(r"[^a-z0-9-]", "-", pod_name.lower())
     pod_name = re.sub(r"^[-]+", "", pod_name)
-    return re.sub(r"[-]+", "-", pod_name)
+    pod_name = re.sub(r"[-]+", "-", pod_name)
+
+    return pod_name[:253]
+
+
+def sanitize_label(label: str) -> str:
+    """Sanitize a label for a Kubernetes resource.
+
+    Args:
+        label: The label to sanitize.
+
+    Returns:
+        The sanitized label.
+    """
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
+    label = re.sub(r"[^a-z0-9-]", "-", label.lower())
+    label = re.sub(r"^[-]+", "", label)
+    label = re.sub(r"[-]+", "-", label)
+
+    return label[:63]
 
 
 def pod_is_not_pending(pod: k8s_client.V1Pod) -> bool:

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -108,7 +108,7 @@ def calculate_max_pod_name_length_for_namespace(namespace: str) -> int:
     # <NAMESPACE>_<POD_NAME>_<UUID>, which adds additional characters and
     # runs into filesystem limitations for filename lengths (255). We therefore
     # subtract the length of a UUID (36), the two underscores and the
-    # namespace length from the pod name.
+    # namespace length from the max filename length.
     return 255 - 38 - len(namespace)
 
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -395,7 +395,9 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 )
 
         pipeline_name = deployment.pipeline_configuration.name
-        orchestrator_run_name = get_orchestrator_run_name(pipeline_name)
+        orchestrator_run_name = get_orchestrator_run_name(
+            pipeline_name, max_length=253
+        )
         pod_name = kube_utils.sanitize_pod_name(orchestrator_run_name)
 
         assert stack.container_registry

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -396,9 +396,14 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
 
         pipeline_name = deployment.pipeline_configuration.name
 
-        # See `kube_utils.sanitize_pod_name` for an explanation of this crazy
-        # calculation
-        max_run_name_length = 253 - 38 - len(self.config.kubernetes_namespace)
+        # We already make sure the orchestrator run name has the correct length
+        # to make sure we don't cut off the randomized suffix later when
+        # sanitizing the pod name. This avoids any pod naming collisions.
+        max_run_name_length = (
+            kube_utils.calculate_max_pod_name_length_for_namespace(
+                namespace=self.config.kubernetes_namespace
+            )
+        )
         orchestrator_run_name = get_orchestrator_run_name(
             pipeline_name, max_length=max_run_name_length
         )

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -395,10 +395,16 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 )
 
         pipeline_name = deployment.pipeline_configuration.name
+
+        # See `kube_utils.sanitize_pod_name` for an explanation of this crazy
+        # calculation
+        max_run_name_length = 253 - 38 - len(self.config.kubernetes_namespace)
         orchestrator_run_name = get_orchestrator_run_name(
-            pipeline_name, max_length=253
+            pipeline_name, max_length=max_run_name_length
         )
-        pod_name = kube_utils.sanitize_pod_name(orchestrator_run_name)
+        pod_name = kube_utils.sanitize_pod_name(
+            orchestrator_run_name, namespace=self.config.kubernetes_namespace
+        )
 
         assert stack.container_registry
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -399,13 +399,11 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
         # We already make sure the orchestrator run name has the correct length
         # to make sure we don't cut off the randomized suffix later when
         # sanitizing the pod name. This avoids any pod naming collisions.
-        max_run_name_length = (
-            kube_utils.calculate_max_pod_name_length_for_namespace(
-                namespace=self.config.kubernetes_namespace
-            )
+        max_length = kube_utils.calculate_max_pod_name_length_for_namespace(
+            namespace=self.config.kubernetes_namespace
         )
         orchestrator_run_name = get_orchestrator_run_name(
-            pipeline_name, max_length=max_run_name_length
+            pipeline_name, max_length=max_length
         )
         pod_name = kube_utils.sanitize_pod_name(
             orchestrator_run_name, namespace=self.config.kubernetes_namespace

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -90,7 +90,9 @@ def main() -> None:
         """
         # Define Kubernetes pod name.
         pod_name = f"{orchestrator_run_id}-{step_name}"
-        pod_name = kube_utils.sanitize_pod_name(pod_name)
+        pod_name = kube_utils.sanitize_pod_name(
+            pod_name, namespace=args.kubernetes_namespace
+        )
 
         image = KubernetesOrchestrator.get_image(
             deployment=deployment_config, step_name=step_name

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -25,6 +25,7 @@ from zenml.constants import ENV_ZENML_ENABLE_REPO_INIT_WARNINGS
 from zenml.integrations.airflow.orchestrators.dag_generator import (
     ENV_ZENML_LOCAL_STORES_PATH,
 )
+from zenml.integrations.kubernetes.orchestrators import kube_utils
 from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
 
 
@@ -167,8 +168,8 @@ def build_pod_manifest(
     # Add run_name and pipeline_name to the labels
     labels.update(
         {
-            "run": run_name,
-            "pipeline": pipeline_name,
+            "run": kube_utils.sanitize_label(run_name),
+            "pipeline": kube_utils.sanitize_label(pipeline_name),
         }
     )
 

--- a/src/zenml/integrations/kubernetes/step_operators/kubernetes_step_operator.py
+++ b/src/zenml/integrations/kubernetes/step_operators/kubernetes_step_operator.py
@@ -197,7 +197,9 @@ class KubernetesStepOperator(BaseStepOperator):
         )
 
         pod_name = f"{info.run_name}_{info.pipeline_step_name}"
-        pod_name = kube_utils.sanitize_pod_name(pod_name)
+        pod_name = kube_utils.sanitize_pod_name(
+            pod_name, namespace=self.config.kubernetes_namespace
+        )
 
         command = entrypoint_command[:3]
         args = entrypoint_command[3:]

--- a/tests/integration/integrations/kubernetes/orchestrators/test_manifest_utils.py
+++ b/tests/integration/integrations/kubernetes/orchestrators/test_manifest_utils.py
@@ -49,8 +49,8 @@ def test_build_pod_manifest_metadata():
     metadata = manifest.metadata
     assert isinstance(metadata, V1ObjectMeta)
     assert metadata.name == "test_name"
-    assert metadata.labels["run"] == "test_run"
-    assert metadata.labels["pipeline"] == "test_pipeline"
+    assert metadata.labels["run"] == "test-run"
+    assert metadata.labels["pipeline"] == "test-pipeline"
     assert metadata.annotations["blupus_loves"] == "strawberries"
 
     container = manifest.spec.containers[0]

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -13,8 +13,11 @@
 #  permissions and limitations under the License.
 from unittest import mock
 
+import pytest
+
 from zenml.enums import StackComponentType
 from zenml.orchestrators.utils import (
+    get_orchestrator_run_name,
     is_setting_enabled,
     register_artifact_store_filesystem,
 )
@@ -126,3 +129,19 @@ def test_register_artifact_store_filesystem(clean_client):
 
         # Exiting the context manager will set it back by calling register again
         assert register.call_count == 3
+
+
+def test_get_orchestrator_run_name():
+    """Tests the orchestrator run name computation."""
+    pipeline_name = "pipeline"
+    assert len(get_orchestrator_run_name(pipeline_name)) == 8 + 1 + 32
+    assert len(get_orchestrator_run_name(pipeline_name, max_length=16)) == 16
+    assert get_orchestrator_run_name(pipeline_name, max_length=16).startswith(
+        pipeline_name
+    )
+    assert get_orchestrator_run_name(pipeline_name, max_length=17).startswith(
+        f"{pipeline_name}_"
+    )
+
+    with pytest.raises(ValueError):
+        get_orchestrator_run_name(pipeline_name, max_length=7)


### PR DESCRIPTION
## Describe changes
Kubernetes pod names must contain at most 253 character and labels must contain at most 63 characters. This PR fixes that for the Kubernetes orchestrator.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

