### PR TITLE
Delete run if model version doesn't exist during creation

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5692,6 +5692,8 @@ class SqlZenStore(BaseZenStore):
             EntityExistsError: If a run with the same name already exists or
                 a log entry with the same source already exists within the
                 scope of the same pipeline run.
+            KeyError: If the run requires a model version that doesn't exist and
+                can not be created.
         """
         self._set_request_user_id(request_model=pipeline_run, session=session)
         self._get_reference_schema_by_id(
@@ -5762,9 +5764,16 @@ class SqlZenStore(BaseZenStore):
                     f"within the scope of the same pipeline run '{new_run.id}'."
                 )
 
-        if model_version_id := self._get_or_create_model_version_for_run(
-            new_run
-        ):
+        try:
+            model_version_id = self._get_or_create_model_version_for_run(
+                new_run
+            )
+        except KeyError as e:
+            session.delete(new_run)
+            session.commit()
+            raise e
+
+        if model_version_id:
             new_run.model_version_id = model_version_id
             session.add(new_run)
             session.commit()


### PR DESCRIPTION
## Describe changes
If someone tries to create a pipeline run with a model that has a numeric version specified, we try to fetch that model version and fail if it doesn't exist. If this happens, the run would still be stored in the DB in an initializing state but would never get updated/deleted.
 
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

