### PR TITLE
Bugfix for duplicated log records for exceptions

### DIFF
--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -258,15 +258,15 @@ def setup_global_print_wrapping() -> None:
 
     def wrapped_print(*args: Any, **kwargs: Any) -> None:
         file_arg = kwargs.get("file", sys.stdout)
-        
-        # IMPORTANT: Don't intercept internal calls to any objects 
-        # other than sys.stdout and sys.stderr. This is especially 
-        # critical for handling tracebacks. The default logging 
-        # formatter uses StringIO to format tracebacks, we don't 
+
+        # IMPORTANT: Don't intercept internal calls to any objects
+        # other than sys.stdout and sys.stderr. This is especially
+        # critical for handling tracebacks. The default logging
+        # formatter uses StringIO to format tracebacks, we don't
         # want to intercept it and create a LogRecord about it.
         if file_arg not in (sys.stdout, sys.stderr):
             return original_print(*args, **kwargs)
-        
+
         # Convert print arguments to message
         message = " ".join(str(arg) for arg in args)
 

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -257,11 +257,18 @@ def setup_global_print_wrapping() -> None:
     original_print = builtins.print
 
     def wrapped_print(*args: Any, **kwargs: Any) -> None:
+        file_arg = kwargs.get("file", sys.stdout)
+        
+        # IMPORTANT: Don't intercept internal calls to StringIO 
+        # or other file-like objects. This is especially critical 
+        # for handling tracebacks. The default logging formatter 
+        # uses StringIO to format tracebacks, we don't want to 
+        # intercept that and create a LogRecord about it.
+        if file_arg not in (sys.stdout, sys.stderr):
+            return original_print(*args, **kwargs)
+        
         # Convert print arguments to message
         message = " ".join(str(arg) for arg in args)
-
-        # Determine if this should go to stderr or stdout based on file argument
-        file_arg = kwargs.get("file", sys.stdout)
 
         # Call active handlers first (for storage)
         if message.strip():

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -259,11 +259,11 @@ def setup_global_print_wrapping() -> None:
     def wrapped_print(*args: Any, **kwargs: Any) -> None:
         file_arg = kwargs.get("file", sys.stdout)
         
-        # IMPORTANT: Don't intercept internal calls to StringIO 
-        # or other file-like objects. This is especially critical 
-        # for handling tracebacks. The default logging formatter 
-        # uses StringIO to format tracebacks, we don't want to 
-        # intercept that and create a LogRecord about it.
+        # IMPORTANT: Don't intercept internal calls to any objects 
+        # other than sys.stdout and sys.stderr. This is especially 
+        # critical for handling tracebacks. The default logging 
+        # formatter uses StringIO to format tracebacks, we don't 
+        # want to intercept it and create a LogRecord about it.
         if file_arg not in (sys.stdout, sys.stderr):
             return original_print(*args, **kwargs)
         


### PR DESCRIPTION
## Describe changes
If something would go wrong during the step execution, we would see logs like this:

<img width="976" height="961" alt="Screenshot 2025-09-17 at 16 10 05" src="https://github.com/user-attachments/assets/f686e15e-cabe-4885-a622-d00e452f11c8" />

This was due to the following steps:

- Something goes wrong during the step execution.
- The exception gets caught by `PipelineLogsStorageContext.__exit__`.
- We create a `LogRecord` with `exc_info` containing the exception details.
- The generated `LogRecord` is passed to `ArtifactStoreHandler.emit`.
- The handler calls `self.format` on the message.
- Since the handler doesn't have a specific formatter, it defaults to pythons logging formatter.
- It detects `exc_info` and calls `formatException`.
- `formatException` creates a `StringIO` to capture traceback text.
- `formatException` calls `traceback.print_exception` with the `StringIO` buffer as the file parameter.
- `traceback.print_exception` internally calls `print(line, file=stringio_buffer)` for each line.
- We catch this call with our wrapper.
- Each line ends up creating an additional `LogRecord` (as they are treated like regular print calls).

As a solution, we now only create `LogRecords` for `print` calls to `stdout` and `stderr`.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [X] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

