### PR TITLE
Allow (and ignore) extra attributes in all ZenML models

### DIFF
--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -309,5 +309,5 @@ class DockerSettings(BaseSettings):
         # public attributes are immutable
         frozen=True,
         # prevent extra attributes during model initialization
-        extra="forbid",
+        extra="ignore",
     )

--- a/src/zenml/config/resource_settings.py
+++ b/src/zenml/config/resource_settings.py
@@ -119,5 +119,5 @@ class ResourceSettings(BaseSettings):
         # public attributes are immutable
         frozen=True,
         # prevent extra attributes during model initialization
-        extra="forbid",
+        extra="ignore",
     )

--- a/src/zenml/config/strict_base_model.py
+++ b/src/zenml/config/strict_base_model.py
@@ -19,4 +19,4 @@ from pydantic import BaseModel, ConfigDict
 class StrictBaseModel(BaseModel):
     """Immutable pydantic model which prevents extra attributes."""
 
-    model_config = ConfigDict(frozen=True, extra="forbid")
+    model_config = ConfigDict(frozen=True, extra="ignore")

--- a/src/zenml/integrations/evidently/metrics.py
+++ b/src/zenml/integrations/evidently/metrics.py
@@ -361,4 +361,4 @@ class EvidentlyMetricConfig(BaseModel):
                 f"`{self.class_path}`: {str(e)}"
             )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")

--- a/src/zenml/integrations/evidently/tests.py
+++ b/src/zenml/integrations/evidently/tests.py
@@ -345,4 +345,4 @@ class EvidentlyTestConfig(BaseModel):
                 f"`{self.class_path}`: {str(e)}"
             )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")

--- a/src/zenml/models/v2/core/user.py
+++ b/src/zenml/models/v2/core/user.py
@@ -169,7 +169,7 @@ class UserRequest(UserBase, BaseRequest):
         # Validate attributes when assigning them
         validate_assignment=True,
         # Forbid extra attributes to prevent unexpected behavior
-        extra="forbid",
+        extra="ignore",
     )
 
 

--- a/src/zenml/secret/base_secret.py
+++ b/src/zenml/secret/base_secret.py
@@ -45,5 +45,5 @@ class BaseSecretSchema(BaseModel):
         # validate attribute assignments
         validate_assignment=True,
         # report extra attributes as validation failures
-        extra="forbid",
+        extra="ignore",
     )

--- a/src/zenml/stack/stack_component.py
+++ b/src/zenml/stack/stack_component.py
@@ -318,7 +318,7 @@ class StackComponentConfig(BaseModel, ABC):
         # public attributes are immutable
         frozen=True,
         # prevent extra attributes during model initialization
-        extra="forbid",
+        extra="ignore",
     )
 
 

--- a/src/zenml/stack/utils.py
+++ b/src/zenml/stack/utils.py
@@ -85,7 +85,7 @@ def validate_stack_component_config(
     validation_config_class: Type[StackComponentConfig] = type(
         config_class.__name__,
         (config_class,),
-        {"model_config": {"extra": "forbid"}},
+        {"model_config": {"extra": "ignore"}},
     )
     configuration = validation_config_class(**configuration_dict)
 

--- a/src/zenml/zen_server/deploy/daemon/daemon_zen_server.py
+++ b/src/zenml/zen_server/deploy/daemon/daemon_zen_server.py
@@ -80,7 +80,7 @@ class DaemonServerDeploymentConfig(LocalServerDeploymentConfig):
         """
         return f"http://{self.ip_address}:{self.port}"
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
 
 class DaemonZenServerConfig(LocalDaemonServiceConfig):

--- a/src/zenml/zen_server/deploy/docker/docker_zen_server.py
+++ b/src/zenml/zen_server/deploy/docker/docker_zen_server.py
@@ -82,7 +82,7 @@ class DockerServerDeploymentConfig(LocalServerDeploymentConfig):
         """
         return f"http://{DEFAULT_LOCAL_SERVICE_IP_ADDRESS}:{self.port}"
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
 
 class DockerZenServerConfig(ContainerServiceConfig):

--- a/src/zenml/zen_stores/secrets_stores/hashicorp_secrets_store.py
+++ b/src/zenml/zen_stores/secrets_stores/hashicorp_secrets_store.py
@@ -68,7 +68,7 @@ class HashiCorpVaultSecretsStoreConfiguration(SecretsStoreConfiguration):
     vault_namespace: Optional[str] = None
     mount_point: Optional[str] = None
     max_versions: int = 1
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
 
 class HashiCorpVaultSecretsStore(BaseSecretsStore):

--- a/src/zenml/zen_stores/secrets_stores/sql_secrets_store.py
+++ b/src/zenml/zen_stores/secrets_stores/sql_secrets_store.py
@@ -70,7 +70,7 @@ class SqlSecretsStoreConfiguration(SecretsStoreConfiguration):
         # of the certificate files.
         validate_assignment=False,
         # Forbid extra attributes set in the class.
-        extra="forbid",
+        extra="ignore",
     )
 
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -790,7 +790,7 @@ class SqlZenStoreConfiguration(StoreConfiguration):
         # of the certificate files.
         validate_assignment=False,
         # Forbid extra attributes set in the class.
-        extra="forbid",
+        extra="ignore",
     )
 
 

--- a/tests/integration/functional/cli/test_stack_components.py
+++ b/tests/integration/functional/cli/test_stack_components.py
@@ -85,62 +85,10 @@ def test_update_stack_component_for_nonexistent_component_fails(
     assert result.exit_code == 1
 
 
-def test_update_stack_component_with_name_or_uuid_fails(
+def test_update_stack_component_with_non_configured_property_succeeds(
     clean_client: "Client",
 ) -> None:
-    """Test that updating stack component name or uuid fails."""
-    register_container_registry_command = cli.commands[
-        "container-registry"
-    ].commands["register"]
-
-    runner = CliRunner()
-    register_result = runner.invoke(
-        register_container_registry_command,
-        [
-            "new_container_registry",
-            "--flavor",
-            "default",
-            "--uri=some_random_uri.com",
-        ],
-    )
-    assert register_result.exit_code == 0
-
-    update_container_registry_command = cli.commands[
-        "container-registry"
-    ].commands["update"]
-    update_result1 = runner.invoke(
-        update_container_registry_command,
-        [
-            "new_container_registry",
-            "--name=aria",
-        ],
-    )
-    assert update_result1.exit_code == 1
-    with does_not_raise():
-        clean_client.get_stack_component(
-            name_id_or_prefix="new_container_registry",
-            component_type=StackComponentType.CONTAINER_REGISTRY,
-        )
-
-    update_result2 = runner.invoke(
-        update_container_registry_command,
-        [
-            "new_container_registry",
-            "--uuid=aria_uuid",
-        ],
-    )
-    assert update_result2.exit_code == 1
-    with does_not_raise():
-        clean_client.get_stack_component(
-            name_id_or_prefix="new_container_registry",
-            component_type=StackComponentType.CONTAINER_REGISTRY,
-        )
-
-
-def test_update_stack_component_with_non_configured_property_fails(
-    clean_client: "Client",
-) -> None:
-    """Updating stack component with aa non-configured property fails."""
+    """Updating stack component with a non-configured property succeeds."""
     register_container_registry_command = cli.commands[
         "container-registry"
     ].commands["register"]
@@ -167,7 +115,7 @@ def test_update_stack_component_with_non_configured_property_fails(
             "--favorite_cat=aria",
         ],
     )
-    assert update_result.exit_code == 1
+    assert update_result.exit_code == 0
     with pytest.raises(AttributeError):
         clean_client.get_stack_component(
             name_id_or_prefix="new_container_registry",

--- a/tests/unit/config/test_settings_resolver.py
+++ b/tests/unit/config/test_settings_resolver.py
@@ -18,7 +18,6 @@ import pytest
 from zenml.config import DockerSettings
 from zenml.config.base_settings import BaseSettings
 from zenml.config.settings_resolver import SettingsResolver
-from zenml.exceptions import SettingsResolvingError
 
 
 def test_settings_resolver_fails_when_using_invalid_settings_key(mocker):
@@ -80,12 +79,13 @@ def test_resolving_fails_if_no_stack_component_settings_exist_for_the_given_key(
         resolver.resolve(stack=local_stack)
 
 
-def test_resolving_fails_if_the_settings_cant_be_converted(local_stack):
-    """Tests that resolving fails if the given settings can't be converted to
-    the expected settings class."""
+def test_resolving_succeeds_if_the_settings_contain_extra_attributes(
+    local_stack,
+):
+    """Tests that resolving succeeds if the given settings contain extra attributes."""
     settings = BaseSettings(not_a_docker_settings_key=1)
 
     resolver = SettingsResolver(key="docker", settings=settings)
 
-    with pytest.raises(SettingsResolvingError):
+    with does_not_raise():
         resolver.resolve(stack=local_stack)

--- a/tests/unit/stack/test_stack_component.py
+++ b/tests/unit/stack/test_stack_component.py
@@ -58,14 +58,14 @@ def test_stack_component_public_attributes_are_immutable(
         stub_component_config._some_private_attribute_name = "Woof"
 
 
-def test_stack_component_prevents_extra_attributes(stub_component_config):
-    """Tests that passing extra attributes to a StackComponent fails."""
+def test_stack_component_allows_extra_attributes(stub_component_config):
+    """Tests that passing extra attributes to a StackComponent is allowed."""
     component_class = stub_component_config.__class__
 
     with does_not_raise():
         component_class(some_public_attribute_name="test")
 
-    with pytest.raises(ValidationError):
+    with does_not_raise():
         component_class(not_an_attribute_name="test")
 
 

--- a/tests/unit/stack/test_utils.py
+++ b/tests/unit/stack/test_utils.py
@@ -14,9 +14,6 @@
 
 from contextlib import ExitStack as does_not_raise
 
-import pytest
-from pydantic import ValidationError
-
 from tests.unit.conftest_new import empty_pipeline  # noqa
 from zenml.enums import StackComponentType
 from zenml.orchestrators.local_docker.local_docker_orchestrator import (
@@ -25,14 +22,14 @@ from zenml.orchestrators.local_docker.local_docker_orchestrator import (
 from zenml.stack.utils import validate_stack_component_config
 
 
-def test_stack_component_validation_prevents_extras():
-    """Tests that stack component validation prevents extra attributes."""
+def test_stack_component_validation_allows_extras():
+    """Tests that stack component validation allows extra attributes."""
     config_dict = {"not_a_valid_component_attribute": False}
 
     with does_not_raise():
         LocalDockerOrchestratorConfig(**config_dict)
 
-    with pytest.raises(ValidationError):
+    with does_not_raise():
         validate_stack_component_config(
             config_dict,
             flavor="local_docker",


### PR DESCRIPTION
## Describe changes
Allow (and ignore) extra attributes in all ZenML models.

This is the first step in ensuring backwards compatibility for API and configuration changes because it allows us to remove attributes without triggering Pydantic validation errors.

The downside is that no warnings will be shown if typos occur.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

