### PR TITLE
Allow the service account project ID to be overriden in the GCP service connector

### DIFF
--- a/docs/book/how-to/infrastructure-deployment/auth-management/gcp-service-connector.md
+++ b/docs/book/how-to/infrastructure-deployment/auth-management/gcp-service-connector.md
@@ -375,7 +375,7 @@ This method requires [a GCP service account](https://cloud.google.com/iam/docs/s
 
 By default, the GCP connector [generates temporary OAuth 2.0 tokens](best-security-practices.md#generating-temporary-and-down-scoped-credentials) from the service account credentials and distributes them to clients. The tokens have a limited lifetime of 1 hour. This behavior can be disabled by setting the `generate_temporary_tokens` configuration option to `False`, in which case, the connector will distribute the service account credentials JSON to clients instead (not recommended).
 
-A GCP project is required and the connector may only be used to access GCP resources in the specified project.
+A GCP project is required and the connector may only be used to access GCP resources in the specified project. If the `project_id` is not provided, the connector will use the one extracted from the service account key JSON.
 
 If you already have the `GOOGLE_APPLICATION_CREDENTIALS` environment variable configured to point to a service account key JSON file, it will be automatically picked up when auto-configuration is used.
 

--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -438,7 +438,7 @@ class GCPUserAccountConfig(GCPBaseProjectIDConfig, GCPUserAccountCredentials):
 class GCPServiceAccountConfig(GCPBaseConfig, GCPServiceAccountCredentials):
     """GCP service account configuration."""
 
-    _project_id: Optional[str] = None
+    project_id: Optional[str] = None
 
     @property
     def gcp_project_id(self) -> str:
@@ -450,14 +450,14 @@ class GCPServiceAccountConfig(GCPBaseConfig, GCPServiceAccountCredentials):
         Returns:
             The GCP project ID.
         """
-        if self._project_id is None:
-            self._project_id = json.loads(
+        if self.project_id is None:
+            self.project_id = json.loads(
                 self.service_account_json.get_secret_value()
             )["project_id"]
             # Guaranteed by the field validator
-            assert self._project_id is not None
+            assert self.project_id is not None
 
-        return self._project_id
+        return self.project_id
 
 
 class GCPExternalAccountConfig(
@@ -798,7 +798,8 @@ connector will distribute the service account credentials JSON to clients
 instead (not recommended).
 
 A GCP project is required and the connector may only be used to access GCP
-resources in the specified project.
+resources in the specified project. If the `project_id` is not provided, the
+connector will use the one extracted from the service account key JSON.
 
 If you already have the GOOGLE_APPLICATION_CREDENTIALS environment variable
 configured to point to a service account key JSON file, it will be automatically


### PR DESCRIPTION
## Describe changes
For GCP service connectors authenticated via service accounts, the GCP project ID is currently taken from the service account key JSON. This doesn't allow the user to configure cross-project authentication.

With his PR, we re-introduce the `project_id` as an optional attribute that can be use to override the value taken from the service account key JSON.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

