### PR TITLE
Use the active artifact store as cache when loading artifacts

### DIFF
--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -823,6 +823,9 @@ def _load_artifact_store(
     if isinstance(artifact_store_id, str):
         artifact_store_id = UUID(artifact_store_id)
 
+    if Client().active_stack.artifact_store.id == artifact_store_id:
+        return Client().active_stack.artifact_store
+
     if zen_store is None:
         zen_store = Client().zen_store
 
@@ -857,9 +860,14 @@ def _load_artifact_store(
 def _get_artifact_store_from_response_or_from_active_stack(
     artifact: ArtifactVersionResponse,
 ) -> "BaseArtifactStore":
+    client = Client()
+
     if artifact.artifact_store_id:
+        if client.active_stack.artifact_store.id == artifact.artifact_store_id:
+            return client.active_stack.artifact_store
+
         try:
-            artifact_store_model = Client().get_stack_component(
+            artifact_store_model = client.get_stack_component(
                 component_type=StackComponentType.ARTIFACT_STORE,
                 name_id_or_prefix=artifact.artifact_store_id,
             )
@@ -881,7 +889,8 @@ def _get_artifact_store_from_response_or_from_active_stack(
                 "the environment that you are loading this artifact from "
                 "has the right dependencies."
             )
-    return Client().active_stack.artifact_store
+
+    return client.active_stack.artifact_store
 
 
 def _load_file_from_artifact_store(

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -20,24 +20,35 @@ from typing import (
     Any,
     Dict,
     Iterator,
+    List,
     Optional,
     Tuple,
     Type,
+    Union,
     cast,
 )
 from uuid import UUID
 
 import boto3
-import sagemaker
 from botocore.exceptions import WaiterError
+from sagemaker.estimator import Estimator
+from sagemaker.inputs import TrainingInput
 from sagemaker.network import NetworkConfig
-from sagemaker.processing import ProcessingInput, ProcessingOutput
+from sagemaker.processing import ProcessingInput, ProcessingOutput, Processor
+from sagemaker.session import Session
+from sagemaker.workflow.entities import PipelineVariable
 from sagemaker.workflow.execution_variables import (
-    ExecutionVariable,
     ExecutionVariables,
 )
 from sagemaker.workflow.pipeline import Pipeline
-from sagemaker.workflow.steps import ProcessingStep, TrainingStep
+from sagemaker.workflow.step_collections import (
+    StepCollection,
+)
+from sagemaker.workflow.steps import (
+    ProcessingStep,
+    Step,
+    TrainingStep,
+)
 from sagemaker.workflow.triggers import PipelineSchedule
 
 from zenml.client import Client
@@ -215,7 +226,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
         """
         return SagemakerOrchestratorSettings
 
-    def _get_sagemaker_session(self) -> sagemaker.Session:
+    def _get_sagemaker_session(self) -> Session:
         """Method to create the sagemaker session with proper authentication.
 
         Returns:
@@ -258,7 +269,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                     aws_session_token=credentials["SessionToken"],
                     region_name=self.config.region,
                 )
-        return sagemaker.Session(
+        return Session(
             boto_session=boto_session, default_bucket=self.config.bucket
         )
 
@@ -324,12 +335,8 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                 SagemakerOrchestratorSettings, self.get_settings(step)
             )
 
-            environment[ENV_ZENML_SAGEMAKER_RUN_ID] = (
-                ExecutionVariables.PIPELINE_EXECUTION_ARN
-            )
-
             if step_settings.environment:
-                step_environment = step_settings.environment.copy()
+                split_environment = step_settings.environment.copy()
                 # Sagemaker does not allow environment variables longer than 256
                 # characters to be passed to Processor steps. If an environment variable
                 # is longer than 256 characters, we split it into multiple environment
@@ -337,9 +344,9 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                 # custom entrypoint configuration.
                 split_environment_variables(
                     size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT,
-                    env=step_environment,
+                    env=split_environment,
                 )
-                environment.update(step_environment)
+                environment.update(split_environment)
 
             use_training_step = (
                 step_settings.use_training_step
@@ -421,28 +428,51 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                     )
 
             # Construct S3 inputs to container for step
-            inputs = None
+            training_inputs: Optional[
+                Union[TrainingInput, Dict[str, TrainingInput]]
+            ] = None
+            processing_inputs: Optional[List[ProcessingInput]] = None
 
             if step_settings.input_data_s3_uri is None:
                 pass
             elif isinstance(step_settings.input_data_s3_uri, str):
-                inputs = [
-                    ProcessingInput(
-                        source=step_settings.input_data_s3_uri,
-                        destination="/opt/ml/processing/input/data",
-                        s3_input_mode=step_settings.input_data_s3_mode,
+                if use_training_step:
+                    training_inputs = TrainingInput(
+                        s3_data=step_settings.input_data_s3_uri,
+                        input_mode=step_settings.input_data_s3_mode,
                     )
-                ]
-            elif isinstance(step_settings.input_data_s3_uri, dict):
-                inputs = []
-                for channel, s3_uri in step_settings.input_data_s3_uri.items():
-                    inputs.append(
+                else:
+                    processing_inputs = [
                         ProcessingInput(
-                            source=s3_uri,
-                            destination=f"/opt/ml/processing/input/data/{channel}",
+                            source=step_settings.input_data_s3_uri,
+                            destination="/opt/ml/processing/input/data",
                             s3_input_mode=step_settings.input_data_s3_mode,
                         )
-                    )
+                    ]
+            elif isinstance(step_settings.input_data_s3_uri, dict):
+                if use_training_step:
+                    training_inputs = {}
+                    for (
+                        channel,
+                        s3_uri,
+                    ) in step_settings.input_data_s3_uri.items():
+                        training_inputs[channel] = TrainingInput(
+                            s3_data=s3_uri,
+                            input_mode=step_settings.input_data_s3_mode,
+                        )
+                else:
+                    processing_inputs = []
+                    for (
+                        channel,
+                        s3_uri,
+                    ) in step_settings.input_data_s3_uri.items():
+                        processing_inputs.append(
+                            ProcessingInput(
+                                source=s3_uri,
+                                destination=f"/opt/ml/processing/input/data/{channel}",
+                                s3_input_mode=step_settings.input_data_s3_mode,
+                            )
+                        )
 
             # Construct S3 outputs from container for step
             outputs = None
@@ -475,42 +505,56 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                         )
                     )
 
-            # Convert environment to a dict of strings
-            environment = {
+            step_environment: Dict[str, Union[str, PipelineVariable]] = {
                 key: str(value)
-                if not isinstance(value, ExecutionVariable)
+                if not isinstance(value, PipelineVariable)
                 else value
                 for key, value in environment.items()
             }
 
+            step_environment[ENV_ZENML_SAGEMAKER_RUN_ID] = (
+                ExecutionVariables.PIPELINE_EXECUTION_ARN
+            )
+
+            sagemaker_step: Step
             if use_training_step:
                 # Create Estimator and TrainingStep
-                estimator = sagemaker.estimator.Estimator(
+                estimator = Estimator(
                     keep_alive_period_in_seconds=step_settings.keep_alive_period_in_seconds,
                     output_path=output_path,
-                    environment=environment,
+                    environment=step_environment,
                     container_entry_point=entrypoint,
                     **args_for_step_executor,
                 )
+
                 sagemaker_step = TrainingStep(
                     name=step_name,
-                    depends_on=step.spec.upstream_steps,
-                    inputs=inputs,
+                    depends_on=cast(
+                        Optional[List[Union[str, Step, StepCollection]]],
+                        step.spec.upstream_steps,
+                    ),
+                    inputs=training_inputs,
                     estimator=estimator,
                 )
             else:
                 # Create Processor and ProcessingStep
-                processor = sagemaker.processing.Processor(
-                    entrypoint=entrypoint,
-                    env=environment,
+                processor = Processor(
+                    entrypoint=cast(
+                        Optional[List[Union[str, PipelineVariable]]],
+                        entrypoint,
+                    ),
+                    env=step_environment,
                     **args_for_step_executor,
                 )
 
                 sagemaker_step = ProcessingStep(
                     name=step_name,
                     processor=processor,
-                    depends_on=step.spec.upstream_steps,
-                    inputs=inputs,
+                    depends_on=cast(
+                        Optional[List[Union[str, Step, StepCollection]]],
+                        step.spec.upstream_steps,
+                    ),
+                    inputs=processing_inputs,
                     outputs=outputs,
                 )
 


### PR DESCRIPTION
## Describe changes
Loading multiple artifacts can take a long time because every call to `artifact.load()` ends up re-initializing the Artifact Store where the artifact is store, which includes fetching an entirely new set of Service Connector client credentials.

A "gather results" step implementation like the following can end up calling the Service Connector client credentials endpoint tens of times, amounting to several minutes or even hours to complete the execution, if hundreds of artifacts are involved:

```
    results = []
    for step_name, step_info in steps.items():
        if not step_name.startswith("load_step"):
            continue

        # Get the output artifact
        output = step_info.outputs.get("output")
        if output:
            # Get the actual artifact data using the client
            artifact_data = output[0].load()
            results.append(artifact_data)
```

This PR makes a minor but powerful change: using the artifact store object in the active stack as a cache, if it happens to be the artifact store where the requested artifact is stored (which is 80% of the cases). This way, only one Artifact Store instance and set of Service Connector client credentials are required.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

