### PR TITLE
Add missing vertex orchestrator dependencies to server image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ gcsfs = { version = ">=2022.11.0", optional = true }
 # Optional dependencies for the Vertex orchestrator
 kfp = { version = ">=2.6.0", optional = true }
 google-cloud-aiplatform = { version = ">=1.34.0", optional = true }
+google-cloud-pipeline-components = { version = ">=2.19.0", optional = true }
 
 # Optional dependencies for the Azure artifact store
 adlfs = { version = ">=2021.10.0", optional = true }
@@ -229,6 +230,7 @@ sagemaker = [
 vertex = [
     "google-cloud-aiplatform",
     "kfp",
+    "google-cloud-pipeline-components",
 ]
 azureml = [
     "azure-ai-ml",


### PR DESCRIPTION
## Describe changes
A new library is required by the `VertexOrchestrator` which was not installed in the server image, which caused the run refresh to fail.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

