### PR TITLE
bugfix: pass iterator to gitlab

### DIFF
--- a/src/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py
+++ b/src/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py
@@ -128,6 +128,7 @@ class GitLabCodeRepository(BaseCodeRepository):
         contents = self.gitlab_project.repository_tree(
             ref=commit,
             path=repo_sub_directory or "",
+            iterator=True
         )
         for content in contents:
             logger.debug(f"Processing {content['path']}")


### PR DESCRIPTION
## Describe changes
I fixed the Gitlab integration to download all files if there are more than 20. Currently, the default call is done to `gitlab_project.repository_tree` which in turn calls the `http_list` with no pagination arguments (be it get_all, page or iterator) thus defaulting to 20 files being returned.

There is this warning when using Gitlab to download a repository which contains packages with more than 20 files.
```
/opt/venv/lib/python3.12/site-packages/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py:128: UserWarning: Calling a list() method without specifying get_all=True or iterator=True will return a maximum of 20 items. Your query returned 20 of 22 items. See https://python-gitlab.readthedocs.io/en/v5.6.0/api-usage.html#pagination for more details. If this was done intentionally, then this warning can be supressed by adding the argument get_all=False to the list() call. (python-gitlab: /opt/venv/lib/python3.12/site-packages/zenml/integrations/gitlab/code_repositories/gitlab_code_repository.py:128)
```
I was unable to test the fix as I can't seem to get this version installed and running in the pods. Repo that reproduces this https://gitlab.com/dragos.mc/zenml-gitlab/-/tree/main?ref_type=heads

## Pre-requisites
Please ensure you have done the following:
- [ x] I have read the **CONTRIBUTING.md** document.
- [ x] I have added tests to cover my changes.
- [ x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

