### PR TITLE
Limit concurrent pipeline runs

### DIFF
--- a/src/zenml/config/server_config.py
+++ b/src/zenml/config/server_config.py
@@ -156,6 +156,8 @@ class ServerConfiguration(BaseModel):
             implementing the workload management interface.
         max_concurrent_template_runs: The maximum number of concurrent template
             runs that can be executed on the server.
+        max_concurrent_pipeline_runs: The maximum number of concurrent pipeline
+            runs that can be executed on the server.
         pipeline_run_auth_window: The default time window in minutes for which
             a pipeline run action is allowed to authenticate with the ZenML
             server.
@@ -297,6 +299,7 @@ class ServerConfiguration(BaseModel):
     max_concurrent_template_runs: int = (
         DEFAULT_ZENML_SERVER_MAX_CONCURRENT_TEMPLATE_RUNS
     )
+    max_concurrent_pipeline_runs: Optional[int] = None
     pipeline_run_auth_window: int = (
         DEFAULT_ZENML_SERVER_PIPELINE_RUN_AUTH_WINDOW
     )

--- a/src/zenml/zen_server/rbac/endpoint_utils.py
+++ b/src/zenml/zen_server/rbac/endpoint_utils.py
@@ -155,12 +155,15 @@ def verify_permissions_and_get_or_create_entity(
     get_or_create_method: Callable[
         [AnyRequest, Optional[Callable[[], None]]], Tuple[AnyResponse, bool]
     ],
+    custom_pre_creation_hook: Optional[Callable[[], None]] = None,
 ) -> Tuple[AnyResponse, bool]:
     """Verify permissions and create the entity if authorized.
 
     Args:
         request_model: The entity request model.
         get_or_create_method: The method to get or create the entity.
+        custom_pre_creation_hook: An optional hook to run before the entity is
+            created.
 
     Returns:
         The entity and a boolean indicating whether the entity was created.
@@ -183,6 +186,8 @@ def verify_permissions_and_get_or_create_entity(
         verify_permission_for_model(model=request_model, action=Action.CREATE)
         if resource_type and needs_usage_increment:
             check_entitlement(resource_type=resource_type)
+        if custom_pre_creation_hook:
+            custom_pre_creation_hook()
 
     model, created = get_or_create_method(request_model, _pre_creation_hook)
 

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -89,8 +89,16 @@ def check_concurrent_run_limit() -> None:
             "You have reached the maximum number of concurrent runs. "
             "Please upgrade your subscription to increase the limit. "
             "If some of your runs are incorrectly still in running state even "
-            "though they've failed already, you can manually delete them by "
-            "running `zenml pipeline runs delete <ID>`."
+            "though they've failed already, you can free up resources by: "
+            "1. Running `zenml pipeline runs list --status=running` and/or "
+            "zenml pipeline runs list --status=initializing "
+            "to find stuck runs "
+            "2. Note the IDs of runs you want to remove from the list "
+            "3. Delete each run with `zenml pipeline runs delete <RUN_ID> -y` "
+            "4. To check if this resolved the issue, run your pipeline again "
+            
+            "For more details on pipeline management, see our documentation at "
+            "https://docs.zenml.io/user-guides/best-practices/keep-your-dashboard-server-clean#deleting-pipeline-runs"
         )
 
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -4985,7 +4985,7 @@ class SqlZenStore(BaseZenStore):
         """
         # Because we can not guarantee that we detect all failed runs, we only
         # count runs that have been running for less than 5 minutes.
-        ten_minutes_ago = utc_now(tz_aware=False) - timedelta(minutes=5)
+        start_time = utc_now(tz_aware=False) - timedelta(minutes=5)
         with Session(self.engine) as session:
             query = (
                 select(func.count(col(PipelineRunSchema.id)))
@@ -4997,7 +4997,7 @@ class SqlZenStore(BaseZenStore):
                         ]
                     )
                 )
-                .where(PipelineRunSchema.start_time > ten_minutes_ago)  # type: ignore[operator]
+                .where(PipelineRunSchema.created > ten_minutes_ago)  # type: ignore[operator]
             )
             count = session.scalar(query)
             return int(count) if count else 0


### PR DESCRIPTION
## Describe changes
Limit the amount of concurrent pipeline runs.

Caveat: Right now, we're not able to guarantee that we detect all failed runs if they fail on the orchestrator side without notifying the ZenML server. For that reason, we only count runs that started in the last 5 minutes to count towards the concurrent run limit.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

