### PR TITLE
Fix Kubernetes service connector

### DIFF
--- a/src/zenml/cli/annotator.py
+++ b/src/zenml/cli/annotator.py
@@ -182,7 +182,7 @@ def register_annotator_subcommands() -> None:
         kwargs_dict = {}
         for arg in kwargs:
             if arg.startswith("--"):
-                key, value = arg.lstrip("--").split("=", 1)
+                key, value = arg.removeprefix("--").split("=", 1)
                 kwargs_dict[key] = value
 
         if annotator.flavor == "prodigy":

--- a/src/zenml/integrations/kubernetes/service_connectors/kubernetes_service_connector.py
+++ b/src/zenml/integrations/kubernetes/service_connectors/kubernetes_service_connector.py
@@ -504,13 +504,17 @@ class KubernetesServiceConnector(ServiceConnector):
                 ).decode("utf-8")
                 if kube_config.ssl_ca_cert
                 else None,
-                cluster_name=kube_config.host.strip("https://").split(":")[0],
+                cluster_name=kube_config.host.removeprefix("https://").split(
+                    ":"
+                )[0],
                 insecure=kube_config.verify_ssl is False,
             )
         else:
             token: Optional[str] = None
             if kube_config.api_key:
-                token = kube_config.api_key["authorization"].strip("Bearer ")
+                token = kube_config.api_key["authorization"].removeprefix(
+                    "Bearer "
+                )
 
             auth_method = KubernetesAuthenticationMethods.TOKEN
             auth_config = KubernetesTokenConfig(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -795,7 +795,7 @@ class SqlZenStoreConfiguration(StoreConfiguration):
                     logger.warning(
                         f"Database SSL setting `{key}` is not a file. "
                     )
-                sqlalchemy_ssl_args[key.lstrip("ssl_")] = ssl_setting
+                sqlalchemy_ssl_args[key.removeprefix("ssl_")] = ssl_setting
             if len(sqlalchemy_ssl_args) > 0:
                 sqlalchemy_ssl_args["check_hostname"] = (
                     self.ssl_verify_server_cert


### PR DESCRIPTION
## Describe changes
We were using `[l]strip()` incorrectly in a bunch of places to remove a prefix, but what this does is it removes all the characters it finds from the passed string argument from the target string. This was breaking the Kubernetes service connector in a rather difficult to debug way. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

