### PR TITLE
Fix broken link

### DIFF
--- a/docs/book/how-to/manage-zenml-server/upgrade-zenml-server.md
+++ b/docs/book/how-to/manage-zenml-server/upgrade-zenml-server.md
@@ -4,7 +4,7 @@ description: Learn how to upgrade your server to a new version of ZenML for the 
 
 # Upgrade the version of the ZenML server
 
-The way to upgrade your ZenML server depends a lot on how you deployed it. However, there are some best practices that apply in all cases. Before you upgrade, check out the [best practices for upgrading ZenML](./best-practices-upgrading-zenml.md) guide.
+The way to upgrade your ZenML server depends a lot on how you deployed it. However, there are some best practices that apply in all cases. Before you upgrade, check out the [best practices for upgrading ZenML](best-practices-upgrading-zenml.md) guide.
 
 In general, upgrade your ZenML server as soon as you can once a new version is released. New versions come with a lot of improvements and fixes from which you can benefit.
 


### PR DESCRIPTION
For whatever reason Gitbook wasn't picking up the link when it had a reference to the current directory. This PR fixes that.