### PR TITLE
Track stack creation and pipeline run with remote artifact store for onboarding state

### DIFF
--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -411,8 +411,14 @@ class OnboardingStep(StrEnum):
     STACK_WITH_REMOTE_ORCHESTRATOR_CREATED = (
         "stack_with_remote_orchestrator_created"
     )
+    STACK_WITH_REMOTE_ARTIFACT_STORE_CREATED = (
+        "stack_with_remote_artifact_store_created"
+    )
     PIPELINE_RUN_WITH_REMOTE_ORCHESTRATOR = (
         "pipeline_run_with_remote_orchestrator"
+    )
+    PIPELINE_RUN_WITH_REMOTE_ARTIFACT_STORE = (
+        "pipeline_run_with_remote_artifact_store"
     )
     PRODUCTION_SETUP_COMPLETED = "production_setup_completed"
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -7635,6 +7635,17 @@ class SqlZenStore(BaseZenStore):
                                 },
                                 session=session,
                             )
+                    if (
+                        defined_component.type
+                        == StackComponentType.ARTIFACT_STORE
+                    ):
+                        if defined_component.flavor != "local":
+                            self._update_onboarding_state(
+                                completed_steps={
+                                    OnboardingStep.STACK_WITH_REMOTE_ARTIFACT_STORE_CREATED
+                                },
+                                session=session,
+                            )
 
                 return new_stack_schema.to_model(
                     include_metadata=True, include_resources=True
@@ -8466,6 +8477,12 @@ class SqlZenStore(BaseZenStore):
                     completed_onboarding_steps.update(
                         {
                             OnboardingStep.PIPELINE_RUN_WITH_REMOTE_ORCHESTRATOR,
+                        }
+                    )
+                if stack_metadata["artifact_store"] != "local":
+                    completed_onboarding_steps.update(
+                        {
+                            OnboardingStep.PIPELINE_RUN_WITH_REMOTE_ARTIFACT_STORE,
                             OnboardingStep.PRODUCTION_SETUP_COMPLETED,
                         }
                     )


### PR DESCRIPTION
## Describe changes
This PR adds tracking of stack creation and pipeline runs with remote artifact stores in the onboarding state.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

