### PR TITLE
Added docs to point to the repo for local python packages

### DIFF
--- a/docs/book/how-to/containerization/containerization.md
+++ b/docs/book/how-to/containerization/containerization.md
@@ -287,12 +287,16 @@ ZenML offers several ways to specify dependencies for your Docker containers:
 
     docker_settings = DockerSettings(required_integrations=[PYTORCH, EVIDENTLY])
     ```
-5.  **Control Stack Requirements**:\
+5.  **Control Stack Requirements**:
     By default, ZenML installs the requirements needed by your active stack. You can disable this behavior if needed:
 
     ```python
     docker_settings = DockerSettings(install_stack_requirements=False)
     ```
+6.  **Local Library Installation**:
+    In cases where your project contains some local python library that your pipeline relies on, you will need to build it into the 
+    docker image explicitely. Here is a small minimal repo that shows you how you can go about this as this requires some nuance: https://github.com/zenml-io/zenml-patterns/tree/main/docker-local-pkg
+
 
 {% hint style="info" %}
 You can combine these methods but do make sure that your list of requirements does not overlap with ones specified explicitly in the Docker settings to avoid version conflicts.
@@ -300,7 +304,7 @@ You can combine these methods but do make sure that your list of requirements do
 
 Depending on the options specified in your Docker settings, ZenML installs the requirements in the following order (each step optional):
 
-1. The packages installed in your local Python environment
+1. The Pypi packages installed in your local Python environment
 2. The packages required by the stack (unless disabled by setting `install_stack_requirements=False`)
 3. The packages specified via the `required_integrations`
 4. The packages specified via the `requirements` attribute


### PR DESCRIPTION
## Describe changes
The question to install some local python library without first building and pushing the wheel has come up multiple times now. We created a repo to address this: https://github.com/zenml-io/zenml-patterns/tree/main/docker-local-pkg and this PR just adds a small section to the docs to solve this.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

