### PR TITLE
Remove deprecation warning in quickstart

### DIFF
--- a/examples/quickstart/steps/model_trainer.py
+++ b/examples/quickstart/steps/model_trainer.py
@@ -24,6 +24,7 @@ from transformers import (
 from typing_extensions import Annotated
 
 from zenml import ArtifactConfig, step
+from zenml.enums import ArtifactType
 from zenml.logger import get_logger
 from zenml.utils.enum_utils import StrEnum
 
@@ -46,7 +47,8 @@ def train_model(
     gradient_accumulation_steps: int,
     dataloader_num_workers: int,
 ) -> Annotated[
-    T5ForConditionalGeneration, "model", ArtifactConfig(is_model_artifact=True)
+    T5ForConditionalGeneration,
+    ArtifactConfig(name="model", artifact_type=ArtifactType.MODEL),
 ]:
     """Train the model and return the path to the saved model."""
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")


### PR DESCRIPTION
## Describe changes
Replace the `is_model_artifact=True` with `artifact_type=...` to get rid of a deprecation warning.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

