### PR TITLE
Allow auth method to be customized during auto-configuration of service connectors

### DIFF
--- a/src/zenml/cli/service_connectors.py
+++ b/src/zenml/cli/service_connectors.py
@@ -668,7 +668,6 @@ def register_service_connector(
         else:
             auto_configure = False
 
-        auth_method = None
         connector_model: Optional[
             Union[ServiceConnectorRequest, ServiceConnectorResponse]
         ] = None
@@ -685,6 +684,7 @@ def register_service_connector(
                         description=description or "",
                         connector_type=connector_type,
                         resource_type=resource_type,
+                        auth_method=auth_method,
                         expires_skew_tolerance=expires_skew_tolerance,
                         auto_configure=True,
                         verify=True,


### PR DESCRIPTION
## Describe changes
Specifying a custom auth method to `zenml service-connector register -i` was previously ignored if auto-configuration was selected.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

