### PR TITLE
Bugfix for handling old logs with timestamp

### DIFF
--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -259,24 +259,30 @@ def parse_log_entry(log_line: str) -> Optional[LogEntry]:
         For plain text logs, only message is populated with INFO level default.
         Returns None only for empty lines.
     """
-    stripped_line = log_line.strip()
-    if not stripped_line:
+    line = log_line.strip()
+    if not line:
         return None
 
-    # Try to parse JSON format first
-    if stripped_line.startswith("{") and stripped_line.endswith("}"):
+    if line.startswith("{") and line.endswith("}"):
         try:
-            return LogEntry.model_validate_json(stripped_line)
+            return LogEntry.model_validate_json(line)
         except Exception:
-            # If JSON parsing or validation fails, treat as plain text
             pass
 
-    # For any other format (plain text), create LogEntry with defaults
+    old_format = re.search(
+        r"\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+UTC\]", line
+    )
+
+    timestamp = None
+    if old_format:
+        timestamp = old_format.group(1)
+        line = line.replace(old_format.group(0), "").strip()
+
     return LogEntry(
-        message=stripped_line,
-        name=None,  # No logger name available for plain text logs
-        level=LoggingLevels.INFO,  # Default level for plain text logs
-        timestamp=None,  # No timestamp available for plain text logs
+        message=line,
+        name=None,
+        level=LoggingLevels.INFO,
+        timestamp=timestamp,
     )
 
 


### PR DESCRIPTION
## Describe changes
I am now trying to parse out the timestamp from the old logs. 

PS: Removed some unnecessary comments just for you @schustmi 😄 

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [X] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

