### PR TITLE
Fix project statistics endpoint

### DIFF
--- a/src/zenml/zen_server/routers/projects_endpoints.py
+++ b/src/zenml/zen_server/routers/projects_endpoints.py
@@ -268,13 +268,17 @@ def get_project_statistics(
     run_filter = PipelineRunFilter(project=project.id)
     run_filter.configure_rbac(
         authenticated_user_id=user_id,
-        id=get_allowed_resource_ids(resource_type=ResourceType.PIPELINE_RUN),
+        id=get_allowed_resource_ids(
+            resource_type=ResourceType.PIPELINE_RUN, project_id=project.id
+        ),
     )
 
     pipeline_filter = PipelineFilter(project=project.id)
     pipeline_filter.configure_rbac(
         authenticated_user_id=user_id,
-        id=get_allowed_resource_ids(resource_type=ResourceType.PIPELINE),
+        id=get_allowed_resource_ids(
+            resource_type=ResourceType.PIPELINE, project_id=project.id
+        ),
     )
 
     return ProjectStatistics(


### PR DESCRIPTION
## Describe changes
The `project_id` wasn't being passed to RBAC resources when using the project statistics endpoint.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

