### PR TITLE
Docs: Migrate to unified log_metadata method in starter guide

### DIFF
--- a/docs/book/user-guide/starter-guide/manage-artifacts.md
+++ b/docs/book/user-guide/starter-guide/manage-artifacts.md
@@ -458,7 +458,7 @@ def model_finetuner_step(
         # artifact_name="my_model", infer_artifact=True
 
         # A dictionary of dictionaries can also be passed to group metadata
-        # in the dashboard
+        #  in the dashboard
         # metadata = {"metrics": {"accuracy": accuracy}}
     )
     return model

--- a/docs/book/user-guide/starter-guide/manage-artifacts.md
+++ b/docs/book/user-guide/starter-guide/manage-artifacts.md
@@ -431,10 +431,10 @@ The [ZenML Pro](https://zenml.io/pro) dashboard offers advanced visualization fe
 {% endtab %}
 {% endtabs %}
 
-A user can also add metadata to an artifact within a step directly using the `log_artifact_metadata` method:
+A user can also add metadata to an artifact directly within a step using the `log_metadata` method:
 
 ```python
-from zenml import step, log_artifact_metadata
+from zenml import step, log_metadata
 
 @step
 def model_finetuner_step(
@@ -447,15 +447,18 @@ def model_finetuner_step(
     accuracy = model.score(dataset[0], dataset[1])
 
     
-    log_artifact_metadata(
-        # Artifact name can be omitted if step returns only one output
-        artifact_name="my_model",
-        # Passing None or omitting this will use the `latest` version
-        version=None,
+    log_metadata(
         # Metadata should be a dictionary of JSON-serializable values
-        metadata={"accuracy": float(accuracy)}
+        metadata={"accuracy": float(accuracy)},
+        # Using infer_artifact=True automatically attaches metadata to the
+        # artifact produced by this step. Since this step has only one output,
+        # we don't need to specify the artifact_name
+        infer_artifact=True
+        # If the step had multiple outputs, we would need to specify which one:
+        # artifact_name="my_model", infer_artifact=True
+
         # A dictionary of dictionaries can also be passed to group metadata
-        #  in the dashboard
+        # in the dashboard
         # metadata = {"metrics": {"accuracy": accuracy}}
     )
     return model

--- a/docs/book/user-guide/starter-guide/track-ml-models.md
+++ b/docs/book/user-guide/starter-guide/track-ml-models.md
@@ -144,10 +144,10 @@ def training_pipeline(gamma: float = 0.002):
 
 ## Logging metadata to the `Model` object
 
-[Just as one can associate metadata with artifacts](manage-artifacts.md#logging-metadata-for-an-artifact), models too can take a dictionary of key-value pairs to capture their metadata. This is achieved using the `log_model_metadata` method:
+[Just as one can associate metadata with artifacts](manage-artifacts.md#logging-metadata-for-an-artifact), models too can take a dictionary of key-value pairs to capture their metadata. This is achieved using the `log_metadata` method:
 
 ```python
-from zenml import get_step_context, step, log_model_metadata 
+from zenml import get_step_context, step, log_metadata
 
 @step
 def svc_trainer(
@@ -162,13 +162,15 @@ def svc_trainer(
 
     model = get_step_context().model
     
-    log_model_metadata(
-        # Model name can be omitted if specified in the step or pipeline context
-        model_name="iris_classifier",
-        # Passing None or omitting this will use the `latest` version
-        version=None,
+    log_metadata(
         # Metadata should be a dictionary of JSON-serializable values
-        metadata={"accuracy": float(accuracy)}
+        metadata={"accuracy": float(accuracy)},
+        # Using infer_model=True automatically attaches metadata to the model
+        # configured for this step
+        infer_model=True
+        # If not running within a step with model configured, specify:
+        # model_name="iris_classifier", model_version="my_version"
+
         # A dictionary of dictionaries can also be passed to group metadata
         #  in the dashboard
         # metadata = {"metrics": {"accuracy": accuracy}}


### PR DESCRIPTION
## Describe changes
Updated the starter guide docs to use the newer unified `log_metadata` method instead of the separate `log_artifact_metadata` and `log_model_metadata` methods. Examples now also show the current parameter usage including `infer_artifact` and `infer_model`.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

