### PR TITLE
Use correct artifact store for nested materializers

### DIFF
--- a/src/zenml/materializers/built_in_materializer.py
+++ b/src/zenml/materializers/built_in_materializer.py
@@ -352,7 +352,9 @@ class BuiltInContainerMaterializer(BaseMaterializer):
                 ):
                     type_ = find_type_by_str(type_str)
                     materializer_class = materializer_registry[type_]
-                    materializer = materializer_class(uri=path_)
+                    materializer = materializer_class(
+                        uri=path_, artifact_store=self.artifact_store
+                    )
                     element = materializer.load(type_)
                     outputs.append(element)
 
@@ -364,7 +366,9 @@ class BuiltInContainerMaterializer(BaseMaterializer):
                     materializer_class = source_utils.load(
                         entry["materializer"]
                     )
-                    materializer = materializer_class(uri=path_)
+                    materializer = materializer_class(
+                        uri=path_, artifact_store=self.artifact_store
+                    )
                     element = materializer.load(type_)
                     outputs.append(element)
 
@@ -427,7 +431,9 @@ class BuiltInContainerMaterializer(BaseMaterializer):
                 self.artifact_store.mkdir(element_path)
                 type_ = type(element)
                 materializer_class = materializer_registry[type_]
-                materializer = materializer_class(uri=element_path)
+                materializer = materializer_class(
+                    uri=element_path, artifact_store=self.artifact_store
+                )
                 materializers.append(materializer)
                 metadata.append(
                     {


### PR DESCRIPTION
## Describe changes
When trying to load an artifact which is stored in an artifact store that is not the same as the active one, the `BuiltInContainerMaterializer` did not pass on the artifact store to its sub-materializers. This caused them to fallback to the active stack, which then lead to an error that the file the sub-materializer is trying to load is out of bounds of the artifact store.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

