### PR TITLE
Pin the ZenML Terraform provider version

### DIFF
--- a/infra/aws/aws-ecr-s3-sagemaker.yaml
+++ b/infra/aws/aws-ecr-s3-sagemaker.yaml
@@ -355,7 +355,7 @@ Resources:
                     send_response(event, context, 'SUCCESS', {'Message': 'Resource updated successfully'})
                     return
 
-                url = os.environ['ZENML_SERVER_URL'].lstrip('/')+'/api/v1/workspaces/default/stacks'
+                url = os.environ['ZENML_SERVER_URL'].lstrip('/')+'/api/v1/stacks'
                 api_token = os.environ['ZENML_SERVER_API_TOKEN']
                 payload = event['ResourceProperties']['Payload']
 

--- a/infra/gcp/gcp-gar-gcs-vertex-deploy.sh
+++ b/infra/gcp/gcp-gar-gcs-vertex-deploy.sh
@@ -159,7 +159,7 @@ echo
 
 set +e
 # Register the ZenML stack with the ZenML server
-curl -X POST "$ZENML_SERVER_URL/api/v1/workspaces/default/stacks" \
+curl -X POST "$ZENML_SERVER_URL/api/v1/stacks" \
     -H "Authorization: Bearer $ZENML_SERVER_API_TOKEN" \
     -H "Content-Type: application/json" \
     -d "$zenml_stack_json"

--- a/src/zenml/stack_deployments/aws_stack_deployment.py
+++ b/src/zenml/stack_deployments/aws_stack_deployment.py
@@ -18,7 +18,8 @@ from typing import ClassVar, Dict, List, Optional
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
 from zenml.stack_deployments.constants import (
-    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+    TERRAFORM_AWS_MODULE_VERSION_SPEC,
+    TERRAFORM_PROVIDER_VERSION_SPEC,
 )
 from zenml.stack_deployments.stack_deployment import (
     STACK_DEPLOYMENT_TERRAFORM,
@@ -206,10 +207,6 @@ console.
         # Based on the AWS regions listed at
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
         return {
-            "US East (Ohio)": "us-east-2",
-            "US East (N. Virginia)": "us-east-1",
-            "US West (N. California)": "us-west-1",
-            "US West (Oregon)": "us-west-2",
             "Africa (Cape Town)": "af-south-1",
             "Asia Pacific (Hong Kong)": "ap-east-1",
             "Asia Pacific (Hyderabad)": "ap-south-2",
@@ -235,6 +232,10 @@ console.
             "Middle East (Bahrain)": "me-south-1",
             "Middle East (UAE)": "me-central-1",
             "South America (São Paulo)": "sa-east-1",
+            "US East (Ohio)": "us-east-2",
+            "US East (N. Virginia)": "us-east-1",
+            "US West (N. California)": "us-west-1",
+            "US West (Oregon)": "us-west-2",
         }
 
     def get_deployment_config(
@@ -290,7 +291,7 @@ console.
         }}
         zenml = {{
             source = "zenml-io/zenml"
-            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
+            version = "{TERRAFORM_PROVIDER_VERSION_SPEC}"
         }}
     }}
 }}
@@ -306,7 +307,7 @@ provider "zenml" {{
 
 module "zenml_stack" {{
     source  = "zenml-io/zenml-stack/aws"
-
+    version = "{TERRAFORM_AWS_MODULE_VERSION_SPEC}"
     zenml_stack_name = "{self.stack_name}"
     zenml_stack_deployment = "{self.deployment_type}"
 }}

--- a/src/zenml/stack_deployments/aws_stack_deployment.py
+++ b/src/zenml/stack_deployments/aws_stack_deployment.py
@@ -17,6 +17,9 @@ from typing import ClassVar, Dict, List, Optional
 
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
+from zenml.stack_deployments.constants import (
+    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+)
 from zenml.stack_deployments.stack_deployment import (
     STACK_DEPLOYMENT_TERRAFORM,
     ZenMLCloudStackDeployment,
@@ -287,6 +290,7 @@ console.
         }}
         zenml = {{
             source = "zenml-io/zenml"
+            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
         }}
     }}
 }}

--- a/src/zenml/stack_deployments/azure_stack_deployment.py
+++ b/src/zenml/stack_deployments/azure_stack_deployment.py
@@ -19,7 +19,8 @@ from typing import ClassVar, Dict, List
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
 from zenml.stack_deployments.constants import (
-    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+    TERRAFORM_AZURE_MODULE_VERSION_SPEC,
+    TERRAFORM_PROVIDER_VERSION_SPEC,
 )
 from zenml.stack_deployments.stack_deployment import ZenMLCloudStackDeployment
 
@@ -159,70 +160,70 @@ ZenML's access to your Azure subscription.
         """
         # Based on `az account list-locations -o table` on 16.07.2024
         return {
-            "(US) East US": "eastus",
-            "(US) South Central US": "southcentralus",
-            "(US) West US 2": "westus2",
-            "(US) West US 3": "westus3",
-            "(Asia Pacific) Australia East": "australiaeast",
-            "(Asia Pacific) Southeast Asia": "southeastasia",
-            "(Europe) North Europe": "northeurope",
-            "(Europe) Sweden Central": "swedencentral",
-            "(Europe) UK South": "uksouth",
-            "(Europe) West Europe": "westeurope",
-            "(US) Central US": "centralus",
             "(Africa) South Africa North": "southafricanorth",
-            "(Asia Pacific) Central India": "centralindia",
-            "(Asia Pacific) East Asia": "eastasia",
-            "(Asia Pacific) Japan East": "japaneast",
-            "(Asia Pacific) Korea Central": "koreacentral",
-            "(Canada) Canada Central": "canadacentral",
-            "(Europe) France Central": "francecentral",
-            "(Europe) Germany West Central": "germanywestcentral",
-            "(Europe) Italy North": "italynorth",
-            "(Europe) Norway East": "norwayeast",
-            "(Europe) Poland Central": "polandcentral",
-            "(Europe) Spain Central": "spaincentral",
-            "(Europe) Switzerland North": "switzerlandnorth",
-            "(Mexico) Mexico Central": "mexicocentral",
-            "(Middle East) UAE North": "uaenorth",
-            "(South America) Brazil South": "brazilsouth",
-            "(Middle East) Israel Central": "israelcentral",
-            "(Middle East) Qatar Central": "qatarcentral",
-            "(US) Central US (Stage)": "centralusstage",
-            "(US) East US (Stage)": "eastusstage",
-            "(US) East US 2 (Stage)": "eastus2stage",
-            "(US) North Central US (Stage)": "northcentralusstage",
-            "(US) South Central US (Stage)": "southcentralusstage",
-            "(US) West US (Stage)": "westusstage",
-            "(US) West US 2 (Stage)": "westus2stage",
-            "(Asia Pacific) East Asia (Stage)": "eastasiastage",
-            "(Asia Pacific) Southeast Asia (Stage)": "southeastasiastage",
-            "(South America) Brazil US": "brazilus",
-            "(US) East US 2": "eastus2",
-            "(US) East US STG": "eastusstg",
-            "(US) North Central US": "northcentralus",
-            "(US) West US": "westus",
-            "(Asia Pacific) Japan West": "japanwest",
-            "(Asia Pacific) Jio India West": "jioindiawest",
-            "(US) Central US EUAP": "centraluseuap",
-            "(US) East US 2 EUAP": "eastus2euap",
-            "(US) West Central US": "westcentralus",
             "(Africa) South Africa West": "southafricawest",
             "(Asia Pacific) Australia Central": "australiacentral",
             "(Asia Pacific) Australia Central 2": "australiacentral2",
+            "(Asia Pacific) Australia East": "australiaeast",
             "(Asia Pacific) Australia Southeast": "australiasoutheast",
+            "(Asia Pacific) Central India": "centralindia",
+            "(Asia Pacific) East Asia": "eastasia",
+            "(Asia Pacific) East Asia (Stage)": "eastasiastage",
+            "(Asia Pacific) Japan East": "japaneast",
+            "(Asia Pacific) Japan West": "japanwest",
             "(Asia Pacific) Jio India Central": "jioindiacentral",
+            "(Asia Pacific) Jio India West": "jioindiawest",
+            "(Asia Pacific) Korea Central": "koreacentral",
             "(Asia Pacific) Korea South": "koreasouth",
             "(Asia Pacific) South India": "southindia",
+            "(Asia Pacific) Southeast Asia": "southeastasia",
+            "(Asia Pacific) Southeast Asia (Stage)": "southeastasiastage",
             "(Asia Pacific) West India": "westindia",
+            "(Canada) Canada Central": "canadacentral",
             "(Canada) Canada East": "canadaeast",
+            "(Europe) France Central": "francecentral",
             "(Europe) France South": "francesouth",
             "(Europe) Germany North": "germanynorth",
+            "(Europe) Germany West Central": "germanywestcentral",
+            "(Europe) Italy North": "italynorth",
+            "(Europe) North Europe": "northeurope",
+            "(Europe) Norway East": "norwayeast",
             "(Europe) Norway West": "norwaywest",
+            "(Europe) Poland Central": "polandcentral",
+            "(Europe) Spain Central": "spaincentral",
+            "(Europe) Sweden Central": "swedencentral",
+            "(Europe) Switzerland North": "switzerlandnorth",
             "(Europe) Switzerland West": "switzerlandwest",
+            "(Europe) UK South": "uksouth",
             "(Europe) UK West": "ukwest",
+            "(Europe) West Europe": "westeurope",
+            "(Mexico) Mexico Central": "mexicocentral",
+            "(Middle East) Israel Central": "israelcentral",
+            "(Middle East) Qatar Central": "qatarcentral",
             "(Middle East) UAE Central": "uaecentral",
+            "(Middle East) UAE North": "uaenorth",
+            "(South America) Brazil South": "brazilsouth",
             "(South America) Brazil Southeast": "brazilsoutheast",
+            "(South America) Brazil US": "brazilus",
+            "(US) Central US": "centralus",
+            "(US) Central US (Stage)": "centralusstage",
+            "(US) Central US EUAP": "centraluseuap",
+            "(US) East US": "eastus",
+            "(US) East US (Stage)": "eastusstage",
+            "(US) East US 2": "eastus2",
+            "(US) East US 2 (Stage)": "eastus2stage",
+            "(US) East US 2 EUAP": "eastus2euap",
+            "(US) East US STG": "eastusstg",
+            "(US) North Central US": "northcentralus",
+            "(US) North Central US (Stage)": "northcentralusstage",
+            "(US) South Central US": "southcentralus",
+            "(US) South Central US (Stage)": "southcentralusstage",
+            "(US) West Central US": "westcentralus",
+            "(US) West US": "westus",
+            "(US) West US (Stage)": "westusstage",
+            "(US) West US 2": "westus2",
+            "(US) West US 2 (Stage)": "westus2stage",
+            "(US) West US 3": "westus3",
         }
 
     @classmethod
@@ -272,7 +273,7 @@ ZenML's access to your Azure subscription.
         }}
         zenml = {{
             source = "zenml-io/zenml"
-            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
+            version = "{TERRAFORM_PROVIDER_VERSION_SPEC}"
         }}
     }}
 }}
@@ -292,6 +293,7 @@ provider "zenml" {{
 
 module "zenml_stack" {{
     source  = "zenml-io/zenml-stack/azure"
+    version = "{TERRAFORM_AZURE_MODULE_VERSION_SPEC}"
 
     location = "{self.location or "eastus"}"
     zenml_stack_name = "{self.stack_name}"

--- a/src/zenml/stack_deployments/azure_stack_deployment.py
+++ b/src/zenml/stack_deployments/azure_stack_deployment.py
@@ -18,6 +18,9 @@ from typing import ClassVar, Dict, List
 
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
+from zenml.stack_deployments.constants import (
+    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+)
 from zenml.stack_deployments.stack_deployment import ZenMLCloudStackDeployment
 
 AZURE_DEPLOYMENT_TYPE = "azure-cloud-shell"
@@ -269,6 +272,7 @@ ZenML's access to your Azure subscription.
         }}
         zenml = {{
             source = "zenml-io/zenml"
+            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
         }}
     }}
 }}

--- a/src/zenml/stack_deployments/constants.py
+++ b/src/zenml/stack_deployments/constants.py
@@ -1,0 +1,18 @@
+#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+
+#       https://www.apache.org/licenses/LICENSE-2.0
+
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Constants for the stack deployments."""
+
+# The ZenML Terraform provider compatible versions
+# (allows 2.0.0 through 2.x.x but not 3.0.0)
+TERRAFORM_PROVIDER_VERSION_REQUIREMENTS = "~> 2.0"

--- a/src/zenml/stack_deployments/constants.py
+++ b/src/zenml/stack_deployments/constants.py
@@ -14,5 +14,17 @@
 """Constants for the stack deployments."""
 
 # The ZenML Terraform provider compatible versions
-# (allows 2.0.0 through 2.x.x but not 3.0.0)
-TERRAFORM_PROVIDER_VERSION_REQUIREMENTS = "~> 2.0"
+# (>= 2.0.0, < 3.0.0)
+TERRAFORM_PROVIDER_VERSION_SPEC = "~> 2.0"
+
+# The ZenML AWS Terraform module compatible versions
+# (>= 2.0.0, < 3.0.0)
+TERRAFORM_AWS_MODULE_VERSION_SPEC = "~> 2.0"
+
+# The ZenML GCP Terraform module compatible versions
+# (>= 2.0.0, < 3.0.0)
+TERRAFORM_GCP_MODULE_VERSION_SPEC = "~> 2.0"
+
+# The ZenML Azure Terraform module compatible versions
+# (>= 2.0.0, < 3.0.0)
+TERRAFORM_AZURE_MODULE_VERSION_SPEC = "~> 2.0"

--- a/src/zenml/stack_deployments/gcp_stack_deployment.py
+++ b/src/zenml/stack_deployments/gcp_stack_deployment.py
@@ -18,6 +18,9 @@ from typing import ClassVar, Dict, List
 
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
+from zenml.stack_deployments.constants import (
+    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+)
 from zenml.stack_deployments.stack_deployment import (
     STACK_DEPLOYMENT_TERRAFORM,
     ZenMLCloudStackDeployment,
@@ -267,6 +270,7 @@ GCP project and to clean up the resources created by the stack by using
         }}
         zenml = {{
             source = "zenml-io/zenml"
+            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
         }}
     }}
 }}

--- a/src/zenml/stack_deployments/gcp_stack_deployment.py
+++ b/src/zenml/stack_deployments/gcp_stack_deployment.py
@@ -19,7 +19,8 @@ from typing import ClassVar, Dict, List
 from zenml.enums import StackDeploymentProvider
 from zenml.models import StackDeploymentConfig
 from zenml.stack_deployments.constants import (
-    TERRAFORM_PROVIDER_VERSION_REQUIREMENTS,
+    TERRAFORM_GCP_MODULE_VERSION_SPEC,
+    TERRAFORM_PROVIDER_VERSION_SPEC,
 )
 from zenml.stack_deployments.stack_deployment import (
     STACK_DEPLOYMENT_TERRAFORM,
@@ -270,7 +271,7 @@ GCP project and to clean up the resources created by the stack by using
         }}
         zenml = {{
             source = "zenml-io/zenml"
-            version = "{TERRAFORM_PROVIDER_VERSION_REQUIREMENTS}"
+            version = "{TERRAFORM_PROVIDER_VERSION_SPEC}"
         }}
     }}
 }}
@@ -287,6 +288,7 @@ provider "zenml" {{
 
 module "zenml_stack" {{
     source  = "zenml-io/zenml-stack/gcp"
+    version = "{TERRAFORM_GCP_MODULE_VERSION_SPEC}"
 
     zenml_stack_name = "{self.stack_name}"
     zenml_stack_deployment = "{self.deployment_type}"

--- a/src/zenml/zen_server/routers/stack_deployment_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_deployment_endpoints.py
@@ -40,6 +40,7 @@ from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission
 from zenml.zen_server.utils import (
     handle_exceptions,
+    server_config,
 )
 
 router = APIRouter(
@@ -105,10 +106,17 @@ def get_stack_deployment_config(
     verify_permission(resource_type=ResourceType.STACK, action=Action.CREATE)
 
     stack_deployment_class = get_stack_deployment_class(provider)
-    # Get the base server URL used to call this FastAPI endpoint
-    url = request.url.replace(path="").replace(query="")
-    # Use HTTPS for the URL
-    url = url.replace(scheme="https")
+
+    config = server_config()
+    if config.server_url:
+        url = config.server_url
+    else:
+        # Get the base server URL used to call this FastAPI endpoint
+        url = str(
+            request.url.replace(path="")
+            .replace(query="")
+            .replace(scheme="https")
+        )
 
     token = auth_context.access_token
     assert token is not None


### PR DESCRIPTION
## Describe changes
This PR pins down the range of compatible ZenML Terraform provider versions to implement the following semantic versioning convention: every time there's a breaking change in the ZenML server REST API that affects the ZenML Terraform provider:
* the Terraform provider is updated and a new major version is released
* the version range encoded here is also updated to match

![image](https://github.com/user-attachments/assets/9cdef910-c2db-42a5-8aca-e828ad813387)


This prevents existing ZenML servers from running into ZenML Terraform provider errors introduced in future major updates.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

