### PR TITLE
Helm chart: Add option to create PVC for local configuration path

### DIFF
--- a/helm/templates/server-config-pvc.yaml
+++ b/helm/templates/server-config-pvc.yaml
@@ -1,5 +1,5 @@
-{{- if and (eq .Values.zenml.database.backupStrategy "dump-file") .Values.zenml.database.backupPVStorageSize }}
-{{- $pvc_name := printf "%s-db-backup" (include "zenml.fullname" .) -}}
+{{- if .Values.zenml.database.persistence.enabled }}
+{{- $pvc_name := printf "%s-config" (include "zenml.fullname" .) -}}
 {{- $pvc := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $pvc_name) }}
 {{- if not $pvc }}
 apiVersion: v1
@@ -13,13 +13,13 @@ metadata:
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  {{- with .Values.zenml.database.persistence.storageClassName }}
+  storageClassName: {{.}}
+  {{- end }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.zenml.database.backupPVStorageSize }}
-  {{- with .Values.zenml.database.backupPVStorageClass }}
-  storageClassName: {{ . }}
-  {{- end }}
+      storage: {{.Values.zenml.database.persistence.size}}
 {{- end }}
 {{- end }}

--- a/helm/templates/server-db-job.yaml
+++ b/helm/templates/server-db-job.yaml
@@ -59,7 +59,12 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: zenml-config
+        {{- if .Values.zenml.database.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zenml.fullname" . }}-config
+        {{- else }}
           emptyDir: {}
+        {{- end }}
       {{- if eq .Values.zenml.database.backupStrategy "dump-file" }}
         # define a volume that will hold a backup of the database
         - name: db-backup

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -59,7 +59,12 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: zenml-config
+        {{- if .Values.zenml.database.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "zenml.fullname" . }}-config
+        {{- else }}
           emptyDir: {}
+        {{- end }}
       {{- if or .Values.zenml.certificates.customCAs .Values.zenml.certificates.secretRefs }}
         - name: custom-certs
           projected:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -268,10 +268,17 @@ zenml:
   enableImplicitAuthMethods: false
 
   # MySQL database configuration. If not set, a local sqlite database will be
-  # used, which will not be persisted across pod restarts.
+  # used. To ensure data are not lost, check the persistence part.
   # NOTE: the certificate files need to be copied in the helm chart folder and
   # the paths configured here need to be relative to the root of the helm chart.
   database:
+
+    # If set to true, path where the local database is created will be
+    # mounted as a persistent volume so the data is not lost on pod restarts.
+    persistence:
+      enabled: false
+      size: 1Gi
+      storageClassName: ""
 
     # The database URL. If not set, a local sqlite database will be used, which
     # will not be persisted across pod restarts. The URL can contain the


### PR DESCRIPTION
This enables persistence for deployment with local sqlite database.

## Describe changes

Added `.database.persistence` section to the helm chart. If enabled, PVC will be created for mounting `zenml-config` so that when the pod restarts, data stored in local db (users, stack components etc.) are not lost

The option is disabled by default to keep the default behavior unchanged.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

