### PR TITLE
Re-authenticate requests that failed authentication

### DIFF
--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -587,25 +587,6 @@ def server_list(verbose: bool = False, all: bool = False) -> None:
             accessible_pro_servers = client.tenant.list(member_only=not all)
         except AuthorizationException as e:
             cli_utils.warning(f"ZenML Pro authorization error: {e}")
-        else:
-            if not all:
-                accessible_pro_servers = [
-                    s
-                    for s in accessible_pro_servers
-                    if s.status == TenantStatus.AVAILABLE
-                ]
-
-            if not accessible_pro_servers:
-                cli_utils.declare(
-                    "No ZenML Pro servers that are accessible to the current "
-                    "user could be found."
-                )
-                if not all:
-                    cli_utils.declare(
-                        "Hint: use the `--all` flag to show all ZenML servers, "
-                        "including those that the client is not currently "
-                        "authorized to access or are not running."
-                    )
 
         # We update the list of stored ZenML Pro servers with the ones that the
         # client is a member of
@@ -632,6 +613,25 @@ def server_list(verbose: bool = False, all: bool = False) -> None:
                 )
                 stored_server.update_server_info(accessible_server)
                 pro_servers.append(stored_server)
+
+        if not all:
+            accessible_pro_servers = [
+                s
+                for s in accessible_pro_servers
+                if s.status == TenantStatus.AVAILABLE
+            ]
+
+        if not accessible_pro_servers:
+            cli_utils.declare(
+                "No ZenML Pro servers that are accessible to the current "
+                "user could be found."
+            )
+            if not all:
+                cli_utils.declare(
+                    "Hint: use the `--all` flag to show all ZenML servers, "
+                    "including those that the client is not currently "
+                    "authorized to access or are not running."
+                )
 
     elif pro_servers:
         cli_utils.warning(

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -4349,46 +4349,74 @@ class RestZenStore(BaseZenStore):
             {source_context.name: source_context.get().value}
         )
 
-        try:
-            return self._handle_response(
-                self.session.request(
-                    method,
-                    url,
-                    params=params,
-                    verify=self.config.verify_ssl,
-                    timeout=timeout or self.config.http_timeout,
-                    **kwargs,
+        # If the server replies with a credentials validation (401 Unauthorized)
+        # error, we (re-)authenticate and retry the request here in the
+        # following cases:
+        #
+        # 1. initial authentication: the last request was not authenticated
+        # with an API token.
+        # 2. re-authentication: the last request was authenticated with an API
+        # token that was rejected by the server. This is to cover the case
+        # of expired tokens that can be refreshed by the client automatically
+        # without user intervention from other sources (e.g. API keys).
+        #
+        # NOTE: it can happen that the same request is retried here for up to
+        # two times: once after initial authentication and once after
+        # re-authentication.
+        re_authenticated = False
+        while True:
+            try:
+                return self._handle_response(
+                    self.session.request(
+                        method,
+                        url,
+                        params=params,
+                        verify=self.config.verify_ssl,
+                        timeout=timeout or self.config.http_timeout,
+                        **kwargs,
+                    )
                 )
-            )
-        except CredentialsNotValid:
-            # NOTE: CredentialsNotValid is raised only when the server
-            # explicitly indicates that the credentials are not valid and they
-            # can be thrown away.
+            except CredentialsNotValid as e:
+                # NOTE: CredentialsNotValid is raised only when the server
+                # explicitly indicates that the credentials are not valid and
+                # they can be thrown away or when the request is not
+                # authenticated at all.
 
-            # We authenticate or re-authenticate here and then try the request
-            # again, this time with a valid API token in the header.
-            self.authenticate(
-                # If the last request was authenticated with an API token,
-                # we force a re-authentication to get a fresh token.
-                force=self._api_token is not None
-            )
-
-        try:
-            return self._handle_response(
-                self.session.request(
-                    method,
-                    url,
-                    params=params,
-                    verify=self.config.verify_ssl,
-                    timeout=self.config.http_timeout,
-                    **kwargs,
-                )
-            )
-        except CredentialsNotValid as e:
-            raise CredentialsNotValid(
-                "The current credentials are no longer valid. Please log in "
-                "again using 'zenml login'."
-            ) from e
+                if self._api_token is None:
+                    # The last request was not authenticated with an API
+                    # token at all. We authenticate here and then try the
+                    # request again, this time with a valid API token in the
+                    # header.
+                    logger.debug(
+                        f"The last request was not authenticated: {e}\n"
+                        "Re-authenticating and retrying..."
+                    )
+                    self.authenticate()
+                elif not re_authenticated:
+                    # The last request was authenticated with an API token
+                    # that was rejected by the server. We attempt a
+                    # re-authentication here and then retry the request.
+                    logger.debug(
+                        "The last request was authenticated with an API token "
+                        f"that was rejected by the server: {e}\n"
+                        "Re-authenticating and retrying..."
+                    )
+                    re_authenticated = True
+                    self.authenticate(
+                        # Ignore the current token and force a re-authentication
+                        force=True
+                    )
+                else:
+                    # The last request was made after re-authenticating but
+                    # still failed. Bailing out.
+                    logger.debug(
+                        f"The last request failed after re-authenticating: {e}\n"
+                        "Bailing out..."
+                    )
+                    raise CredentialsNotValid(
+                        "The current credentials are no longer valid. Please "
+                        "log in again using 'zenml login'."
+                    ) from e
 
     def get(
         self,


### PR DESCRIPTION
## Describe changes
When the zenml server to which a client is connected is being removed and then re-deployed to the same URL (e.g. when a ZenML Pro tenant is deactivated and then re-activated), the API token cached by the client becomes invalid (because the key used by the server to sign the API tokens changes).

When this happens, the client is expected to silently recover without throwing any errors, by leveraging other means of re-authentication at its disposal (e.g. server API key or ZenML Pro control plane authentication). However, the cached token is not currently invalidated and properly removed, which results in errors such as the following:

```
$ zenml login
No server argument was provided. Re-authenticating to ZenML Pro...
Hint: You can run 'zenml login <server-url-id-or-name>' to connect to a specific ZenML Pro server.
If your browser did not open automatically, please open the following URL into your browser to proceed with the authentication:

https://staging.cloud.zenml.io/devices/verify?user_code=...

Successfully logged in to ZenML Pro.
You can now run 'zenml server list' to view the available ZenML Pro servers and then 'zenml login <server-url-name-or-id>' to connect to a specific server without having to log in again until your session
expires.
Connecting to ZenML Pro server: ...
Authenticating to ZenML server ...
Error: Authorization error: The current credentials are no longer valid. Please log in again using 'zenml login'.
```

This PR corrects this behavior by making the client even more robust and trying requests for up to 3 times if the server responds with authentication errors:

* firstly, without authentication (i.e. authenticating to the server is done lazily, only when needed)
* secondly, after authenticating to the server or re-using a cached session token
* thirdly, after re-authenticating, to account for cases where the existing cached token, even though still valid, is rejected by the server for other reasons (e.g. the signature is no longer valid)

This PR also contains a small fix to the `zenml server list` CLI command to remove inactive ZenML Pro servers from the output, unless `--all` is specified. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

