### PR TITLE
Docs: Starter guide fixes

### DIFF
--- a/docs/book/user-guide/starter-guide/cache-previous-executions.md
+++ b/docs/book/user-guide/starter-guide/cache-previous-executions.md
@@ -20,17 +20,9 @@ Step svc_trainer has finished in 0.932s.
 
 ZenML understands that nothing has changed between subsequent runs, so it re-uses the output of the previous run (the outputs are persisted in the [artifact store](https://docs.zenml.io/stacks/artifact-stores)). This behavior is known as **caching**.
 
-ZenML understands that nothing has changed between subsequent runs, so it re-uses the output of the previous run (the outputs are persisted in the [artifact store](https://docs.zenml.io/stacks/artifact-stores)). This behavior is known as **caching**.
-
-ZenML understands that nothing has changed between subsequent runs, so it re-uses the output of the previous run (the outputs are persisted in the [artifact store](https://docs.zenml.io/stacks/artifact-stores)). This behavior is known as **caching**.
-
-ZenML understands that nothing has changed between subsequent runs, so it re-uses the output of the previous run (the outputs are persisted in the [artifact store](https://docs.zenml.io/stacks/artifact-stores)). This behavior is known as **caching**.
-
-
 In ZenML, caching is enabled by default. Since ZenML automatically tracks and versions all inputs, outputs, and parameters of steps and pipelines, steps will not be re-executed within the **same pipeline** on subsequent pipeline runs as long as there is **no change** in the inputs, parameters, or code of a step.
 
-If you run a pipeline without a schedule, ZenML will be able to compute the cached steps on your client machine. This means that these steps don't have to be executed by your [orchestrator](https://docs.zenml.io/stacks/orchestrators), which can save time and money when you're executing your pipelines remotely. If you always want your orchestrator
-to compute cached steps dynamically, you can set the `ZENML_PREVENT_CLIENT_SIDE_CACHING` environment variable to `True`.
+If you run a pipeline without a schedule, ZenML will be able to compute the cached steps on your client machine. This means that these steps don't have to be executed by your [orchestrator](https://docs.zenml.io/stacks/orchestrators), which can save time and money when you're executing your pipelines remotely. If you always want your orchestrator to compute cached steps dynamically, you can set the `ZENML_PREVENT_CLIENT_SIDE_CACHING` environment variable to `True`.
 
 {% hint style="warning" %}
 The caching does not automatically detect changes within the file system or on external APIs. Make sure to **manually** set caching to `False` on steps that depend on **external inputs, file-system changes,** or if the step should run regardless of caching.

--- a/docs/book/user-guide/starter-guide/manage-artifacts.md
+++ b/docs/book/user-guide/starter-guide/manage-artifacts.md
@@ -125,7 +125,7 @@ def annotation_approach() -> str:
     return "string"
 
 
-# There are other was to attach this information to different versions of your 
+# There are other ways to attach this information to different versions of your
 # artifacts as well. For instance, you will see a step with a single output below.
 # If you modify the call to include the `infer_artifact` flag, these functions
 # will attach this information to the artifact version instead.


### PR DESCRIPTION
## Describe changes
I implemented fixes for:

1.  [Same sentence appearing four times in a row](https://docs.zenml.io/user-guides/starter-guide/cache-previous-executions#:~:text=cached%20pipeline%20run-,ZenML%20understands%20that%20nothing%20has%20changed)
2. Abrupt line break present [here](https://docs.zenml.io/user-guides/starter-guide/cache-previous-executions#:~:text=If%20you%20always%20want%20your%20orchestrator)
3. Minor typo [here](https://docs.zenml.io/user-guides/starter-guide/manage-artifacts#:~:text=There%20are%20other%20was%20to%20attach): was --> ways

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)

