### PR TITLE
Async wrapper for FastAPI endpoints to run serialization in event loop

### DIFF
--- a/src/zenml/zen_server/routers/actions_endpoints.py
+++ b/src/zenml/zen_server/routers/actions_endpoints.py
@@ -44,7 +44,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     plugin_flavor_registry,
     zen_store,
@@ -61,7 +61,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_actions(
     action_filter_model: ActionFilter = Depends(make_dependable(ActionFilter)),
     hydrate: bool = False,
@@ -132,7 +132,7 @@ def list_actions(
     "/{action_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_action(
     action_id: UUID,
     hydrate: bool = True,
@@ -179,7 +179,7 @@ def get_action(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_action(
     action: ActionRequest,
     _: AuthContext = Security(authorize),
@@ -225,7 +225,7 @@ def create_action(
     "/{action_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_action(
     action_id: UUID,
     action_update: ActionUpdate,
@@ -280,7 +280,7 @@ def update_action(
     "/{action_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_action(
     action_id: UUID,
     force: bool = False,

--- a/src/zenml/zen_server/routers/artifact_endpoint.py
+++ b/src/zenml/zen_server/routers/artifact_endpoint.py
@@ -36,7 +36,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 )
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -52,7 +52,7 @@ artifact_router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_artifacts(
     artifact_filter_model: ArtifactFilter = Depends(
         make_dependable(ArtifactFilter)
@@ -83,7 +83,7 @@ def list_artifacts(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_artifact(
     artifact: ArtifactRequest,
     _: AuthContext = Security(authorize),
@@ -106,7 +106,7 @@ def create_artifact(
     "/{artifact_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_artifact(
     artifact_id: UUID,
     hydrate: bool = True,
@@ -133,7 +133,7 @@ def get_artifact(
     "/{artifact_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_artifact(
     artifact_id: UUID,
     artifact_update: ArtifactUpdate,
@@ -160,7 +160,7 @@ def update_artifact(
     "/{artifact_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_artifact(
     artifact_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/artifact_version_endpoints.py
+++ b/src/zenml/zen_server/routers/artifact_version_endpoints.py
@@ -66,7 +66,7 @@ from zenml.zen_server.rbac.utils import (
     get_allowed_resource_ids,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     set_filter_project_scope,
     zen_store,
@@ -83,7 +83,7 @@ artifact_version_router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_artifact_versions(
     artifact_version_filter_model: ArtifactVersionFilter = Depends(
         make_dependable(ArtifactVersionFilter)
@@ -127,7 +127,7 @@ def list_artifact_versions(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_artifact_version(
     artifact_version: ArtifactVersionRequest,
     _: AuthContext = Security(authorize),
@@ -150,7 +150,7 @@ def create_artifact_version(
     BATCH,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def batch_create_artifact_version(
     artifact_versions: List[ArtifactVersionRequest],
     _: AuthContext = Security(authorize),
@@ -173,7 +173,7 @@ def batch_create_artifact_version(
     "/{artifact_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_artifact_version(
     artifact_version_id: UUID,
     hydrate: bool = True,
@@ -200,7 +200,7 @@ def get_artifact_version(
     "/{artifact_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_artifact_version(
     artifact_version_id: UUID,
     artifact_version_update: ArtifactVersionUpdate,
@@ -227,7 +227,7 @@ def update_artifact_version(
     "/{artifact_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_artifact_version(
     artifact_version_id: UUID,
     _: AuthContext = Security(authorize),
@@ -248,7 +248,7 @@ def delete_artifact_version(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def prune_artifact_versions(
     project_name_or_id: Union[str, UUID],
     only_versions: bool = True,
@@ -275,7 +275,7 @@ def prune_artifact_versions(
     "/{artifact_version_id}" + VISUALIZE,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_artifact_visualization(
     artifact_version_id: UUID,
     index: int = 0,
@@ -303,7 +303,7 @@ def get_artifact_visualization(
     "/{artifact_version_id}" + DOWNLOAD_TOKEN,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_artifact_download_token(
     artifact_version_id: UUID,
     _: AuthContext = Security(authorize),
@@ -334,7 +334,7 @@ def get_artifact_download_token(
     "/{artifact_version_id}" + DATA,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def download_artifact_data(
     artifact_version_id: UUID, token: str
 ) -> FileResponse:

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -341,6 +341,7 @@ def logout(
     DEVICE_AUTHORIZATION,
     response_model=OAuthDeviceAuthorizationResponse,
 )
+@handle_exceptions
 def device_authorization(
     request: Request,
     client_id: UUID = Form(...),

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -222,11 +222,11 @@ class OAuthLoginRequestForm:
     LOGIN,
     response_model=Union[OAuthTokenResponse, OAuthRedirectResponse],
 )
+@handle_exceptions
 @rate_limit_requests(
     day_limit=server_config().login_rate_limit_day,
     minute_limit=server_config().login_rate_limit_minute,
 )
-@handle_exceptions
 def token(
     request: Request,
     response: Response,

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -71,8 +71,8 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
+    async_fastapi_endpoint_wrapper,
     get_ip_location,
-    handle_exceptions,
     server_config,
     zen_store,
 )
@@ -222,7 +222,7 @@ class OAuthLoginRequestForm:
     LOGIN,
     response_model=Union[OAuthTokenResponse, OAuthRedirectResponse],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 @rate_limit_requests(
     day_limit=server_config().login_rate_limit_day,
     minute_limit=server_config().login_rate_limit_minute,
@@ -341,7 +341,7 @@ def logout(
     DEVICE_AUTHORIZATION,
     response_model=OAuthDeviceAuthorizationResponse,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def device_authorization(
     request: Request,
     client_id: UUID = Form(...),
@@ -472,7 +472,7 @@ def device_authorization(
     API_TOKEN,
     response_model=str,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def api_token(
     token_type: APITokenType = APITokenType.GENERIC,
     expires_in: Optional[int] = None,

--- a/src/zenml/zen_server/routers/code_repositories_endpoints.py
+++ b/src/zenml/zen_server/routers/code_repositories_endpoints.py
@@ -38,7 +38,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -62,7 +62,7 @@ router = APIRouter(
     deprecated=True,
     tags=["code_repositories"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_code_repository(
     code_repository: CodeRepositoryRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -99,7 +99,7 @@ def create_code_repository(
     deprecated=True,
     tags=["code_repositories"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_code_repositories(
     filter_model: CodeRepositoryFilter = Depends(
         make_dependable(CodeRepositoryFilter)
@@ -135,7 +135,7 @@ def list_code_repositories(
     "/{code_repository_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_code_repository(
     code_repository_id: UUID,
     hydrate: bool = True,
@@ -162,7 +162,7 @@ def get_code_repository(
     "/{code_repository_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_code_repository(
     code_repository_id: UUID,
     update: CodeRepositoryUpdate,
@@ -189,7 +189,7 @@ def update_code_repository(
     "/{code_repository_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_code_repository(
     code_repository_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/devices_endpoints.py
+++ b/src/zenml/zen_server/routers/devices_endpoints.py
@@ -39,7 +39,7 @@ from zenml.utils.time_utils import utc_now
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     zen_store,
@@ -56,7 +56,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_authorized_devices(
     filter_model: OAuthDeviceFilter = Depends(
         make_dependable(OAuthDeviceFilter)
@@ -86,7 +86,7 @@ def list_authorized_devices(
     "/{device_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_authorization_device(
     device_id: UUID,
     user_code: Optional[str] = None,
@@ -136,7 +136,7 @@ def get_authorization_device(
     "/{device_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_authorized_device(
     device_id: UUID,
     update: OAuthDeviceUpdate,
@@ -172,7 +172,7 @@ def update_authorized_device(
     "/{device_id}" + DEVICE_VERIFY,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def verify_authorized_device(
     device_id: UUID,
     request: OAuthDeviceVerificationRequest,
@@ -276,7 +276,7 @@ def verify_authorized_device(
     "/{device_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_authorized_device(
     device_id: UUID,
     auth_context: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/event_source_endpoints.py
+++ b/src/zenml/zen_server/routers/event_source_endpoints.py
@@ -39,7 +39,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     plugin_flavor_registry,
     zen_store,
@@ -59,7 +59,7 @@ event_source_router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_event_sources(
     event_source_filter_model: EventSourceFilter = Depends(
         make_dependable(EventSourceFilter)
@@ -133,7 +133,7 @@ def list_event_sources(
     "/{event_source_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_event_source(
     event_source_id: UUID,
     hydrate: bool = True,
@@ -185,7 +185,7 @@ def get_event_source(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_event_source(
     event_source: EventSourceRequest,
     _: AuthContext = Security(authorize),
@@ -227,7 +227,7 @@ def create_event_source(
     "/{event_source_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_event_source(
     event_source_id: UUID,
     event_source_update: EventSourceUpdate,
@@ -279,7 +279,7 @@ def update_event_source(
     "/{event_source_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_event_source(
     event_source_id: UUID,
     force: bool = False,

--- a/src/zenml/zen_server/routers/flavors_endpoints.py
+++ b/src/zenml/zen_server/routers/flavors_endpoints.py
@@ -37,7 +37,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -53,7 +53,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_flavors(
     flavor_filter_model: FlavorFilter = Depends(make_dependable(FlavorFilter)),
     hydrate: bool = False,
@@ -82,7 +82,7 @@ def list_flavors(
     "/{flavor_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_flavor(
     flavor_id: UUID,
     hydrate: bool = True,
@@ -107,7 +107,7 @@ def get_flavor(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_flavor(
     flavor: FlavorRequest,
     _: AuthContext = Security(authorize),
@@ -130,7 +130,7 @@ def create_flavor(
     "/{flavor_id}",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_flavor(
     flavor_id: UUID,
     flavor_update: FlavorUpdate,
@@ -159,7 +159,7 @@ def update_flavor(
     "/{flavor_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_flavor(
     flavor_id: UUID,
     _: AuthContext = Security(authorize),
@@ -180,7 +180,7 @@ def delete_flavor(
     "/sync",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def sync_flavors(
     _: AuthContext = Security(authorize),
 ) -> None:

--- a/src/zenml/zen_server/routers/logs_endpoints.py
+++ b/src/zenml/zen_server/routers/logs_endpoints.py
@@ -29,7 +29,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
     verify_permissions_and_get_entity,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     zen_store,
 )
 
@@ -44,7 +44,7 @@ router = APIRouter(
     "/{logs_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_logs(
     logs_id: UUID,
     hydrate: bool = True,

--- a/src/zenml/zen_server/routers/model_versions_endpoints.py
+++ b/src/zenml/zen_server/routers/model_versions_endpoints.py
@@ -59,7 +59,7 @@ from zenml.zen_server.routers.models_endpoints import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     set_filter_project_scope,
     zen_store,
@@ -89,7 +89,7 @@ router = APIRouter(
     deprecated=True,
     tags=["model_versions"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_model_version(
     model_version: ModelVersionRequest,
     model_id: Optional[UUID] = None,
@@ -127,7 +127,7 @@ def create_model_version(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_model_versions(
     model_version_filter_model: ModelVersionFilter = Depends(
         make_dependable(ModelVersionFilter)
@@ -176,7 +176,7 @@ def list_model_versions(
     "/{model_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_model_version(
     model_version_id: UUID,
     hydrate: bool = True,
@@ -204,7 +204,7 @@ def get_model_version(
     "/{model_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_model_version(
     model_version_id: UUID,
     model_version_update_model: ModelVersionUpdate,
@@ -238,7 +238,7 @@ def update_model_version(
     "/{model_version_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_model_version(
     model_version_id: UUID,
     _: AuthContext = Security(authorize),
@@ -270,7 +270,7 @@ model_version_artifacts_router = APIRouter(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_model_version_artifact_link(
     model_version_artifact_link: ModelVersionArtifactRequest,
     _: AuthContext = Security(authorize),
@@ -300,7 +300,7 @@ def create_model_version_artifact_link(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_model_version_artifact_links(
     model_version_artifact_link_filter_model: ModelVersionArtifactFilter = Depends(
         make_dependable(ModelVersionArtifactFilter)
@@ -331,7 +331,7 @@ def list_model_version_artifact_links(
     + "/{model_version_artifact_link_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_model_version_artifact_link(
     model_version_id: UUID,
     model_version_artifact_link_name_or_id: Union[str, UUID],
@@ -357,7 +357,7 @@ def delete_model_version_artifact_link(
     "/{model_version_id}" + ARTIFACTS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_all_model_version_artifact_links(
     model_version_id: UUID,
     only_links: bool = True,
@@ -392,7 +392,7 @@ model_version_pipeline_runs_router = APIRouter(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_model_version_pipeline_run_link(
     model_version_pipeline_run_link: ModelVersionPipelineRunRequest,
     _: AuthContext = Security(authorize),
@@ -423,7 +423,7 @@ def create_model_version_pipeline_run_link(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_model_version_pipeline_run_links(
     model_version_pipeline_run_link_filter_model: ModelVersionPipelineRunFilter = Depends(
         make_dependable(ModelVersionPipelineRunFilter)
@@ -454,7 +454,7 @@ def list_model_version_pipeline_run_links(
     + "/{model_version_pipeline_run_link_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_model_version_pipeline_run_link(
     model_version_id: UUID,
     model_version_pipeline_run_link_name_or_id: Union[str, UUID],

--- a/src/zenml/zen_server/routers/models_endpoints.py
+++ b/src/zenml/zen_server/routers/models_endpoints.py
@@ -43,7 +43,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     zen_store,
@@ -72,7 +72,7 @@ router = APIRouter(
     deprecated=True,
     tags=["models"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_model(
     model: ModelRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -101,7 +101,7 @@ def create_model(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_models(
     model_filter_model: ModelFilter = Depends(make_dependable(ModelFilter)),
     hydrate: bool = False,
@@ -130,7 +130,7 @@ def list_models(
     "/{model_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_model(
     model_id: UUID,
     hydrate: bool = True,
@@ -155,7 +155,7 @@ def get_model(
     "/{model_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_model(
     model_id: UUID,
     model_update: ModelUpdate,
@@ -182,7 +182,7 @@ def update_model(
     "/{model_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_model(
     model_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/pipeline_builds_endpoints.py
+++ b/src/zenml/zen_server/routers/pipeline_builds_endpoints.py
@@ -36,7 +36,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -60,7 +60,7 @@ router = APIRouter(
     deprecated=True,
     tags=["builds"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_build(
     build: PipelineBuildRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -97,7 +97,7 @@ def create_build(
     deprecated=True,
     tags=["builds"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_builds(
     build_filter_model: PipelineBuildFilter = Depends(
         make_dependable(PipelineBuildFilter)
@@ -133,7 +133,7 @@ def list_builds(
     "/{build_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_build(
     build_id: UUID,
     hydrate: bool = True,
@@ -158,7 +158,7 @@ def get_build(
     "/{build_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_build(
     build_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/pipeline_deployments_endpoints.py
+++ b/src/zenml/zen_server/routers/pipeline_deployments_endpoints.py
@@ -36,7 +36,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     workload_manager,
@@ -93,7 +93,7 @@ router = APIRouter(
     deprecated=True,
     tags=["deployments"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_deployment(
     request: Request,
     deployment: PipelineDeploymentRequest,
@@ -142,7 +142,7 @@ def create_deployment(
     deprecated=True,
     tags=["deployments"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_deployments(
     request: Request,
     deployment_filter_model: PipelineDeploymentFilter = Depends(
@@ -196,7 +196,7 @@ def list_deployments(
     "/{deployment_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_deployment(
     request: Request,
     deployment_id: UUID,
@@ -235,7 +235,7 @@ def get_deployment(
     "/{deployment_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_deployment(
     deployment_id: UUID,
     _: AuthContext = Security(authorize),
@@ -260,7 +260,7 @@ def delete_deployment(
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def deployment_logs(
     deployment_id: UUID,
     offset: int = 0,

--- a/src/zenml/zen_server/routers/pipelines_endpoints.py
+++ b/src/zenml/zen_server/routers/pipelines_endpoints.py
@@ -48,7 +48,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     zen_store,
@@ -73,7 +73,7 @@ router = APIRouter(
     deprecated=True,
     tags=["pipelines"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_pipeline(
     pipeline: PipelineRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -119,7 +119,7 @@ def create_pipeline(
     deprecated=True,
     tags=["pipelines"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_pipelines(
     pipeline_filter_model: PipelineFilter = Depends(
         make_dependable(PipelineFilter)
@@ -155,7 +155,7 @@ def list_pipelines(
     "/{pipeline_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_pipeline(
     pipeline_id: UUID,
     hydrate: bool = True,
@@ -180,7 +180,7 @@ def get_pipeline(
     "/{pipeline_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_pipeline(
     pipeline_id: UUID,
     pipeline_update: PipelineUpdate,
@@ -207,7 +207,7 @@ def update_pipeline(
     "/{pipeline_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_pipeline(
     pipeline_id: UUID,
     _: AuthContext = Security(authorize),
@@ -238,7 +238,7 @@ def delete_pipeline(
     "/{pipeline_id}" + RUNS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_pipeline_runs(
     pipeline_run_filter_model: PipelineRunFilter = Depends(
         make_dependable(PipelineRunFilter)

--- a/src/zenml/zen_server/routers/plugin_endpoints.py
+++ b/src/zenml/zen_server/routers/plugin_endpoints.py
@@ -30,7 +30,7 @@ from zenml.models.v2.base.page import Page
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     plugin_flavor_registry,
 )
 
@@ -49,7 +49,7 @@ plugin_router = APIRouter(
     response_model=Page[BasePluginFlavorResponse],  # type: ignore[type-arg]
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_flavors(
     type: PluginType,
     subtype: PluginSubType,
@@ -83,7 +83,7 @@ def list_flavors(
     "/{name}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_flavor(
     name: str,
     type: PluginType = Query(..., alias="type"),

--- a/src/zenml/zen_server/routers/projects_endpoints.py
+++ b/src/zenml/zen_server/routers/projects_endpoints.py
@@ -52,7 +52,7 @@ from zenml.zen_server.rbac.utils import (
     get_allowed_resource_ids,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     zen_store,
@@ -81,7 +81,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_projects(
     project_filter_model: ProjectFilter = Depends(
         make_dependable(ProjectFilter)
@@ -118,7 +118,7 @@ def list_projects(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_project(
     project_request: ProjectRequest,
     _: AuthContext = Security(authorize),
@@ -149,7 +149,7 @@ def create_project(
     "/{project_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_project(
     project_name_or_id: Union[str, UUID],
     hydrate: bool = True,
@@ -184,7 +184,7 @@ def get_project(
     "/{project_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_project(
     project_name_or_id: UUID,
     project_update: ProjectUpdate,
@@ -219,7 +219,7 @@ def update_project(
     "/{project_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_project(
     project_name_or_id: Union[str, UUID],
     _: AuthContext = Security(authorize),
@@ -249,7 +249,7 @@ def delete_project(
     "/{project_name_or_id}" + STATISTICS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_project_statistics(
     project_name_or_id: Union[str, UUID],
     auth_context: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/run_metadata_endpoints.py
+++ b/src/zenml/zen_server/routers/run_metadata_endpoints.py
@@ -29,7 +29,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
-from zenml.zen_server.utils import handle_exceptions, zen_store
+from zenml.zen_server.utils import async_fastapi_endpoint_wrapper, zen_store
 
 router = APIRouter(
     prefix=API + VERSION_1 + RUN_METADATA,
@@ -50,7 +50,7 @@ router = APIRouter(
     deprecated=True,
     tags=["run_metadata"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_run_metadata(
     run_metadata: RunMetadataRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,

--- a/src/zenml/zen_server/routers/run_templates_endpoints.py
+++ b/src/zenml/zen_server/routers/run_templates_endpoints.py
@@ -55,7 +55,7 @@ from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     zen_store,
@@ -80,7 +80,7 @@ router = APIRouter(
     deprecated=True,
     tags=["run_templates"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_run_template(
     run_template: RunTemplateRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -117,7 +117,7 @@ def create_run_template(
     deprecated=True,
     tags=["run_templates"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_run_templates(
     filter_model: RunTemplateFilter = Depends(
         make_dependable(RunTemplateFilter)
@@ -153,7 +153,7 @@ def list_run_templates(
     "/{template_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_run_template(
     template_id: UUID,
     hydrate: bool = True,
@@ -180,7 +180,7 @@ def get_run_template(
     "/{template_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_run_template(
     template_id: UUID,
     update: RunTemplateUpdate,
@@ -207,7 +207,7 @@ def update_run_template(
     "/{template_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_run_template(
     template_id: UUID,
     _: AuthContext = Security(authorize),
@@ -235,7 +235,7 @@ if server_config().workload_manager_enabled:
             429: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def create_template_run(
         template_id: UUID,
         config: Optional[PipelineRunConfiguration] = None,

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -54,7 +54,7 @@ from zenml.zen_server.rbac.utils import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     workload_manager,
@@ -83,7 +83,7 @@ logger = get_logger(__name__)
     deprecated=True,
     tags=["runs"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_or_create_pipeline_run(
     pipeline_run: PipelineRunRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -121,7 +121,7 @@ def get_or_create_pipeline_run(
     deprecated=True,
     tags=["runs"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_runs(
     runs_filter_model: PipelineRunFilter = Depends(
         make_dependable(PipelineRunFilter)
@@ -156,7 +156,7 @@ def list_runs(
     "/{run_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_run(
     run_id: UUID,
     hydrate: bool = True,
@@ -222,7 +222,7 @@ def get_run(
     "/{run_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_run(
     run_id: UUID,
     run_model: PipelineRunUpdate,
@@ -249,7 +249,7 @@ def update_run(
     "/{run_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_run(
     run_id: UUID,
     _: AuthContext = Security(authorize),
@@ -270,7 +270,7 @@ def delete_run(
     "/{run_id}" + STEPS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_run_steps(
     run_id: UUID,
     step_run_filter_model: StepRunFilter = Depends(
@@ -299,7 +299,7 @@ def get_run_steps(
     "/{run_id}" + PIPELINE_CONFIGURATION,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_pipeline_configuration(
     run_id: UUID,
     _: AuthContext = Security(authorize),
@@ -322,7 +322,7 @@ def get_pipeline_configuration(
     "/{run_id}" + STATUS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_run_status(
     run_id: UUID,
     _: AuthContext = Security(authorize),
@@ -345,7 +345,7 @@ def get_run_status(
     "/{run_id}" + REFRESH,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def refresh_run_status(
     run_id: UUID,
     _: AuthContext = Security(authorize),
@@ -394,7 +394,7 @@ def refresh_run_status(
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def run_logs(
     run_id: UUID,
     offset: int = 0,

--- a/src/zenml/zen_server/routers/schedule_endpoints.py
+++ b/src/zenml/zen_server/routers/schedule_endpoints.py
@@ -33,7 +33,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -57,7 +57,7 @@ router = APIRouter(
     deprecated=True,
     tags=["schedules"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_schedule(
     schedule: ScheduleRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -97,7 +97,7 @@ def create_schedule(
     deprecated=True,
     tags=["schedules"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_schedules(
     schedule_filter_model: ScheduleFilter = Depends(
         make_dependable(ScheduleFilter)
@@ -131,7 +131,7 @@ def list_schedules(
     "/{schedule_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_schedule(
     schedule_id: UUID,
     hydrate: bool = True,
@@ -157,7 +157,7 @@ def get_schedule(
     "/{schedule_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_schedule(
     schedule_id: UUID,
     schedule_update: ScheduleUpdate,
@@ -182,7 +182,7 @@ def update_schedule(
     "/{schedule_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_schedule(
     schedule_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/secrets_endpoints.py
+++ b/src/zenml/zen_server/routers/secrets_endpoints.py
@@ -51,7 +51,7 @@ from zenml.zen_server.rbac.utils import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -81,7 +81,7 @@ op_router = APIRouter(
     deprecated=True,
     tags=["secrets"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_secret(
     secret: SecretRequest,
     workspace_name_or_id: Optional[Union[str, UUID]] = None,
@@ -106,7 +106,7 @@ def create_secret(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_secrets(
     secret_filter_model: SecretFilter = Depends(make_dependable(SecretFilter)),
     hydrate: bool = False,
@@ -153,7 +153,7 @@ def list_secrets(
     "/{secret_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_secret(
     secret_id: UUID,
     hydrate: bool = True,
@@ -185,7 +185,7 @@ def get_secret(
     "/{secret_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_secret(
     secret_id: UUID,
     secret_update: SecretUpdate,
@@ -225,7 +225,7 @@ def update_secret(
     "/{secret_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_secret(
     secret_id: UUID,
     _: AuthContext = Security(authorize),
@@ -246,7 +246,7 @@ def delete_secret(
     SECRETS_BACKUP,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def backup_secrets(
     ignore_errors: bool = True,
     delete_secrets: bool = False,
@@ -276,7 +276,7 @@ def backup_secrets(
     SECRETS_RESTORE,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def restore_secrets(
     ignore_errors: bool = False,
     delete_secrets: bool = False,

--- a/src/zenml/zen_server/routers/server_endpoints.py
+++ b/src/zenml/zen_server/routers/server_endpoints.py
@@ -56,7 +56,7 @@ router = APIRouter(
 
 
 @router.get("/version")
-def version() -> str:
+async def version() -> str:
     """Get version of the server.
 
     Returns:

--- a/src/zenml/zen_server/routers/server_endpoints.py
+++ b/src/zenml/zen_server/routers/server_endpoints.py
@@ -46,7 +46,11 @@ from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.rbac.utils import get_allowed_resource_ids
-from zenml.zen_server.utils import handle_exceptions, server_config, zen_store
+from zenml.zen_server.utils import (
+    async_fastapi_endpoint_wrapper,
+    server_config,
+    zen_store,
+)
 
 router = APIRouter(
     prefix=API + VERSION_1,
@@ -69,7 +73,7 @@ async def version() -> str:
     INFO,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def server_info() -> ServerModel:
     """Get information about the server.
 
@@ -83,7 +87,7 @@ def server_info() -> ServerModel:
     LOAD_INFO,
     response_model=ServerLoadInfo,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def server_load_info(_: AuthContext = Security(authorize)) -> ServerLoadInfo:
     """Get information about the server load.
 
@@ -132,7 +136,7 @@ def server_load_info(_: AuthContext = Security(authorize)) -> ServerLoadInfo:
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_onboarding_state(
     _: AuthContext = Security(authorize),
 ) -> List[str]:
@@ -159,7 +163,7 @@ if server_config().external_server_id is None:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def get_settings(
         _: AuthContext = Security(authorize),
         hydrate: bool = True,
@@ -182,7 +186,7 @@ if server_config().external_server_id is None:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def update_server_settings(
         settings_update: ServerSettingsUpdate,
         auth_context: AuthContext = Security(authorize),
@@ -227,7 +231,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def activate_server(
         activate_request: ServerActivationRequest,
     ) -> Optional[UserResponse]:
@@ -246,7 +250,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
     STATISTICS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_server_statistics(
     auth_context: AuthContext = Security(authorize),
 ) -> ServerStatistics:

--- a/src/zenml/zen_server/routers/service_accounts_endpoints.py
+++ b/src/zenml/zen_server/routers/service_accounts_endpoints.py
@@ -49,7 +49,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission_for_model
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -73,7 +73,7 @@ router = APIRouter(
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_service_account(
     service_account: ServiceAccountRequest,
     _: AuthContext = Security(authorize),
@@ -96,7 +96,7 @@ def create_service_account(
     "/{service_account_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_service_account(
     service_account_name_or_id: Union[str, UUID],
     _: AuthContext = Security(authorize),
@@ -123,7 +123,7 @@ def get_service_account(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_service_accounts(
     filter_model: ServiceAccountFilter = Depends(
         make_dependable(ServiceAccountFilter)
@@ -158,7 +158,7 @@ def list_service_accounts(
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_service_account(
     service_account_name_or_id: Union[str, UUID],
     service_account_update: ServiceAccountUpdate,
@@ -185,7 +185,7 @@ def update_service_account(
     "/{service_account_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_service_account(
     service_account_name_or_id: Union[str, UUID],
     _: AuthContext = Security(authorize),
@@ -211,7 +211,7 @@ def delete_service_account(
     "/{service_account_id}" + API_KEYS,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_api_key(
     service_account_id: UUID,
     api_key: APIKeyRequest,
@@ -249,7 +249,7 @@ def create_api_key(
     "/{service_account_id}" + API_KEYS + "/{api_key_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
@@ -282,7 +282,7 @@ def get_api_key(
     "/{service_account_id}" + API_KEYS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_api_keys(
     service_account_id: UUID,
     filter_model: APIKeyFilter = Depends(make_dependable(APIKeyFilter)),
@@ -316,7 +316,7 @@ def list_api_keys(
     "/{service_account_id}" + API_KEYS + "/{api_key_name_or_id}",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
@@ -350,7 +350,7 @@ def update_api_key(
     + API_KEY_ROTATE,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def rotate_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
@@ -381,7 +381,7 @@ def rotate_api_key(
     "/{service_account_id}" + API_KEYS + "/{api_key_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],

--- a/src/zenml/zen_server/routers/service_connectors_endpoints.py
+++ b/src/zenml/zen_server/routers/service_connectors_endpoints.py
@@ -61,7 +61,7 @@ from zenml.zen_server.rbac.utils import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -91,7 +91,7 @@ types_router = APIRouter(
     deprecated=True,
     tags=["service_connectors"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_service_connector(
     connector: ServiceConnectorRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -124,7 +124,7 @@ def create_service_connector(
     deprecated=True,
     tags=["service_connectors"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_service_connectors(
     connector_filter_model: ServiceConnectorFilter = Depends(
         make_dependable(ServiceConnectorFilter)
@@ -198,7 +198,7 @@ def list_service_connectors(
     deprecated=True,
     tags=["service_connectors"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_service_connector_resources(
     filter_model: ServiceConnectorFilter = Depends(
         make_dependable(ServiceConnectorFilter)
@@ -234,7 +234,7 @@ def list_service_connector_resources(
     "/{connector_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_service_connector(
     connector_id: UUID,
     expand_secrets: bool = True,
@@ -276,7 +276,7 @@ def get_service_connector(
     "/{connector_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_service_connector(
     connector_id: UUID,
     connector_update: ServiceConnectorUpdate,
@@ -303,7 +303,7 @@ def update_service_connector(
     "/{connector_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_service_connector(
     connector_id: UUID,
     _: AuthContext = Security(authorize),
@@ -324,7 +324,7 @@ def delete_service_connector(
     SERVICE_CONNECTOR_VERIFY,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def validate_and_verify_service_connector_config(
     connector: ServiceConnectorRequest,
     list_resources: bool = True,
@@ -357,7 +357,7 @@ def validate_and_verify_service_connector_config(
     "/{connector_id}" + SERVICE_CONNECTOR_VERIFY,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def validate_and_verify_service_connector(
     connector_id: UUID,
     resource_type: Optional[str] = None,
@@ -398,7 +398,7 @@ def validate_and_verify_service_connector(
     "/{connector_id}" + SERVICE_CONNECTOR_CLIENT,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_service_connector_client(
     connector_id: UUID,
     resource_type: Optional[str] = None,
@@ -435,7 +435,7 @@ def get_service_connector_client(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_service_connector_types(
     connector_type: Optional[str] = None,
     resource_type: Optional[str] = None,
@@ -465,7 +465,7 @@ def list_service_connector_types(
     "/{connector_type}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_service_connector_type(
     connector_type: str,
     _: AuthContext = Security(authorize),
@@ -485,7 +485,7 @@ def get_service_connector_type(
     SERVICE_CONNECTOR_FULL_STACK,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_resources_based_on_service_connector_info(
     connector_info: Optional[ServiceConnectorInfo] = None,
     connector_uuid: Optional[UUID] = None,

--- a/src/zenml/zen_server/routers/service_endpoints.py
+++ b/src/zenml/zen_server/routers/service_endpoints.py
@@ -38,7 +38,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import ResourceType
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -62,7 +62,7 @@ router = APIRouter(
     deprecated=True,
     tags=["services"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_service(
     service: ServiceRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -91,7 +91,7 @@ def create_service(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_services(
     filter_model: ServiceFilter = Depends(make_dependable(ServiceFilter)),
     hydrate: bool = False,
@@ -120,7 +120,7 @@ def list_services(
     "/{service_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_service(
     service_id: UUID,
     hydrate: bool = True,
@@ -147,7 +147,7 @@ def get_service(
     "/{service_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_service(
     service_id: UUID,
     update: ServiceUpdate,
@@ -174,7 +174,7 @@ def update_service(
     "/{service_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_service(
     service_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/stack_components_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_components_endpoints.py
@@ -40,7 +40,7 @@ from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission_for_model
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -70,7 +70,7 @@ types_router = APIRouter(
     deprecated=True,
     tags=["stack_components"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_stack_component(
     component: ComponentRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -120,7 +120,7 @@ def create_stack_component(
     deprecated=True,
     tags=["stack_components"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_stack_components(
     component_filter_model: ComponentFilter = Depends(
         make_dependable(ComponentFilter)
@@ -153,7 +153,7 @@ def list_stack_components(
     "/{component_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_stack_component(
     component_id: UUID,
     hydrate: bool = True,
@@ -180,7 +180,7 @@ def get_stack_component(
     "/{component_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_stack_component(
     component_id: UUID,
     component_update: ComponentUpdate,
@@ -226,7 +226,7 @@ def update_stack_component(
     "/{component_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def deregister_stack_component(
     component_id: UUID,
     _: AuthContext = Security(authorize),
@@ -247,7 +247,7 @@ def deregister_stack_component(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_stack_component_types(
     _: AuthContext = Security(authorize),
 ) -> List[str]:

--- a/src/zenml/zen_server/routers/stack_deployment_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_deployment_endpoints.py
@@ -39,7 +39,7 @@ from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import verify_permission
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     server_config,
 )
 
@@ -53,7 +53,7 @@ router = APIRouter(
 @router.get(
     INFO,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_stack_deployment_info(
     provider: StackDeploymentProvider,
     _: AuthContext = Security(authorize),
@@ -73,7 +73,7 @@ def get_stack_deployment_info(
 @router.get(
     CONFIG,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_stack_deployment_config(
     request: Request,
     provider: StackDeploymentProvider,
@@ -139,7 +139,7 @@ def get_stack_deployment_config(
 @router.get(
     STACK,
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_deployed_stack(
     provider: StackDeploymentProvider,
     stack_name: str,

--- a/src/zenml/zen_server/routers/stacks_endpoints.py
+++ b/src/zenml/zen_server/routers/stacks_endpoints.py
@@ -42,7 +42,7 @@ from zenml.zen_server.rbac.utils import (
 )
 from zenml.zen_server.routers.projects_endpoints import workspace_router
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -66,7 +66,7 @@ router = APIRouter(
     deprecated=True,
     tags=["stacks"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_stack(
     stack: StackRequest,
     project_name_or_id: Optional[Union[str, UUID]] = None,
@@ -136,7 +136,7 @@ def create_stack(
     deprecated=True,
     tags=["stacks"],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_stacks(
     project_name_or_id: Optional[Union[str, UUID]] = None,
     stack_filter_model: StackFilter = Depends(make_dependable(StackFilter)),
@@ -167,7 +167,7 @@ def list_stacks(
     "/{stack_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_stack(
     stack_id: UUID,
     hydrate: bool = True,
@@ -192,7 +192,7 @@ def get_stack(
     "/{stack_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_stack(
     stack_id: UUID,
     stack_update: StackUpdate,
@@ -230,7 +230,7 @@ def update_stack(
     "/{stack_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_stack(
     stack_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/steps_endpoints.py
+++ b/src/zenml/zen_server/routers/steps_endpoints.py
@@ -48,7 +48,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     set_filter_project_scope,
     zen_store,
@@ -65,7 +65,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_run_steps(
     step_run_filter_model: StepRunFilter = Depends(
         make_dependable(StepRunFilter)
@@ -109,7 +109,7 @@ def list_run_steps(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_run_step(
     step: StepRunRequest,
     _: AuthContext = Security(authorize),
@@ -136,7 +136,7 @@ def create_run_step(
     "/{step_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_step(
     step_id: UUID,
     hydrate: bool = True,
@@ -169,7 +169,7 @@ def get_step(
     "/{step_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_step(
     step_id: UUID,
     step_model: StepRunUpdate,
@@ -198,7 +198,7 @@ def update_step(
     "/{step_id}" + STEP_CONFIGURATION,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_step_configuration(
     step_id: UUID,
     _: AuthContext = Security(authorize),
@@ -222,7 +222,7 @@ def get_step_configuration(
     "/{step_id}" + STATUS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_step_status(
     step_id: UUID,
     _: AuthContext = Security(authorize),
@@ -246,7 +246,7 @@ def get_step_status(
     "/{step_id}" + LOGS,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_step_logs(
     step_id: UUID,
     offset: int = 0,

--- a/src/zenml/zen_server/routers/tag_resource_endpoints.py
+++ b/src/zenml/zen_server/routers/tag_resource_endpoints.py
@@ -27,7 +27,7 @@ from zenml.models import TagResourceRequest, TagResourceResponse
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     zen_store,
 )
 
@@ -42,7 +42,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_tag_resource(
     tag_resource: TagResourceRequest,
     _: AuthContext = Security(authorize),
@@ -62,7 +62,7 @@ def create_tag_resource(
     BATCH,
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def batch_create_tag_resource(
     tag_resources: List[TagResourceRequest],
     _: AuthContext = Security(authorize),
@@ -85,7 +85,7 @@ def batch_create_tag_resource(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_tag_resource(
     tag_resource: TagResourceRequest,
     _: AuthContext = Security(authorize),
@@ -102,7 +102,7 @@ def delete_tag_resource(
     BATCH,
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def batch_delete_tag_resource(
     tag_resources: List[TagResourceRequest],
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/tags_endpoints.py
+++ b/src/zenml/zen_server/routers/tags_endpoints.py
@@ -38,7 +38,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
     verify_permissions_and_update_entity,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     zen_store,
 )
@@ -58,7 +58,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_tag(
     tag: TagRequest,
     _: AuthContext = Security(authorize),
@@ -78,7 +78,7 @@ def create_tag(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_tags(
     tag_filter_model: TagFilter = Depends(make_dependable(TagFilter)),
     hydrate: bool = False,
@@ -105,7 +105,7 @@ def list_tags(
     "/{tag_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_tag(
     tag_name_or_id: Union[str, UUID],
     hydrate: bool = True,
@@ -132,7 +132,7 @@ def get_tag(
     "/{tag_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_tag(
     tag_id: UUID,
     tag_update_model: TagUpdate,
@@ -159,7 +159,7 @@ def update_tag(
     "/{tag_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_tag(
     tag_name_or_id: Union[str, UUID],
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/triggers_endpoints.py
+++ b/src/zenml/zen_server/routers/triggers_endpoints.py
@@ -43,7 +43,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     plugin_flavor_registry,
     zen_store,
@@ -60,7 +60,7 @@ router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_triggers(
     trigger_filter_model: TriggerFilter = Depends(
         make_dependable(TriggerFilter)
@@ -91,7 +91,7 @@ def list_triggers(
     "/{trigger_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_trigger(
     trigger_id: UUID,
     hydrate: bool = True,
@@ -116,7 +116,7 @@ def get_trigger(
     "",
     responses={401: error_response, 409: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def create_trigger(
     trigger: TriggerRequest,
     _: AuthContext = Security(authorize),
@@ -167,7 +167,7 @@ def create_trigger(
     "/{trigger_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_trigger(
     trigger_id: UUID,
     trigger_update: TriggerUpdate,
@@ -230,7 +230,7 @@ def update_trigger(
     "/{trigger_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_trigger(
     trigger_id: UUID,
     _: AuthContext = Security(authorize),
@@ -258,7 +258,7 @@ executions_router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_trigger_executions(
     trigger_execution_filter_model: TriggerExecutionFilter = Depends(
         make_dependable(TriggerExecutionFilter)
@@ -289,7 +289,7 @@ def list_trigger_executions(
     "/{trigger_execution_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_trigger_execution(
     trigger_execution_id: UUID,
     hydrate: bool = True,
@@ -316,7 +316,7 @@ def get_trigger_execution(
     "/{trigger_execution_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def delete_trigger_execution(
     trigger_execution_id: UUID,
     _: AuthContext = Security(authorize),

--- a/src/zenml/zen_server/routers/users_endpoints.py
+++ b/src/zenml/zen_server/routers/users_endpoints.py
@@ -56,7 +56,7 @@ from zenml.zen_server.rbac.utils import (
     verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     make_dependable,
     server_config,
     verify_admin_status_if_no_rbac,
@@ -95,7 +95,7 @@ current_user_router = APIRouter(
     "",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def list_users(
     user_filter_model: UserFilter = Depends(make_dependable(UserFilter)),
     hydrate: bool = False,
@@ -144,7 +144,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def create_user(
         user: UserRequest,
         auth_context: AuthContext = Security(authorize),
@@ -193,7 +193,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
     "/{user_name_or_id}",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_user(
     user_name_or_id: Union[str, UUID],
     hydrate: bool = True,
@@ -237,7 +237,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def activate_user(
         user_name_or_id: Union[str, UUID],
         user_update: UserUpdate,
@@ -297,7 +297,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def deactivate_user(
         user_name_or_id: Union[str, UUID],
         auth_context: AuthContext = Security(authorize),
@@ -345,7 +345,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def delete_user(
         user_name_or_id: Union[str, UUID],
         auth_context: AuthContext = Security(authorize),
@@ -387,7 +387,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def email_opt_in_response(
         user_name_or_id: Union[str, UUID],
         user_response: UserUpdate,
@@ -439,7 +439,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
         422: error_response,
     },
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def update_user(
     user_name_or_id: Union[str, UUID],
     user_update: UserUpdate,
@@ -599,7 +599,7 @@ def update_user(
     "/current-user",
     responses={401: error_response, 404: error_response, 422: error_response},
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def get_current_user(
     auth_context: AuthContext = Security(authorize),
 ) -> UserResponse:
@@ -626,7 +626,7 @@ if server_config().auth_scheme != AuthScheme.EXTERNAL:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def update_myself(
         user: UserUpdate,
         request: Request,
@@ -705,7 +705,7 @@ if server_config().rbac_enabled:
             422: error_response,
         },
     )
-    @handle_exceptions
+    @async_fastapi_endpoint_wrapper
     def update_user_resource_membership(
         resource_type: str,
         resource_id: UUID,

--- a/src/zenml/zen_server/routers/webhook_endpoints.py
+++ b/src/zenml/zen_server/routers/webhook_endpoints.py
@@ -26,7 +26,7 @@ from zenml.event_sources.webhooks.base_webhook_event_source import (
 from zenml.exceptions import AuthorizationException, WebhookInactiveError
 from zenml.logger import get_logger
 from zenml.zen_server.utils import (
-    handle_exceptions,
+    async_fastapi_endpoint_wrapper,
     plugin_flavor_registry,
     zen_store,
 )
@@ -55,7 +55,7 @@ async def get_body(request: Request) -> bytes:
     "/{event_source_id}",
     response_model=Dict[str, str],
 )
-@handle_exceptions
+@async_fastapi_endpoint_wrapper
 def webhook(
     event_source_id: UUID,
     request: Request,

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -24,7 +24,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    ParamSpec,
     Tuple,
     Type,
     TypeVar,
@@ -33,6 +32,7 @@ from typing import (
 from uuid import UUID
 
 from pydantic import BaseModel, ValidationError
+from typing_extensions import ParamSpec
 
 from zenml import __version__ as zenml_version
 from zenml.config.global_config import GlobalConfiguration

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -303,8 +303,16 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def handle_exceptions(func: Callable[P, R]) -> Callable[P, Awaitable[R]]:
-    """Decorator to handle exceptions in the API.
+def async_fastapi_endpoint_wrapper(
+    func: Callable[P, R],
+) -> Callable[P, Awaitable[R]]:
+    """Decorator for FastAPI endpoints.
+
+    This decorator for FastAPI endpoints does the following:
+    - Sets the auth_context context variable if the endpoint is authenticated.
+    - Converts exceptions to HTTPExceptions with the correct status code.
+    - Converts the sync endpoint function to an coroutine and runs the original
+      function in a worker threadpool. See below for more details.
 
     Args:
         func: Function to decorate.


### PR DESCRIPTION
## Describe changes
When having a sync FastAPI endpoint, it runs the endpoint function in a worker threadpool. If all threads are busy, it will queue the task. The problem is that after the endpoint code returns, FastAPI will queue another task in the same threadpool to serialize the response. If there are many tasks already in the queue, this means that the response serialization will wait for a long time instead of returning the response immediately. By making our endpoints async and then immediately dispatching them to the threadpool ourselves (which is essentially what FastAPI does when having a sync endpoint), we can avoid this problem. The serialization logic will now run on the event loop and not wait for a worker thread to become available.

See: https://github.com/fastapi/fastapi/blob/ea7b1054762c72a79bc111e747e20d4c67721afc/fastapi/routing.py#L165-L170 and https://github.com/fastapi/fastapi/pull/888 for more information.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

