### PR TITLE
Fix `DockerServiceConnector._verify` assertion error when no `resource_id` is provided

### DIFF
--- a/src/zenml/service_connectors/docker_service_connector.py
+++ b/src/zenml/service_connectors/docker_service_connector.py
@@ -374,8 +374,9 @@ class DockerServiceConnector(ServiceConnector):
                 f"\nSkipping Docker connector verification."
             )
         else:
-            assert resource_id is not None
-            self._authorize_client(docker_client, resource_id)
-            docker_client.close()
+            # Only attempt to authorize the client if a resource ID is provided
+            if resource_id is not None:
+                self._authorize_client(docker_client, resource_id)
+                docker_client.close()
 
         return [resource_id] if resource_id else []

--- a/tests/unit/service_connectors/__init__.py
+++ b/tests/unit/service_connectors/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ZenML service connectors."""

--- a/tests/unit/service_connectors/test_docker_service_connector.py
+++ b/tests/unit/service_connectors/test_docker_service_connector.py
@@ -1,0 +1,84 @@
+"""Tests for the Docker Service Connector."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from docker.errors import DockerException
+
+from zenml.service_connectors.docker_service_connector import (
+    DockerServiceConnector,
+    DockerConfiguration,
+)
+from zenml.utils.secret_utils import PlainSerializedSecretStr
+
+class TestDockerServiceConnector:
+    """Test for the Docker service connector."""
+
+    @pytest.fixture
+    def docker_connector(self):
+        """Create a Docker service connector for testing."""
+        config = DockerConfiguration(
+            username=PlainSerializedSecretStr("test-user"),
+            password=PlainSerializedSecretStr("test-password"),
+            registry="docker.io",
+        )
+        return DockerServiceConnector(
+            auth_method="password", 
+            config=config
+        )
+
+    @patch("zenml.service_connectors.docker_service_connector.DockerClient")
+    def test_verify_with_resource_id(self, mock_docker_client, docker_connector):
+        """Test the _verify method when a resource ID is provided."""
+        # Setup
+        mock_client = MagicMock()
+        mock_docker_client.from_env.return_value = mock_client
+        
+        # Test
+        resource_ids = docker_connector._verify(
+            resource_type="docker-registry",
+            resource_id="docker.io"
+        )
+        
+        # Assert
+        assert resource_ids == ["docker.io"]
+        mock_client.login.assert_called_once()
+        mock_client.close.assert_called_once()
+
+    @patch("zenml.service_connectors.docker_service_connector.DockerClient")
+    def test_verify_without_resource_id(self, mock_docker_client, docker_connector):
+        """Test the _verify method when no resource ID is provided.
+        
+        This tests our fix for the assertion issue.
+        """
+        # Setup
+        mock_client = MagicMock()
+        mock_docker_client.from_env.return_value = mock_client
+        
+        # Test
+        resource_ids = docker_connector._verify(
+            resource_type="docker-registry",
+            resource_id=None
+        )
+        
+        # Assert
+        assert resource_ids == []
+        mock_client.login.assert_not_called()
+        mock_client.close.assert_not_called()
+
+    @patch("zenml.service_connectors.docker_service_connector.DockerClient")
+    def test_verify_with_docker_exception(self, mock_docker_client, docker_connector):
+        """Test the _verify method when Docker client raises an exception."""
+        # Setup
+        mock_docker_client.from_env.side_effect = DockerException("Docker not available")
+        
+        # Test
+        resource_ids = docker_connector._verify(
+            resource_type="docker-registry",
+            resource_id="docker.io"
+        )
+        
+        # Assert - should still return the resource ID despite the exception
+        assert resource_ids == ["docker.io"]
+
+if __name__ == "__main__":
+    pytest.main(["-xvs", __file__])

--- a/tests/unit/service_connectors/test_docker_service_connector.py
+++ b/tests/unit/service_connectors/test_docker_service_connector.py
@@ -1,14 +1,16 @@
 """Tests for the Docker Service Connector."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 from docker.errors import DockerException
 
 from zenml.service_connectors.docker_service_connector import (
-    DockerServiceConnector,
     DockerConfiguration,
+    DockerServiceConnector,
 )
 from zenml.utils.secret_utils import PlainSerializedSecretStr
+
 
 class TestDockerServiceConnector:
     """Test for the Docker service connector."""
@@ -21,64 +23,67 @@ class TestDockerServiceConnector:
             password=PlainSerializedSecretStr("test-password"),
             registry="docker.io",
         )
-        return DockerServiceConnector(
-            auth_method="password", 
-            config=config
-        )
+        return DockerServiceConnector(auth_method="password", config=config)
 
     @patch("zenml.service_connectors.docker_service_connector.DockerClient")
-    def test_verify_with_resource_id(self, mock_docker_client, docker_connector):
+    def test_verify_with_resource_id(
+        self, mock_docker_client, docker_connector
+    ):
         """Test the _verify method when a resource ID is provided."""
         # Setup
         mock_client = MagicMock()
         mock_docker_client.from_env.return_value = mock_client
-        
+
         # Test
         resource_ids = docker_connector._verify(
-            resource_type="docker-registry",
-            resource_id="docker.io"
+            resource_type="docker-registry", resource_id="docker.io"
         )
-        
+
         # Assert
         assert resource_ids == ["docker.io"]
         mock_client.login.assert_called_once()
         mock_client.close.assert_called_once()
 
     @patch("zenml.service_connectors.docker_service_connector.DockerClient")
-    def test_verify_without_resource_id(self, mock_docker_client, docker_connector):
+    def test_verify_without_resource_id(
+        self, mock_docker_client, docker_connector
+    ):
         """Test the _verify method when no resource ID is provided.
-        
+
         This tests our fix for the assertion issue.
         """
         # Setup
         mock_client = MagicMock()
         mock_docker_client.from_env.return_value = mock_client
-        
+
         # Test
         resource_ids = docker_connector._verify(
-            resource_type="docker-registry",
-            resource_id=None
+            resource_type="docker-registry", resource_id=None
         )
-        
+
         # Assert
         assert resource_ids == []
         mock_client.login.assert_not_called()
         mock_client.close.assert_not_called()
 
     @patch("zenml.service_connectors.docker_service_connector.DockerClient")
-    def test_verify_with_docker_exception(self, mock_docker_client, docker_connector):
+    def test_verify_with_docker_exception(
+        self, mock_docker_client, docker_connector
+    ):
         """Test the _verify method when Docker client raises an exception."""
         # Setup
-        mock_docker_client.from_env.side_effect = DockerException("Docker not available")
-        
+        mock_docker_client.from_env.side_effect = DockerException(
+            "Docker not available"
+        )
+
         # Test
         resource_ids = docker_connector._verify(
-            resource_type="docker-registry",
-            resource_id="docker.io"
+            resource_type="docker-registry", resource_id="docker.io"
         )
-        
+
         # Assert - should still return the resource ID despite the exception
         assert resource_ids == ["docker.io"]
+
 
 if __name__ == "__main__":
     pytest.main(["-xvs", __file__])


### PR DESCRIPTION
## Summary
- Fixed bug in DockerServiceConnector._verify where it unconditionally asserts resource_id is not None
- Added unit tests to verify both with and without resource_id cases
- This error would occur when ServiceConnector.verify attempts to perform global verification without a specific resource ID

## Details
The DockerServiceConnector._verify method was asserting that resource_id is not None, but the parent ServiceConnector.verify method may call _verify with a None resource_id when it tests global authentication. This caused assertion errors during verification when no specific resource was being verified.

The fix modifies the method to only attempt to authorize the client when a resource ID is provided, avoiding the assertion error and allowing the method to gracefully handle global verification.

🤖 Generated with [Claude Code](https://claude.ai/code)