### PR TITLE
Don't log parent image digest warning if build is skipped

### DIFF
--- a/src/zenml/config/build_configuration.py
+++ b/src/zenml/config/build_configuration.py
@@ -108,6 +108,13 @@ class BuildConfiguration(BaseModel):
             )
             if digest:
                 hash_.update(digest.encode())
+            elif self.settings.skip_build:
+                # If the user has specified to skip the build, the image being
+                # used for the run is whatever they set for `parent_image`.
+                # In this case, the bevavior depends on the orchestrators image
+                # pull policy, and whether there is any caching involved. This
+                # is out of our control here, so we don't log any warning.
+                pass
             else:
                 logger.warning(
                     "Unable to fetch parent image digest for image `%s`. "


### PR DESCRIPTION
## Describe changes
Don't log a warning if `skip_build=True` if the parent image digest can't be fetched.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

