### PR TITLE
bugfix: correctly parse and match Gitlab URLs

### DIFF
--- a/src/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py
+++ b/src/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py
@@ -16,6 +16,7 @@
 import os
 import re
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from gitlab import Gitlab
@@ -175,8 +176,13 @@ class GitLabCodeRepository(BaseCodeRepository):
         Returns:
             Whether the remote url is correct.
         """
-        https_url = f"https://{self.config.host}/{self.config.group}/{self.config.project}.git"
-        if url == https_url:
+        parsed_url = urlparse(url)
+        if (
+            parsed_url.scheme == "https"
+            and parsed_url.hostname == self.config.host
+            and parsed_url.path
+            == f"/{self.config.group}/{self.config.project}.git"
+        ):
             return True
 
         ssh_regex = re.compile(

--- a/tests/integration/integrations/gitlab/code_repositories/test_gitlab_code_repository.py
+++ b/tests/integration/integrations/gitlab/code_repositories/test_gitlab_code_repository.py
@@ -77,6 +77,16 @@ class DummyGitLabCodeRepository(GitLabCodeRepository):
             "https://private-gitlab.example.com/example/test.invalid",
             False,
         ),
+        (
+            CONFIG_II,
+            "https://gitlab-ci-token:[MASKED]@private-gitlab.example.com/example/test.git",
+            True,
+        ),
+        (
+            CONFIG_II,
+            "https://gitlab-ci-token:[MASKED]@private-gitlab.example.com/example/test.invalid",
+            False,
+        ),
     ],
 )
 def test_check_remote_url(


### PR DESCRIPTION
## Describe changes
I fixed the way Gitlab URLs are matched with existing repository URLs. Gitlab, when checking out the repository for building, uses basic auth with a username and a token to clone.

## Pre-requisites
Please ensure you have done the following:
- [ x] I have read the **CONTRIBUTING.md** document.
- [ x] I have added tests to cover my changes.
- [ x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

