### PR TITLE
Prevent stopping runs without orchestrator run id

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -57,7 +57,11 @@ from zenml.integrations.kubernetes.orchestrators.manifest_utils import (
 )
 from zenml.logger import get_logger
 from zenml.logging.step_logging import setup_orchestrator_logging
-from zenml.models import PipelineDeploymentResponse, PipelineRunResponse
+from zenml.models import (
+    PipelineDeploymentResponse,
+    PipelineRunResponse,
+    PipelineRunUpdate,
+)
 from zenml.orchestrators import publish_utils
 from zenml.orchestrators.step_run_utils import (
     StepRunRequestFactory,
@@ -257,7 +261,12 @@ def main() -> None:
     else:
         orchestrator_run_id = orchestrator_pod_name
         if args.run_id:
-            pipeline_run = client.get_pipeline_run(args.run_id)
+            pipeline_run = client.zen_store.update_run(
+                run_id=args.run_id,
+                run_update=PipelineRunUpdate(
+                    orchestrator_run_id=orchestrator_run_id
+                ),
+            )
         else:
             pipeline_run = create_placeholder_run(
                 deployment=deployment,

--- a/src/zenml/models/v2/core/pipeline_run.py
+++ b/src/zenml/models/v2/core/pipeline_run.py
@@ -144,6 +144,7 @@ class PipelineRunUpdate(BaseUpdate):
 
     status: Optional[ExecutionStatus] = None
     end_time: Optional[datetime] = None
+    orchestrator_run_id: Optional[str] = None
     # TODO: we should maybe have a different update model here, the upper
     #  three attributes should only be for internal use
     add_tags: Optional[List[str]] = Field(

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -35,7 +35,11 @@ from zenml.constants import (
     handle_bool_env_var,
 )
 from zenml.enums import ExecutionStatus, StackComponentType
-from zenml.exceptions import RunMonitoringError, RunStoppedException
+from zenml.exceptions import (
+    IllegalOperationError,
+    RunMonitoringError,
+    RunStoppedException,
+)
 from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType
 from zenml.orchestrators.publish_utils import (
@@ -485,6 +489,7 @@ class BaseOrchestrator(StackComponent, ABC):
         Raises:
             NotImplementedError: If any orchestrator inheriting from the base
                 class does not implement this logic.
+            IllegalOperationError: If the run has no orchestrator run id yet.
         """
         # Check if the orchestrator supports cancellation
         if (
@@ -494,6 +499,12 @@ class BaseOrchestrator(StackComponent, ABC):
             raise NotImplementedError(
                 f"The '{self.__class__.__name__}' orchestrator does not "
                 "support stopping pipeline runs."
+            )
+
+        if not run.orchestrator_run_id:
+            raise IllegalOperationError(
+                "Cannot stop a pipeline run that has no orchestrator run id "
+                "yet."
             )
 
         # Update pipeline status to STOPPING before calling concrete implementation

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -599,6 +599,9 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             self.status = run_update.status.value
             self.end_time = run_update.end_time
 
+        if run_update.orchestrator_run_id:
+            self.orchestrator_run_id = run_update.orchestrator_run_id
+
         self.updated = utc_now()
         return self
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -6147,6 +6147,9 @@ class SqlZenStore(BaseZenStore):
         Raises:
             EntityExistsError: If a log entry with the same source already
                 exists within the scope of the same pipeline run.
+            IllegalOperationError: If the orchestrator run id is being updated
+                on a non-placeholder run or if the orchestrator run id is
+                already set and is different from the new orchestrator run id.
         """
         with Session(self.engine) as session:
             # Check if pipeline run with the given ID exists
@@ -6155,6 +6158,24 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineRunSchema,
                 session=session,
             )
+
+            if run_update.orchestrator_run_id:
+                if not existing_run.is_placeholder_run():
+                    raise IllegalOperationError(
+                        "Cannot update the orchestrator run id of a pipeline "
+                        "run that is not a placeholder run."
+                    )
+
+                if (
+                    existing_run.orchestrator_run_id
+                    and existing_run.orchestrator_run_id
+                    != run_update.orchestrator_run_id
+                ):
+                    raise IllegalOperationError(
+                        "Pipeline run already has a different orchestrator run "
+                        f"id. Existing: {existing_run.orchestrator_run_id}, "
+                        f"New: {run_update.orchestrator_run_id}"
+                    )
 
             existing_run.update(run_update=run_update)
             session.add(existing_run)


### PR DESCRIPTION
## Describe changes
When stopping a run that does not yet have an orchestrator run id, our orchestrators don't actually know what to delete. Additionally, when the first step container is in the process of starting while the run is being stopped, the following happens:
- The step starts, and tries to replace the placeholder run (which essentially means setting the orchestrator run id)
- There is no placeholder run anymore (status = `INITIALIZING`), as the status of the run was already updated to `STOPPING`.
- The step therefore assumes there is no placeholder run, and instead creates a new run.
- There are now two runs
  - one in `STOPPING` state without any steps
  - another one in `RUNNING` state with a single step, which will (depending on the orchestrator) never finish

This PR fixes this by not allowing runs without an orchestrator run ID to be cancelled.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

