### PR TITLE
Improve alerter documentation with comprehensive ask step coverage

### DIFF
--- a/docs/book/component-guide/alerters/README.md
+++ b/docs/book/component-guide/alerters/README.md
@@ -48,5 +48,76 @@ zenml stack register ... -al <ALERTER_NAME>
 Afterward, you can import the alerter standard steps provided by the respective integration and directly use them in
 your pipelines.
 
+## Using the Ask Step for Human-in-the-Loop Workflows
+
+All alerters provide an `ask()` method and corresponding ask steps that enable human-in-the-loop workflows. These are essential for:
+
+- Getting approval before deploying models to production
+- Confirming critical pipeline decisions  
+- Manual intervention points in automated workflows
+
+### How Ask Steps Work
+
+Ask steps (like `discord_alerter_ask_step` and `slack_alerter_ask_step`):
+
+1. **Post a message** to your chat service with your question
+2. **Wait for user response** containing specific approval or disapproval keywords
+3. **Return a boolean** - `True` if approved, `False` if disapproved or timeout
+
+```python
+from zenml import step, pipeline
+from zenml.integrations.slack.steps.slack_alerter_ask_step import slack_alerter_ask_step
+
+@step
+def deploy_model(model, approved: bool) -> None:
+    if approved:
+        # Deploy the model to production
+        print("Deploying model to production...")
+        # deployment logic here
+    else:
+        print("Deployment cancelled by user")
+
+@pipeline
+def deployment_pipeline():
+    trained_model = train_model()
+    # Ask for human approval before deployment
+    approved = slack_alerter_ask_step("Deploy model to production?")
+    deploy_model(trained_model, approved)
+```
+
+### Default Response Keywords
+
+By default, alerters recognize these response options:
+
+**Approval:** `approve`, `LGTM`, `ok`, `yes`  
+**Disapproval:** `decline`, `disapprove`, `no`, `reject`
+
+### Customizing Response Keywords
+
+You can customize the approval and disapproval keywords using alerter parameters:
+
+```python
+from zenml.integrations.slack.steps.slack_alerter_ask_step import slack_alerter_ask_step
+from zenml.integrations.slack.alerters.slack_alerter import SlackAlerterParameters
+
+# Use custom approval/disapproval keywords
+params = SlackAlerterParameters(
+    approve_msg_options=["deploy", "ship it", "✅"],
+    disapprove_msg_options=["stop", "cancel", "❌"]
+)
+
+approved = slack_alerter_ask_step(
+    "Deploy model to production?", 
+    params=params
+)
+```
+
+### Important Notes
+
+- **Return Type**: Ask steps return a boolean value - ensure your pipeline logic handles this correctly
+- **Keywords**: Response keywords are case-sensitive (except Slack, which converts to lowercase)
+- **Timeout**: If no valid response is received within the timeout period, the step returns `False`
+- **Permissions**: Ensure your bot has permissions to read messages in the target channel
+
 <!-- For scarf -->
 <figure><img alt="ZenML Scarf" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" /></figure>

--- a/docs/book/component-guide/alerters/custom.md
+++ b/docs/book/component-guide/alerters/custom.md
@@ -15,6 +15,13 @@ The base abstraction for alerters is very basic, as it only defines two abstract
 * `post()` takes a string, posts it to the desired chat service, and returns `True` if the operation succeeded, else `False`.
 * `ask()` does the same as `post()`, but after sending the message, it waits until someone approves or rejects the operation from within the chat service (e.g., by sending "approve" / "reject" to the bot as a response). `ask()` then only returns `True` if the operation succeeded and was approved, else `False`.
 
+The `ask()` method is particularly useful for implementing human-in-the-loop workflows. When implementing this method, you should:
+- Wait for user responses containing approval keywords (like `"approve"`, `"yes"`, `"ok"`, `"LGTM"`)
+- Wait for user responses containing disapproval keywords (like `"reject"`, `"no"`, `"cancel"`, `"stop"`)
+- Return `True` only when explicit approval is received
+- Return `False` for disapproval, timeout, or any errors
+- Consider implementing configurable approval/disapproval keywords via parameters
+
 Then base abstraction looks something like this:
 
 ```python
@@ -40,7 +47,7 @@ This is a slimmed-down version of the base implementation. To see the full docst
 
 ### Building your own custom alerter
 
-Creating your own custom alerter can be done in three steps:
+Creating your own custom alerter can be done in four steps:
 
 1.  Create a class that inherits from the `BaseAlerter` and implement the `post()` and `ask()` methods.
 
@@ -54,18 +61,58 @@ Creating your own custom alerter can be done in three steps:
         """My alerter class."""
 
         def post(
-            self, message: str, config: Optional[BaseAlerterStepParameters]
+            self, message: str, params: Optional[BaseAlerterStepParameters]
         ) -> bool:
             """Post a message to a chat service."""
-            ...
-            return "Hey, I implemented an alerter."
+            try:
+                # Implement your chat service posting logic here
+                # e.g., send HTTP request to chat API
+                print(f"Posting message: {message}")
+                return True
+            except Exception as e:
+                print(f"Failed to post message: {e}")
+                return False
 
         def ask(
-            self, question: str, config: Optional[BaseAlerterStepParameters]
+            self, question: str, params: Optional[BaseAlerterStepParameters]
         ) -> bool:
             """Post a message to a chat service and wait for approval."""
-            ...
-            return True
+            try:
+                # First, post the question
+                if not self.post(question, params):
+                    return False
+                    
+                # Define default approval/disapproval options
+                approve_options = ["approve", "yes", "ok", "LGTM"]
+                disapprove_options = ["reject", "no", "cancel", "stop"]
+                
+                # Check if custom options are provided in params
+                if params and hasattr(params, 'approve_msg_options'):
+                    approve_options = params.approve_msg_options
+                if params and hasattr(params, 'disapprove_msg_options'):
+                    disapprove_options = params.disapprove_msg_options
+                
+                # Wait for response (implement your chat service polling logic)
+                # This is a simplified example - you'd implement actual polling
+                response = self._wait_for_user_response()
+                
+                if response.lower() in [opt.lower() for opt in approve_options]:
+                    return True
+                elif response.lower() in [opt.lower() for opt in disapprove_options]:
+                    return False
+                else:
+                    # Invalid response or timeout
+                    return False
+                    
+            except Exception as e:
+                print(f"Failed to get approval: {e}")
+                return False
+                
+        def _wait_for_user_response(self) -> str:
+            """Wait for user response - implement based on your chat service."""
+            # This is where you'd implement the actual waiting logic
+            # e.g., polling your chat service API for new messages
+            return "approve"  # Placeholder
     ```
 2.  If you need to configure your custom alerter, you can also implement a config object.
 
@@ -76,7 +123,25 @@ Creating your own custom alerter can be done in three steps:
     class MyAlerterConfig(BaseAlerterConfig):
         my_param: str 
     ```
-3.  Finally, you can bring the implementation and the configuration together in a new flavor object.
+
+3.  Optionally, you can create custom parameter classes to support configurable approval/disapproval keywords:
+
+    ```python
+    from typing import List, Optional
+    from zenml.alerter.base_alerter import BaseAlerterStepParameters
+
+
+    class MyAlerterParameters(BaseAlerterStepParameters):
+        """Custom parameters for MyAlerter."""
+        
+        # Custom approval/disapproval message options
+        approve_msg_options: Optional[List[str]] = None
+        disapprove_msg_options: Optional[List[str]] = None
+        
+        # Any other custom parameters for your alerter
+        custom_channel: Optional[str] = None
+    ```
+4.  Finally, you can bring the implementation and the configuration together in a new flavor object.
 
     ```python
     from typing import Type, TYPE_CHECKING

--- a/docs/book/component-guide/alerters/discord.md
+++ b/docs/book/component-guide/alerters/discord.md
@@ -69,7 +69,7 @@ If you don't see any 'Copy Channel ID' option for your channel, go to "User Sett
 
 #### DISCORD\_TOKEN
 
-This is the Discord token of your bot. You can find the instructions on how to set up a bot, invite it to your channel, and find its token[here](https://discordpy.readthedocs.io/en/latest/discord.html).
+This is the Discord token of your bot. You can find the instructions on how to set up a bot, invite it to your channel, and find its token [here](https://discordpy.readthedocs.io/en/latest/discord.html).
 
 {% hint style="warning" %}
 When inviting the bot to your channel, make sure it has at least the following permissions:

--- a/docs/book/component-guide/alerters/discord.md
+++ b/docs/book/component-guide/alerters/discord.md
@@ -148,8 +148,12 @@ By default, the Discord alerter recognizes these keywords:
 
 **Important Notes:**
 - The ask step returns a boolean (`True` for approval, `False` for disapproval/timeout)
-- Keywords are case-sensitive
+- **Keywords are case-sensitive** - you must respond with exact case (e.g., `LGTM` not `lgtm`)
 - If no valid response is received, the step returns `False`
+
+{% hint style="warning" %}
+**Discord Case Sensitivity**: The Discord alerter implementation requires exact case matching for approval keywords. Make sure to respond with the exact case specified (e.g., `LGTM`, not `lgtm`).
+{% endhint %}
 
 For more information and a full list of configurable attributes of the Discord alerter, check out the [SDK Docs](https://sdkdocs.zenml.io/latest/integration_code_docs/integrations-discord.html#zenml.integrations.discord) .
 

--- a/docs/book/component-guide/alerters/discord.md
+++ b/docs/book/component-guide/alerters/discord.md
@@ -51,6 +51,23 @@ zenml alerter register discord_alerter \
     --default_discord_channel_id=<DISCORD_CHANNEL_ID>
 ```
 
+{% hint style="info" %}
+**Using Secrets for Token Management**: Instead of passing your Discord token directly, it's recommended to store it as a ZenML secret and reference it in your alerter configuration. This approach keeps sensitive information secure:
+
+```shell
+# Create a secret for your Discord token
+zenml secret create discord_secret --discord_token=<DISCORD_TOKEN>
+
+# Register the alerter referencing the secret
+zenml alerter register discord_alerter \
+    --flavor=discord \
+    --discord_token={{discord_secret.discord_token}} \
+    --default_discord_channel_id=<DISCORD_CHANNEL_ID>
+```
+
+Learn more about [referencing secrets in stack component attributes and settings](https://docs.zenml.io/concepts/secrets#reference-secrets-in-stack-component-attributes-and-settings).
+{% endhint %}
+
 After you have registered the `discord_alerter`, you can add it to your stack like this:
 
 ```shell

--- a/docs/book/component-guide/alerters/discord.md
+++ b/docs/book/component-guide/alerters/discord.md
@@ -97,17 +97,59 @@ def my_formatter_step(artifact_to_be_communicated) -> str:
     return f"Here is my artifact {artifact_to_be_communicated}!"
 
 
+@step
+def conditional_step(artifact, approved: bool) -> None:
+    if approved:
+        # Proceed with the operation
+        print(f"User approved! Processing {artifact}")
+        # Your logic here
+    else:
+        print("User disapproved. Skipping operation.")
+
+
 @pipeline
 def my_pipeline(...):
     ...
     artifact_to_be_communicated = ...
     message = my_formatter_step(artifact_to_be_communicated)
     approved = discord_alerter_ask_step(message)
-    ... # Potentially have different behavior in subsequent steps if `approved`
+    conditional_step(artifact_to_be_communicated, approved)
 
 if __name__ == "__main__":
     my_pipeline()
 ```
+
+## Using Custom Approval Keywords
+
+You can customize which words trigger approval or disapproval by using `DiscordAlerterParameters`:
+
+```python
+from zenml.integrations.discord.steps.discord_alerter_ask_step import discord_alerter_ask_step
+from zenml.integrations.discord.alerters.discord_alerter import DiscordAlerterParameters
+
+# Custom approval/disapproval keywords
+params = DiscordAlerterParameters(
+    approve_msg_options=["deploy", "ship it", "✅"],
+    disapprove_msg_options=["stop", "cancel", "❌"]
+)
+
+approved = discord_alerter_ask_step(
+    "Deploy model to production?", 
+    params=params
+)
+```
+
+### Default Response Keywords
+
+By default, the Discord alerter recognizes these keywords:
+
+**Approval:** `approve`, `LGTM`, `ok`, `yes`  
+**Disapproval:** `decline`, `disapprove`, `no`, `reject`
+
+**Important Notes:**
+- The ask step returns a boolean (`True` for approval, `False` for disapproval/timeout)
+- Keywords are case-sensitive
+- If no valid response is received, the step returns `False`
 
 For more information and a full list of configurable attributes of the Discord alerter, check out the [SDK Docs](https://sdkdocs.zenml.io/latest/integration_code_docs/integrations-discord.html#zenml.integrations.discord) .
 

--- a/docs/book/component-guide/alerters/discord.md
+++ b/docs/book/component-guide/alerters/discord.md
@@ -115,7 +115,7 @@ def my_formatter_step(artifact_to_be_communicated) -> str:
 
 
 @step
-def conditional_step(artifact, approved: bool) -> None:
+def process_approval_response(artifact, approved: bool) -> None:
     if approved:
         # Proceed with the operation
         print(f"User approved! Processing {artifact}")
@@ -130,7 +130,7 @@ def my_pipeline(...):
     artifact_to_be_communicated = ...
     message = my_formatter_step(artifact_to_be_communicated)
     approved = discord_alerter_ask_step(message)
-    conditional_step(artifact_to_be_communicated, approved)
+    process_approval_response(artifact_to_be_communicated, approved)
 
 if __name__ == "__main__":
     my_pipeline()

--- a/docs/book/component-guide/alerters/slack.md
+++ b/docs/book/component-guide/alerters/slack.md
@@ -255,9 +255,13 @@ The `ask()` method and `slack_alerter_ask_step` recognize these keywords by defa
 
 **Important Notes:**
 - The ask step returns a boolean (`True` for approval, `False` for disapproval/timeout)
-- Response keywords are converted to lowercase before matching
+- **Response keywords are case-insensitive** - keywords are converted to lowercase before matching (e.g., both `LGTM` and `lgtm` work)
 - If no valid response is received within the timeout period, the step returns `False`
 - The default timeout is 300 seconds (5 minutes) but can be configured
+
+{% hint style="info" %}
+**Slack Case Handling**: The Slack alerter implementation automatically converts all response keywords to lowercase before matching, making responses case-insensitive. You can respond with `LGTM`, `lgtm`, or `Lgtm` - they'll all work.
+{% endhint %}
 
 For more information and a full list of configurable attributes of the Slack 
 alerter, check out the [SDK Docs](https://sdkdocs.zenml.io/latest/integration_code_docs/integrations-slack.html#zenml.integrations.slack) .

--- a/docs/book/component-guide/alerters/slack.md
+++ b/docs/book/component-guide/alerters/slack.md
@@ -200,7 +200,7 @@ def ask_question() -> bool:
     return Client().active_stack.alerter.ask(question=message, params=params)
 
 @step  
-def conditional_step(approved: bool) -> None:
+def process_approval_response(approved: bool) -> None:
     if approved:
         print("User approved! Continuing with operation...")
         # Your logic here
@@ -212,7 +212,7 @@ def conditional_step(approved: bool) -> None:
 def my_pipeline():
     post_statement()
     approved = ask_question()
-    conditional_step(approved)
+    process_approval_response(approved)
 
 
 if __name__ == "__main__":
@@ -235,7 +235,7 @@ from zenml.integrations.slack.steps.slack_alerter_ask_step import (
 )
 
 @step
-def handle_response(approved: bool) -> None:
+def process_approval_response(approved: bool) -> None:
     if approved:
         print("Operation approved!")
     else:
@@ -245,7 +245,7 @@ def handle_response(approved: bool) -> None:
 def my_pipeline():
     slack_alerter_post_step("Posting a statement.")
     approved = slack_alerter_ask_step("Asking a question. Should I continue?")
-    handle_response(approved)
+    process_approval_response(approved)
 
 
 if __name__ == "__main__":

--- a/docs/book/component-guide/alerters/slack.md
+++ b/docs/book/component-guide/alerters/slack.md
@@ -55,6 +55,12 @@ zenml alerter register slack_alerter \
     --slack_channel_id=<SLACK_CHANNEL_ID>
 ```
 
+{% hint style="info" %}
+**Using Secrets for Token Management**: The example above demonstrates the recommended approach of storing your Slack token as a ZenML secret and referencing it using the `{{secret_name.key}}` syntax. This keeps sensitive information secure and follows security best practices.
+
+Learn more about [referencing secrets in stack component attributes and settings](https://docs.zenml.io/concepts/secrets#reference-secrets-in-stack-component-attributes-and-settings).
+{% endhint %}
+
 Here is where you can find the required parameters:
 
 * `<SLACK_CHANNEL_ID>`: The channel ID can be found in the channel details.


### PR DESCRIPTION
## Summary

- Enhanced alerter documentation to comprehensively cover the ask step functionality for human-in-the-loop workflows
- Added detailed section explaining how ask steps work, default keywords, and customization options
- Updated all alerter docs (main, Discord, Slack, custom) with consistent examples and patterns

## Key Changes

### Main Alerter Documentation
- **New section**: "Using the Ask Step for Human-in-the-Loop Workflows"
- **Proper ZenML patterns**: Shows conditional logic inside steps (not pipeline functions)
- **Default keywords**: Documents built-in approval (`approve`, `LGTM`, `ok`, `yes`) and disapproval (`decline`, `disapprove`, `no`, `reject`) options
- **Customization examples**: Shows how to use custom keywords with alerter parameters

### Discord & Slack Alerter Documentation  
- **Enhanced examples**: Updated pipeline examples to show proper conditional step patterns
- **Custom approval keywords**: Added sections showing how to use `DiscordAlerterParameters` and `SlackAlerterParameters`
- **Boolean return type**: Clearly documented that ask steps return `True`/`False`
- **Timeout behavior**: Explained what happens when no valid response is received

### Custom Alerter Documentation
- **Realistic implementation**: Provided comprehensive ask() method example with proper approval/disapproval logic
- **Parameter support**: Added `MyAlerterParameters` class showing how to support custom approval keywords
- **Error handling**: Demonstrated proper exception handling and return patterns
- **Implementation guidance**: Added detailed notes on what custom alerters should do

## Technical Details

The ask step functionality works by:
1. Posting a message to the chat service
2. Waiting for user responses containing specific keywords
3. Returning `True` for approval, `False` for disapproval/timeout

Default keywords are defined in:
- `discord_alerter.py:31-32` (`DEFAULT_APPROVE_MSG_OPTIONS`, `DEFAULT_DISAPPROVE_MSG_OPTIONS`)
- `slack_alerter.py:35-36` (same pattern)

Both support customization via `approve_msg_options` and `disapprove_msg_options` parameters.

## Test Plan

- [x] Read all updated documentation for clarity and consistency
- [x] Verify code examples follow proper ZenML patterns
- [x] Check that all parameter names match actual implementation
- [x] Ensure examples show realistic use cases

🤖 Generated with [Claude Code](https://claude.ai/code)