### PR TITLE
Avoid extra newlines in logs

### DIFF
--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -263,7 +263,7 @@ class StepLogsStorage:
             formatted_message = (
                 f"[{timestamp} UTC] {remove_ansi_escape_codes(text)}"
             )
-            self.buffer.append(formatted_message)
+            self.buffer.append(formatted_message.rstrip())
             self.save_to_file()
 
     @property


### PR DESCRIPTION
## Describe changes
I fixed how the logs are being written to avoid extra newlines being produced.

Before the fix:
![image](https://github.com/user-attachments/assets/7989834c-2ecb-4473-98ef-9be231628092)

With the fix:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/b09364c0-64c1-41cc-bfdf-e94eba7b82ff" />


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

