### PR TITLE
Fix setuptools vulnerabilities and switch to UV as the DockerSettings default

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -20,7 +20,8 @@ RUN set -ex \
   && apt-get upgrade -y \
   && apt-get autoremove -y \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --upgrade pip setuptools
 
 FROM base AS builder
 
@@ -64,8 +65,7 @@ RUN if [ "$ZENML_NIGHTLY" = "true" ]; then \
     else \
       PACKAGE_NAME="zenml"; \
     fi \
-    && pip install --upgrade pip \
-    && pip install --upgrade uv \
+    && pip install --upgrade pip uv setuptools \
     && uv pip install ${PACKAGE_NAME}${ZENML_VERSION:+==$ZENML_VERSION} \
     && pip freeze > requirements.txt
 
@@ -89,8 +89,7 @@ RUN if [ "$ZENML_NIGHTLY" = "true" ]; then \
     else \
       PACKAGE_NAME="zenml"; \
     fi \
-    && pip install --upgrade pip \
-    && pip install --upgrade uv \
+    && pip install --upgrade pip uv setuptools \
     && uv pip install "${PACKAGE_NAME}[server,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure,azureml,sagemaker,vertex]${ZENML_VERSION:+==$ZENML_VERSION}" "alembic==1.15.2" \
     && pip freeze > requirements.txt
 

--- a/docker/zenml-dev.Dockerfile
+++ b/docker/zenml-dev.Dockerfile
@@ -14,7 +14,8 @@ RUN set -ex \
   && apt-get upgrade -y \
   && apt-get autoremove -y \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install --upgrade pip setuptools
 
 FROM base AS builder
 
@@ -52,8 +53,7 @@ COPY src/zenml/__init__.py ./src/zenml/
 # dependencies for reproducibility and debugging.
 # NOTE: we uninstall zenml at the end because we install it separately in the
 # final stage
-RUN pip install --upgrade pip \
-  && pip install uv \
+RUN pip install --upgrade pip uv setuptools \
   && uv pip install . \
   && uv pip uninstall zenml \
   && uv pip freeze > requirements.txt

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -29,7 +29,8 @@ RUN set -ex && \
   fi && \
   apt-get autoremove -y && \
   apt-get clean -y && \
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* \
+  && pip install --upgrade pip setuptools
 
 # Create the user and group which will be used to run the ZenML server.
 RUN groupadd --gid $USER_GID $USERNAME && \
@@ -85,8 +86,7 @@ COPY --chown=$USERNAME:$USER_GID src/zenml/__init__.py ./src/zenml/
 # dependencies for reproducibility and debugging.
 # NOTE: we uninstall zenml at the end because we install it separately in the
 # final stage
-RUN pip install --upgrade pip \
-    && pip install uv \
+RUN pip install --upgrade pip uv setuptools \
     && uv pip install .[server,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure,azureml,sagemaker,vertex] "alembic==1.15.2" \
     && uv pip uninstall zenml \
     && uv pip freeze > requirements.txt

--- a/docs/book/how-to/containerization/containerization.md
+++ b/docs/book/how-to/containerization/containerization.md
@@ -358,19 +358,19 @@ Control how packages are installed:
 # Use custom installer arguments
 docker_settings = DockerSettings(python_package_installer_args={"timeout": 1000})
 
-# Use uv instead of pip (experimental)
+# Use pip instead of uv
 from zenml.config import DockerSettings, PythonPackageInstaller
-docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.UV)
-# Or as a string
-docker_settings = DockerSettings(python_package_installer="uv")
-
-# Use pip (default)
 docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.PIP)
+# Or as a string
+docker_settings = DockerSettings(python_package_installer="pip")
+
+# Use uv (default)
+docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.UV)
 ```
 
 The available package installers are:
-- `pip`: The default Python package installer
-- `uv`: A faster alternative to pip (experimental)
+- `pip`: The standard Python package installer
+- `uv`: A faster alternative to pip (default)
 
 {% hint style="info" %}
 `uv` is a relatively new project and not as stable as `pip` yet, which might lead to errors during package installation. If this happens, try switching the installer back to `pip` and see if that solves the issue.

--- a/docs/book/how-to/containerization/containerization.md
+++ b/docs/book/how-to/containerization/containerization.md
@@ -358,22 +358,28 @@ Control how packages are installed:
 # Use custom installer arguments
 docker_settings = DockerSettings(python_package_installer_args={"timeout": 1000})
 
-# Use pip instead of uv
+# Use uv instead of pip
 from zenml.config import DockerSettings, PythonPackageInstaller
-docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.PIP)
-# Or as a string
-docker_settings = DockerSettings(python_package_installer="pip")
-
-# Use uv (default)
 docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.UV)
+# Or as a string
+docker_settings = DockerSettings(python_package_installer="uv")
+
+# Use pip (default)
+docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.PIP)
 ```
 
 The available package installers are:
-- `pip`: The standard Python package installer
-- `uv`: A faster alternative to pip (default)
+- `pip`: The default Python package installer
+- `uv`: A faster alternative to pip
 
-{% hint style="info" %}
-`uv` is a relatively new project and not as stable as `pip` yet, which might lead to errors during package installation. If this happens, try switching the installer back to `pip` and see if that solves the issue.
+{% hint style="warning" %}
+In an upcoming release, ZenML will switch from `pip` to `uv` as the default package installer due to its significantly better performance. We encourage you to try it out in advance to prepare for this change:
+
+```python
+docker_settings = DockerSettings(python_package_installer=PythonPackageInstaller.UV)
+```
+
+This will help ensure a smooth transition for the entire community. If you encounter any issues, please report them on our [GitHub repository](https://github.com/zenml-io/zenml/issues).
 {% endhint %}
 
 Full documentation for how `uv` works with PyTorch can be found on the Astral Docs website [here](https://docs.astral.sh/uv/guides/integration/pytorch/). It covers some of the particular gotchas and details you might need to know.

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -402,9 +402,11 @@ class DockerSettings(BaseSettings):
         """
         if "python_package_installer" not in data:
             logger.warning(
-                "In a future release, the default Python package installer will "
-                "change from 'pip' to 'uv'. To maintain current behavior, you "
-                "can explicitly set `python_package_installer=PythonPackageInstaller.PIP` "
+                "In a future release, the default Python package installer "
+                "used by ZenML to build container images for your "
+                "containerized pipelines will change from 'pip' to 'uv'. "
+                "To maintain current behavior, you can explicitly set "
+                "`python_package_installer=PythonPackageInstaller.PIP` "
                 "in your DockerSettings."
             )
         return data

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -211,7 +211,7 @@ class DockerSettings(BaseSettings):
     prevent_build_reuse: bool = False
     target_repository: Optional[str] = None
     python_package_installer: PythonPackageInstaller = (
-        PythonPackageInstaller.PIP
+        PythonPackageInstaller.UV
     )
     python_package_installer_args: Dict[str, Any] = {}
     disable_automatic_requirements_detection: bool = True

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -211,7 +211,7 @@ class DockerSettings(BaseSettings):
     prevent_build_reuse: bool = False
     target_repository: Optional[str] = None
     python_package_installer: PythonPackageInstaller = (
-        PythonPackageInstaller.UV
+        PythonPackageInstaller.PIP
     )
     python_package_installer_args: Dict[str, Any] = {}
     disable_automatic_requirements_detection: bool = True
@@ -385,6 +385,29 @@ class DockerSettings(BaseSettings):
             )
 
         return self
+
+    @model_validator(mode="before")
+    @classmethod
+    @before_validator_handler
+    def _warn_about_future_default_installer(
+        cls, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Warns about the future change of default package installer from pip to uv.
+
+        Args:
+            data: The model data.
+
+        Returns:
+            The validated settings values.
+        """
+        if "python_package_installer" not in data:
+            logger.warning(
+                "In a future release, the default Python package installer will "
+                "change from 'pip' to 'uv'. To maintain current behavior, you "
+                "can explicitly set `python_package_installer=PythonPackageInstaller.PIP` "
+                "in your DockerSettings."
+            )
+        return data
 
     model_config = ConfigDict(
         # public attributes are immutable


### PR DESCRIPTION
## Describe changes
This PR fixes those pesky setuptools vulnerabilities in our Docker images once and for all by upgrading `setuptools` in the base image.

In addition to that, it also warns about switching to UV as the default package builder used in DockerSettings in a future release.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

