### PR TITLE
Convert string to raw to avoid warnings in python 3.12+

### DIFF
--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -425,7 +425,7 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
         with tempfile.NamedTemporaryFile(mode="w", delete=True) as f:
             # Define bash line and command line
             bash_line = "#!/bin/bash\n"
-            command_line = f'cd {directory_name} && echo {ENV_ZENML_HYPERAI_RUN_ID}="{deployment_id}_$(date +\%s)" > .env && docker compose up -d'
+            command_line = fr'cd {directory_name} && echo {ENV_ZENML_HYPERAI_RUN_ID}="{deployment_id}_$(date +\%s)" > .env && docker compose up -d'
 
             # Write script to temporary file
             with f.file as f_:

--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -425,7 +425,7 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
         with tempfile.NamedTemporaryFile(mode="w", delete=True) as f:
             # Define bash line and command line
             bash_line = "#!/bin/bash\n"
-            command_line = fr'cd {directory_name} && echo {ENV_ZENML_HYPERAI_RUN_ID}="{deployment_id}_$(date +\%s)" > .env && docker compose up -d'
+            command_line = rf'cd {directory_name} && echo {ENV_ZENML_HYPERAI_RUN_ID}="{deployment_id}_$(date +\%s)" > .env && docker compose up -d'
 
             # Write script to temporary file
             with f.file as f_:


### PR DESCRIPTION
String with "invalid escape sequence" (due to the presence of the "\\\%" bit, which is not meant for escaping anyway) raises a warning in python 3.12+, tagging as raw string to supress the warning.
