### PR TITLE
Fix GET step run endpoint to return unhydrated response if requested

### DIFF
--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -142,9 +142,15 @@ def get_step(
     Returns:
         The step.
     """
-    step = zen_store().get_run_step(step_id, hydrate=hydrate)
+    # We always fetch the step hydrated because we need the pipeline_run_id
+    # for the permission checks. If the user requested an unhydrated response,
+    # we later remove the metadata
+    step = zen_store().get_run_step(step_id, hydrate=True)
     pipeline_run = zen_store().get_run(step.pipeline_run_id)
     verify_permission_for_model(pipeline_run, action=Action.READ)
+
+    if hydrate is False:
+        step.metadata = None
 
     return dehydrate_response_model(step)
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -373,7 +373,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             step_substitutions = {}
             for step_name, step in steps.items():
                 step_substitutions[step_name] = step.config.substitutions
-                # We fetch the steps hydrated before, but won't them unhydrated
+                # We fetch the steps hydrated before, but want them unhydrated
                 # in the response -> We need to reset the metadata here
                 step.metadata = None
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -298,7 +298,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
         )
 
         if self.deployment is not None:
-            deployment = self.deployment.to_model()
+            deployment = self.deployment.to_model(include_metadata=True)
 
             config = deployment.pipeline_configuration
             new_substitutions = config._get_full_substitutions(self.start_time)
@@ -365,12 +365,18 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             ):
                 is_templatable = True
 
-            steps = {step.name: step.to_model() for step in self.step_runs}
-
-            step_substitutions = {
-                step_name: step.config.substitutions
-                for step_name, step in steps.items()
+            steps = {
+                step.name: step.to_model(include_metadata=True)
+                for step in self.step_runs
             }
+
+            step_substitutions = {}
+            for step_name, step in steps.items():
+                step_substitutions[step_name] = step.config.substitutions
+                # We fetch the steps hydrated before, but won't them unhydrated
+                # in the response -> We need to reset the metadata here
+                step.metadata = None
+
             metadata = PipelineRunResponseMetadata(
                 workspace=self.workspace.to_model(),
                 run_metadata=self.fetch_metadata(),

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -8633,7 +8633,11 @@ class SqlZenStore(BaseZenStore):
 
         # Deployment always exists for pipeline runs of newer versions
         assert pipeline_run.deployment
-        num_steps = len(pipeline_run.deployment.to_model().step_configurations)
+        num_steps = len(
+            pipeline_run.deployment.to_model(
+                include_metadata=True
+            ).step_configurations
+        )
         new_status = get_pipeline_run_status(
             step_statuses=[
                 ExecutionStatus(step_run.status) for step_run in step_runs


### PR DESCRIPTION
## Describe changes
This PR fixes a few hydration issues:
- When requesting an unhydrated step run in the `GET`, it always included the metadata
- When requesting a hydrated pipeline run, it always included the metadata for all steps (two layers of hydration)
- Some unnecessary server-side hydration calls

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] If my change requires a change to docs, I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] If my changes require changes to the dashboard, these changes are communicated/requested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

