### PR TITLE
Disable default project behaviour for pro workspaces

### DIFF
--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -450,20 +450,6 @@ class BaseZenStore(
         """
         return os.getenv(ENV_ZENML_DEFAULT_PROJECT_NAME, DEFAULT_PROJECT_NAME)
 
-    def _get_default_project(self) -> ProjectResponse:
-        """Get the default project.
-
-        Raises:
-            KeyError: If the default project doesn't exist.
-
-        Returns:
-            The default project.
-        """
-        try:
-            return self.get_project(self._default_project_name)
-        except KeyError:
-            raise KeyError("Unable to find default project.")
-
     def _get_default_stack(
         self,
     ) -> StackResponse:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1155,19 +1155,7 @@ class SqlZenStore(BaseZenStore):
 
     def _initialize_database(self) -> None:
         """Initialize the database if not already initialized."""
-        # When running in a Pro ZenML server, the default project is not
-        # created on database initialization but on server onboarding.
-        create_default_project = True
-        if ENV_ZENML_SERVER in os.environ:
-            from zenml.config.server_config import ServerConfiguration
-
-            if (
-                ServerConfiguration.get_server_config().deployment_type
-                == ServerDeploymentType.CLOUD
-            ):
-                create_default_project = False
-
-        if create_default_project:
+        if self._default_project_enabled:
             # Make sure the default project exists
             self._get_or_create_default_project()
         # Make sure the default stack exists
@@ -9440,7 +9428,8 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
             if (
-                existing_project.name == self._default_project_name
+                self._default_project_enabled
+                and existing_project.name == self._default_project_name
                 and "name" in project_update.model_fields_set
                 and project_update.name != existing_project.name
             ):
@@ -9481,7 +9470,10 @@ class SqlZenStore(BaseZenStore):
                 schema_class=ProjectSchema,
                 session=session,
             )
-            if project.name == self._default_project_name:
+            if (
+                self._default_project_enabled
+                and project.name == self._default_project_name
+            ):
                 raise IllegalOperationError(
                     "The default project cannot be deleted."
                 )
@@ -9541,6 +9533,22 @@ class SqlZenStore(BaseZenStore):
             return self.create_project(
                 ProjectRequest(name=default_project_name)
             )
+
+    @property
+    def _default_project_enabled(self) -> bool:
+        # When running in a Pro ZenML server, the default project is not
+        # created on database initialization but on server onboarding.
+        default_project_enabled = True
+        if ENV_ZENML_SERVER in os.environ:
+            from zenml.config.server_config import ServerConfiguration
+
+            if (
+                ServerConfiguration.get_server_config().deployment_type
+                == ServerDeploymentType.CLOUD
+            ):
+                default_project_enabled = False
+
+        return default_project_enabled
 
     # =======================
     # Internal helper methods
@@ -9915,7 +9923,7 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
             project_id = project.id
-        else:
+        elif self._default_project_enabled:
             # Use the default project as a last resort.
             try:
                 project = self._get_schema_by_name_or_id(
@@ -9926,6 +9934,8 @@ class SqlZenStore(BaseZenStore):
                 project_id = project.id
             except KeyError:
                 raise ValueError("Project scope missing from the filter")
+        else:
+            raise ValueError("Project scope missing from the filter")
 
         filter_model.project = project_id
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -9536,8 +9536,13 @@ class SqlZenStore(BaseZenStore):
 
     @property
     def _default_project_enabled(self) -> bool:
-        # When running in a Pro ZenML server, the default project is not
-        # created on database initialization but on server onboarding.
+        """Check if the default project is enabled.
+
+        When running in a Pro ZenML server, the default project is not enabled.
+
+        Returns:
+            True if the default project is enabled, False otherwise.
+        """
         default_project_enabled = True
         if ENV_ZENML_SERVER in os.environ:
             from zenml.config.server_config import ServerConfiguration


### PR DESCRIPTION
## Describe changes
Disables some "default project" behaviour for Pro workspaces which shouldn't have been enabled:
- Deleting a project called "default" is now allowed
- Updating the name of a project called "default" is now allowed
- Missing project ids in filter models will now not fallback to a project called "default" anymore

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

