### PR TITLE
Log job completion for Vertex orchestrator

### DIFF
--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -736,6 +736,9 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
                         "Waiting for the Vertex AI Pipelines job to finish..."
                     )
                     run.wait()
+                    logger.info(
+                        "Vertex AI Pipelines job completed successfully."
+                    )
 
         except google_exceptions.ClientError as e:
             logger.error("Failed to create the Vertex AI Pipelines job: %s", e)


### PR DESCRIPTION
* Added an info log statement to indicate when the Vertex AI Pipelines job has completed successfully, improving traceability and debugging capabilities.

Previously you'd just have a log like:

```shell
Waiting for the Vertex AI Pipelines job to finish...
```

And then when your Vertex pipeline completes you get no acknowledgement of that in your terminal.