### PR TITLE
Disable client-side caching for some orchestrators

### DIFF
--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -134,6 +134,17 @@ class KubernetesOrchestratorConfig(
         """
         return True
 
+    @property
+    def supports_client_side_caching(self) -> bool:
+        """Whether the orchestrator supports client side caching.
+
+        Returns:
+            Whether the orchestrator supports client side caching.
+        """
+        # The Kubernetes orchestrator starts step pods from a pipeline pod.
+        # This is currently not supported when using client-side caching.
+        return False
+
 
 class KubernetesOrchestratorFlavor(BaseOrchestratorFlavor):
     """Kubernetes orchestrator flavor."""

--- a/src/zenml/integrations/lightning/flavors/lightning_orchestrator_flavor.py
+++ b/src/zenml/integrations/lightning/flavors/lightning_orchestrator_flavor.py
@@ -94,6 +94,17 @@ class LightningOrchestratorConfig(
         """
         return False
 
+    @property
+    def supports_client_side_caching(self) -> bool:
+        """Whether the orchestrator supports client side caching.
+
+        Returns:
+            Whether the orchestrator supports client side caching.
+        """
+        # The Lightning orchestrator starts step studios from a pipeline studio.
+        # This is currently not supported when using client-side caching.
+        return False
+
 
 class LightningOrchestratorFlavor(BaseOrchestratorFlavor):
     """Lightning orchestrator flavor."""

--- a/src/zenml/integrations/skypilot/flavors/skypilot_orchestrator_base_vm_config.py
+++ b/src/zenml/integrations/skypilot/flavors/skypilot_orchestrator_base_vm_config.py
@@ -144,3 +144,15 @@ class SkypilotBaseOrchestratorConfig(
             True if this config is for a local component, False otherwise.
         """
         return False
+
+    @property
+    def supports_client_side_caching(self) -> bool:
+        """Whether the orchestrator supports client side caching.
+
+        Returns:
+            Whether the orchestrator supports client side caching.
+        """
+        # The Skypilot orchestrator runs the entire pipeline in a single VM, or
+        # starts additional VMs from the root VM. Both of those cases are
+        # currently not supported when using client-side caching.
+        return False

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -242,6 +242,8 @@ class BaseOrchestrator(StackComponent, ABC):
                 self._cleanup_run()
                 logger.info("All steps of the pipeline run were cached.")
                 return
+        else:
+            logger.debug("Skipping client-side caching.")
 
         try:
             if metadata_iterator := self.prepare_or_run_pipeline(

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -84,6 +84,15 @@ class BaseOrchestratorConfig(StackComponentConfig):
         """
         return False
 
+    @property
+    def supports_client_side_caching(self) -> bool:
+        """Whether the orchestrator supports client side caching.
+
+        Returns:
+            Whether the orchestrator supports client side caching.
+        """
+        return True
+
 
 class BaseOrchestrator(StackComponent, ABC):
     """Base class for all orchestrators.
@@ -205,6 +214,7 @@ class BaseOrchestrator(StackComponent, ABC):
 
         if (
             placeholder_run
+            and self.config.supports_client_side_caching
             and not deployment.schedule
             and not prevent_client_side_caching
         ):

--- a/src/zenml/service_connectors/service_connector_utils.py
+++ b/src/zenml/service_connectors/service_connector_utils.py
@@ -60,15 +60,9 @@ def _raise_specific_cloud_exception_if_needed(
     orchestrators: List[ResourcesInfo],
     container_registries: List[ResourcesInfo],
 ) -> None:
-    AWS_DOCS = (
-        "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/aws-service-connector"
-    )
-    GCP_DOCS = (
-        "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/gcp-service-connector"
-    )
-    AZURE_DOCS = (
-        "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/azure-service-connector"
-    )
+    AWS_DOCS = "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/aws-service-connector"
+    GCP_DOCS = "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/gcp-service-connector"
+    AZURE_DOCS = "https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/azure-service-connector"
 
     if not artifact_stores:
         error_msg = (


### PR DESCRIPTION
## Describe changes
Client-side caching is failing for orchestrators that don't follow our usual process of creating an orchestrator intermediate representation and then forwarding that to the orchestrator.

Instead, these orchestrators have their own entrypoint that runs in one environment and spins up additional environments for the actual steps to run. There is no easy solution to make this work with the client-side caching implementation, which is why I disabled it for these orchestrators for now.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

