### PR TITLE
Allow setting environment variables through `KubernetesPodSettings`

### DIFF
--- a/docs/book/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/component-guide/orchestrators/kubernetes.md
@@ -129,9 +129,9 @@ The Kubernetes orchestrator will by default use a Kubernetes namespace called `z
 
 For additional configuration of the Kubernetes orchestrator, you can pass `KubernetesOrchestratorSettings` which allows you to configure (among others) the following attributes:
 
-* `pod_settings`: Node selectors, labels, affinity, and tolerations, and image pull secrets to apply to the Kubernetes Pods running the steps of your pipeline. These can be either specified using the Kubernetes model objects or as dictionaries.
+* `pod_settings`: Node selectors, labels, affinity, and tolerations, secrets, environment variables and image pull secrets to apply to the Kubernetes Pods running the steps of your pipeline. These can be either specified using the Kubernetes model objects or as dictionaries.
 
-* `orchestrator_pod_settings`:  Node selectors, labels, affinity, and tolerations, and image pull secrets to apply to the Kubernetes Pod that is responsible for orchestrating the pipeline and starting the other Pods. These can be either specified using the Kubernetes model objects or as dictionaries.
+* `orchestrator_pod_settings`:  Node selectors, labels, affinity, tolerations, secrets, environment variables and image pull secrets to apply to the Kubernetes Pod that is responsible for orchestrating the pipeline and starting the other Pods. These can be either specified using the Kubernetes model objects or as dictionaries.
 
 ```python
 from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import KubernetesOrchestratorSettings
@@ -212,6 +212,19 @@ kubernetes_settings = KubernetesOrchestratorSettings(
                 "name": "config-volume",
                 "mountPath": "/etc/ml-config",
                 "readOnly": True
+            }
+        ],
+        "env": [
+            {
+                "name": "MY_ENVIRONMENT_VARIABLE",
+                "value": "1",
+            }
+        ],
+        "env_from": [
+            {
+                "secretRef": {
+                    "name": "secret-name",
+                }
             }
         ],
         "host_ipc": True,

--- a/docs/book/component-guide/step-operators/kubernetes.md
+++ b/docs/book/component-guide/step-operators/kubernetes.md
@@ -114,7 +114,7 @@ kubectl delete pod -n zenml -l pipeline=kubernetes_example_pipeline
 
 For additional configuration of the Kubernetes step operator, you can pass `KubernetesStepOperatorSettings` which allows you to configure (among others) the following attributes:
 
-* `pod_settings`: Node selectors, labels, affinity, and tolerations, and image pull secrets to apply to the Kubernetes Pods. These can be either specified using the Kubernetes model objects or as dictionaries.
+* `pod_settings`: Node selectors, labels, affinity, tolerations, secrets, environment variables and image pull secrets to apply to the Kubernetes Pods. These can be either specified using the Kubernetes model objects or as dictionaries.
 * `service_account_name`: The name of the service account to use for the Kubernetes Pods.
 
 ```python
@@ -196,6 +196,19 @@ kubernetes_settings = KubernetesStepOperatorSettings(
                 "name": "config-volume",
                 "mountPath": "/etc/ml-config",
                 "readOnly": True
+            }
+        ],
+        "env": [
+            {
+                "name": "MY_ENVIRONMENT_VARIABLE",
+                "value": "1",
+            }
+        ],
+        "env_from": [
+            {
+                "secretRef": {
+                    "name": "secret-name",
+                }
             }
         ],
         "host_ipc": True,

--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -476,6 +476,11 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
                             "Volume mounts are set but not supported in "
                             "Vertex with Kubeflow Pipelines 2.x. Ignoring..."
                         )
+                    if pod_settings.env or pod_settings.env_from:
+                        logger.warning(
+                            "Environment variables are set but not supported "
+                            "in Vertex with Vertex Pipelines 2.x. Ignoring..."
+                        )
                     for key in pod_settings.node_selectors:
                         if (
                             key

--- a/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
+++ b/src/zenml/integrations/kubeflow/orchestrators/kubeflow_orchestrator.py
@@ -578,6 +578,12 @@ class KubeflowOrchestrator(ContainerizedOrchestrator):
                             "Volume mounts are set but not supported in "
                             "Kubeflow with Kubeflow Pipelines 2.x. Ignoring..."
                         )
+                    if pod_settings.env or pod_settings.env_from:
+                        logger.warning(
+                            "Environment variables are set but not supported "
+                            "in Kubeflow with Kubeflow Pipelines 2.x. "
+                            "Ignoring..."
+                        )
 
                     # apply pod settings
                     if (

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -222,6 +222,18 @@ def add_pod_settings(
             else:
                 container.volume_mounts = settings.volume_mounts
 
+        if settings.env:
+            if container.env:
+                container.env.extend(settings.env)
+            else:
+                container.env = settings.env
+
+        if settings.env_from:
+            if container.env_from:
+                container.env_from.extend(settings.env_from)
+            else:
+                container.env_from = settings.env_from
+
     if settings.volumes:
         if pod_spec.volumes:
             pod_spec.volumes.extend(settings.volumes)

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -35,6 +35,8 @@ class KubernetesPodSettings(BaseSettings):
         host_ipc: Whether to enable host IPC for the pod.
         image_pull_secrets: Image pull secrets to use for the pod.
         labels: Labels to apply to the pod.
+        env: Environment variables to apply to the container.
+        env_from: Environment variables to apply to the container.
     """
 
     node_selectors: Dict[str, str] = {}
@@ -47,6 +49,8 @@ class KubernetesPodSettings(BaseSettings):
     host_ipc: bool = False
     image_pull_secrets: List[str] = []
     labels: Dict[str, str] = {}
+    env: List[Dict[str, Any]] = []
+    env_from: List[Dict[str, Any]] = []
 
     @field_validator("volumes", mode="before")
     @classmethod
@@ -155,3 +159,51 @@ class KubernetesPodSettings(BaseSettings):
             return serialization_utils.serialize_kubernetes_model(value)
         else:
             return value
+
+    @field_validator("env", mode="before")
+    @classmethod
+    def _convert_env(cls, value: Any) -> Any:
+        """Converts Kubernetes EnvVar to a dict.
+
+        Args:
+            value: The env value.
+
+        Returns:
+            The converted value.
+        """
+        from kubernetes.client.models import V1EnvVar
+
+        result = []
+        for element in value:
+            if isinstance(element, V1EnvVar):
+                result.append(
+                    serialization_utils.serialize_kubernetes_model(element)
+                )
+            else:
+                result.append(element)
+
+        return result
+
+    @field_validator("env_from", mode="before")
+    @classmethod
+    def _convert_env_from(cls, value: Any) -> Any:
+        """Converts Kubernetes EnvFromSource to a dict.
+
+        Args:
+            value: The env from value.
+
+        Returns:
+            The converted value.
+        """
+        from kubernetes.client.models import V1EnvFromSource
+
+        result = []
+        for element in value:
+            if isinstance(element, V1EnvFromSource):
+                result.append(
+                    serialization_utils.serialize_kubernetes_model(element)
+                )
+            else:
+                result.append(element)
+
+        return result

--- a/src/zenml/integrations/tekton/orchestrators/tekton_orchestrator.py
+++ b/src/zenml/integrations/tekton/orchestrators/tekton_orchestrator.py
@@ -547,6 +547,11 @@ class TektonOrchestrator(ContainerizedOrchestrator):
                             "Volume mounts are set but not supported in "
                             "Tekton with Tekton Pipelines 2.x. Ignoring..."
                         )
+                    if pod_settings.env or pod_settings.env_from:
+                        logger.warning(
+                            "Environment variables are set but not supported "
+                            "in Tekton with Tekton Pipelines 2.x. Ignoring..."
+                        )
                     # apply pod settings
                     if (
                         KFP_ACCELERATOR_NODE_SELECTOR_CONSTRAINT_LABEL


### PR DESCRIPTION
## Describe changes
This PR enables setting environment variables for the `KubernetesOrchestrator` either directly or through secret/config map references.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

