### PR TITLE
Fix run template fetching

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -3540,9 +3540,10 @@ class Client(metaclass=ClientMetaClass):
         Returns:
             The run template.
         """
+
         return self._get_entity_by_id_or_name_or_prefix(
             get_method=self.zen_store.get_run_template,
-            list_method=self.list_run_templates,
+            list_method=functools.partial(self.list_run_templates, hidden=None),
             name_id_or_prefix=name_id_or_prefix,
             allow_name_prefix_match=False,
             project=project,

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -3540,10 +3540,11 @@ class Client(metaclass=ClientMetaClass):
         Returns:
             The run template.
         """
-
         return self._get_entity_by_id_or_name_or_prefix(
             get_method=self.zen_store.get_run_template,
-            list_method=functools.partial(self.list_run_templates, hidden=None),
+            list_method=functools.partial(
+                self.list_run_templates, hidden=None
+            ),
             name_id_or_prefix=name_id_or_prefix,
             allow_name_prefix_match=False,
             project=project,


### PR DESCRIPTION
## Describe changes
The default value for the `hidden` attribute when listing run templates was set to `False`. When now trying to fetch a single run template with `Client().get_run_template(<ID-PREFIX>)`, the `or` filter operator caused any non-hidden template to show up in the results, even if the ID didn't match.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

