### PR TITLE
More explicit handling of carriage return logs in steps

### DIFF
--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -551,7 +551,7 @@ class PipelineLogsStorageContext:
 
                 if step_context and args[0] not in ["\n", ""]:
                     # For progress bar updates (with \r), inject the step name after the \r
-                    if isinstance(message, str) and "\r" in message:
+                    if "\r" in message:
                         message = message.replace(
                             "\r", f"\r[{step_context.step_name}] "
                         )


### PR DESCRIPTION
## Describe changes
Before - step name was duplicated:
![image](https://github.com/user-attachments/assets/121487a3-248d-4383-9ba0-5720fe9a71a0)

After - only one step name:
![image](https://github.com/user-attachments/assets/c0665b8b-f7f7-4717-a83e-93a1a9d47bb1)



## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

