### PR TITLE
Add intermediate cleanup in CLI profiling CI

### DIFF
--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -69,6 +69,12 @@ jobs:
           chmod +x scripts/profile-cli.sh
           ./scripts/profile-cli.sh -o $TARGET_RESULTS_FILE -v -t $COMMAND_TIMEOUT -s $SLOW_THRESHOLD
 
+      # Delete local files so we start with a fresh DB. This might otherwise fail the profiling
+      # of the current branch if the target branch contains DB migrations that are not yet applied.
+      - name: Cleanup
+        run: |
+          zenml clean -y
+
       # Profile current branch with isolated environment
       - name: Checkout current branch
         run: |


### PR DESCRIPTION
## Describe changes
When running the CLI profiling CI, if the target branch (usually `develop`) contained some DB migrations which have not yet been merged into the current feature branch, it would fail because of an unknown DB revision. This PR fixes this by cleaning up the DB in between the target and current branch profiling.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

