### PR TITLE
Ensure visualizations are committed before potential transaction rollback

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -3218,6 +3218,7 @@ class SqlZenStore(BaseZenStore):
                         artifact_version_id=artifact_version_schema.id,
                     )
                     session.add(vis_schema)
+                session.commit()
 
             # Save tags of the artifact
             self._attach_tags_to_resources(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -3037,18 +3037,17 @@ class SqlZenStore(BaseZenStore):
 
         if artifact is None:
             try:
-                with session.begin_nested():
-                    artifact_request = ArtifactRequest(
-                        name=name,
-                        project=project_id,
-                        has_custom_name=has_custom_name,
-                    )
-                    self._set_request_user_id(
-                        request_model=artifact_request, session=session
-                    )
-                    artifact = ArtifactSchema.from_request(artifact_request)
-                    session.add(artifact)
-                    session.commit()
+                artifact_request = ArtifactRequest(
+                    name=name,
+                    project=project_id,
+                    has_custom_name=has_custom_name,
+                )
+                self._set_request_user_id(
+                    request_model=artifact_request, session=session
+                )
+                artifact = ArtifactSchema.from_request(artifact_request)
+                session.add(artifact)
+                session.commit()
                 session.refresh(artifact)
             except IntegrityError:
                 # We have to rollback the failed session first in order to


### PR DESCRIPTION
## Describe changes
Commits the transaction before adding tags to an artifact version, which potentially rolls back the visualizations if a tag already existed.

Additionally, this PR removes a wrong usage of `session.begin_nested()` in the artifact creation method.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

