### PR TITLE
Add ability to strip the timestamps from the logs, on request

### DIFF
--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -251,6 +251,7 @@ def get_step_logs(
     step_id: UUID,
     offset: int = 0,
     length: int = 1024 * 1024 * 16,  # Default to 16MiB of data
+    strip_timestamp: bool = False,
     _: AuthContext = Security(authorize),
 ) -> str:
     """Get the logs of a specific step.
@@ -259,6 +260,7 @@ def get_step_logs(
         step_id: ID of the step for which to get the logs.
         offset: The offset from which to start reading.
         length: The amount of bytes that should be read.
+        strip_timestamp: Whether to strip the timestamp in logs or not.
 
     Returns:
         The logs of the step.
@@ -282,4 +284,5 @@ def get_step_logs(
         logs_uri=logs.uri,
         offset=offset,
         length=length,
+        strip_timestamp=strip_timestamp,
     )

--- a/tests/unit/artifacts/test_utils.py
+++ b/tests/unit/artifacts/test_utils.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from zenml.artifacts.utils import (
     _load_artifact_from_uri,
+    _strip_timestamp_from_multiline_string,
     load_artifact_from_response,
     load_model_from_metadata,
     save_model_metadata,
@@ -189,3 +190,31 @@ def test__load_artifact(builtin_type_file_uri):
     )
     assert artifact is not None
     assert isinstance(artifact, TempClass)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (
+            "[2025-05-16 16:20:23 UTC] Using cached version of step XYZ.\n",
+            "Using cached version of step XYZ.\n",
+        ),
+        (
+            "[2025-05-16 16:20:23 UTC] Using cached version of step XYZ.\n[2025-05-16 16:20:59 UTC] Log 2.\n",
+            "Using cached version of step XYZ.\nLog 2.\n",
+        ),
+        (
+            "Using cached version of step XYZ.\nLog 2.\n",
+            "Using cached version of step XYZ.\nLog 2.\n",
+        ),
+        ("", ""),
+        (
+            "[2025-05-16 16:20:23 UTC] Using cached version of step XYZ.\nNo timestamp here\n"
+            "[2025-05-16 16:20:59 UTC] Log 2.\n",
+            "Using cached version of step XYZ.\nNo timestamp here\nLog 2.\n",
+        ),
+    ],
+)
+def test__strip_timestamp_from_multiline_string(raw: str, expected: str):
+    """Test the _strip_timestamp_from_multiline_string function to properly strip the logs."""
+    assert _strip_timestamp_from_multiline_string(raw) == expected


### PR DESCRIPTION
## Describe changes
I implemented the flag `strip_timestamp` for `fetch_logs` and corresponding REST endpoint to make it possible to strip the timestamps of the logs, from the UI, on user request.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

