### PR TITLE
Fix wrong warning log when directly connecting to MySQL DB

### DIFF
--- a/src/zenml/cli/login.py
+++ b/src/zenml/cli/login.py
@@ -791,6 +791,8 @@ def login(
 
     if server is not None:
         if re.match(r"^mysql://", server):
+            # The server argument is a MySQL URL, we can directly connect to it
+
             connect_to_server(
                 url=server,
                 api_key=api_key_value,

--- a/src/zenml/cli/login.py
+++ b/src/zenml/cli/login.py
@@ -790,15 +790,14 @@ def login(
     )
 
     if server is not None:
-        if not re.match(r"^(https?|mysql)://", server):
-            # The server argument is a ZenML Pro server name or UUID
-            connect_to_pro_server(
-                pro_server=server,
+        if re.match(r"^mysql://", server):
+            connect_to_server(
+                url=server,
                 api_key=api_key_value,
+                verify_ssl=verify_ssl,
                 refresh=refresh,
-                pro_api_url=pro_api_url,
             )
-        else:
+        elif re.match(r"^https?://", server):
             # The server argument is a server URL
 
             # First, try to discover if the server is a ZenML Pro server or not
@@ -819,6 +818,14 @@ def login(
                     verify_ssl=verify_ssl,
                     refresh=refresh,
                 )
+        else:
+            # The server argument is a ZenML Pro server name or UUID
+            connect_to_pro_server(
+                pro_server=server,
+                api_key=api_key_value,
+                refresh=refresh,
+                pro_api_url=pro_api_url,
+            )
 
     elif current_non_local_server:
         # The server argument is not provided, so we default to


### PR DESCRIPTION
## Describe changes
When logging in with `zenml login mysql://...`, we printed a warning message because the URL was interpreted as a remote server URL and failed while trying to create a `RestZenStoreConfig` in the `zenml.login.server_info.get_server_info(...)` function. This PR adds a case distinction and doesn't check whether a MySQL URL is a pro server (it isn't) and therefore avoids the warning.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

