### PR TITLE
Don't create multiple model versions when running parallel steps

### DIFF
--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -180,11 +180,13 @@ class StepLauncher:
                         pipeline_run_metadata=pipeline_run_metadata,
                     )
 
-                pipeline_model_version, pipeline_run = (
-                    step_run_utils.prepare_pipeline_run_model_version(
-                        pipeline_run
+                    pipeline_model_version, pipeline_run = (
+                        step_run_utils.prepare_pipeline_run_model_version(
+                            pipeline_run
+                        )
                     )
-                )
+                else:
+                    pipeline_model_version = pipeline_run.model_version
 
                 request_factory = step_run_utils.StepRunRequestFactory(
                     deployment=self._deployment,


### PR DESCRIPTION
## Describe changes
The actual fix for this race condition would be to create the model versions server-side, however that is very complicated due to issues with different implementations of unique constraints for different MySQL flavors. This PR at least makes sure that only a single model version is created for a pipeline run.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

