### PR TITLE
Fix version validation

### DIFF
--- a/scripts/validate-new-version.sh
+++ b/scripts/validate-new-version.sh
@@ -40,8 +40,10 @@ IFS='.' read -r P_MAJOR P_MINOR P_PATCH <<< "$PLANNED_VERSION"
 # List PRs merged after the latest release date and filter by breaking change label
 PRS=$(gh pr list --search "is:merged merged:>$TAG_DATE label:$LABEL_BREAKING_CHANGE base:develop" --json number,title)
 
-# Check if the PRs list for breaking changes is empty
-if [ -z "$PRS" ]; then
+# Check if there are any PRs with breaking changes
+PR_COUNT=$(echo "$PRS" | jq '. | length')
+
+if [ "$PR_COUNT" -eq 0 ]; then
   IDEAL_NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
 
   # Warn in case of a mismatch
@@ -61,5 +63,4 @@ else
   if [ "$PLANNED_VERSION" != "$IDEAL_NEW_VERSION" ]; then
     echo "::warning::Warning: The new planned version '$PLANNED_VERSION' is not the same as the ideal version '$IDEAL_NEW_VERSION'. Please, make sure this '$PLANNED_VERSION' is selected on purpose."
   fi
-
 fi


### PR DESCRIPTION
## Describe changes
The current check if [ -z "$PRS" ] was not working as expected because the gh command returned an empty JSON array [] rather than an empty string

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

