### PR TITLE
Add additional way to fetch docker repo digest

### DIFF
--- a/src/zenml/utils/docker_utils.py
+++ b/src/zenml/utils/docker_utils.py
@@ -266,6 +266,14 @@ def push_image(
     logger.info("Finished pushing Docker image.")
 
     image_name_without_tag, _ = image_name.rsplit(":", maxsplit=1)
+
+    image = docker_client.images.get(image_name)
+    repo_digests: List[str] = image.attrs["RepoDigests"]
+
+    for digest in repo_digests:
+        if digest.startswith(f"{image_name_without_tag}@"):
+            return digest
+
     for info in reversed(aux_info):
         try:
             repo_digest = info["Digest"]
@@ -304,6 +312,7 @@ def get_image_digest(image_name: str) -> Optional[str]:
 
     image = docker_client.images.get(image_name)
     repo_digests = image.attrs["RepoDigests"]
+
     if len(repo_digests) == 1:
         return cast(str, repo_digests[0])
     else:


### PR DESCRIPTION
## Describe changes
Something changed in some dependency that made pushing to an ECR registry fail because the output stream did not contain the repo digest anymore. This PR adds an additional way to fetch the docker repo digest to fix this.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

