### PR TITLE
Publish Codespace docker image with release

### DIFF
--- a/.github/workflows/publish_codespace_image.yml
+++ b/.github/workflows/publish_codespace_image.yml
@@ -1,0 +1,71 @@
+---
+name: Publish ZenML Codespace Docker image
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (leave empty for latest)'
+        required: false
+        type: string
+        default: ''
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+      - develop
+  pull_request:
+    paths:
+      - 'docker/zenml-codespace.Dockerfile'
+
+jobs:
+  publish_codespace_image:
+    name: Build and publish zenml-codespace Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ZENML_DEBUG: 1
+      ZENML_ANALYTICS_OPT_IN: false
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@v4.2.2
+      
+      - name: Determine version
+        run: |-
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            CURRENT_VERSION=$(cat src/zenml/VERSION)
+            DATE=$(date +"%Y%m%d")
+            VERSION="${CURRENT_VERSION}.dev${DATE}"
+          fi
+          VERSION=$(echo $VERSION | sed 's/[^a-zA-Z0-9._-]/-/g')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Determined VERSION=$VERSION"
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5.0.0
+        with:
+          context: .
+          file: ./docker/zenml-codespace.Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            zenmldocker/zenml-codespace:${{ env.VERSION }}
+            ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && 'zenmldocker/zenml-codespace:latest' || '' }}
+          build-args: |
+            ZENML_VERSION=${{ env.VERSION }}
+            PYTHON_VERSION=3.11 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,16 @@ jobs:
     needs: wait-for-package-release
     uses: ./.github/workflows/publish_docker_image.yml
     secrets: inherit
-  publish-helm-chart:
+  publish-codespace-image:
     if: github.repository == 'zenml-io/zenml'
     needs: publish-docker-image
+    uses: ./.github/workflows/publish_codespace_image.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit
+  publish-helm-chart:
+    if: github.repository == 'zenml-io/zenml'
+    needs: publish-codespace-image
     uses: ./.github/workflows/publish_helm_chart.yml
     secrets: inherit
   wait-for-package-release-again:

--- a/docker/zenml-codespace.Dockerfile
+++ b/docker/zenml-codespace.Dockerfile
@@ -1,0 +1,57 @@
+ARG PYTHON_VERSION=3.11
+ARG ZENML_VERSION=latest
+
+# Use the official ZenML image as a base
+FROM zenmldocker/zenml:latest as base
+
+# Set user to root for installations
+USER root
+
+# Install prerequisites (curl already added) + extras from Modal example
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    dumb-init \
+    git \
+    git-lfs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Define code-server versions/locations (same as Modal example)
+ARG CODE_SERVER_INSTALLER="https://code-server.dev/install.sh"
+ARG CODE_SERVER_ENTRYPOINT="https://raw.githubusercontent.com/coder/code-server/refs/tags/v4.96.1/ci/release-image/entrypoint.sh"
+ARG FIXUD_INSTALLER="https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$(dpkg --print-architecture).tar.gz"
+
+# Install code-server AND download the specific entrypoint script
+RUN curl -fsSL ${CODE_SERVER_INSTALLER} | sh \
+    && curl -fsSL ${CODE_SERVER_ENTRYPOINT} -o /code-server.sh \
+    && chmod u+x /code-server.sh
+
+# Install fixuid (mimicking Modal example's run_commands)
+# Note: Using $(dpkg --print-architecture) directly in ARG might not work as expected during build-arg expansion.
+# We embed it in the RUN command instead.
+RUN ARCH="$(dpkg --print-architecture)" \
+    && curl -fsSL "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-${ARCH}.tar.gz" | tar -C /usr/local/bin -xzf - \
+    && chown root:root /usr/local/bin/fixuid \
+    && chmod 4755 /usr/local/bin/fixuid \
+    && mkdir -p /etc/fixuid \
+    && echo "user: root" >> /etc/fixuid/config.yml \
+    && echo "group: root" >> /etc/fixuid/config.yml
+
+# Ensure /usr/local/bin (common install location) is in PATH
+ENV PATH="/usr/local/bin:${PATH}"
+
+# Create /home/coder directory (as in Modal example)
+RUN mkdir -p /home/coder
+# Optional: Set ownership if needed, depends on base image and desired execution user
+# RUN chown someuser:somegroup /home/coder
+
+# Set environment variables (as in Modal example)
+ENV ENTRYPOINTD=""
+
+# Default working directory from base image is likely /app
+WORKDIR /app
+
+# Expose the default code-server port (optional, for documentation)
+EXPOSE 8080
+
+# Default command - using dumb-init is often good practice with containers
+CMD ["dumb-init", "--", "/bin/bash"] 


### PR DESCRIPTION
## Describe changes
This adds Github action and Dockerfile to build and push docker image for the codespace with release. This image builds on top of zenml lates docker image and add code-server dependency

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

