### PR TITLE
Use step ID instead of name in step logs

### DIFF
--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -154,8 +154,8 @@ class StepLauncher:
         if step_logging_enabled:
             # Configure the logs
             logs_uri = step_logging.prepare_logs_uri(
-                self._stack.artifact_store,
-                self._step.config.name,
+                artifact_store=self._stack.artifact_store,
+                step_name=self._step_name,
             )
 
             logs_context = step_logging.StepLogsStorageContext(


### PR DESCRIPTION
## Describe changes
When using a custom `id` for a step in a pipeline, the logs would be stored in a directory of the original step name instead of the newly assigned ID, which made it hard to find.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

