### PR TITLE
Remove remaining RBAC check when fetching tags

### DIFF
--- a/src/zenml/zen_server/routers/tags_endpoints.py
+++ b/src/zenml/zen_server/routers/tags_endpoints.py
@@ -34,7 +34,6 @@ from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.endpoint_utils import (
     verify_permissions_and_delete_entity,
-    verify_permissions_and_get_entity,
     verify_permissions_and_update_entity,
 )
 from zenml.zen_server.utils import (
@@ -121,9 +120,8 @@ def get_tag(
     Returns:
         The tag with the given name or ID.
     """
-    return verify_permissions_and_get_entity(
-        id=tag_name_or_id,
-        get_method=zen_store().get_tag,
+    return zen_store().get_tag(
+        tag_name_or_id=tag_name_or_id,
         hydrate=hydrate,
     )
 


### PR DESCRIPTION
## Describe changes
We've decided that tag creation and reading is not protected by RBAC, only update and delete is. However, there was one remaining RBAC check in code when reading tags, which causes issues when used with low-permission custom roles.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

