### PR TITLE
Reset active project after deleting local database

### DIFF
--- a/src/zenml/config/global_config.py
+++ b/src/zenml/config/global_config.py
@@ -751,13 +751,15 @@ class GlobalConfiguration(BaseModel, metaclass=GlobalConfigMetaClass):
         Returns:
             The model of the active project.
         """
-        project_id = self.get_active_project_id()
+        # Initialize the store first. This might create a local database if it
+        # doesn't exist yet, which will then refresh our active project ID.
+        _ = self.zen_store
 
         if self._active_project is not None:
             return self._active_project
 
         project = self.zen_store.get_project(
-            project_name_or_id=project_id,
+            project_name_or_id=self.get_active_project_id(),
         )
         return self.set_active_project(project)
 


### PR DESCRIPTION
## Describe changes
This fixes the following case:
- Use ZenML with a local SQLite DB
- Delete the DB
- Run a pipeline without running any other previous command

The ID of the previously active project will still be stored in the global config, but won't exist anymore in the newly created database. This lead to an error that the project can not be found.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

