### PR TITLE
Fixing the CI 

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -5,10 +5,10 @@ on:
   workflow_call:
   push:
     branches: [main]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
+    paths-ignore: [docs/**, '*', '!pyproject.toml', '**.md']
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
+    paths-ignore: [docs/**, '*', '!pyproject.toml', '**.md']
 concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -5,10 +5,10 @@ on:
   workflow_call:
   push:
     branches: [main]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
+    paths-ignore: [docs/**, '*', '!pyproject.toml', '**.md']
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths-ignore: [docs/**, docker/**, '*', '!pyproject.toml', '**.md']
+    paths-ignore: [docs/**, '*', '!pyproject.toml', '**.md']
 concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,10 +5,10 @@ on:
   workflow_call:
   push:
     branches: [main]
-    paths-ignore: [docker/**, '*', '!pyproject.toml']
+    paths-ignore: ['*', '!pyproject.toml']
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths-ignore: [docker/**, '*', '!pyproject.toml']
+    paths-ignore: ['*', '!pyproject.toml']
 concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -37,12 +37,14 @@ RUN groupadd --gid $USER_GID $USERNAME && \
   mkdir -p $VIRTUAL_ENV && \
   chown -R $USER_UID:$USER_GID $VIRTUAL_ENV
 
+WORKDIR /zenml
+
+RUN chown -R $USER_UID:$USER_GID .
+
 # Switch to non-privileged user
 USER $USERNAME
 
 ENV PATH="$VIRTUAL_ENV/bin:/home/$USERNAME/.local/bin:$PATH"
-
-WORKDIR /zenml
 
 FROM base AS builder
 

--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -151,7 +151,7 @@ def show_dashboard(url: str) -> None:
     """
     environment = get_environment()
     if environment in (EnvironmentType.NOTEBOOK, EnvironmentType.COLAB):
-        from IPython.core.display import display
+        from IPython.core.display_functions import display
         from IPython.display import IFrame
 
         display(IFrame(src=url, width="100%", height=720))

--- a/src/zenml/utils/visualization_utils.py
+++ b/src/zenml/utils/visualization_utils.py
@@ -16,7 +16,8 @@
 import json
 from typing import TYPE_CHECKING, Optional
 
-from IPython.core.display import HTML, JSON, Image, Markdown, display
+from IPython.core.display_functions import display
+from IPython.display import HTML, JSON, Image, Markdown
 
 from zenml.artifacts.utils import load_artifact_visualization
 from zenml.enums import VisualizationType

--- a/tests/integration/integrations/gcp/orchestrators/test_vertex_orchestrator.py
+++ b/tests/integration/integrations/gcp/orchestrators/test_vertex_orchestrator.py
@@ -141,13 +141,9 @@ def test_vertex_orchestrator_stack_validation(
             {"cpu_limit": "4", "gpu_limit": 4, "memory_limit": "1G"},
             {
                 "accelerator": {
-                    "count": "1",
-                    "type": "NVIDIA_TESLA_K80",
                     "resourceCount": "1",
                     "resourceType": "NVIDIA_TESLA_K80",
                 },
-                "cpuLimit": 1.0,
-                "memoryLimit": 1.0,
                 "resourceCpuLimit": "1.0",
                 "resourceMemoryLimit": "1G",
             },
@@ -158,13 +154,9 @@ def test_vertex_orchestrator_stack_validation(
             {"cpu_limit": "1.0", "gpu_limit": 1, "memory_limit": "1G"},
             {
                 "accelerator": {
-                    "count": "1",
-                    "type": "NVIDIA_TESLA_K80",
                     "resourceCount": "1",
                     "resourceType": "NVIDIA_TESLA_K80",
                 },
-                "cpuLimit": 1.0,
-                "memoryLimit": 1.0,
                 "resourceCpuLimit": "1.0",
                 "resourceMemoryLimit": "1G",
             },
@@ -174,8 +166,6 @@ def test_vertex_orchestrator_stack_validation(
             ResourceSettings(cpu_count=1, gpu_count=None, memory="1GB"),
             {"cpu_limit": None, "gpu_limit": None, "memory_limit": None},
             {
-                "cpuLimit": 1.0,
-                "memoryLimit": 1.0,
                 "resourceCpuLimit": "1.0",
                 "resourceMemoryLimit": "1G",
             },
@@ -185,8 +175,6 @@ def test_vertex_orchestrator_stack_validation(
             ResourceSettings(cpu_count=1, gpu_count=0, memory="1GB"),
             {"cpu_limit": None, "gpu_limit": None, "memory_limit": None},
             {
-                "cpuLimit": 1.0,
-                "memoryLimit": 1.0,
                 "resourceCpuLimit": "1.0",
                 "resourceMemoryLimit": "1G",
             },
@@ -260,4 +248,33 @@ def test_vertex_orchestrator_configure_container_resources(
     if "resourceMemoryLimit" not in job_spec["resources"]:
         expected_resources.pop("resourceMemoryLimit", None)
 
-    assert job_spec["resources"] == expected_resources
+    def assert_dict_is_subset(actual, expected):
+        """Checks if the expected dictionary is a subset of the actual dictionary.
+
+        Args:
+            actual: The actual dictionary to compare
+            expected: The expected dictionary to compare against
+
+        Raises:
+            AssertionError: If the expected dictionary is not a subset 
+            of the actual dictionary
+        """
+        if actual is None or expected is None:
+            assert actual == expected
+            return
+        d1_set = set(actual.items())
+        d2_set = set(expected.items())
+
+        # Now we can directly compare them
+        assert d1_set >= d2_set, (
+            f"Expected dictionary is not a subset of the actual "
+            "dictionary.\nExpected: {expected}\nActual: {actual}"
+        )
+
+    assert_dict_is_subset(
+        job_spec["resources"].get("accelerator"),
+        expected_resources.get("accelerator"),
+    )
+    job_spec["resources"].pop("accelerator", None)
+    expected_resources.pop("accelerator", None)
+    assert_dict_is_subset(job_spec["resources"], expected_resources)


### PR DESCRIPTION
## Describe changes

## IPython display issues

Fixed faulty imports in our utils module based on Stefan's previous changes.

## The dockerfiles permission issue

Our docker dev files were updated last week, that ended up creating a permission issue. The tests that uses these files did not catch this error in the original PR's CI, because our CI doesn't trigger on changes to these dockerfiles. I have changed that as well. The missing part of our CI will now run on the changes to the `docker/` files.

## Fixing the failing `gcp` orchestrator tests due to the new `kfp` release

Last week, Kubeflow Pipelines SDK released [a new version 2.12](https://github.com/kubeflow/pipelines/releases/tag/sdk-2.12.0). With this version, they included some changes that changed the way [they handled resource configurations](https://github.com/kubeflow/pipelines/pull/11501/files).

In the earlier versions, when we compiled a pipeline with `kfp`, the resulting pipeline json had duplicated values in its deployment spec:

```json
{
  "deploymentSpec": {
    "executors": {
      "exec-unit-test": {
        "container": {
          "image": "hello-world",
          "resources": {
            "accelerator": {
              "count": "1",
              "resourceCount": "1",
              "resourceType": "NVIDIA_TESLA_K80",
              "type": "NVIDIA_TESLA_K80"
            },
            "cpuLimit": 1.0,
            "memoryLimit": 1.0,
            "resourceCpuLimit": "1.0",
            "resourceMemoryLimit": "1G"
          }
        }
      }
    }
  },
}
```

With their latest changes, the duplicated values are now removed. Since we were checking these values in our tests, I have adjusted our tests. 

Also, since we do not limit the `kfp` version, we might run into another dependency issue in the future which might force us to run `kfp<2.12.0` again in the future. That's why I adjusted the test not to compare the dicts directly but to check whether the expected values are placed correctly. This way the tests are adaptable to both `kfp>=2.12` and `kfp<2.12`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

