### PR TITLE
Bump `click` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ zenml = "zenml.cli.cli:cli"
 [tool.poetry.dependencies]
 alembic = { version = "~1.8.1" }
 bcrypt = { version = "4.0.1" }
-click = "^8.0.1,<8.1.4"
+click = "^8.0.1,<8.1.8"
 cloudpickle = ">=2.0.0,<3"
 distro = "^1.6.0"
 docker = "~7.1.0"


### PR DESCRIPTION
No breaking changes mentioned in [click's release notes](https://github.com/pallets/click/releases) between 8.1.4 and 8.1.8. Will test it a bit and let the tests run, but assuming there will be no problems.

Will unlock #3444 to install crewai packages.