### PR TITLE
Add unique instance label to helm chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -41,21 +41,17 @@ app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
-{{- define "zenml.metadataLabels" -}}
-helm.sh/chart: {{ include "zenml.chart" . }}
-{{ include "zenml.metadataSelectorLabels" . }}
-{{- if .Chart.Version }}
-app.kubernetes.io/version: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "zenml.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "zenml.name" . }}
+{{- if .Values.zenml.instanceLabel }}
+app.kubernetes.io/instance: {{ .Values.zenml.instanceLabel | quote }}
+{{- else }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/templates/server-db-job.yaml
+++ b/helm/templates/server-db-job.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "zenml.fullname" . }}-db-migration
   labels:
     {{- include "zenml.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db-migration
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
@@ -20,6 +21,7 @@ spec:
       {{- end }}
       labels:
         {{- include "zenml.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: db-migration
     spec:
       {{- if or .Values.zenml.certificates.customCAs .Values.zenml.certificates.secretRefs }}
       initContainers:

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "zenml.fullname" . }}
   labels:
     {{- include "zenml.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
 spec:
   {{- if .Values.zenml.database.url }}
   {{- if not .Values.autoscaling.enabled }}
@@ -24,6 +25,7 @@ spec:
       {{- end }}
       labels:
         {{- include "zenml.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
     spec:
       {{- if or .Values.zenml.certificates.customCAs .Values.zenml.certificates.secretRefs }}
       initContainers:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -989,6 +989,20 @@ zenml:
   # mounted as environment variables in the ZenML server container.
   secretEnvironment: {}
 
+  # Custom 'app.kubernetes.io/instance' label value to use. This is used to
+  # uniquely identify the ZenML deployment in the Kubernetes cluster. All
+  # resources in the deployment will be labeled with this value, if set. The
+  # label will also be used as a selector label for the ZenML server deployment
+  # and database migration job.
+  #
+  # If not set, the default value will be the release name.
+  #
+  # It is recommended to set this value to a unique identifier in your cluster
+  # to avoid conflicts with other ZenML deployments in the same cluster,
+  # especially when using the same Helm release name for multiple deployments.
+  # This can also be useful when used in conjunction with affinity rules.
+  instanceLabel:
+
   service:
     type: ClusterIP
     port: 80


### PR DESCRIPTION
## Describe changes
It is currently not possible to properly configure Kubernetes affinity rules for ZenML Helm deployments for the following reason: there is no way to uniquely label all the pods belonging to the same ZenML Helm deployment.

Currently, all pods belonging to the same deployment are labeled with:

```
app.kubernetes.io/instance: {{ .Release.Name }}
```

where `.Release.Name` is the name used for the Helm release and is usually not unique across a Kubernetes cluster (e.g. usually just set to `zenml`). When deploying multiple ZenML servers in the same cluster, this poses a problem, because multiple ZenML pods may have the same labels (albeit across different namespaces).

This PR introduces a new option, `zenml.instanceLabel` that when set will be used as a `app.kubernetes.io/instance` label value instead of `.Release.Name`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

