### PR TITLE
Fix requirements for local agentic examples tests

### DIFF
--- a/examples/agent_framework_integrations/autogen/requirements.txt
+++ b/examples/agent_framework_integrations/autogen/requirements.txt
@@ -1,3 +1,3 @@
 autogen-core>=0.4.0
 autogen-ext[openai]>=0.4.0
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/aws-strands/requirements.txt
+++ b/examples/agent_framework_integrations/aws-strands/requirements.txt
@@ -1,3 +1,3 @@
 strands-agents[openai]>=1.0.0
 strands-agents-tools>=0.0.1
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/crewai/requirements.txt
+++ b/examples/agent_framework_integrations/crewai/requirements.txt
@@ -1,2 +1,2 @@
 crewai>=0.28.8
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/google_adk/requirements.txt
+++ b/examples/agent_framework_integrations/google_adk/requirements.txt
@@ -1,2 +1,2 @@
 google-adk>=1.6.1
-zenml>=0.84.3
+zenml[local]>=0.84.3

--- a/examples/agent_framework_integrations/haystack/requirements.txt
+++ b/examples/agent_framework_integrations/haystack/requirements.txt
@@ -1,2 +1,2 @@
 haystack-ai>=2.0.0
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/langchain/requirements.txt
+++ b/examples/agent_framework_integrations/langchain/requirements.txt
@@ -2,4 +2,4 @@ langchain>=0.2.0
 langchain-openai>=0.2.0
 langchain-community>=0.2.0
 beautifulsoup4
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/langgraph/requirements.txt
+++ b/examples/agent_framework_integrations/langgraph/requirements.txt
@@ -1,4 +1,4 @@
 langgraph>=0.5.3
 langchain>=0.2.0
 langchain-openai>=0.2.0
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/llama_index/requirements.txt
+++ b/examples/agent_framework_integrations/llama_index/requirements.txt
@@ -1,3 +1,3 @@
 llama-index
 llama-index-llms-openai
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/openai_agents_sdk/requirements.txt
+++ b/examples/agent_framework_integrations/openai_agents_sdk/requirements.txt
@@ -1,2 +1,2 @@
 openai-agents>=0.1.0
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/pydanticai/requirements.txt
+++ b/examples/agent_framework_integrations/pydanticai/requirements.txt
@@ -1,2 +1,2 @@
 pydantic-ai>=0.4.3
-zenml
+zenml[local]

--- a/examples/agent_framework_integrations/semantic-kernel/requirements.txt
+++ b/examples/agent_framework_integrations/semantic-kernel/requirements.txt
@@ -1,2 +1,2 @@
 semantic-kernel>=1.6.2
-zenml
+zenml[local]


### PR DESCRIPTION
Agent examples tests were failing because we recently (?) changed how zenml is installed in the cases of purely local use. We now require users to specify the `zenml[local]` extra.

Fixes failures like https://github.com/zenml-io/zenml/actions/runs/17940183043