### PR TITLE
Fetch model hydrated during deletion process

### DIFF
--- a/src/zenml/zen_server/rbac/endpoint_utils.py
+++ b/src/zenml/zen_server/rbac/endpoint_utils.py
@@ -306,8 +306,7 @@ def verify_permissions_and_delete_entity(
     Returns:
         The deleted entity.
     """
-    # We don't need the hydrated version here
-    model = get_method(id, False)
+    model = get_method(id, True)
     verify_permission_for_model(model, action=Action.DELETE)
     delete_method(model.id, **delete_method_kwargs)
     delete_model_resource(model)


### PR DESCRIPTION
## Describe changes
When fetching the resource for a model that was just deleted, the hydration request necessary to fetch the project ID failed because the model did not exist in the database anymore.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

