### PR TITLE
Fix the retry logic and credential refresh for the Vertex step operator

### DIFF
--- a/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
+++ b/src/zenml/integrations/gcp/step_operators/vertex_step_operator.py
@@ -307,9 +307,7 @@ class VertexStepOperator(BaseStepOperator, GoogleCredentialsMixin):
         while response.state not in VERTEX_JOB_STATES_COMPLETED:
             time.sleep(POLLING_INTERVAL_IN_SECONDS)
             if self.connector_has_expired():
-                logger.warning(
-                    "Connector has expired. Recreating client..."
-                )
+                logger.warning("Connector has expired. Recreating client...")
                 # This call will refresh the credentials if they expired.
                 credentials, project_id = self._get_authentication()
                 # Recreate the Python API client.


### PR DESCRIPTION
## Describe changes
The current retry logic used to poll the Vertex AI job spawned by the Vertex AI step operator is faulty:

* it exits on the first exception it encounters instead of retrying
* it refreshes the service connector credentials and rebuilds the client *after* any exception has occurred instead of doing it proactively  

Logs example after the fix:

<img width="1913" height="964" alt="image" src="https://github.com/user-attachments/assets/e9dbe49a-3b69-46d7-b1ce-13ed3e4b0fd9" />

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

