### PR TITLE
Don't log missing active project warnings preemtively 

### DIFF
--- a/scripts/check_broken_links.py
+++ b/scripts/check_broken_links.py
@@ -41,24 +41,29 @@ def find_markdown_files(directory):
 def extract_relative_links(content):
     """Extract all relative markdown links from content."""
     links = []
-    
+
     # Match [text](path.md) or [text](../path.md) patterns
     # Excluding URLs (http:// or https://)
     md_pattern = r"\[([^\]]+)\]\((?!http[s]?://)(.[^\)]+\.md)\)"
     md_matches = re.finditer(md_pattern, content)
     links.extend([(m.group(1), m.group(2), "markdown") for m in md_matches])
-    
+
     # Match ![text](path.png) or ![text](../path.jpg) patterns for images
     # Excluding URLs (http:// or https://)
     img_pattern = r"!\[([^\]]*)\]\((?!http[s]?://)(.[^\)]+\.(png|jpg|jpeg|gif|svg|webp))\)"
     img_matches = re.finditer(img_pattern, content)
     links.extend([(m.group(1), m.group(2), "image") for m in img_matches])
-    
+
     # Match [text](broken-reference) patterns
     broken_ref_pattern = r"\[([^\]]+)\]\(broken-reference\)"
     broken_ref_matches = re.finditer(broken_ref_pattern, content)
-    links.extend([(m.group(1), "broken-reference", "broken-reference") for m in broken_ref_matches])
-    
+    links.extend(
+        [
+            (m.group(1), "broken-reference", "broken-reference")
+            for m in broken_ref_matches
+        ]
+    )
+
     return links
 
 
@@ -119,9 +124,16 @@ def create_comment_body(broken_links):
     # Calculate statistics
     total_files = len({link["source_file"] for link in broken_links})
     total_broken = len(broken_links)
-    md_links = sum(1 for link in broken_links if link["link_type"] == "markdown" and link["broken_path"] != "broken-reference")
+    md_links = sum(
+        1
+        for link in broken_links
+        if link["link_type"] == "markdown"
+        and link["broken_path"] != "broken-reference"
+    )
     img_links = sum(1 for link in broken_links if link["link_type"] == "image")
-    broken_ref_links = sum(1 for link in broken_links if link["broken_path"] == "broken-reference")
+    broken_ref_links = sum(
+        1 for link in broken_links if link["broken_path"] == "broken-reference"
+    )
 
     body = [
         "# 🔍 Broken Links Report",
@@ -147,7 +159,7 @@ def create_comment_body(broken_links):
         display_name = (
             f"{parent}/{file_name}"  # Combine parent folder and filename
         )
-        
+
         # Use emoji to indicate link type
         if link["broken_path"] == "broken-reference":
             link_type_icon = "⚠️"  # Warning icon for broken-reference

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -268,6 +268,7 @@ def status() -> None:
         # Write about the active entities
         scope = "repository" if client.uses_local_configuration else "global"
         cli_utils.declare(f"  The active user is: '{client.active_user.name}'")
+        cli_utils.declare(f"  The active project is: '{client.active_project.name}'")
         cli_utils.declare(
             f"  The active stack is: '{client.active_stack_model.name}' ({scope})"
         )

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -268,7 +268,9 @@ def status() -> None:
         # Write about the active entities
         scope = "repository" if client.uses_local_configuration else "global"
         cli_utils.declare(f"  The active user is: '{client.active_user.name}'")
-        cli_utils.declare(f"  The active project is: '{client.active_project.name}'")
+        cli_utils.declare(
+            f"  The active project is: '{client.active_project.name}'"
+        )
         cli_utils.declare(
             f"  The active stack is: '{client.active_stack_model.name}' ({scope})"
         )

--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -333,8 +333,8 @@ class BaseZenStore(
                     active_project = self.get_project(user.default_project_id)
                 except (KeyError, IllegalOperationError):
                     logger.warning(
-                        "The default project %s for the active user is no longer "
-                        "available.",
+                        "The default project %s for the active user is no "
+                        "longer available.",
                         user.default_project_id,
                     )
                 else:
@@ -349,28 +349,13 @@ class BaseZenStore(
                     project_filter_model=ProjectFilter()
                 )
             except Exception:
-                # There was some failure, we force the user to set the active
-                # project manually
-                logger.warning(
-                    "An active project is not set. Please set the active "
-                    "project by running `zenml project set <NAME>`."
-                )
+                pass
             else:
-                if len(projects) == 0:
-                    logger.warning(
-                        "No available projects. Please create a project by "
-                        "running `zenml project register <NAME> --set`."
-                    )
-                elif len(projects) == 1:
+                if len(projects) == 1:
                     active_project = projects.items[0]
                     logger.info(
                         f"Setting the {config_name} active project "
                         f"to '{active_project.name}'."
-                    )
-                else:
-                    logger.warning(
-                        "Multiple projects are available. Please set the "
-                        "active project by running `zenml project set <NAME>`."
                     )
 
         active_stack: StackResponse


### PR DESCRIPTION
## Describe changes
We currently logged warning messages for the active project not being set whenever we sanitize the global config or the client configuration. This caused us to
- log these warnings on the global level, even if an active project was set in the client
- log these warnings even when the user just wanted to list server scoped resources like stacks

This PR removes these warnings, as we anyway fail with a "missing active project" error in case the user wants to perform any project related requests.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

