### PR TITLE
Disable coderabbit status message

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@ early_access: false
 reviews:
   high_level_summary: true
   poem: true
-  review_status: true
+  review_status: false
   collapse_walkthrough: true
   path_filters:
   - "!**/.xml"


### PR DESCRIPTION
This change gets rid of this status message which was happening automatically on every push to a PR:

<img width="923" height="552" alt="CleanShot 2025-09-24 at 15 34 52" src="https://github.com/user-attachments/assets/c79625eb-a705-4941-a353-d964681b0cca" />
