### PR TITLE
Include missing pipeline substitutions for legacy steps

### DIFF
--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -380,9 +380,22 @@ class Step(StrictBaseModel):
             config = StepConfiguration.model_validate(
                 data["step_config_overrides"]
             )
-            config = config.apply_pipeline_configuration(
+            data["config"] = config.apply_pipeline_configuration(
                 pipeline_configuration
             )
-            data["config"] = config
+        else:
+            # We still need to apply the pipeline substitutions for legacy step
+            # objects which include the full config object.
+            from zenml.config.pipeline_configurations import (
+                PipelineConfiguration,
+            )
+
+            config = StepConfiguration.model_validate(data["config"])
+            data["config"] = config.apply_pipeline_configuration(
+                PipelineConfiguration(
+                    name=pipeline_configuration.name,
+                    substitutions=pipeline_configuration.substitutions,
+                )
+            )
 
         return cls.model_validate(data)


### PR DESCRIPTION
## Describe changes
The `substitutions` of step responses didn't include the substitutions defined on the pipeline for step that ran before version `0.82.1`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

