### PR TITLE
Implement failure retries and pending timeouts for the k8s orchestrator pod

### DIFF
--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_step_operator_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_step_operator_flavor.py
@@ -35,11 +35,23 @@ class KubernetesStepOperatorSettings(BaseSettings):
         pod_settings: Pod settings to apply to pods executing the steps.
         service_account_name: Name of the service account to use for the pod.
         privileged: If the container should be run in privileged mode.
+        pod_startup_timeout: The maximum time to wait for a pending step pod to
+            start (in seconds).
+        pod_failure_max_retries: The maximum number of times to retry a step
+            pod if the step Kubernetes pod fails to start
+        pod_failure_retry_delay: The delay in seconds between pod
+            failure retries and pod startup retries (in seconds)
+        pod_failure_backoff: The backoff factor for pod failure retries and
+            pod startup retries.
     """
 
     pod_settings: Optional[KubernetesPodSettings] = None
     service_account_name: Optional[str] = None
     privileged: bool = False
+    pod_startup_timeout: int = 60 * 10  # Default 10 minutes
+    pod_failure_max_retries: int = 3
+    pod_failure_retry_delay: int = 10
+    pod_failure_backoff: float = 1.0
 
 
 class KubernetesStepOperatorConfig(

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -407,6 +407,9 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
 
         Raises:
             RuntimeError: If the Kubernetes orchestrator is not configured.
+            TimeoutError: If the orchestrator pod is still in a pending state
+                after the maximum wait time has elapsed.
+            Exception: If the orchestrator pod fails to start.
         """
         for step_name, step in deployment.step_configurations.items():
             if self.requires_resources_in_orchestration_environment(step):

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -31,6 +31,7 @@
 """Kubernetes-native orchestrator."""
 
 import os
+import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -543,10 +544,69 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                 mount_local_stores=self.config.is_local,
             )
 
-            self._k8s_core_api.create_namespaced_pod(
-                namespace=self.config.kubernetes_namespace,
-                body=pod_manifest,
-            )
+            retries = 0
+            max_retries = settings.pod_failure_max_retries
+            delay: float = settings.pod_failure_retry_delay
+            backoff = settings.pod_failure_backoff
+
+            while retries < max_retries:
+                try:
+                    # Create and run pod.
+                    self._k8s_core_api.create_namespaced_pod(
+                        namespace=self.config.kubernetes_namespace,
+                        body=pod_manifest,
+                    )
+                    break
+                except Exception as e:
+                    retries += 1
+                    if retries < max_retries:
+                        logger.debug(f"Orchestrator pod failed to start: {e}")
+                        logger.error(
+                            f"Failed to create orchestrator pod. "
+                            f"Retrying in {delay} seconds..."
+                        )
+                        time.sleep(delay)
+                        delay *= backoff
+                    else:
+                        logger.error(
+                            f"Failed to create orchestrator pod after "
+                            f"{max_retries} retries. Exiting."
+                        )
+                        raise
+
+            # Wait for pod to start
+            logger.info("Waiting for orchestrator pod to start...")
+            max_wait = settings.pod_startup_timeout
+            total_wait: float = 0
+            delay = settings.pod_failure_retry_delay
+            while True:
+                pod = kube_utils.get_pod(
+                    core_api=self._k8s_core_api,
+                    pod_name=pod_name,
+                    namespace=self.config.kubernetes_namespace,
+                )
+                if not pod or kube_utils.pod_is_not_pending(pod):
+                    break
+                if total_wait >= max_wait:
+                    # Have to delete the pending pod so it doesn't start running
+                    # later on.
+                    try:
+                        self._k8s_core_api.delete_namespaced_pod(
+                            name=pod_name,
+                            namespace=self.config.kubernetes_namespace,
+                        )
+                    except Exception:
+                        pass
+                    raise TimeoutError(
+                        f"Orchestrator pod is still in a pending state "
+                        f"after {total_wait} seconds. Exiting."
+                    )
+
+                if total_wait + delay > max_wait:
+                    delay = max_wait - total_wait
+                total_wait += delay
+                time.sleep(delay)
+                delay *= backoff
 
             # Wait for the orchestrator pod to finish and stream logs.
             if settings.synchronous:

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -173,6 +173,7 @@ def main() -> None:
             mount_local_stores=mount_local_stores,
         )
 
+        logger.info(f"Waiting for pod of step `{step_name}` to start...")
         kube_utils.create_and_wait_for_pod_to_start(
             core_api=core_api,
             pod_display_name=f"pod for step `{step_name}`",

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -209,6 +209,7 @@ def main() -> None:
                     raise
 
         # Wait for pod to start
+        logger.info(f"Waiting for pod of step `{step_name}` to start...")
         max_wait = settings.pod_startup_timeout
         total_wait: float = 0
         delay = settings.pod_failure_retry_delay

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -15,7 +15,6 @@
 
 import argparse
 import socket
-import time
 from typing import Any, Dict
 from uuid import UUID
 
@@ -103,8 +102,6 @@ def main() -> None:
 
         Raises:
             Exception: If the pod fails to start.
-            TimeoutError: If the pod is still in a pending state after the
-                maximum wait time has elapsed.
         """
         # Define Kubernetes pod name.
         pod_name = f"{orchestrator_run_id}-{step_name}"
@@ -187,70 +184,6 @@ def main() -> None:
             startup_failure_backoff=settings.pod_failure_backoff,
             startup_timeout=settings.pod_startup_timeout,
         )
-
-        retries = 0
-        max_retries = settings.pod_failure_max_retries
-        delay: float = settings.pod_failure_retry_delay
-        backoff = settings.pod_failure_backoff
-
-        while retries < max_retries:
-            try:
-                # Create and run pod.
-                core_api.create_namespaced_pod(
-                    namespace=args.kubernetes_namespace,
-                    body=pod_manifest,
-                )
-                break
-            except Exception as e:
-                retries += 1
-                if retries < max_retries:
-                    logger.debug(
-                        f"Pod for step `{step_name}` failed to start: {e}"
-                    )
-                    logger.error(
-                        f"Failed to create pod for step `{step_name}`. "
-                        f"Retrying in {delay} seconds..."
-                    )
-                    time.sleep(delay)
-                    delay *= backoff
-                else:
-                    logger.error(
-                        f"Failed to create pod for step `{step_name}` after "
-                        f"{max_retries} retries. Exiting."
-                    )
-                    raise
-
-        # Wait for pod to start
-        logger.info(f"Waiting for pod of step `{step_name}` to start...")
-        max_wait = settings.pod_startup_timeout
-        total_wait: float = 0
-        delay = settings.pod_failure_retry_delay
-        while True:
-            pod = kube_utils.get_pod(
-                core_api, pod_name, args.kubernetes_namespace
-            )
-            if not pod or kube_utils.pod_is_not_pending(pod):
-                break
-            if total_wait >= max_wait:
-                # Have to delete the pending pod so it doesn't start running
-                # later on.
-                try:
-                    core_api.delete_namespaced_pod(
-                        name=pod_name,
-                        namespace=args.kubernetes_namespace,
-                    )
-                except Exception:
-                    pass
-                raise TimeoutError(
-                    f"Pod for step `{step_name}` is still in a pending state "
-                    f"after {total_wait} seconds. Exiting."
-                )
-
-            if total_wait + delay > max_wait:
-                delay = max_wait - total_wait
-            total_wait += delay
-            time.sleep(delay)
-            delay *= backoff
 
         # Wait for pod to finish.
         logger.info(f"Waiting for pod of step `{step_name}` to finish...")

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -176,6 +176,18 @@ def main() -> None:
             mount_local_stores=mount_local_stores,
         )
 
+        kube_utils.create_and_wait_for_pod_to_start(
+            core_api=core_api,
+            pod_display_name=f"pod for step `{step_name}`",
+            pod_name=pod_name,
+            pod_manifest=pod_manifest,
+            namespace=args.kubernetes_namespace,
+            startup_max_retries=settings.pod_failure_max_retries,
+            startup_failure_delay=settings.pod_failure_retry_delay,
+            startup_failure_backoff=settings.pod_failure_backoff,
+            startup_timeout=settings.pod_startup_timeout,
+        )
+
         retries = 0
         max_retries = settings.pod_failure_max_retries
         delay: float = settings.pod_failure_retry_delay


### PR DESCRIPTION
## Describe changes
This PR reused the existing Kubernetes Orchestrator settings to implement failure retries and pending timeouts for the main kubernetes orchestrator pod in the same manner they are implemented for kubernetes orchestrator step pods.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

