### PR TITLE
Fix server spin-up integration tests

### DIFF
--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -72,7 +72,7 @@ install_integrations() {
     # which causes our server to fail in case both are installed. We
     # need to uninstall this library for now until the changes make it into
     # fastapi and then need to bump the fastapi version to resolve this.
-    uv pip uninstall multipart
+    uv pip uninstall $PIP_ARGS multipart
 }
 
 set -x

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -66,6 +66,13 @@ install_integrations() {
 
     uv pip install $PIP_ARGS -r integration-requirements.txt
     rm integration-requirements.txt
+
+    # https://github.com/Kludex/python-multipart/pull/166
+    # There is an install conflict between multipart and python_multipart
+    # which causes our server to fail in case both are installed. We
+    # need to uninstall this library for now until the changes make it into
+    # fastapi and then need to bump the fastapi version to resolve this.
+    uv pip uninstall multipart
 }
 
 set -x


### PR DESCRIPTION
## Describe changes
There server spinup was not working in our CI due to a dependency conflict: Evidently installs the `multipart` library, which shadows the installation of the `python_multipart` library required by starlette (and therefore fastapi). This PR uninstalls the `multipart` library in our CI until the underlying issue is resolved.

There is one more integration test failing (great expectations example) due to `openml.org` being down, which prevents us from downloading the dataset for the pipeline. We can ignore this until it's back up, as it won't interfere with the release process.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

