### PR TITLE
Fix code download for custom flavor components

### DIFF
--- a/src/zenml/exceptions.py
+++ b/src/zenml/exceptions.py
@@ -314,3 +314,7 @@ class SecretsStoreNotConfiguredError(NotImplementedError):
 
 class BackupSecretsStoreNotConfiguredError(NotImplementedError):
     """Raised when a backup secrets store is not configured."""
+
+
+class CustomFlavorImportError(ImportError):
+    """Raised when failing to import a custom flavor."""

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -27,7 +27,7 @@ from zenml.config.build_configuration import BuildConfiguration
 from zenml.config.step_configurations import Step
 from zenml.config.step_run_info import StepRunInfo
 from zenml.enums import StackComponentType
-from zenml.exceptions import AuthorizationException, CustomFlavorImportError
+from zenml.exceptions import AuthorizationException
 from zenml.logger import get_logger
 from zenml.models import (
     PipelineRunResponse,
@@ -400,26 +400,12 @@ class StackComponent:
             The created StackComponent.
 
         Raises:
-            CustomFlavorImportError: If the custom flavor can't be imported.
             ImportError: If the flavor can't be imported.
         """
+        from zenml.stack import Flavor
+
         flavor_model = component_model.flavor
-
-        try:
-            from zenml.stack import Flavor
-
-            flavor = Flavor.from_model(flavor_model)
-        except (ModuleNotFoundError, ImportError, NotImplementedError) as err:
-            if flavor_model.is_custom:
-                raise CustomFlavorImportError(
-                    f"Couldn't import custom flavor {flavor_model.name}: "
-                    f"{err}. Make sure the implementation file of the custom "
-                    f"flavor `{flavor_model.source}` is available."
-                )
-            else:
-                raise ImportError(
-                    f"Couldn't import flavor {flavor_model.name}: {err}"
-                )
+        flavor = Flavor.from_model(flavor_model)
 
         configuration = flavor.config_class(**component_model.configuration)
 

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -414,7 +414,7 @@ class StackComponent:
                 raise CustomFlavorImportError(
                     f"Couldn't import custom flavor {flavor_model.name}: "
                     f"{err}. Make sure the implementation file of the custom "
-                    f"flavor {flavor_model.source} is available."
+                    f"flavor `{flavor_model.source}` is available."
                 )
             else:
                 raise ImportError(

--- a/src/zenml/utils/code_utils.py
+++ b/src/zenml/utils/code_utils.py
@@ -273,7 +273,10 @@ def download_code_from_artifact_store(
     logger.info("Downloading code from artifact store path `%s`.", code_path)
 
     if not code_path.startswith(artifact_store.path):
-        raise RuntimeError("Code stored in different artifact store.")
+        raise RuntimeError(
+            "The code is not stored in the artifact store "
+            f"{artifact_store.name} that was passed to download it."
+        )
 
     # Make sure we register the artifact store filesystem here so the
     # fileio.copy call will pick up the right credentials

--- a/src/zenml/utils/code_utils.py
+++ b/src/zenml/utils/code_utils.py
@@ -249,16 +249,7 @@ def download_and_extract_code(code_path: str, extract_dir: str) -> None:
     Args:
         code_path: Path where the code is uploaded.
         extract_dir: Directory where to code should be extracted to.
-
-    Raises:
-        RuntimeError: If the code is stored in an artifact store which is
-            not active.
     """
-    artifact_store = Client().active_stack.artifact_store
-
-    if not code_path.startswith(artifact_store.path):
-        raise RuntimeError("Code stored in different artifact store.")
-
     download_path = os.path.basename(code_path)
     fileio.copy(code_path, download_path)
 
@@ -266,17 +257,27 @@ def download_and_extract_code(code_path: str, extract_dir: str) -> None:
     os.remove(download_path)
 
 
-def download_code_from_artifact_store(code_path: str) -> None:
+def download_code_from_artifact_store(
+    code_path: str, artifact_store: "BaseArtifactStore"
+) -> None:
     """Download code from the artifact store.
 
     Args:
         code_path: Path where the code is stored.
+        artifact_store: The artifact store to use for the download.
+
+    Raises:
+        RuntimeError: If the code is stored in an artifact store which is
+            not active.
     """
     logger.info("Downloading code from artifact store path `%s`.", code_path)
 
-    # Do not remove this line, we need to instantiate the artifact store to
-    # register the filesystem needed for the file download
-    _ = Client().active_stack.artifact_store
+    if not code_path.startswith(artifact_store.path):
+        raise RuntimeError("Code stored in different artifact store.")
+
+    # Make sure we register the artifact store filesystem here so the
+    # fileio.copy call will pick up the right credentials
+    artifact_store._register()
 
     extract_dir = os.path.abspath("code")
     os.makedirs(extract_dir)


### PR DESCRIPTION
## Describe changes
When running with a containerized orchestrator, the following case was a potential issue:
- The stack contains a custom flavor component, for which the flavor implementation is not part of a library but part of the local user code files.
- The user allowed downloading code from the artifact store.
- When trying to download code in the entrypoint of the Docker container, ZenML would try to instantiate the stack to fetch the artifact store for downloading the code. This would fail because some components of the stack are missing their flavor implementation.

This PR fixes this for all components other than artifact stores, for which there is no fix. Instead, an explicit exception is used to tell users how to solve this in case they run into it.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

