### PR TITLE
Fix stack and component URL when connected to a cloud workspace

### DIFF
--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -3,7 +3,7 @@ name: ZenML CLI Performance Profiling
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-    paths: ["src/zenml"]
+    paths: [src/zenml]
   workflow_dispatch:
 concurrency:
   # New commit on branch cancels running workflows of the same branch

--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -91,7 +91,8 @@ def get_stack_url(stack: StackResponse) -> Optional[str]:
     base_url = get_server_dashboard_url()
 
     if base_url:
-        return base_url + constants.STACKS
+        # There is no filtering in OSS, we just link to the stack list.
+        return f"{base_url}{constants.STACKS}"
 
     return None
 
@@ -112,7 +113,7 @@ def get_component_url(component: ComponentResponse) -> Optional[str]:
     base_url = get_server_dashboard_url()
 
     if base_url:
-        return base_url + constants.STACKS
+        return f"{base_url}{constants.STACK_COMPONENTS}/{component.id}"
 
     return None
 

--- a/src/zenml/utils/dashboard_utils.py
+++ b/src/zenml/utils/dashboard_utils.py
@@ -82,6 +82,12 @@ def get_stack_url(stack: StackResponse) -> Optional[str]:
     Returns:
         the URL to the stack if the dashboard is available, else None.
     """
+    cloud_url = get_cloud_dashboard_url()
+    if cloud_url:
+        # We don't have a stack detail page here, so just link to the filtered
+        # list of stacks.
+        return f"{cloud_url}{constants.STACKS}?id={stack.id}"
+
     base_url = get_server_dashboard_url()
 
     if base_url:
@@ -99,6 +105,10 @@ def get_component_url(component: ComponentResponse) -> Optional[str]:
     Returns:
         the URL to the component if the dashboard is available, else None.
     """
+    cloud_url = get_cloud_dashboard_url()
+    if cloud_url:
+        return f"{cloud_url}{constants.STACK_COMPONENTS}/{component.id}"
+
     base_url = get_server_dashboard_url()
 
     if base_url:


### PR DESCRIPTION
## Describe changes
This was implemented before we had stack/component UI in the cloud, which is why it still pointed to the OSS dashboard. However, cloud workspaces redirect any request to the OSS dashboard to the overview page of the workspace, which makes the previous links useless.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

