### PR TITLE
Fix incorrect step access method in documentation

### DIFF
--- a/docs/book/component-guide/experiment-trackers/comet.md
+++ b/docs/book/component-guide/experiment-trackers/comet.md
@@ -142,7 +142,7 @@ You can find the URL of the Comet experiment linked to a specific ZenML run via 
 from zenml.client import Client
 
 last_run = client.get_pipeline("<PIPELINE_NAME>").last_run
-trainer_step = last_run.get_step("<STEP_NAME>")
+trainer_step = last_run.steps["<STEP_NAME>"]
 tracking_url = trainer_step.run_metadata["experiment_tracker_url"].value
 print(tracking_url)
 ```

--- a/docs/book/component-guide/experiment-trackers/mlflow.md
+++ b/docs/book/component-guide/experiment-trackers/mlflow.md
@@ -168,7 +168,7 @@ You can find the URL of the MLflow experiment linked to a specific ZenML run via
 from zenml.client import Client
 
 last_run = client.get_pipeline("<PIPELINE_NAME>").last_run
-trainer_step = last_run.get_step("<STEP_NAME>")
+trainer_step = last_run.steps["<STEP_NAME>"]
 tracking_url = trainer_step.run_metadata["experiment_tracker_url"].value
 print(tracking_url)
 ```

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -152,7 +152,7 @@ You can find the URL of the Weights & Biases experiment linked to a specific Zen
 from zenml.client import Client
 
 last_run = client.get_pipeline("<PIPELINE_NAME>").last_run
-trainer_step = last_run.get_step("<STEP_NAME>")
+trainer_step = last_run.steps["<STEP_NAME>"]
 tracking_url = trainer_step.run_metadata["experiment_tracker_url"].value
 print(tracking_url)
 ```

--- a/docs/book/how-to/popular-integrations/mlflow.md
+++ b/docs/book/how-to/popular-integrations/mlflow.md
@@ -71,7 +71,7 @@ You can find the URL to the MLflow experiment for a ZenML run:
 
 ```python
 last_run = client.get_pipeline("<PIPELINE_NAME>").last_run
-trainer_step = last_run.get_step("<STEP_NAME>")
+trainer_step = last_run.steps["<STEP_NAME>"]
 tracking_url = trainer_step.run_metadata["experiment_tracker_url"].value
 ```
 


### PR DESCRIPTION
## Describe changes

- This PR fixes incorrect step access method references throughout the docs.
- Updated 4 documents to replace the incorrect method with the working approach

I noticed this issue while reviewing the [MLFlow documentation](https://docs.zenml.io/stacks/experiment-trackers/mlflow#mlflow-ui). The docs show examples using `last_run.get_step("<STEP_NAME>")`, but this method doesn't exist on `PipelineRunResponse` and throws an `AttributeError`. The correct way to access steps is through the steps dictionary: `last_run.steps["<STEP_NAME>"]`.



## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

