### PR TITLE
Fix stack validation for incluster Kubernetes orchestrator

### DIFF
--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -3,7 +3,7 @@ name: ZenML CLI Performance Profiling
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths: ["src/zenml"]
+    paths: [src/zenml]
   workflow_dispatch:
 concurrency:
   # New commit on branch cancels running workflows of the same branch


### PR DESCRIPTION
## Describe changes
Don't require a service connector or kubernetes context when using an `incluster=True` Kubernetes orchestrator.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

