### PR TITLE
Store validated config with converted types in DB

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -2024,7 +2024,9 @@ class Client(metaclass=ClientMetaClass):
             name=name,
             type=component_type,
             flavor=flavor,
-            configuration=configuration,
+            configuration=validated_config.model_dump(
+                mode="json", exclude_unset=True
+            ),
             labels=labels,
         )
 
@@ -2112,7 +2114,9 @@ class Client(metaclass=ClientMetaClass):
             assert validated_config is not None
             warn_if_config_server_mismatch(validated_config)
 
-            update_model.configuration = existing_configuration
+            update_model.configuration = validated_config.model_dump(
+                mode="json", exclude_unset=True
+            )
 
         if labels is not None:
             existing_labels = component.labels or {}

--- a/src/zenml/zen_server/routers/stack_components_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_components_endpoints.py
@@ -93,7 +93,7 @@ def create_stack_component(
 
     from zenml.stack.utils import validate_stack_component_config
 
-    validate_stack_component_config(
+    validated_config = validate_stack_component_config(
         configuration_dict=component.configuration,
         flavor=component.flavor,
         component_type=component.type,
@@ -101,6 +101,11 @@ def create_stack_component(
         # We allow custom flavors to fail import on the server side.
         validate_custom_flavors=False,
     )
+
+    if validated_config:
+        component.configuration = validated_config.model_dump(
+            mode="json", exclude_unset=True
+        )
 
     return verify_permissions_and_create_entity(
         request_model=component,
@@ -199,7 +204,7 @@ def update_stack_component(
         from zenml.stack.utils import validate_stack_component_config
 
         existing_component = zen_store().get_stack_component(component_id)
-        validate_stack_component_config(
+        validated_config = validate_stack_component_config(
             configuration_dict=component_update.configuration,
             flavor=existing_component.flavor_name,
             component_type=existing_component.type,
@@ -207,6 +212,10 @@ def update_stack_component(
             # We allow custom flavors to fail import on the server side.
             validate_custom_flavors=False,
         )
+        if validated_config:
+            component_update.configuration = validated_config.model_dump(
+                mode="json", exclude_unset=True
+            )
 
     if component_update.connector:
         service_connector = zen_store().get_service_connector(


### PR DESCRIPTION
## Describe changes
When creating or updating a stack component, we stored the user-provided configuration in the database as a serialized JSON string. When using the CLI to register/update, this means all values were stored as strings, which lead to some validation errors in the frontend.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

