### PR TITLE
Fix missing artifact nodes in DAG

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5188,9 +5188,19 @@ class SqlZenStore(BaseZenStore):
                             # we want to display them as separate nodes in the
                             # DAG. We can therefore always create a new node
                             # here.
+                            is_manual_load = (
+                                input.type == StepRunInputArtifactType.MANUAL
+                            )
                             artifact_node = helper.add_artifact_node(
                                 node_id=helper.get_artifact_node_id(
-                                    name=input.name,
+                                    # For manual loads, the name might not be
+                                    # unique, so we use the artifact ID instead.
+                                    # We don't need to keep the name consistent
+                                    # with placeholder nodes as they don't exist
+                                    # for manual loads.
+                                    name=str(input.artifact_id)
+                                    if is_manual_load
+                                    else input.name,
                                     step_name=step_name,
                                     io_type=input.type,
                                     is_input=True,
@@ -5221,9 +5231,20 @@ class SqlZenStore(BaseZenStore):
                         # want to merge these and instead display them
                         # separately in the DAG, but if that should ever change
                         # this would be the place to merge them.
+                        is_manual_save = (
+                            output.artifact_version.save_type
+                            == ArtifactSaveType.MANUAL
+                        )
                         artifact_node = helper.add_artifact_node(
                             node_id=helper.get_artifact_node_id(
-                                name=output.name,
+                                # For manual saves, the name might not be
+                                # unique, so we use the artifact ID instead.
+                                # We don't need to keep the name consistent
+                                # with placeholder nodes as they don't exist
+                                # for manual saves.
+                                name=str(output.artifact_id)
+                                if is_manual_save
+                                else output.name,
                                 step_name=step_name,
                                 io_type=output.artifact_version.save_type,
                                 is_input=False,


### PR DESCRIPTION
## Describe changes
When having a step that dynamically saves (`save_artifact(...)`) or loads (`load_artifact(...)`) multiple versions of the same artifact, only one of them would show up in the DAG.

This PR fixes that by using their ID instead of the artifact name for the `node_id`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

