### PR TITLE
Allow passing step artifacts to specify upstream steps

### DIFF
--- a/docs/book/how-to/pipeline-development/build-pipelines/control-execution-order-of-steps.md
+++ b/docs/book/how-to/pipeline-development/build-pipelines/control-execution-order-of-steps.md
@@ -31,6 +31,18 @@ def example_pipeline():
 ```
 
 This pipeline is similar to the one explained above, but this time ZenML will make sure to only start `step_1` after `step_2` has finished.
+
+For convenience you can also pass the output artifacts of a step so you don't have to manually write the step names:
+```python
+from zenml import pipeline
+
+@pipeline
+def example_pipeline():
+    step_2_output = step_2()
+    step_1_output = step_1(after=step_2_output)
+    step_3(step_1_output, step_2_output)
+```
+
 <!-- For scarf -->
 <figure><img alt="ZenML Scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" /></figure>
 

--- a/docs/book/how-to/pipeline-development/build-pipelines/fan-in-fan-out.md
+++ b/docs/book/how-to/pipeline-development/build-pipelines/fan-in-fan-out.md
@@ -45,8 +45,8 @@ def fan_out_fan_in_pipeline(parallel_count: int) -> None:
     # Fan out: Process data in parallel branches
     after = []
     for i in range(parallel_count):
-        _ = process_step(input_data, id=f"process_{i}")
-        after.append(f"process_{i}")
+        artifact = process_step(input_data, id=f"process_{i}")
+        after.append(artifact)
 
     # Fan in: Combine results from all parallel branches
     combine_step(step_prefix="process_", output_name="output", after=after)

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -1233,7 +1233,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             return id_
 
         if not allow_suffix:
-            raise RuntimeError("Duplicate step ID")
+            raise RuntimeError(f"Duplicate step ID `{id_}`")
 
         for index in range(2, 10000):
             id_ = f"{base_id}_{index}"

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -432,7 +432,9 @@ class BaseStep:
         self,
         *args: Any,
         id: Optional[str] = None,
-        after: Union[str, Sequence[str], None] = None,
+        after: Union[
+            str, StepArtifact, Sequence[Union[str, StepArtifact]], None
+        ] = None,
         **kwargs: Any,
     ) -> Any:
         """Handle a call of the step.
@@ -497,8 +499,14 @@ class BaseStep:
         }
         if isinstance(after, str):
             upstream_steps.add(after)
+        elif isinstance(after, StepArtifact):
+            upstream_steps.add(after.invocation_id)
         elif isinstance(after, Sequence):
-            upstream_steps = upstream_steps.union(after)
+            for item in after:
+                if isinstance(item, str):
+                    upstream_steps.add(item)
+                elif isinstance(item, StepArtifact):
+                    upstream_steps.add(item.invocation_id)
 
         invocation_id = Pipeline.ACTIVE_PIPELINE.add_step_invocation(
             step=self,

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -503,6 +503,22 @@ def test_upstream_step_computation():
     }
 
 
+def test_upstream_step_computation_from_step_artifact():
+    """Tests that step upstream works with step artifacts."""
+
+    @pipeline
+    def p():
+        a = upstream_test_step_1()
+        upstream_test_step_2(after=a)
+
+    p.prepare()
+
+    assert not p._invocations["upstream_test_step_1"].upstream_steps
+    assert p._invocations["upstream_test_step_2"].upstream_steps == {
+        "upstream_test_step_1",
+    }
+
+
 @step
 def step_with_two_letter_string_output() -> Tuple[
     Annotated[str, "a"], Annotated[str, "b"]


### PR DESCRIPTION
## Describe changes
This PR enables passing `StepArtifact` objects to specify upstream steps during pipeline compilation.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

