### PR TITLE
Rename some legacy attributes

### DIFF
--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -454,7 +454,7 @@ class Compiler:
             source=invocation.step.resolve(),
             upstream_steps=sorted(invocation.upstream_steps),
             inputs=inputs,
-            pipeline_parameter_name=invocation.id,
+            invocation_id=invocation.id,
         )
 
     def _compile_step_invocation(

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -406,8 +406,15 @@ class StepSpec(FrozenBaseModel):
     source: SourceWithValidator
     upstream_steps: List[str]
     inputs: Dict[str, InputSpec] = {}
-    # The default value is to ensure compatibility with specs of version <0.2
-    pipeline_parameter_name: str = ""
+    invocation_id: str
+
+    @model_validator(mode="before")
+    @classmethod
+    @before_validator_handler
+    def _migrate_invocation_id(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        if "invocation_id" not in data:
+            data["invocation_id"] = data.pop("pipeline_parameter_name", "")
+        return data
 
     def __eq__(self, other: Any) -> bool:
         """Returns whether the other object is referring to the same step.
@@ -431,7 +438,7 @@ class StepSpec(FrozenBaseModel):
             if self.inputs != other.inputs:
                 return False
 
-            if self.pipeline_parameter_name != other.pipeline_parameter_name:
+            if self.invocation_id != other.invocation_id:
                 return False
 
             return self.source.import_path == other.source.import_path

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -129,7 +129,7 @@ class StepLauncher:
             )
 
         self._stack = Stack.from_model(snapshot.stack)
-        self._step_name = step.spec.pipeline_parameter_name
+        self._invocation_id = step.spec.invocation_id
 
         # Internal properties and methods
         self._step_run: Optional[StepRunResponse] = None
@@ -155,7 +155,7 @@ class StepLauncher:
             """
             logger.info(
                 f"Received signal shutdown {signum}. Requesting shutdown "
-                f"for step '{self._step_name}'..."
+                f"for step '{self._invocation_id}'..."
             )
 
             try:
@@ -260,7 +260,7 @@ class StepLauncher:
             # Configure the logs
             logs_uri = step_logging.prepare_logs_uri(
                 artifact_store=self._stack.artifact_store,
-                step_name=self._step_name,
+                step_name=self._invocation_id,
             )
 
             logs_context = step_logging.PipelineLogsStorageContext(
@@ -293,14 +293,16 @@ class StepLauncher:
                 stack=self._stack,
             )
             step_run_request = request_factory.create_request(
-                invocation_id=self._step_name
+                invocation_id=self._invocation_id
             )
             step_run_request.logs = logs_model
 
             try:
                 request_factory.populate_request(request=step_run_request)
             except BaseException as e:
-                logger.exception(f"Failed preparing step `{self._step_name}`.")
+                logger.exception(
+                    f"Failed preparing step `{self._invocation_id}`."
+                )
                 step_run_request.status = ExecutionStatus.FAILED
                 step_run_request.end_time = utc_now()
                 step_run_request.exception_info = (
@@ -316,7 +318,7 @@ class StepLauncher:
                     )
 
             if not step_run.status.is_finished:
-                logger.info(f"Step `{self._step_name}` has started.")
+                logger.info(f"Step `{self._invocation_id}` has started.")
 
                 try:
                     # here pass a forced save_to_file callable to be
@@ -345,14 +347,14 @@ class StepLauncher:
                 except BaseException as e:  # noqa: E722
                     logger.error(
                         "Failed to run step `%s`: %s",
-                        self._step_name,
+                        self._invocation_id,
                         e,
                     )
                     publish_utils.publish_failed_step_run(step_run.id)
                     raise
             else:
                 logger.info(
-                    f"Using cached version of step `{self._step_name}`."
+                    f"Using cached version of step `{self._invocation_id}`."
                 )
                 if (
                     model_version := step_run.model_version
@@ -414,7 +416,7 @@ class StepLauncher:
             config=self._step.config,
             pipeline=self._snapshot.pipeline_configuration,
             run_name=pipeline_run.name,
-            pipeline_step_name=self._step_name,
+            pipeline_step_name=self._invocation_id,
             run_id=pipeline_run.id,
             step_run_id=step_run.id,
             force_write_logs=force_write_logs,
@@ -452,7 +454,7 @@ class StepLauncher:
 
         duration = time.time() - start_time
         logger.info(
-            f"Step `{self._step_name}` has finished in "
+            f"Step `{self._invocation_id}` has finished in "
             f"`{string_utils.get_human_readable_time(duration)}`."
         )
 
@@ -475,7 +477,7 @@ class StepLauncher:
         entrypoint_command = (
             entrypoint_cfg_class.get_entrypoint_command()
             + entrypoint_cfg_class.get_entrypoint_arguments(
-                step_name=self._step_name,
+                step_name=self._invocation_id,
                 snapshot_id=self._snapshot.id,
                 step_run_id=str(step_run_info.step_run_id),
             )
@@ -493,7 +495,7 @@ class StepLauncher:
         logger.info(
             "Using step operator `%s` to run step `%s`.",
             step_operator.name,
-            self._step_name,
+            self._invocation_id,
         )
         step_operator.launch(
             info=step_run_info,

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -531,13 +531,13 @@ class StepRunner:
             StepInterfaceError: If the step function return values do not
                 match the output annotations.
         """
-        step_name = self._step.spec.pipeline_parameter_name
+        invocation_id = self._step.spec.invocation_id
 
         # if there are no outputs, the return value must be `None`.
         if len(output_annotations) == 0:
             if return_values is not None:
                 raise StepInterfaceError(
-                    f"Wrong step function output type for step `{step_name}`: "
+                    f"Wrong step function output type for step `{invocation_id}`: "
                     f"Expected no outputs but the function returned something: "
                     f"{return_values}."
                 )
@@ -553,7 +553,7 @@ class StepRunner:
         # or tuple.
         if not isinstance(return_values, (list, tuple)):
             raise StepInterfaceError(
-                f"Wrong step function output type for step `{step_name}`: "
+                f"Wrong step function output type for step `{invocation_id}`: "
                 f"Expected multiple outputs ({output_annotations}) but "
                 f"the function did not return a list or tuple "
                 f"(actual return value: {return_values})."
@@ -564,7 +564,7 @@ class StepRunner:
         if len(output_annotations) != len(return_values):
             raise StepInterfaceError(
                 f"Wrong amount of step function outputs for step "
-                f"'{step_name}: Expected {len(output_annotations)} outputs "
+                f"'{invocation_id}: Expected {len(output_annotations)} outputs "
                 f"but the function returned {len(return_values)} outputs"
                 f"(return values: {return_values})."
             )
@@ -585,7 +585,7 @@ class StepRunner:
                 if not isinstance(return_value, output_type):
                     raise StepInterfaceError(
                         f"Wrong type for output '{output_name}' of step "
-                        f"'{step_name}' (expected type: {output_type}, "
+                        f"'{invocation_id}' (expected type: {output_type}, "
                         f"actual type: {type(return_value)})."
                     )
             validated_outputs[output_name] = return_value

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -1218,7 +1218,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             hash_.update(self.source_code.encode())
 
         for step_spec in pipeline_spec.steps:
-            invocation = self.invocations[step_spec.pipeline_parameter_name]
+            invocation = self.invocations[step_spec.invocation_id]
             step_source = invocation.step.source_code
             hash_.update(step_source.encode())
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -424,9 +424,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             )
             steps = {}
             for step_spec in pipeline_spec.steps:
-                steps[step_spec.pipeline_parameter_name] = (
-                    step_spec.upstream_steps
-                )
+                steps[step_spec.invocation_id] = step_spec.upstream_steps
             return steps
         else:
             raise RuntimeError("Pipeline run has no snapshot.")

--- a/tests/integration/functional/utils/test_run_utils.py
+++ b/tests/integration/functional/utils/test_run_utils.py
@@ -113,7 +113,7 @@ def test_build_dag(clean_client):
 
     steps = {}
     for step_spec in snapshot.pipeline_spec.steps:
-        steps[step_spec.pipeline_parameter_name] = step_spec.upstream_steps
+        steps[step_spec.invocation_id] = step_spec.upstream_steps
 
     # Build the DAG using our function
     dag = build_dag(steps)
@@ -141,7 +141,7 @@ def test_find_all_downstream_steps(clean_client):
 
     steps = {}
     for step_spec in snapshot.pipeline_spec.steps:
-        steps[step_spec.pipeline_parameter_name] = step_spec.upstream_steps
+        steps[step_spec.invocation_id] = step_spec.upstream_steps
 
     # Build the DAG
     dag = build_dag(steps)
@@ -184,7 +184,7 @@ def test_dag_with_failed_step(clean_client):
 
     steps = {}
     for step_spec in snapshot.pipeline_spec.steps:
-        steps[step_spec.pipeline_parameter_name] = step_spec.upstream_steps
+        steps[step_spec.invocation_id] = step_spec.upstream_steps
 
     # Build the DAG
     dag = build_dag(steps)

--- a/tests/unit/config/test_compiler.py
+++ b/tests/unit/config/test_compiler.py
@@ -605,7 +605,7 @@ def test_spec_compilation(local_stack):
                 {
                     "source": "tests.unit.config.test_compiler.s1",
                     "upstream_steps": [],
-                    "pipeline_parameter_name": "s1",
+                    "invocation_id": "s1",
                 },
                 {
                     "source": "tests.unit.config.test_compiler.s2",
@@ -616,7 +616,7 @@ def test_spec_compilation(local_stack):
                             "output_name": "output",
                         }
                     },
-                    "pipeline_parameter_name": "s2",
+                    "invocation_id": "s2",
                 },
             ],
         }

--- a/tests/unit/config/test_step_configurations.py
+++ b/tests/unit/config/test_step_configurations.py
@@ -83,13 +83,12 @@ def test_step_spec_inputs_equality():
     )
 
 
-def test_step_spec_pipeline_parameter_name_equality():
-    """Tests the step spec equality operator regarding the pipeline parameter
-    name."""
+def test_step_spec_invocation_id_equality():
+    """Tests the step spec equality operator regarding the invocation id."""
     assert StepSpec(
-        source="src", upstream_steps=[], pipeline_parameter_name="name"
+        source="src", upstream_steps=[], invocation_id="name"
     ) != StepSpec(
         source="src",
         upstream_steps=[],
-        pipeline_parameter_name="different_name",
+        invocation_id="different_name",
     )


### PR DESCRIPTION
## Describe changes

Renames a step spec attribute that still had a legacy name. In the current form of this PR, this is breaking all old clients.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

