### PR TITLE
Add option to set a private service connect to the Vertex AI orchestrator

### DIFF
--- a/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
+++ b/src/zenml/integrations/gcp/flavors/vertex_orchestrator_flavor.py
@@ -112,6 +112,11 @@ class VertexOrchestratorConfig(
         network: the full name of the Compute Engine Network to which the job
             should be peered. For example, `projects/12345/global/networks/myVPC`
             If not provided, the job will not be peered with any network.
+        private_service_connect: the full name of a Private Service Connect
+            endpoint to which the job should be peered. For example,
+            `projects/12345/regions/us-central1/networkAttachments/NETWORK_ATTACHMENT_NAME`
+            If not provided, the job will not be peered with any private service
+            connect endpoint.
         cpu_limit: The maximum CPU limit for this operator. This string value
             can be a number (integer value for number of CPUs) as string,
             or a number followed by "m", which means 1/1000. You can specify
@@ -130,6 +135,7 @@ class VertexOrchestratorConfig(
     encryption_spec_key_name: Optional[str] = None
     workload_service_account: Optional[str] = None
     network: Optional[str] = None
+    private_service_connect: Optional[str] = None
 
     # Deprecated
     cpu_limit: Optional[str] = None

--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -48,7 +48,15 @@ from uuid import UUID
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import aiplatform
+from google.cloud.aiplatform.compat.services import (
+    pipeline_service_client_v1beta1,
+)
+from google.cloud.aiplatform.compat.types import pipeline_job_v1beta1
 from google.cloud.aiplatform_v1.types import PipelineState
+from google.cloud.aiplatform_v1beta1.types.service_networking import (
+    PscInterfaceConfig,
+)
+from google.protobuf import json_format
 from google_cloud_pipeline_components.v1.custom_job.utils import (
     create_custom_training_job_from_component,
 )
@@ -735,6 +743,39 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
                 "The Vertex AI Pipelines job will be peered with the `%s` "
                 "network.",
                 self.config.network,
+            )
+
+        if self.config.private_service_connect:
+            # The PSC setting isn't yet part of the stable v1 API. We need to
+            # temporarily hack the aiplatform.PipelineJob object in two places:
+            # * to use the v1beta1 PipelineJob primitive which supports the
+            #   psc_interface_config field instead of the v1 PipelineJob
+            #   primitive.
+            # * to use the v1beta1 PipelineServiceClient instead of the v1
+            #   PipelineServiceClient.
+            #
+            # We achieve the first by converting the v1 PipelineJob to a
+            # v1beta1 PipelineJob and the second by replacing the v1
+            # PipelineServiceClient with a v1beta1 PipelineServiceClient.
+            #
+            # TODO: Remove this once the v1 stable API is updated to support
+            # the PSC setting.
+            pipeline_job_dict = json_format.MessageToDict(
+                run._gca_resource._pb, preserving_proto_field_name=True
+            )
+            run._gca_resource = pipeline_job_v1beta1.PipelineJob(
+                **pipeline_job_dict,
+                psc_interface_config=PscInterfaceConfig(
+                    network_attachment=self.config.private_service_connect,
+                ),
+            )
+            run.api_client = (
+                pipeline_service_client_v1beta1.PipelineServiceClient(
+                    credentials=run.credentials,
+                    client_options={
+                        "api_endpoint": run.api_client.api_endpoint,
+                    },
+                )
             )
 
         try:


### PR DESCRIPTION
## Describe changes
Add an option to set a private service connect to the Vertex AI orchestrator.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

