### PR TITLE
Warn if passing invalid kubernetes model data

### DIFF
--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -34,7 +34,13 @@ def warn_if_invalid_model_data(data: Dict[str, Any], class_name: str) -> None:
     try:
         serialization_utils.deserialize_kubernetes_model(data, class_name)
     except KeyError as e:
-        logger.warning("Invalid data for model %s: %s", class_name, e)
+        logger.warning(
+            "Invalid data for Kubernetes model class `%s`: %s. "
+            "Hint: Kubernetes expects attribute names in CamelCase, not "
+            "snake_case.",
+            class_name,
+            e,
+        )
 
 
 class KubernetesPodSettings(BaseSettings):

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -24,6 +24,9 @@ from zenml.logger import get_logger
 logger = get_logger(__name__)
 
 
+_pod_settings_logged_warnings = []
+
+
 def warn_if_invalid_model_data(data: Any, class_name: str) -> None:
     """Validates the data of a Kubernetes model.
 
@@ -37,13 +40,15 @@ def warn_if_invalid_model_data(data: Any, class_name: str) -> None:
     try:
         serialization_utils.deserialize_kubernetes_model(data, class_name)
     except KeyError as e:
-        logger.warning(
-            "Invalid data for Kubernetes model class `%s`: %s. "
-            "Hint: Kubernetes expects attribute names in CamelCase, not "
-            "snake_case.",
-            class_name,
-            e,
-        )
+        if str(e) not in _pod_settings_logged_warnings:
+            _pod_settings_logged_warnings.append(str(e))
+            logger.warning(
+                "Invalid data for Kubernetes model class `%s`: %s. "
+                "Hint: Kubernetes expects attribute names in CamelCase, not "
+                "snake_case.",
+                class_name,
+                e,
+            )
 
 
 class KubernetesPodSettings(BaseSettings):

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -24,13 +24,16 @@ from zenml.logger import get_logger
 logger = get_logger(__name__)
 
 
-def warn_if_invalid_model_data(data: Dict[str, Any], class_name: str) -> None:
+def warn_if_invalid_model_data(data: Any, class_name: str) -> None:
     """Validates the data of a Kubernetes model.
 
     Args:
         data: The data to validate.
         class_name: Name of the class of the model.
     """
+    if not isinstance(data, dict):
+        return
+
     try:
         serialization_utils.deserialize_kubernetes_model(data, class_name)
     except KeyError as e:

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -19,6 +19,22 @@ from pydantic import field_validator
 
 from zenml.config.base_settings import BaseSettings
 from zenml.integrations.kubernetes import serialization_utils
+from zenml.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def warn_if_invalid_model_data(data: Dict[str, Any], class_name: str) -> None:
+    """Validates the data of a Kubernetes model.
+
+    Args:
+        data: The data to validate.
+        class_name: Name of the class of the model.
+    """
+    try:
+        serialization_utils.deserialize_kubernetes_model(data, class_name)
+    except KeyError as e:
+        logger.warning("Invalid data for model %s: %s", class_name, e)
 
 
 class KubernetesPodSettings(BaseSettings):
@@ -77,6 +93,7 @@ class KubernetesPodSettings(BaseSettings):
                     serialization_utils.serialize_kubernetes_model(element)
                 )
             else:
+                warn_if_invalid_model_data(element, "V1Volume")
                 result.append(element)
 
         return result
@@ -101,6 +118,7 @@ class KubernetesPodSettings(BaseSettings):
                     serialization_utils.serialize_kubernetes_model(element)
                 )
             else:
+                warn_if_invalid_model_data(element, "V1VolumeMount")
                 result.append(element)
 
         return result
@@ -121,6 +139,7 @@ class KubernetesPodSettings(BaseSettings):
         if isinstance(value, V1Affinity):
             return serialization_utils.serialize_kubernetes_model(value)
         else:
+            warn_if_invalid_model_data(value, "V1Affinity")
             return value
 
     @field_validator("tolerations", mode="before")
@@ -143,6 +162,7 @@ class KubernetesPodSettings(BaseSettings):
                     serialization_utils.serialize_kubernetes_model(element)
                 )
             else:
+                warn_if_invalid_model_data(element, "V1Toleration")
                 result.append(element)
 
         return result
@@ -163,6 +183,7 @@ class KubernetesPodSettings(BaseSettings):
         if isinstance(value, V1ResourceRequirements):
             return serialization_utils.serialize_kubernetes_model(value)
         else:
+            warn_if_invalid_model_data(value, "V1ResourceRequirements")
             return value
 
     @field_validator("env", mode="before")
@@ -185,6 +206,7 @@ class KubernetesPodSettings(BaseSettings):
                     serialization_utils.serialize_kubernetes_model(element)
                 )
             else:
+                warn_if_invalid_model_data(element, "V1EnvVar")
                 result.append(element)
 
         return result
@@ -209,6 +231,7 @@ class KubernetesPodSettings(BaseSettings):
                     serialization_utils.serialize_kubernetes_model(element)
                 )
             else:
+                warn_if_invalid_model_data(element, "V1EnvFromSource")
                 result.append(element)
 
         return result

--- a/src/zenml/integrations/kubernetes/serialization_utils.py
+++ b/src/zenml/integrations/kubernetes/serialization_utils.py
@@ -117,7 +117,8 @@ def deserialize_kubernetes_model(data: Dict[str, Any], class_name: str) -> Any:
         if key not in attribute_mapping:
             raise KeyError(
                 f"Got value for attribute {key} which is not one of the "
-                f"available attributes {set(attribute_mapping)}."
+                f"available attributes for class {class_name}: "
+                f"{set(attribute_mapping)}."
             )
 
         attribute_name = attribute_mapping[key]


### PR DESCRIPTION
## Describe changes
Passing snake case attributes for some pod settings values was silently ignored by the kubernetes library, as it expects camel case instead. This PR warns the user when the relevant model can not be parsed from the given data.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

