### PR TITLE
Fix fetching model version by UUID passed as string

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -6428,9 +6428,15 @@ class Client(metaclass=ClientMetaClass):
         if model_version_name_or_number_or_id is None:
             model_version_name_or_number_or_id = ModelStages.LATEST
 
-        if isinstance(model_version_name_or_number_or_id, UUID):
+        if is_valid_uuid(model_version_name_or_number_or_id):
+            assert not isinstance(model_version_name_or_number_or_id, int)
+            model_version_id = (
+                UUID(model_version_name_or_number_or_id)
+                if isinstance(model_version_name_or_number_or_id, str)
+                else model_version_name_or_number_or_id
+            )
             return self.zen_store.get_model_version(
-                model_version_id=model_version_name_or_number_or_id,
+                model_version_id=model_version_id,
                 hydrate=hydrate,
             )
         elif isinstance(model_version_name_or_number_or_id, int):


### PR DESCRIPTION
## Describe changes
When the model version ID was being passed as a string (e.g. `"4e7ab40e-7fee-487f-9fd5-a657a507303c"`), it wasn't recognized as a UUID and treated as the version name instead. This PR fixes that by detecting whether the string is a UUID, in which case we fetch the version by ID.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

