### PR TITLE
Fix materializer for new pytorch version

### DIFF
--- a/src/zenml/integrations/pytorch/materializers/base_pytorch_materializer.py
+++ b/src/zenml/integrations/pytorch/materializers/base_pytorch_materializer.py
@@ -44,7 +44,7 @@ class BasePyTorchMaterializer(BaseMaterializer):
             # NOTE (security): The `torch.load` function uses `pickle` as
             # the default unpickler, which is NOT secure. This materializer
             # is intended for use with trusted data sources.
-            return torch.load(f)  # nosec
+            return torch.load(f, weights_only=False)  # nosec
 
     def save(self, obj: Any) -> None:
         """Uses `torch.save` to save a PyTorch object.


### PR DESCRIPTION
## Describe changes
In the `2.6.0` release, pytorch changed the default value of the `weights_only` argument of `torch.load(...)` which breaks our materializer. This PR makes sure the parameter is set to `False` to keep the previous behaviour.

See https://github.com/pytorch/pytorch/releases/tag/v2.6.0

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

