### PR TITLE
Pass API token as kubernetes secret

### DIFF
--- a/docs/book/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/component-guide/orchestrators/kubernetes.md
@@ -40,7 +40,6 @@ To use the Kubernetes orchestrator, we need:
     zenml integration install kubernetes
     ```
 * [Docker](https://www.docker.com) installed and running.
-* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed.
 * A [remote artifact store](../artifact-stores/artifact-stores.md) as part of your stack.
 * A [remote container registry](../container-registries/container-registries.md) as part of your stack.
 * A Kubernetes cluster [deployed](kubernetes.md#how-to-deploy-it)
@@ -126,6 +125,7 @@ The Kubernetes orchestrator will by default use a Kubernetes namespace called `z
 
 * `kubernetes_namespace`: The Kubernetes namespace to use for running the pipelines. The namespace must already exist in the Kubernetes cluster.
 * `service_account_name`: The name of a Kubernetes service account to use for running the pipelines. If configured, it must point to an existing service account in the default or configured `namespace` that has associated RBAC roles granting permissions to create and manage pods in that namespace. This can also be configured as an individual pipeline setting in addition to the global orchestrator setting.
+* `pass_zenml_token_as_secret`: By default, the Kubernetes orchestrator will pass a short-lived API token to authenticate to the ZenML server as an environment variable as part of the Pod manifest. If you want this token to be stored in a Kubernetes secret instead, set `pass_zenml_token_as_secret=True` when registering your orchestrator. If you do so, make sure the service connector that you configure for your has permissions to create Kubernetes secrets. Additionally, the service account used for the Pods running your pipeline must have permissions to delete secrets, otherwise the cleanup will fail and you'll be left with orphaned secrets.
 
 For additional configuration of the Kubernetes orchestrator, you can pass `KubernetesOrchestratorSettings` which allows you to configure (among others) the following attributes:
 

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_orchestrator_flavor.py
@@ -85,6 +85,9 @@ class KubernetesOrchestratorConfig(
         parallel_step_startup_waiting_period: How long to wait in between
             starting parallel steps. This can be used to distribute server
             load when running pipelines with a huge amount of parallel steps.
+        pass_zenml_token_as_secret: If `True`, the ZenML token will be passed
+            as a Kubernetes secret to the pods. For this to work, the Kubernetes
+            client must have permissions to create secrets in the namespace.
     """
 
     incluster: bool = False
@@ -93,6 +96,7 @@ class KubernetesOrchestratorConfig(
     local: bool = False
     skip_local_validations: bool = False
     parallel_step_startup_waiting_period: Optional[float] = None
+    pass_zenml_token_as_secret: bool = False
 
     @property
     def is_remote(self) -> bool:

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -430,6 +430,10 @@ def create_or_update_secret(
         secret_name: The name of the secret to create or update.
         data: The secret data. If the value is None, the key will be removed
             from the secret.
+
+    Raises:
+        ApiException: If the secret creation failed for any reason other than
+            the secret already existing.
     """
     try:
         create_secret(core_api, namespace, secret_name, data)

--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -34,7 +34,7 @@ Adjusted from https://github.com/tensorflow/tfx/blob/master/tfx/utils/kube_utils
 import enum
 import re
 import time
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, Optional, TypeVar, cast
 
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
@@ -43,6 +43,7 @@ from kubernetes.client.rest import ApiException
 from zenml.integrations.kubernetes.orchestrators.manifest_utils import (
     build_namespace_manifest,
     build_role_binding_manifest_for_service_account,
+    build_secret_manifest,
     build_service_account_manifest,
 )
 from zenml.logger import get_logger
@@ -371,3 +372,23 @@ def create_namespace(core_api: k8s_client.CoreV1Api, namespace: str) -> None:
     """
     manifest = build_namespace_manifest(namespace)
     _if_not_exists(core_api.create_namespace)(body=manifest)
+
+
+def create_secret(
+    core_api: k8s_client.CoreV1Api,
+    namespace: str,
+    secret_name: str,
+    data: Dict[str, str],
+) -> None:
+    """Create a Kubernetes secret.
+
+    Args:
+        core_api: Client of Core V1 API of Kubernetes API.
+        namespace: The namespace in which to create the secret.
+        secret_name: The name of the secret to create.
+        data: The secret data.
+    """
+    core_api.create_namespaced_secret(
+        namespace=namespace,
+        body=build_secret_manifest(name=secret_name, data=data),
+    )

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -373,6 +373,9 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
     def get_token_secret_name(self, deployment_id: UUID) -> str:
         """Returns the name of the secret that contains the ZenML token.
 
+        Args:
+            deployment_id: The ID of the deployment.
+
         Returns:
             The name of the secret that contains the ZenML token.
         """

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -439,6 +439,36 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
         # Authorize pod to run Kubernetes commands inside the cluster.
         service_account_name = self._get_service_account_name(settings)
 
+        # We set some default minimum resource requests for the orchestrator pod
+        # here if the user has not specified any, because the orchestrator pod
+        # takes up some memory resources itself and, if not specified, the pod
+        # will be scheduled on any node regardless of available memory and risk
+        # negatively impacting or even crashing the node due to memory pressure.
+        orchestrator_pod_settings = self.apply_default_resource_requests(
+            memory="400Mi",
+            cpu="100m",
+            pod_settings=settings.orchestrator_pod_settings,
+        )
+
+        if self.config.pass_zenml_token_as_secret:
+            secret_name = pod_name
+            token = environment.pop("ZENML_STORE_API_TOKEN")
+
+            kube_utils.create_secret(
+                core_api=self._k8s_core_api,
+                namespace=self.config.kubernetes_namespace,
+                secret_name=secret_name,
+                data={"ZENML_STORE_API_TOKEN": token},
+            )
+
+            orchestrator_pod_settings.env_from.append(
+                {
+                    "secretRef": {
+                        "name": secret_name,
+                    },
+                }
+            )
+
         # Schedule as CRON job if CRON schedule is given.
         if deployment.schedule:
             if not deployment.schedule.cron_expression:
@@ -458,7 +488,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 args=args,
                 service_account_name=service_account_name,
                 privileged=False,
-                pod_settings=settings.orchestrator_pod_settings,
+                pod_settings=orchestrator_pod_settings,
                 env=environment,
                 mount_local_stores=self.config.is_local,
             )
@@ -472,56 +502,45 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 f'`"{cron_expression}"`.'
             )
             return
-
-        # We set some default minimum resource requests for the orchestrator pod
-        # here if the user has not specified any, because the orchestrator pod
-        # takes up some memory resources itself and, if not specified, the pod
-        # will be scheduled on any node regardless of available memory and risk
-        # negatively impacting or even crashing the node due to memory pressure.
-        orchestrator_pod_settings = self.apply_default_resource_requests(
-            memory="400Mi",
-            cpu="100m",
-            pod_settings=settings.orchestrator_pod_settings,
-        )
-
-        # Create and run the orchestrator pod.
-        pod_manifest = build_pod_manifest(
-            run_name=orchestrator_run_name,
-            pod_name=pod_name,
-            pipeline_name=pipeline_name,
-            image_name=image,
-            command=command,
-            args=args,
-            privileged=False,
-            pod_settings=orchestrator_pod_settings,
-            service_account_name=service_account_name,
-            env=environment,
-            mount_local_stores=self.config.is_local,
-        )
-
-        self._k8s_core_api.create_namespaced_pod(
-            namespace=self.config.kubernetes_namespace,
-            body=pod_manifest,
-        )
-
-        # Wait for the orchestrator pod to finish and stream logs.
-        if settings.synchronous:
-            logger.info("Waiting for Kubernetes orchestrator pod...")
-            kube_utils.wait_pod(
-                kube_client_fn=self.get_kube_client,
-                pod_name=pod_name,
-                namespace=self.config.kubernetes_namespace,
-                exit_condition_lambda=kube_utils.pod_is_done,
-                timeout_sec=settings.timeout,
-                stream_logs=True,
-            )
         else:
-            logger.info(
-                f"Orchestration started asynchronously in pod "
-                f"`{self.config.kubernetes_namespace}:{pod_name}`. "
-                f"Run the following command to inspect the logs: "
-                f"`kubectl logs {pod_name} -n {self.config.kubernetes_namespace}`."
+            # Create and run the orchestrator pod.
+            pod_manifest = build_pod_manifest(
+                run_name=orchestrator_run_name,
+                pod_name=pod_name,
+                pipeline_name=pipeline_name,
+                image_name=image,
+                command=command,
+                args=args,
+                privileged=False,
+                pod_settings=orchestrator_pod_settings,
+                service_account_name=service_account_name,
+                env=environment,
+                mount_local_stores=self.config.is_local,
             )
+
+            self._k8s_core_api.create_namespaced_pod(
+                namespace=self.config.kubernetes_namespace,
+                body=pod_manifest,
+            )
+
+            # Wait for the orchestrator pod to finish and stream logs.
+            if settings.synchronous:
+                logger.info("Waiting for Kubernetes orchestrator pod...")
+                kube_utils.wait_pod(
+                    kube_client_fn=self.get_kube_client,
+                    pod_name=pod_name,
+                    namespace=self.config.kubernetes_namespace,
+                    exit_condition_lambda=kube_utils.pod_is_done,
+                    timeout_sec=settings.timeout,
+                    stream_logs=True,
+                )
+            else:
+                logger.info(
+                    f"Orchestration started asynchronously in pod "
+                    f"`{self.config.kubernetes_namespace}:{pod_name}`. "
+                    f"Run the following command to inspect the logs: "
+                    f"`kubectl logs {pod_name} -n {self.config.kubernetes_namespace}`."
+                )
 
     def _get_service_account_name(
         self, settings: KubernetesOrchestratorSettings

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -130,11 +130,17 @@ def main() -> None:
 
         if orchestrator.config.pass_zenml_token_as_secret:
             env.pop("ZENML_STORE_API_TOKEN")
-            secret_name = orchestrator_run_id
-            pod_settings.env_from.append(
+            secret_name = orchestrator.get_token_secret_name(
+                deployment_config.id
+            )
+            pod_settings.env.append(
                 {
-                    "secretRef": {
-                        "name": secret_name,
+                    "name": "ZENML_STORE_API_TOKEN",
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": secret_name,
+                            "key": "token",
+                        }
                     },
                 }
             )

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -128,6 +128,17 @@ def main() -> None:
             pod_settings=settings.pod_settings,
         )
 
+        if orchestrator.config.pass_zenml_token_as_secret:
+            env.pop("ZENML_STORE_API_TOKEN")
+            secret_name = orchestrator_run_id
+            pod_settings.env_from.append(
+                {
+                    "secretRef": {
+                        "name": secret_name,
+                    },
+                }
+            )
+
         # Define Kubernetes pod manifest.
         pod_manifest = build_pod_manifest(
             pod_name=pod_name,

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -83,6 +83,9 @@ def main() -> None:
     kube_client = orchestrator.get_kube_client(incluster=True)
     core_api = k8s_client.CoreV1Api(kube_client)
 
+    env = get_config_environment_vars()
+    env[ENV_ZENML_KUBERNETES_RUN_ID] = orchestrator_run_id
+    
     def run_step_on_kubernetes(step_name: str) -> None:
         """Run a pipeline step in a separate Kubernetes pod.
 
@@ -116,9 +119,6 @@ def main() -> None:
             orchestrator_settings
         )
 
-        env = get_config_environment_vars()
-        env[ENV_ZENML_KUBERNETES_RUN_ID] = orchestrator_run_id
-
         # We set some default minimum memory resource requests for the step pod
         # here if the user has not specified any, because the step pod takes up
         # some memory resources itself and, if not specified, the pod will be
@@ -130,7 +130,7 @@ def main() -> None:
         )
 
         if orchestrator.config.pass_zenml_token_as_secret:
-            env.pop("ZENML_STORE_API_TOKEN")
+            env.pop("ZENML_STORE_API_TOKEN", None)
             secret_name = orchestrator.get_token_secret_name(
                 deployment_config.id
             )

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -209,6 +209,5 @@ def main() -> None:
                 logger.error(f"Error cleaning up secret {secret_name}: {e}")
 
 
-
 if __name__ == "__main__":
     main()

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -85,7 +85,7 @@ def main() -> None:
 
     env = get_config_environment_vars()
     env[ENV_ZENML_KUBERNETES_RUN_ID] = orchestrator_run_id
-    
+
     def run_step_on_kubernetes(step_name: str) -> None:
         """Run a pipeline step in a separate Kubernetes pod.
 

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Utility functions for building manifests for k8s pods."""
 
+import base64
 import os
 import sys
 from typing import Any, Dict, List, Optional
@@ -389,4 +390,35 @@ def build_namespace_manifest(namespace: str) -> Dict[str, Any]:
         "metadata": {
             "name": namespace,
         },
+    }
+
+
+def build_secret_manifest(
+    name: str,
+    data: Dict[str, str],
+    secret_type: str = "Opaque",
+) -> Dict[str, Any]:
+    """Builds a Kubernetes secret manifest.
+
+    Args:
+        name: Name of the secret.
+        data: The secret data.
+        secret_type: The secret type.
+
+    Returns:
+        The secret manifest.
+    """
+    encoded_data = {
+        key: base64.b64encode(value.encode()).decode()
+        for key, value in data.items()
+    }
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": name,
+        },
+        "type": secret_type,
+        "data": encoded_data,
     }

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -16,7 +16,7 @@
 import base64
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from kubernetes import client as k8s_client
 
@@ -395,7 +395,7 @@ def build_namespace_manifest(namespace: str) -> Dict[str, Any]:
 
 def build_secret_manifest(
     name: str,
-    data: Dict[str, str],
+    data: Mapping[str, Optional[str]],
     secret_type: str = "Opaque",
 ) -> Dict[str, Any]:
     """Builds a Kubernetes secret manifest.
@@ -409,7 +409,7 @@ def build_secret_manifest(
         The secret manifest.
     """
     encoded_data = {
-        key: base64.b64encode(value.encode()).decode()
+        key: base64.b64encode(value.encode()).decode() if value else None
         for key, value in data.items()
     }
 


### PR DESCRIPTION
## Describe changes
Add option to pass the ZenML server API token as a Kubernetes secret instead of plain environment variable.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

