### PR TITLE
Fix kubernetes name sanitization

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -141,46 +141,6 @@ def load_kube_config(
         k8s_config.load_kube_config(context=context)
 
 
-def calculate_max_pod_name_length_for_namespace(namespace: str) -> int:
-    """Calculate the max pod length for a certain namespace.
-
-    Args:
-        namespace: The namespace in which the pod will be created.
-
-    Returns:
-        The maximum pod name length.
-    """
-    # Kubernetes allows Pod names to have 253 characters. However, when
-    # creating a pod they try to create a log file which is called
-    # <NAMESPACE>_<POD_NAME>_<UUID>, which adds additional characters and
-    # runs into filesystem limitations for filename lengths (255). We therefore
-    # subtract the length of a UUID (36), the two underscores and the
-    # namespace length from the max filename length.
-    return 255 - 38 - len(namespace)
-
-
-def sanitize_pod_name(pod_name: str, namespace: str) -> str:
-    """Sanitize pod names so they conform to Kubernetes pod naming convention.
-
-    Args:
-        pod_name: Arbitrary input pod name.
-        namespace: Namespace in which the Pod will be created.
-
-    Returns:
-        Sanitized pod name.
-    """
-    # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-    pod_name = re.sub(r"[^a-z0-9-]", "-", pod_name.lower())
-    pod_name = re.sub(r"^[-]+", "", pod_name)
-    pod_name = re.sub(r"[-]+$", "", pod_name)
-    pod_name = re.sub(r"[-]+", "-", pod_name)
-
-    allowed_length = calculate_max_pod_name_length_for_namespace(
-        namespace=namespace
-    )
-    return pod_name[:allowed_length]
-
-
 def sanitize_label(label: str) -> str:
     """Sanitize a label for a Kubernetes resource.
 
@@ -193,10 +153,13 @@ def sanitize_label(label: str) -> str:
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
     label = re.sub(r"[^a-z0-9-]", "-", label.lower())
     label = re.sub(r"^[-]+", "", label)
-    label = re.sub(r"[-]+$", "", label)
     label = re.sub(r"[-]+", "-", label)
+    label = label[:63]
+    # Remove trailing dashes after truncation to make sure we end with an
+    # alphanumeric character
+    label = re.sub(r"[-]+$", "", label)
 
-    return label[:63]
+    return label
 
 
 def pod_is_not_pending(pod: k8s_client.V1Pod) -> bool:


### PR DESCRIPTION
## Describe changes
In certain cases, label or job names could end up with a trailing `-`, which caused an error as label/resource names need to start and end with alphanumeric characters.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

