### PR TITLE
Fix appending to DB migrations in release action

### DIFF
--- a/scripts/add-migration-test-version.sh
+++ b/scripts/add-migration-test-version.sh
@@ -25,7 +25,7 @@ else
     git checkout -b "$NEW_BRANCH"
 
     # Add the new version to the VERSIONS list
-    sed -i '' "/^VERSIONS=(.*)$/s/)/ \"$NEW_VERSION\")/" scripts/test-migrations.sh
+    sed -i "/^VERSIONS=(/s/)$/ \"$NEW_VERSION\")/" scripts/test-migrations.sh
     echo "Added new version $NEW_VERSION to scripts/test-migrations.sh"
 
     # Add, commit and push the new changes


### PR DESCRIPTION
## Describe changes
The command used was working for BSD sed used on MacOS, but not GNU sed running on the GH runners.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

