### PR TITLE
Fix service connector docs example

### DIFF
--- a/docs/book/how-to/stack-components/service_connectors.md
+++ b/docs/book/how-to/stack-components/service_connectors.md
@@ -146,7 +146,7 @@ def upload_model(model):
     # No credential handling required
     from zenml.integrations.s3.artifact_stores import S3ArtifactStore
     store = S3ArtifactStore()
-    store.upload_file(model.path, 'models/model.pkl')
+    store.copyfile(model.path, 'models/model.pkl')
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- update doc example to use `copyfile` instead of nonexistent `upload_file`

## Testing
- `scripts/lint.sh` *(fails: yamlfix not found)*