### PR TITLE
Fix PyPI download stats badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [pypi-shield]: https://img.shields.io/pypi/pyversions/zenml?color=281158
 [pypi-url]: https://pypi.org/project/zenml/
 [pypiversion-shield]: https://img.shields.io/pypi/v/zenml?color=361776
-[downloads-shield]: https://img.shields.io/pypi/dm/zenml?color=431D93
+[downloads-shield]: https://static.pepy.tech/badge/zenml
 [downloads-url]: https://pypi.org/project/zenml/
 [contributors-shield]: https://img.shields.io/github/contributors/zenml-io/zenml?color=7A3EF4
 [contributors-url]: https://github.com/zenml-io/zenml/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [pypi-shield]: https://img.shields.io/pypi/pyversions/zenml?color=281158
 [pypi-url]: https://pypi.org/project/zenml/
 [pypiversion-shield]: https://img.shields.io/pypi/v/zenml?color=361776
-[downloads-shield]: https://static.pepy.tech/badge/zenml
+[downloads-shield]: https://img.shields.io/pepy/dt/zenml?color=431D93
 [downloads-url]: https://pypi.org/project/zenml/
 [contributors-shield]: https://img.shields.io/github/contributors/zenml-io/zenml?color=7A3EF4
 [contributors-url]: https://github.com/zenml-io/zenml/graphs/contributors


### PR DESCRIPTION
@znegrin no way that I can see to configure the colour, but the shields.io badge was broken, so I've switched it out for this pepy.tech one. If you prefer the badge to shift location (to make the colour fade nicer), feel free to suggest an alt placement.