### PR TITLE
Add hint when trying to connect with api key

### DIFF
--- a/docs/book/how-to/project-setup-and-management/connecting-to-zenml/connect-with-a-service-account.md
+++ b/docs/book/how-to/project-setup-and-management/connecting-to-zenml/connect-with-a-service-account.md
@@ -22,6 +22,10 @@ export ZENML_STORE_URL=https://...
 export ZENML_STORE_API_KEY=<API_KEY>
 ```
 
+{% hint style="info" %}
+You don't need to run `zenml login` after setting these two environment variables.
+{% endhint %}
+
 To see all the service accounts you've created and their API keys, use the following commands:
 
 ```bash

--- a/docs/book/how-to/project-setup-and-management/connecting-to-zenml/connect-with-a-service-account.md
+++ b/docs/book/how-to/project-setup-and-management/connecting-to-zenml/connect-with-a-service-account.md
@@ -23,7 +23,8 @@ export ZENML_STORE_API_KEY=<API_KEY>
 ```
 
 {% hint style="info" %}
-You don't need to run `zenml login` after setting these two environment variables.
+You don't need to run `zenml login` after setting these two environment
+variables and can start interacting with your server right away.
 {% endhint %}
 
 To see all the service accounts you've created and their API keys, use the following commands:

--- a/src/zenml/cli/__init__.py
+++ b/src/zenml/cli/__init__.py
@@ -2242,6 +2242,9 @@ export ZENML_STORE_URL=https://...
 export ZENML_STORE_API_KEY=<API_KEY>
 ```
 
+You don't need to run `zenml login` after setting these two environment
+variables and can start interacting with your server right away.
+
 To see all the service accounts you've created and their API keys, use the
 following commands:
 

--- a/src/zenml/cli/login.py
+++ b/src/zenml/cli/login.py
@@ -14,6 +14,7 @@
 """CLI for managing ZenML server deployments."""
 
 import ipaddress
+import os
 import re
 import sys
 import time
@@ -670,6 +671,15 @@ def login(
             dashboard on a public domain. Primarily used for accessing the
             dashboard in Colab.
     """
+    if "ZENML_STORE_API_KEY" in os.environ:
+        cli_utils.warning(
+            "You're running `zenml login` while having the "
+            "`ZENML_STORE_API_KEY` environment variable set. If you want to "
+            "use this environment variable to authenticate to your ZenML "
+            "server, you don't need to run `zenml login` and can instead start "
+            "interacting with your server right away."
+        )
+
     if local:
         if api_key:
             cli_utils.error(

--- a/src/zenml/cli/login.py
+++ b/src/zenml/cli/login.py
@@ -415,7 +415,7 @@ def connect_to_pro_server(
 
 
 def _fail_if_authentication_environment_variables_set() -> None:
-    """Fail if one of the authentication environment variables are set."""
+    """Fail if any of the authentication environment variables are set."""
     environment_variables = [
         "ZENML_STORE_URL",
         "ZENML_STORE_API_KEY",


### PR DESCRIPTION
## Describe changes
Add docs and warnings so users don't try to run `zenml login` when using the `ZENML_STORE_API_KEY` environment variable.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

