### PR TITLE
Fixing the timestamps in logs

### DIFF
--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -255,7 +255,9 @@ class StepLogsStorage:
         if not self.disabled:
             # Add timestamp to the message when it's received
             timestamp = utc_now().strftime("%Y-%m-%d %H:%M:%S")
-            formatted_message = f"[{timestamp} UTC] {remove_ansi_escape_codes(text)}"
+            formatted_message = (
+                f"[{timestamp} UTC] {remove_ansi_escape_codes(text)}"
+            )
             self.buffer.append(formatted_message)
             self.save_to_file()
 

--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -426,7 +426,6 @@ class StepLogsStorageContext:
         self.storage = StepLogsStorage(
             logs_uri=logs_uri, artifact_store=artifact_store
         )
-        self._timer = None
 
     def __enter__(self) -> "StepLogsStorageContext":
         """Enter condition of the context manager.
@@ -437,8 +436,6 @@ class StepLogsStorageContext:
         Returns:
             self
         """
-        import threading
-
         self.stdout_write = getattr(sys.stdout, "write")
         self.stdout_flush = getattr(sys.stdout, "flush")
 
@@ -450,28 +447,6 @@ class StepLogsStorageContext:
 
         setattr(sys.stderr, "write", self._wrap_write(self.stdout_write))
         setattr(sys.stderr, "flush", self._wrap_flush(self.stdout_flush))
-
-        # Start a timer that periodically checks if logs need to be saved
-        def check_and_save_logs():
-            if time.time() - self.storage.last_save_time >= self.storage.time_interval:
-                self.storage.save_to_file(force=True)
-            
-            # Reschedule the timer if we're still in the context
-            if redirected.get():
-                self._timer = threading.Timer(
-                    self.storage.time_interval / 2,  # Check twice as often as the save interval
-                    check_and_save_logs
-                )
-                self._timer.daemon = True  # Don't block program exit
-                self._timer.start()
-        
-        # Start the initial timer
-        self._timer = threading.Timer(
-            self.storage.time_interval / 2,  # Check twice as often as the save interval
-            check_and_save_logs
-        )
-        self._timer.daemon = True  # Don't block program exit
-        self._timer.start()
 
         redirected.set(True)
         return self
@@ -491,11 +466,6 @@ class StepLogsStorageContext:
 
         Restores the `write` method of both stderr and stdout.
         """
-        # Cancel the timer if it's running
-        if self._timer:
-            self._timer.cancel()
-            self._timer = None
-
         self.storage.save_to_file(force=True)
 
         setattr(sys.stdout, "write", self.stdout_write)


### PR DESCRIPTION
## Describe changes
Previously, we were adding the timestamps to logs only when we emptied out the buffer through the `save_to_file` method. I have changed it so that the timestamp will be added when the message gets added to the buffer.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

