### PR TITLE
Fix yanked fsspec pip resolution issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ azure-storage-blob = { version = ">=12.0.0", optional = true }
 azure-mgmt-resource = { version = ">=21.0.0", optional = true }
 
 # Optional dependencies for the S3 artifact store
-s3fs = { version = ">=2022.11.0", optional = true }
+s3fs = { version = ">=2022.11.0,!=2025.3.1", optional = true }
 
 # Optional dependencies for the Sagemaker orchestrator
 sagemaker = { version = ">=2.199.0", optional = true }

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -1213,7 +1213,6 @@ class Client(metaclass=ClientMetaClass):
             name=name,
             components=stack_components,
             stack_spec_path=stack_spec_file,
-            project=self.active_project.id,
             labels=labels,
         )
 
@@ -1339,7 +1338,6 @@ class Client(metaclass=ClientMetaClass):
 
         # Create the update model
         update_model = StackUpdate(
-            project=self.active_project.id,
             stack_spec_path=stack_spec_file,
         )
 
@@ -2027,7 +2025,6 @@ class Client(metaclass=ClientMetaClass):
             type=component_type,
             flavor=flavor,
             configuration=configuration,
-            project=self.active_project.id,
             labels=labels,
         )
 
@@ -2075,9 +2072,7 @@ class Client(metaclass=ClientMetaClass):
             allow_name_prefix_match=False,
         )
 
-        update_model = ComponentUpdate(
-            project=self.active_project.id,
-        )
+        update_model = ComponentUpdate()
 
         if name is not None:
             existing_components = self.list_stack_components(

--- a/src/zenml/integrations/s3/__init__.py
+++ b/src/zenml/integrations/s3/__init__.py
@@ -31,17 +31,10 @@ class S3Integration(Integration):
     NAME = S3
     # boto3 isn't required for the filesystem to work, but it is required
     # for the AWS/S3 connector that can be used with the artifact store.
-    # NOTE: to keep the dependency resolution for botocore consistent and fast
-    # between s3fs and boto3, the boto3 upper version used here should be the
-    # same as the one resolved by pip when installing boto3 without a
-    # restriction alongside s3fs, e.g.:
-    #
-    #   pip install 's3fs>2022.3.0,<=2023.4.0' boto3
-    #
-    # The above command installs boto3==1.26.76, so we use the same version
-    # here to avoid the dependency resolution overhead.
     REQUIREMENTS = [
-        "s3fs>2022.3.0",
+        # Explicitly exclude 2025.3.1 to avoid pulling in the yanked fsspec
+        # package with the same version
+        "s3fs>2022.3.0,!=2025.3.1",
         "boto3",
         # The following dependencies are only required for the AWS connector.
         "aws-profile-manager",

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -75,7 +75,7 @@ class WandbExperimentTrackerSettings(BaseSettings):
             # `make_static` or `to_dict` is available to convert the settings
             # to a dictionary
             if isinstance(value, BaseModel):
-                return value.model_dump()
+                return value.model_dump()  # type: ignore[no-untyped-call]
             elif hasattr(value, "make_static"):
                 return cast(Dict[str, Any], value.make_static())
             elif hasattr(value, "to_dict"):


### PR DESCRIPTION
## Describe changes
This currently happens with any stack that has both an AWS stack component and an S3 artifact store, regardless of ZenML version:

```
Building Docker image(s) for pipeline super_simple_pipeline.
Building Docker image 339712793861.dkr.ecr.eu-central-1.amazonaws.com/zenml:super_simple_pipeline-orchestrator.
- Including stack requirements: aws-profile-manager, boto3, kubernetes, kubernetes>=21.7,<26, s3fs>2024.10.0, sagemaker>=2.199.0
WARNING! Your password will be stored unencrypted in /home/stefan/snap/docker/3064/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credential-stores

Login Succeeded
Step 1/9 : FROM zenmldocker/zenml:0.80.1-py3.10
Step 2/9 : WORKDIR /app
Step 3/9 : ENV ZENML_LOGGING_COLORS_DISABLED=False
Step 4/9 : COPY .zenml_stack_integration_requirements .
Step 5/9 : RUN pip install --no-cache-dir --default-timeout=60 -r .zenml_stack_integration_requirements
ERROR: Ignored the following yanked versions: 2022.8.0, 2022.8.1, 2025.3.1

ERROR: Could not find a version that satisfies the requirement fsspec==2025.3.1.* (from s3fs) (from versions: 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.5.1, 0.5.2, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.8.6, 0.8.7, 0.9.0, 2021.4.0, 2021.5.0, 2021.6.0, 2021.6.1, 2021.7.0, 2021.8.1, 2021.9.0, 2021.10.0, 2021.10.1, 2021.11.0, 2021.11.1, 2022.1.0, 2022.2.0, 2022.3.0, 2022.5.0, 2022.7.0, 2022.7.1, 2022.8.2, 2022.10.0, 2022.11.0, 2023.1.0, 2023.3.0, 2023.4.0, 2023.5.0, 2023.6.0, 2023.9.0, 2023.9.1, 2023.9.2, 2023.10.0, 2023.12.0, 2023.12.1, 2023.12.2, 2024.2.0, 2024.3.0, 2024.3.1, 2024.5.0, 2024.6.0, 2024.6.1, 2024.9.0, 2024.10.0, 2024.12.0, 2025.2.0, 2025.3.0, 2025.3.2)

ERROR: No matching distribution found for fsspec==2025.3.1.*

╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/stefan/aspyre/src/zenml/examples/as_simple_as_it_gets/run.py:50 in <module>                │
│                                                                                                  │
│   47                                                                                             │
│   48                                                                                             │
│   49 if __name__ == "__main__":                                                                  │
│ ❱ 50 │   main()                                                                                  │
│   51                                                                                             │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/examples/as_simple_as_it_gets/run.py:46 in main                    │
│                                                                                                  │
│   43                                                                                             │
│   44                                                                                             │
│   45 def main():                                                                                 │
│ ❱ 46 │   super_simple_pipeline()                                                                 │
│   47                                                                                             │
│   48                                                                                             │
│   49 if __name__ == "__main__":                                                                  │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/pipelines/pipeline_definition.py:1411 in __call__        │
│                                                                                                  │
│   1408 │   │   │   return self.entrypoint(*args, **kwargs)                                       │
│   1409 │   │                                                                                     │
│   1410 │   │   self.prepare(*args, **kwargs)                                                     │
│ ❱ 1411 │   │   return self._run()                                                                │
│   1412 │                                                                                         │
│   1413 │   def _call_entrypoint(self, *args: Any, **kwargs: Any) -> None:                        │
│   1414 │   │   """Calls the pipeline entrypoint function with the given arguments.               │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/pipelines/pipeline_definition.py:809 in _run             │
│                                                                                                  │
│    806 │   │                                                                                     │
│    807 │   │   with track_handler(AnalyticsEvent.RUN_PIPELINE) as analytics_handler:             │
│    808 │   │   │   stack = Client().active_stack                                                 │
│ ❱  809 │   │   │   deployment = self._create_deployment(**self._run_args)                        │
│    810 │   │   │                                                                                 │
│    811 │   │   │   self.log_pipeline_deployment_metadata(deployment)                             │
│    812 │   │   │   run = create_placeholder_run(deployment=deployment)                           │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/pipelines/pipeline_definition.py:730 in                  │
│ _create_deployment                                                                               │
│                                                                                                  │
│    727 │   │   │   │   "`DockerSettings.prevent_build_reuse` instead."                           │
│    728 │   │   │   )                                                                             │
│    729 │   │                                                                                     │
│ ❱  730 │   │   build_model = build_utils.reuse_or_create_pipeline_build(                         │
│    731 │   │   │   deployment=deployment,                                                        │
│    732 │   │   │   pipeline_id=pipeline_id,                                                      │
│    733 │   │   │   allow_build_reuse=not prevent_build_reuse,                                    │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/pipelines/build_utils.py:208 in                          │
│ reuse_or_create_pipeline_build                                                                   │
│                                                                                                  │
│   205 │   │   │   │   │   "are the same as for the existing build."                              │
│   206 │   │   │   │   )                                                                          │
│   207 │   │                                                                                      │
│ ❱ 208 │   │   return create_pipeline_build(                                                      │
│   209 │   │   │   deployment=deployment,                                                         │
│   210 │   │   │   pipeline_id=pipeline_id,                                                       │
│   211 │   │   │   code_repository=code_repository,                                               │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/pipelines/build_utils.py:390 in create_pipeline_build    │
│                                                                                                  │
│   387 │   │   │   │   image_name_or_digest,                                                      │
│   388 │   │   │   │   dockerfile,                                                                │
│   389 │   │   │   │   requirements,                                                              │
│ ❱ 390 │   │   │   ) = docker_image_builder.build_docker_image(                                   │
│   391 │   │   │   │   docker_settings=build_config.settings,                                     │
│   392 │   │   │   │   tag=tag,                                                                   │
│   393 │   │   │   │   stack=stack,                                                               │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/utils/pipeline_docker_image_builder.py:342 in            │
│ build_docker_image                                                                               │
│                                                                                                  │
│   339 │   │   │   │   │   │   destination=destination, source=source                             │
│   340 │   │   │   │   │   )                                                                      │
│   341 │   │   │                                                                                  │
│ ❱ 342 │   │   │   image_name_or_digest = image_builder.build(                                    │
│   343 │   │   │   │   image_name=target_image_name,                                              │
│   344 │   │   │   │   build_context=build_context,                                               │
│   345 │   │   │   │   docker_build_options=build_options,                                        │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/image_builders/local_image_builder.py:129 in build       │
│                                                                                                  │
│   126 │   │   │   │   tag=image_name,                                                            │
│   127 │   │   │   │   **(docker_build_options or {}),                                            │
│   128 │   │   │   )                                                                              │
│ ❱ 129 │   │   docker_utils._process_stream(output_stream)                                        │
│   130 │   │                                                                                      │
│   131 │   │   if container_registry:                                                             │
│   132 │   │   │   return container_registry.push_image(image_name)                               │
│                                                                                                  │
│ /home/stefan/aspyre/src/zenml/src/zenml/utils/docker_utils.py:386 in _process_stream             │
│                                                                                                  │
│   383 │   │   │   try:                                                                           │
│   384 │   │   │   │   line_json = json.loads(line)                                               │
│   385 │   │   │   │   if "error" in line_json:                                                   │
│ ❱ 386 │   │   │   │   │   raise RuntimeError(f"Docker error: {line_json['error']}.")             │
│   387 │   │   │   │   elif "stream" in line_json:                                                │
│   388 │   │   │   │   │   text = line_json["stream"].strip()                                     │
│   389 │   │   │   │   │   if "ERROR" in text:                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Docker error: The command '/bin/sh -c pip install --no-cache-dir --default-timeout=60 -r .zenml_stack_integration_requirements' returned a non-zero code: 1.
```

The problem can be distilled to:
* this works
```
pip install 's3fs>2022.3.0' boto3
```
* this doesn’t
```
pip install boto3 's3fs>2022.3.0'
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

