### PR TITLE
Stop CLI profiler running so much

### DIFF
--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -3,6 +3,7 @@ name: ZenML CLI Performance Profiling
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+    paths: ["src/zenml"]
   workflow_dispatch:
 concurrency:
   # New commit on branch cancels running workflows of the same branch

--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
   workflow_dispatch:
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   profile-cli-performance:
     name: Profile ZenML CLI Performance


### PR DESCRIPTION
This small update cancels running workflows of the CLI profiler on the same branch when you push new changes