### PR TITLE
Performance boost fix: don't fetch entire pipeline run to verify pipeline API token validity

### DIFF
--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -434,16 +434,9 @@ def authenticate_credentials(
                     run does not exist.
                 """
                 try:
-                    pipeline_run = zen_store().get_run(
-                        pipeline_run_id, hydrate=True
-                    )
+                    return zen_store().get_run_status(pipeline_run_id)
                 except KeyError:
                     return None, None
-
-                return (
-                    pipeline_run.status,
-                    pipeline_run.end_time,
-                )
 
             (
                 pipeline_run_status,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5103,6 +5103,26 @@ class SqlZenStore(BaseZenStore):
                 include_python_packages=include_python_packages,
             )
 
+    def get_run_status(
+        self,
+        run_id: UUID,
+    ) -> Tuple[ExecutionStatus, Optional[datetime]]:
+        """Gets the status of a pipeline run.
+
+        Args:
+            run_id: The ID of the pipeline run to get.
+
+        Returns:
+            The pipeline run status and end time.
+        """
+        with Session(self.engine) as session:
+            run = self._get_schema_by_id(
+                resource_id=run_id,
+                schema_class=PipelineRunSchema,
+                session=session,
+            )
+            return ExecutionStatus(run.status), run.end_time
+
     def _replace_placeholder_run(
         self,
         pipeline_run: PipelineRunRequest,


### PR DESCRIPTION
## Describe changes
We're currently fetching the fully hydrated current pipeline run from the database to verify if the API tokens being used by pipeline run steps are still valid. Some caching is involved, but this still significantly slows down API calls when the cache expires, especially with larger pipelines.

This simple fix fetches just the necessary pipeline run bits, without hydrating the model, and avoids incurring up to tens of seconds of additional delay on API calls.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

