### PR TITLE
Fix sorting by columns with potentially empty values

### DIFF
--- a/src/zenml/models/v2/base/scoped.py
+++ b/src/zenml/models/v2/base/scoped.py
@@ -241,8 +241,9 @@ class UserScopedFilter(BaseFilter):
         if sort_by == "user":
             column = UserSchema.name
 
-            query = query.join(
-                UserSchema, getattr(table, "user_id") == UserSchema.id
+            query = query.outerjoin(
+                UserSchema,
+                getattr(table, "user_id") == UserSchema.id,
             )
 
             query = query.add_columns(UserSchema.name)

--- a/src/zenml/models/v2/core/pipeline_run.py
+++ b/src/zenml/models/v2/core/pipeline_run.py
@@ -950,31 +950,31 @@ class PipelineRunFilter(WorkspaceScopedTaggableFilter):
         sort_by, operand = self.sorting_params
 
         if sort_by == "pipeline":
-            query = query.join(
+            query = query.outerjoin(
                 PipelineSchema,
                 PipelineRunSchema.pipeline_id == PipelineSchema.id,
             )
             column = PipelineSchema.name
         elif sort_by == "stack":
-            query = query.join(
+            query = query.outerjoin(
                 PipelineDeploymentSchema,
                 PipelineRunSchema.deployment_id == PipelineDeploymentSchema.id,
-            ).join(
+            ).outerjoin(
                 StackSchema,
                 PipelineDeploymentSchema.stack_id == StackSchema.id,
             )
             column = StackSchema.name
         elif sort_by == "model":
-            query = query.join(
+            query = query.outerjoin(
                 ModelVersionSchema,
                 PipelineRunSchema.model_version_id == ModelVersionSchema.id,
-            ).join(
+            ).outerjoin(
                 ModelSchema,
                 ModelVersionSchema.model_id == ModelSchema.id,
             )
             column = ModelSchema.name
         elif sort_by == "model_version":
-            query = query.join(
+            query = query.outerjoin(
                 ModelVersionSchema,
                 PipelineRunSchema.model_version_id == ModelVersionSchema.id,
             )

--- a/tests/integration/functional/models/test_sorting.py
+++ b/tests/integration/functional/models/test_sorting.py
@@ -108,14 +108,16 @@ def test_sorting_entities(clean_client):
 
     # Sorting runs by model name
     results = clean_client.list_pipeline_runs(sort_by="asc:model")
-    assert results[0].model_version.model.name == "Model1"
+    assert results[0].model_version is None
+    assert results[1].model_version.model.name == "Model1"
     assert results[-1].model_version.model.name == "Model2"
     clean_client.list_pipeline_runs(sort_by="desc:model")
 
     # Sorting runs by model version
     results = clean_client.list_pipeline_runs(sort_by="asc:model_version")
 
-    assert results[0].model_version.name == "1"
+    assert results[0].model_version is None
+    assert results[1].model_version.name == "1"
     assert results[-1].model_version.name == "second"
 
     clean_client.list_pipeline_runs(sort_by="desc:model")


### PR DESCRIPTION
## Describe changes
During some of our sorting code, we were joining tables on columns that could optionally be `NULL`. If that was the case, these rows would get removed from the result entirely, resulting in e.g. the `default` stack not being displayed when sorting by user. This PR fixes that by instead using outer joins.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

