### PR TITLE
Fix trivy image scanning GitHub actions

### DIFF
--- a/.github/workflows/trivy-zenml-core.yml
+++ b/.github/workflows/trivy-zenml-core.yml
@@ -9,7 +9,7 @@ jobs:
   trivy-scan:
     name: Trivy zenml scan & analysis
     if: github.repository == 'zenml-io/zenml'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/trivy-zenserver.yml
+++ b/.github/workflows/trivy-zenserver.yml
@@ -9,7 +9,7 @@ jobs:
   trivy-scan:
     name: Trivy ZenServer scan & analysis
     if: github.repository == 'zenml-io/zenml'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
## Describe changes
Our periodic Trivy scanning jobs have been failing lately because they are using a retired ubuntu runner version.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

