### PR TITLE
Fix sorting when using custom fetching

### DIFF
--- a/docs/book/component-guide/image-builders/kaniko.md
+++ b/docs/book/component-guide/image-builders/kaniko.md
@@ -143,7 +143,7 @@ List of some possible additional flags:
 
 * `--cache`: Set to `false` to disable caching. Defaults to `true`.
 * `--cache-dir`: Set the directory where to store cached layers. Defaults to `/cache`.
-* `--cache-repo`: Set the repository where to store cached layers. Defaults to `gcr.io/kaniko-project/executor`.
+* `--cache-repo`: Set the repository where to store cached layers.
 * `--cache-ttl`: Set the cache expiration time. Defaults to `24h`.
 * `--cleanup`: Set to `false` to disable cleanup of the working directory. Defaults to `true`.
 * `--compressed-caching`: Set to `false` to disable compressed caching. Defaults to `true`.

--- a/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
@@ -86,7 +86,7 @@ class VertexOrchestratorConfig(
             then a subdirectory of the artifact store will be used.
         encryption_spec_key_name: The Cloud KMS resource identifier of the
             customer managed encryption key used to protect the job. Has the form:
-            `projects/<PRJCT>/locations/<REGION>/keyRings/<KR>/cryptoKeys/<KEY>`
+            `projects/<PROJECT>/locations/<REGION>/keyRings/<KR>/cryptoKeys/<KEY>`
             . The key needs to be in the same region as where the compute
             resource is created.
         workload_service_account: the service account for workload run-as
@@ -124,13 +124,14 @@ class VertexOrchestratorConfig(
     pipeline_root: Optional[str] = None
     encryption_spec_key_name: Optional[str] = None
     workload_service_account: Optional[str] = None
-    function_service_account: Optional[str] = None
-    scheduler_service_account: Optional[str] = None
     network: Optional[str] = None
 
+    # Deprecated
     cpu_limit: Optional[str] = None
     memory_limit: Optional[str] = None
     gpu_limit: Optional[int] = None
+    function_service_account: Optional[str] = None
+    scheduler_service_account: Optional[str] = None
 
     _resource_deprecation = deprecation_utils.deprecate_pydantic_attributes(
         "cpu_limit",

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -986,6 +986,7 @@ class SqlZenStore(BaseZenStore):
             RuntimeError: if the schema does not have a `to_model` method.
         """
         query = filter_model.apply_filter(query=query, table=table)
+        query = filter_model.apply_sorting(query=query, table=table)
         query = query.distinct()
 
         # Get the total amount of items in the database for a given query
@@ -1004,9 +1005,6 @@ class SqlZenStore(BaseZenStore):
                 total = result
             else:
                 total = 0
-
-        # Sorting
-        query = filter_model.apply_sorting(query=query, table=table)
 
         # Get the total amount of pages in the database for a given query
         if total == 0:


### PR DESCRIPTION
## Describe changes
We have an option that allows some SQLZenStore methods to adjust the filtering/sorting behaviour by passing a `custom_fetch` function to `filter_and_paginate`. However, the query we passed to the custom fetch function did not have the sorting applied, which means sorting got completely ignored for entities using this (for example service connectors).

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

