### PR TITLE
Bump allowed versions of click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ zenml = "zenml.cli.cli:cli"
 [tool.poetry.dependencies]
 alembic = { version = ">=1.8.1,<=1.15.2" }
 bcrypt = { version = "4.0.1" }
-click = "^8.0.1,<8.2.1"
+click = "^8.0.1,<=8.2.1"
 cloudpickle = ">=2.0.0,<3"
 distro = "^1.6.0"
 docker = "~7.1.0"


### PR DESCRIPTION
Our upper ceiling on the versions of `click` we allow means that we can't, for example, install google's ADK agent framework in the same environment as ZenML.

Following how we did it in #3445 I'm just bumping the upper ceiling of click to allow for more wiggle room.