### PR TITLE
Use the build python version to collect stack requirements for run templates

### DIFF
--- a/src/zenml/integrations/databricks/__init__.py
+++ b/src/zenml/integrations/databricks/__init__.py
@@ -50,8 +50,8 @@ class DatabricksIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            NumpyIntegration.get_requirements(target_os=target_os) + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            NumpyIntegration.get_requirements(target_os=target_os, python_version=python_version) + \
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/databricks/__init__.py
+++ b/src/zenml/integrations/databricks/__init__.py
@@ -34,11 +34,14 @@ class DatabricksIntegration(Integration):
     REQUIREMENTS_IGNORED_ON_UNINSTALL = ["numpy", "pandas"]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.

--- a/src/zenml/integrations/deepchecks/__init__.py
+++ b/src/zenml/integrations/deepchecks/__init__.py
@@ -58,11 +58,14 @@ class DeepchecksIntegration(Integration):
         from zenml.integrations.deepchecks import materializers  # noqa
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.

--- a/src/zenml/integrations/deepchecks/__init__.py
+++ b/src/zenml/integrations/deepchecks/__init__.py
@@ -73,7 +73,7 @@ class DeepchecksIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/evidently/__init__.py
+++ b/src/zenml/integrations/evidently/__init__.py
@@ -60,11 +60,14 @@ class EvidentlyIntegration(Integration):
     REQUIREMENTS_IGNORED_ON_UNINSTALL = ["tenacity", "pandas"]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -72,7 +75,7 @@ class EvidentlyIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/facets/__init__.py
+++ b/src/zenml/integrations/facets/__init__.py
@@ -31,11 +31,14 @@ class FacetsIntegration(Integration):
         from zenml.integrations.facets import materializers  # noqa
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.

--- a/src/zenml/integrations/facets/__init__.py
+++ b/src/zenml/integrations/facets/__init__.py
@@ -46,5 +46,5 @@ class FacetsIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 

--- a/src/zenml/integrations/feast/__init__.py
+++ b/src/zenml/integrations/feast/__init__.py
@@ -46,11 +46,13 @@ class FeastIntegration(Integration):
         return [FeastFeatureStoreFlavor]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -58,5 +60,5 @@ class FeastIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 

--- a/src/zenml/integrations/great_expectations/__init__.py
+++ b/src/zenml/integrations/great_expectations/__init__.py
@@ -53,11 +53,13 @@ class GreatExpectationsIntegration(Integration):
         return [GreatExpectationsDataValidatorFlavor]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -65,4 +67,4 @@ class GreatExpectationsIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)

--- a/src/zenml/integrations/huggingface/__init__.py
+++ b/src/zenml/integrations/huggingface/__init__.py
@@ -37,11 +37,13 @@ class HuggingfaceIntegration(Integration):
         from zenml.integrations.huggingface import services
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Defines platform specific requirements for the integration.
 
         Args:
             target_os: The target operating system.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -59,7 +61,7 @@ class HuggingfaceIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return requirements + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/integration.py
+++ b/src/zenml/integrations/integration.py
@@ -133,11 +133,16 @@ class Integration(metaclass=IntegrationMeta):
         return True
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls,
+        target_os: Optional[str] = None,
+        python_version: Optional[str] = None,
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.

--- a/src/zenml/integrations/langchain/materializers/openai_embedding_materializer.py
+++ b/src/zenml/integrations/langchain/materializers/openai_embedding_materializer.py
@@ -13,16 +13,15 @@
 #  permissions and limitations under the License.
 """Implementation of the Langchain OpenAI embedding materializer."""
 
-import sys
-from typing import TYPE_CHECKING, Any, ClassVar, Tuple, Type
+from typing import Any, ClassVar, Tuple, Type
+
+from langchain_community.embeddings import (
+    OpenAIEmbeddings,
+)
 
 from zenml.enums import ArtifactType
 from zenml.materializers.cloudpickle_materializer import (
     CloudpickleMaterializer,
-)
-
-from langchain_community.embeddings import (
-    OpenAIEmbeddings,
 )
 
 

--- a/src/zenml/integrations/langchain/materializers/openai_embedding_materializer.py
+++ b/src/zenml/integrations/langchain/materializers/openai_embedding_materializer.py
@@ -21,12 +21,9 @@ from zenml.materializers.cloudpickle_materializer import (
     CloudpickleMaterializer,
 )
 
-if TYPE_CHECKING and sys.version_info < (3, 8):
-    OpenAIEmbeddings = Any
-else:
-    from langchain_community.embeddings import (
-        OpenAIEmbeddings,
-    )
+from langchain_community.embeddings import (
+    OpenAIEmbeddings,
+)
 
 
 class LangchainOpenaiEmbeddingMaterializer(CloudpickleMaterializer):

--- a/src/zenml/integrations/langchain/materializers/vector_store_materializer.py
+++ b/src/zenml/integrations/langchain/materializers/vector_store_materializer.py
@@ -13,15 +13,14 @@
 #  permissions and limitations under the License.
 """Implementation of the langchain vector store materializer."""
 
-import sys
-from typing import TYPE_CHECKING, Any, ClassVar, Tuple, Type
+from typing import Any, ClassVar, Tuple, Type
+
+from langchain.vectorstores.base import VectorStore
 
 from zenml.enums import ArtifactType
 from zenml.materializers.cloudpickle_materializer import (
     CloudpickleMaterializer,
 )
-
-from langchain.vectorstores.base import VectorStore
 
 
 class LangchainVectorStoreMaterializer(CloudpickleMaterializer):

--- a/src/zenml/integrations/langchain/materializers/vector_store_materializer.py
+++ b/src/zenml/integrations/langchain/materializers/vector_store_materializer.py
@@ -21,10 +21,7 @@ from zenml.materializers.cloudpickle_materializer import (
     CloudpickleMaterializer,
 )
 
-if TYPE_CHECKING and sys.version_info < (3, 8):
-    VectorStore = Any
-else:
-    from langchain.vectorstores.base import VectorStore
+from langchain.vectorstores.base import VectorStore
 
 
 class LangchainVectorStoreMaterializer(CloudpickleMaterializer):

--- a/src/zenml/integrations/llama_index/materializers/document_materializer.py
+++ b/src/zenml/integrations/llama_index/materializers/document_materializer.py
@@ -25,12 +25,8 @@
 #     from zenml.metadata.metadata_types import MetadataType
 
 
-# if TYPE_CHECKING and sys.version_info < (3, 8):
-#     Document = Any
-#     LCDocument = Any
-# else:
-#     from langchain.docstore.document import Document as LCDocument
-#     from llama_index.readers.schema.base import Document
+# from langchain.docstore.document import Document as LCDocument
+# from llama_index.readers.schema.base import Document
 
 
 # class LlamaIndexDocumentMaterializer(LangchainDocumentMaterializer):

--- a/src/zenml/integrations/llama_index/materializers/gpt_index_materializer.py
+++ b/src/zenml/integrations/llama_index/materializers/gpt_index_materializer.py
@@ -34,13 +34,8 @@
 # DEFAULT_FILENAME = "index.json"
 # DEFAULT_FAISS_FILENAME = "faiss_index.json"
 
-# if TYPE_CHECKING and sys.version_info < (3, 8):
-#     BaseGPTIndex = Any
-#     GPTFaissIndex = Any
-#     T = TypeVar("T", bound=Any)
-# else:
-#     from llama_index.indices.base import BaseGPTIndex
-#     from llama_index.indices.vector_store import GPTFaissIndex
+# from llama_index.indices.base import BaseGPTIndex
+# from llama_index.indices.vector_store import GPTFaissIndex
 
 #     T = TypeVar("T", bound=BaseGPTIndex[Any])
 

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -78,11 +78,11 @@ class MlflowIntegration(Integration):
         ]
 
         if python_version:
-            version_info = version.parse(python_version)
+            version_minor = version.parse(python_version).minor
         else:
-            version_info = sys.version_info
+            version_minor = sys.version_info.minor
 
-        if version_info.minor >= 12:
+        if version_minor >= 12:
             logger.debug(
                 "The MLflow integration on Python 3.12 and above is not yet "
                 "fully supported: The extra dependencies 'mlserver' and "

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -54,6 +54,7 @@ class MlflowIntegration(Integration):
         Args:
             target_os: The target operating system to get the requirements for.
             python_version: The Python version to use for the requirements.
+
         Returns:
             A list of requirements.
         """

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -16,6 +16,7 @@
 The MLflow integrations currently enables you to use MLflow tracking as a
 convenient way to visualize your experiment runs within the MLflow UI.
 """
+from packaging import version
 from typing import List, Type, Optional
 
 from zenml.integrations.constants import MLFLOW
@@ -45,17 +46,20 @@ class MlflowIntegration(Integration):
     ]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(
+        cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
-
+            python_version: The Python version to use for the requirements.
         Returns:
             A list of requirements.
         """
         from zenml.integrations.numpy import NumpyIntegration
         from zenml.integrations.pandas import PandasIntegration
+        
 
         reqs = [
             "mlflow>=2.1.1,<2.21.0",
@@ -71,7 +75,13 @@ class MlflowIntegration(Integration):
             # downgrade will not happen.
             "pydantic>=2.8.0,<2.9.0",
         ]
-        if sys.version_info.minor >= 12:
+
+        if python_version:
+            version_info = version.parse(python_version)
+        else:
+            version_info = sys.version_info
+
+        if version_info.minor >= 12:
             logger.debug(
                 "The MLflow integration on Python 3.12 and above is not yet "
                 "fully supported: The extra dependencies 'mlserver' and "

--- a/src/zenml/integrations/mlflow/__init__.py
+++ b/src/zenml/integrations/mlflow/__init__.py
@@ -94,8 +94,8 @@ class MlflowIntegration(Integration):
                 "mlserver-mlflow>=1.3.3",
             ])
 
-        reqs.extend(NumpyIntegration.get_requirements(target_os=target_os))
-        reqs.extend(PandasIntegration.get_requirements(target_os=target_os))
+        reqs.extend(NumpyIntegration.get_requirements(target_os=target_os, python_version=python_version))
+        reqs.extend(PandasIntegration.get_requirements(target_os=target_os, python_version=python_version))
         return reqs
 
     @classmethod

--- a/src/zenml/integrations/seldon/__init__.py
+++ b/src/zenml/integrations/seldon/__init__.py
@@ -53,11 +53,13 @@ class SeldonIntegration(Integration):
         return [SeldonModelDeployerFlavor]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -65,5 +67,5 @@ class SeldonIntegration(Integration):
         from zenml.integrations.numpy import NumpyIntegration
 
         return cls.REQUIREMENTS + \
-            NumpyIntegration.get_requirements(target_os=target_os)
+            NumpyIntegration.get_requirements(target_os=target_os, python_version=python_version)
 

--- a/src/zenml/integrations/tensorboard/__init__.py
+++ b/src/zenml/integrations/tensorboard/__init__.py
@@ -25,11 +25,13 @@ class TensorBoardIntegration(Integration):
     REQUIREMENTS = []
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Defines platform specific requirements for the integration.
 
         Args:
             target_os: The target operating system.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.

--- a/src/zenml/integrations/tensorflow/__init__.py
+++ b/src/zenml/integrations/tensorflow/__init__.py
@@ -41,11 +41,13 @@ class TensorflowIntegration(Integration):
         from zenml.integrations.tensorflow import materializers  # noqa
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Defines platform specific requirements for the integration.
 
         Args:
             target_os: The target operating system.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -60,7 +62,6 @@ class TensorflowIntegration(Integration):
                 "tensorflow>=2.12,<2.15",
                 "tensorflow_io>=0.24.0",
             ]
-        if sys.version_info.minor == 8:
-            requirements.append("typing-extensions>=4.6.1")
+
         return requirements
 

--- a/src/zenml/integrations/whylogs/__init__.py
+++ b/src/zenml/integrations/whylogs/__init__.py
@@ -50,11 +50,13 @@ class WhylogsIntegration(Integration):
         return [WhylogsDataValidatorFlavor]
 
     @classmethod
-    def get_requirements(cls, target_os: Optional[str] = None) -> List[str]:
+    def get_requirements(cls, target_os: Optional[str] = None, python_version: Optional[str] = None
+    ) -> List[str]:
         """Method to get the requirements for the integration.
 
         Args:
             target_os: The target operating system to get the requirements for.
+            python_version: The Python version to use for the requirements.
 
         Returns:
             A list of requirements.
@@ -62,6 +64,6 @@ class WhylogsIntegration(Integration):
         from zenml.integrations.pandas import PandasIntegration
 
         return cls.REQUIREMENTS + \
-            PandasIntegration.get_requirements(target_os=target_os)
+            PandasIntegration.get_requirements(target_os=target_os, python_version=python_version)
 
 

--- a/src/zenml/utils/requirements_utils.py
+++ b/src/zenml/utils/requirements_utils.py
@@ -30,6 +30,7 @@ def get_requirements_for_stack(
     Args:
         stack: The stack for which to get the requirements.
         python_version: The Python version to use for the requirements.
+
     Returns:
         Tuple of PyPI and APT requirements of the stack.
     """

--- a/src/zenml/utils/requirements_utils.py
+++ b/src/zenml/utils/requirements_utils.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Requirement utils."""
 
-from typing import TYPE_CHECKING, List, Set, Tuple
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 from zenml.integrations.utils import get_integration_for_module
 
@@ -23,12 +23,13 @@ if TYPE_CHECKING:
 
 def get_requirements_for_stack(
     stack: "StackResponse",
+    python_version: Optional[str] = None,
 ) -> Tuple[List[str], List[str]]:
     """Get requirements for a stack model.
 
     Args:
         stack: The stack for which to get the requirements.
-
+        python_version: The Python version to use for the requirements.
     Returns:
         Tuple of PyPI and APT requirements of the stack.
     """
@@ -41,7 +42,10 @@ def get_requirements_for_stack(
         (
             component_pypi_requirements,
             component_apt_packages,
-        ) = get_requirements_for_component(component=component)
+        ) = get_requirements_for_component(
+            component=component,
+            python_version=python_version,
+        )
         pypi_requirements = pypi_requirements.union(
             component_pypi_requirements
         )
@@ -52,11 +56,13 @@ def get_requirements_for_stack(
 
 def get_requirements_for_component(
     component: "ComponentResponse",
+    python_version: Optional[str] = None,
 ) -> Tuple[List[str], List[str]]:
     """Get requirements for a component model.
 
     Args:
         component: The component for which to get the requirements.
+        python_version: The Python version to use for the requirements.
 
     Returns:
         Tuple of PyPI and APT requirements of the component.
@@ -66,6 +72,8 @@ def get_requirements_for_component(
     )
 
     if integration:
-        return integration.get_requirements(), integration.APT_PACKAGES
+        return integration.get_requirements(
+            python_version=python_version
+        ), integration.APT_PACKAGES
     else:
         return [], []

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -8804,11 +8804,7 @@ class SqlZenStore(BaseZenStore):
             # We pass the zenml_schemas module as the globals dict to
             # _evaluate, because this is where the schema classes are
             # defined
-            if sys.version_info < (3, 9):
-                # For Python versions <3.9, leave out the third parameter to
-                # _evaluate
-                target_schema = schema_ref._evaluate(vars(zenml_schemas), {})
-            elif sys.version_info >= (3, 12, 4):
+            if sys.version_info >= (3, 12, 4):
                 target_schema = schema_ref._evaluate(
                     vars(zenml_schemas), {}, recursive_guard=frozenset()
                 )


### PR DESCRIPTION
## Describe changes
When we compile the list of python requirements to use for the runner container image for run templates, we're currently using the python version of the running server instead of the build's python version. This PR fixes that. 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

