### PR TITLE
Fix 0.80.0 database migration

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/288f4fb6e112_make_tags_user_scoped.py
+++ b/src/zenml/zen_stores/migrations/versions/288f4fb6e112_make_tags_user_scoped.py
@@ -1,7 +1,7 @@
 """make tags user scoped [288f4fb6e112].
 
 Revision ID: 288f4fb6e112
-Revises: 3b1776345020
+Revises: 41b28cae31ce
 Create Date: 2025-02-19 15:16:42.954792
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 # revision identifiers, used by Alembic.
 revision = "288f4fb6e112"
-down_revision = "3b1776345020"
+down_revision = "41b28cae31ce"
 branch_labels = None
 depends_on = None
 

--- a/src/zenml/zen_stores/migrations/versions/41b28cae31ce_make_artifacts_workspace_scoped.py
+++ b/src/zenml/zen_stores/migrations/versions/41b28cae31ce_make_artifacts_workspace_scoped.py
@@ -1,7 +1,7 @@
 """make artifacts workspace scoped [41b28cae31ce].
 
 Revision ID: 41b28cae31ce
-Revises: 288f4fb6e112
+Revises: 3b1776345020
 Create Date: 2025-02-19 23:23:08.133826
 
 """
@@ -21,7 +21,7 @@ from zenml.constants import (
 
 # revision identifiers, used by Alembic.
 revision = "41b28cae31ce"
-down_revision = "288f4fb6e112"
+down_revision = "3b1776345020"
 branch_labels = None
 depends_on = None
 

--- a/src/zenml/zen_stores/migrations/versions/f1d723fd723b_add_secret_private_attr.py
+++ b/src/zenml/zen_stores/migrations/versions/f1d723fd723b_add_secret_private_attr.py
@@ -1,7 +1,7 @@
 """add secret private attr [f1d723fd723b].
 
 Revision ID: f1d723fd723b
-Revises: 41b28cae31ce
+Revises: 288f4fb6e112
 Create Date: 2025-02-21 19:40:14.596681
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f1d723fd723b"
-down_revision = "41b28cae31ce"
+down_revision = "288f4fb6e112"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Describe changes
The 0.80.0 database migration is failing if there are any tagged artifacts, because it assumes that artifacts are already user-scoped (i.e. have a `user_id` column). This is incorrect, as the DB migration script that updates artifacts to be user-scoped entities comes after the one updating tags to be user-scoped.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

