### PR TITLE
Better CLI error messages

### DIFF
--- a/src/zenml/cli/artifact.py
+++ b/src/zenml/cli/artifact.py
@@ -105,7 +105,7 @@ def update_artifact(
             remove_tags=remove_tag,
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Artifact '{artifact.id}' updated.")
 
@@ -192,7 +192,7 @@ def update_artifact_version(
             remove_tags=remove_tag,
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Artifact version '{artifact_version.id}' updated.")
 

--- a/src/zenml/cli/authorized_device.py
+++ b/src/zenml/cli/authorized_device.py
@@ -47,7 +47,7 @@ def describe_authorized_device(id_or_prefix: str) -> None:
             id_or_prefix=id_or_prefix,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     cli_utils.print_pydantic_model(
         title=f"Authorized device `{device.id}`",
@@ -93,7 +93,7 @@ def lock_authorized_device(id: str) -> None:
             locked=True,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Locked authorized device `{id}`.")
 
@@ -112,7 +112,7 @@ def unlock_authorized_device(id: str) -> None:
             locked=False,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Locked authorized device `{id}`.")
 
@@ -143,6 +143,6 @@ def delete_authorized_device(id: str, yes: bool = False) -> None:
     try:
         Client().delete_authorized_device(id_or_prefix=id)
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted authorized device `{id}`.")

--- a/src/zenml/cli/code_repository.py
+++ b/src/zenml/cli/code_repository.py
@@ -180,7 +180,7 @@ def describe_code_repository(name_id_or_prefix: str) -> None:
             name_id_or_prefix=name_id_or_prefix,
         )
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         cli_utils.print_pydantic_model(
             title=f"Code repository '{code_repository.name}'",
@@ -303,6 +303,6 @@ def delete_code_repository(name_or_id: str, yes: bool = False) -> None:
     try:
         Client().delete_code_repository(name_id_or_prefix=name_or_id)
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted code repository `{name_or_id}`.")

--- a/src/zenml/cli/deployment.py
+++ b/src/zenml/cli/deployment.py
@@ -83,7 +83,7 @@ def list_deployments(**kwargs: Any) -> None:
         with console.status("Listing deployments...\n"):
             deployments = client.list_deployments(**kwargs)
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         if not deployments.items:
             cli_utils.declare("No deployments found for this filter.")
@@ -140,7 +140,7 @@ def describe_deployment(
             name_id_or_prefix=deployment_name_or_id,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.pretty_print_deployment(
             deployment,
@@ -245,7 +245,7 @@ def provision_deployment(
                 timeout=timeout,
             )
         except KeyError as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
         else:
             cli_utils.declare(
                 f"Provisioned deployment '{deployment_name_or_id}'."
@@ -580,7 +580,7 @@ def refresh_deployment(
         )
 
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.pretty_print_deployment(deployment, show_secret=True)
 
@@ -694,7 +694,7 @@ def log_deployment(
             tail=tail,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         for log in logs:
             print(log)

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -89,7 +89,7 @@ def get_requirements(integration_name: Optional[str] = None) -> None:
             integration_name
         )
     except KeyError as e:
-        error(str(e))
+        exception(e)
     else:
         if requirements:
             title(

--- a/src/zenml/cli/integration.py
+++ b/src/zenml/cli/integration.py
@@ -26,6 +26,7 @@ from zenml.cli.utils import (
     confirmation,
     declare,
     error,
+    exception,
     format_integration_list,
     install_packages,
     print_table,

--- a/src/zenml/cli/model.py
+++ b/src/zenml/cli/model.py
@@ -212,7 +212,7 @@ def register_model(
             )
         )
     except (EntityExistsError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     cli_utils.print_table([_model_to_print(model)])
 
@@ -380,7 +380,7 @@ def delete_model(
             model_name_or_id=model_name_or_id,
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Model '{model_name_or_id}' deleted.")
 
@@ -558,7 +558,7 @@ def delete_model_version(
             model_version_id=model_version.id,
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(
             f"Model version '{model_version_name_or_number_or_id}' deleted from model '{model_name_or_id}'."

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -621,7 +621,7 @@ def delete_pipeline(
             name_id_or_prefix=pipeline_name_or_id,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted pipeline `{pipeline_name_or_id}`.")
 
@@ -681,7 +681,7 @@ def update_schedule(
             cron_expression=cron_expression,
         )
     except Exception as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Updated schedule '{schedule_name_or_id}'.")
 
@@ -713,7 +713,7 @@ def delete_schedule(schedule_name_or_id: str, yes: bool = False) -> None:
     try:
         Client().delete_schedule(name_id_or_prefix=schedule_name_or_id)
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted schedule '{schedule_name_or_id}'.")
 
@@ -736,7 +736,7 @@ def list_pipeline_runs(**kwargs: Any) -> None:
         with console.status("Listing pipeline runs...\n"):
             pipeline_runs = client.list_pipeline_runs(**kwargs)
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         if not pipeline_runs.items:
             cli_utils.declare("No pipeline runs found for this filter.")
@@ -832,7 +832,7 @@ def delete_pipeline_run(
             name_id_or_prefix=run_name_or_id,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted pipeline run '{run_name_or_id}'.")
 
@@ -862,7 +862,7 @@ def refresh_pipeline_run(
         )
 
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(
             f"Refreshed the status of pipeline run '{run.name}'."
@@ -887,7 +887,7 @@ def list_pipeline_builds(**kwargs: Any) -> None:
         with console.status("Listing pipeline builds...\n"):
             pipeline_builds = client.list_builds(hydrate=True, **kwargs)
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         if not pipeline_builds.items:
             cli_utils.declare("No pipeline builds found for this filter.")
@@ -935,7 +935,7 @@ def delete_pipeline_build(
     try:
         Client().delete_build(build_id)
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted pipeline build '{build_id}'.")
 
@@ -1224,7 +1224,7 @@ def deploy_snapshot(
                 timeout=timeout,
             )
         except KeyError as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
         else:
             cli_utils.declare(
                 f"Provisioned deployment '{deployment_name_or_id}'."
@@ -1245,7 +1245,7 @@ def list_pipeline_snapshots(**kwargs: Any) -> None:
         with console.status("Listing pipeline snapshots...\n"):
             pipeline_snapshots = client.list_snapshots(hydrate=True, **kwargs)
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         if not pipeline_snapshots.items:
             cli_utils.declare("No pipeline snapshots found for this filter.")

--- a/src/zenml/cli/project.py
+++ b/src/zenml/cli/project.py
@@ -111,7 +111,7 @@ def register_project(
             )
             cli_utils.success("✔ Project created successfully.")
         except Exception as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
 
     if set_project:
         client.set_active_project(project_name)
@@ -153,7 +153,7 @@ def set_project(project_name_or_id: str, default: bool = False) -> None:
                 f"✔ The active project has been set to {project_name_or_id}"
             )
         except Exception as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
 
     if default:
         client.update_user(
@@ -184,7 +184,7 @@ def describe_project(project_name_or_id: Optional[str] = None) -> None:
         try:
             project_ = client.get_project(project_name_or_id)
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         else:
             cli_utils.print_pydantic_models(
                 [project_], exclude_columns=["created", "updated"]
@@ -208,4 +208,4 @@ def delete_project(project_name_or_id: str) -> None:
                 f"Project '{project_name_or_id}' deleted successfully."
             )
         except Exception as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)

--- a/src/zenml/cli/server.py
+++ b/src/zenml/cli/server.py
@@ -780,4 +780,4 @@ def show(local: bool = False, ngrok_token: Optional[str] = None) -> None:
     try:
         zenml.show(ngrok_token=ngrok_token)
     except RuntimeError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)

--- a/src/zenml/cli/service_accounts.py
+++ b/src/zenml/cli/service_accounts.py
@@ -58,7 +58,7 @@ def _create_api_key(
                 description=description or "",
             )
         except (KeyError, EntityExistsError) as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
 
         cli_utils.declare(f"Successfully created API key `{name}`.")
 
@@ -150,7 +150,7 @@ def create_service_account(
 
         cli_utils.declare(f"Created service account '{service_account.name}'.")
     except EntityExistsError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     if create_api_key:
         _create_api_key(
@@ -176,7 +176,7 @@ def describe_service_account(service_account_name_or_id: str) -> None:
             service_account_name_or_id
         )
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         cli_utils.print_pydantic_model(
             title=f"Service account '{service_account.name}'",
@@ -261,7 +261,7 @@ def update_service_account(
             active=active,
         )
     except (KeyError, EntityExistsError) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
 
 @service_account.command("delete")
@@ -276,7 +276,7 @@ def delete_service_account(service_account_name_or_id: str) -> None:
     try:
         client.delete_service_account(service_account_name_or_id)
     except (KeyError, IllegalOperationError) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     cli_utils.declare(
         f"Deleted service account '{service_account_name_or_id}'."
@@ -370,7 +370,7 @@ def describe_api_key(service_account_name_or_id: str, name_or_id: str) -> None:
                 name_id_or_prefix=name_or_id,
             )
         except KeyError as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
 
         cli_utils.print_pydantic_model(
             title=f"API key '{api_key.name}'",
@@ -399,7 +399,7 @@ def list_api_keys(service_account_name_or_id: str, /, **kwargs: Any) -> None:
                 **kwargs,
             )
         except KeyError as e:
-            cli_utils.error(str(e))
+            cli_utils.exception(e)
 
         if not api_keys.items:
             cli_utils.declare("No API keys found for this filter.")
@@ -455,7 +455,7 @@ def update_api_key(
             active=active,
         )
     except (KeyError, EntityExistsError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     cli_utils.declare(f"Successfully updated API key `{name_or_id}`.")
 
@@ -510,7 +510,7 @@ def rotate_api_key(
             retain_period_minutes=retain,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     cli_utils.declare(f"Successfully rotated API key `{name_or_id}`.")
     if retain:
@@ -581,6 +581,6 @@ def delete_api_key(
             name_id_or_prefix=name_or_id,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Deleted API key `{name_or_id}`.")

--- a/src/zenml/cli/service_connectors.py
+++ b/src/zenml/cli/service_connectors.py
@@ -1133,7 +1133,7 @@ def describe_service_connector(
                 expand_secrets=show_secrets,
             )
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
     with console.status(f"Describing connector '{connector.name}'..."):
         active_stack = client.active_stack_model
@@ -1381,7 +1381,7 @@ def update_service_connector(
             expand_secrets=True,
         )
     except KeyError as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     if interactive:
         # Fetch the connector type specification if not already embedded
@@ -1677,7 +1677,7 @@ def delete_service_connector(name_id_or_prefix: str) -> None:
                 name_id_or_prefix=name_id_or_prefix,
             )
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         cli_utils.declare(f"Deleted service connector: {name_id_or_prefix}")
 
 

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""CLI for manipulating ZenML local and global config file."""
+"""Stack CLI."""
 
 import getpass
 import re
@@ -85,13 +85,12 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-# Stacks
 @cli.group(
     cls=TagGroup,
     tag=CliCategories.MANAGEMENT_TOOLS,
 )
 def stack() -> None:
-    """Stacks to define various environments."""
+    """Manage stacks."""
 
 
 @stack.command(
@@ -552,7 +551,7 @@ def register_stack(
                 )
             )
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         cli_utils.declare(
             f"Stack '{created_stack.name}' successfully registered!"
@@ -827,7 +826,7 @@ def update_stack(
             )
 
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         cli_utils.declare(
             f"Stack `{updated_stack.name}` successfully updated!"
@@ -1005,7 +1004,7 @@ def remove_stack_component(
                 component_updates=stack_component_update,
             )
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         cli_utils.declare(
             f"Stack `{updated_stack.name}` successfully updated!"
         )
@@ -1033,7 +1032,7 @@ def rename_stack(
                 name=new_stack_name,
             )
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         cli_utils.declare(
             f"Stack `{stack_name_or_id}` successfully renamed to `"
             f"{new_stack_name}`!"
@@ -1089,7 +1088,7 @@ def describe_stack(stack_name_or_id: Optional[str] = None) -> None:
                 name_id_or_prefix=stack_name_or_id
             )
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         cli_utils.print_stack_configuration(
             stack=stack_,
@@ -1155,7 +1154,7 @@ def delete_stack(
         try:
             client.delete_stack(stack_name_or_id)
         except (KeyError, ValueError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         cli_utils.declare(f"Deleted stack '{stack_name_or_id}'.")
 
 
@@ -1176,7 +1175,7 @@ def set_active_stack_command(stack_name_or_id: str) -> None:
         try:
             client.activate_stack(stack_name_id_or_prefix=stack_name_or_id)
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         cli_utils.declare(
             f"Active {scope} stack set to: '{client.active_stack_model.name}'"
@@ -1195,7 +1194,7 @@ def get_active_stack() -> None:
                 f"The {scope} active stack is: '{client.active_stack_model.name}'"
             )
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
 
 @stack.command("export", help="Exports a stack to a YAML file.")
@@ -1216,7 +1215,7 @@ def export_stack(
     try:
         stack_to_export = client.get_stack(name_id_or_prefix=stack_name_or_id)
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     # write zenml version and stack dict to YAML
     yaml_data = stack_to_export.to_yaml()
@@ -1384,7 +1383,7 @@ def copy_stack(source_stack_name_or_id: str, target_stack: str) -> None:
                 name_id_or_prefix=source_stack_name_or_id
             )
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         component_mapping: Dict[StackComponentType, Union[str, UUID]] = {}
 
@@ -2091,7 +2090,7 @@ def export_requirements(
             name_id_or_prefix=stack_name_or_id
         )
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     requirements, _ = requirements_utils.get_requirements_for_stack(
         stack_model

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -112,7 +112,7 @@ def generate_stack_component_describe_command(
                 component_type=component_type,
             )
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
         with console.status(f"Describing component '{component_.name}'..."):
             active_component_id = None
@@ -432,7 +432,7 @@ def generate_stack_component_update_command(
                     environment=environment,
                 )
             except KeyError as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             cli_utils.declare(
                 f"Successfully updated {display_name} "
@@ -495,7 +495,7 @@ def generate_stack_component_remove_attribute_command(
                     labels={k: None for k in labels} if labels else None,
                 )
             except (KeyError, IllegalOperationError) as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             cli_utils.declare(
                 f"Successfully updated {display_name} `{name_id_or_prefix}`."
@@ -549,7 +549,7 @@ def generate_stack_component_rename_command(
                     name=new_name,
                 )
             except (KeyError, IllegalOperationError) as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             cli_utils.declare(
                 f"Successfully renamed {display_name} `{name_id_or_prefix}` to"
@@ -591,7 +591,7 @@ def generate_stack_component_delete_command(
                     component_type=component_type,
                 )
             except (KeyError, IllegalOperationError) as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
             cli_utils.declare(f"Deleted {display_name}: {name_id_or_prefix}")
 
     return delete_stack_component_command
@@ -637,7 +637,7 @@ def generate_stack_component_copy_command(
                     component_type=component_type,
                 )
             except KeyError as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             copied_component = client.create_stack_component(
                 name=target_component,
@@ -694,7 +694,7 @@ def generate_stack_component_logs_command(
                     component_type=component_type,
                 )
             except KeyError as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             from zenml.stack import StackComponent
 
@@ -1209,7 +1209,7 @@ def generate_stack_component_disconnect_command(
                     disconnect=True,
                 )
             except (KeyError, IllegalOperationError) as err:
-                cli_utils.error(str(err))
+                cli_utils.exception(err)
 
             cli_utils.declare(
                 f"Successfully disconnected the service-connector from {display_name} `{name_id_or_prefix}`."
@@ -1432,7 +1432,7 @@ def connect_stack_component_with_service_connector(
             component_type=component_type,
         )
     except KeyError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     requirements = component_model.flavor.connector_requirements
 
@@ -1588,7 +1588,7 @@ def connect_stack_component_with_service_connector(
                 connector_resource_id=resource_id,
             )
         except (KeyError, IllegalOperationError) as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
 
     if connector_resources is not None:
         cli_utils.declare(

--- a/src/zenml/cli/tag.py
+++ b/src/zenml/cli/tag.py
@@ -83,7 +83,7 @@ def register_tag(name: str, color: Optional[ColorVariants]) -> None:
     try:
         tag = Client().create_tag(**request_dict)
     except (EntityExistsError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     cli_utils.print_pydantic_models(
         [tag],
@@ -158,7 +158,7 @@ def delete_tag(
             .tagged_count
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
 
     if not yes or tagged_count > 0:
         confirmation = cli_utils.confirmation(
@@ -178,6 +178,6 @@ def delete_tag(
             tag_name_or_id=tag_name_or_id,
         )
     except (KeyError, ValueError) as e:
-        cli_utils.error(str(e))
+        cli_utils.exception(e)
     else:
         cli_utils.declare(f"Tag '{tag_name_or_id}' deleted.")

--- a/src/zenml/cli/user_management.py
+++ b/src/zenml/cli/user_management.py
@@ -62,7 +62,7 @@ def describe_user(user_name_or_id: Optional[str] = None) -> None:
         try:
             user = client.get_user(user_name_or_id)
         except KeyError as err:
-            cli_utils.error(str(err))
+            cli_utils.exception(err)
         else:
             cli_utils.print_pydantic_models(
                 [user],
@@ -174,7 +174,7 @@ def create_user(
 
         cli_utils.declare(f"Created user '{new_user.name}'.")
     except EntityExistsError as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     else:
         if not new_user.active and new_user.activation_token is not None:
             user_info = f"?user={str(new_user.id)}&username={new_user.name}&token={new_user.activation_token}"
@@ -295,7 +295,7 @@ def update_user(
             active=active,
         )
     except (KeyError, IllegalOperationError) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
 
 @user.command(
@@ -361,7 +361,7 @@ def change_user_password(
             updated_password=password,
         )
     except (KeyError, IllegalOperationError, AuthorizationException) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     cli_utils.declare(
         f"Successfully updated password for active user '{active_user.name}'."
@@ -400,7 +400,7 @@ def deactivate_user(
             name_id_or_prefix=user_name_or_id,
         )
     except (KeyError, IllegalOperationError) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
 
     user_info = f"?user={str(user.id)}&username={user.name}&token={user.activation_token}"
     cli_utils.declare(
@@ -425,5 +425,5 @@ def delete_user(user_name_or_id: str) -> None:
     try:
         Client().delete_user(user_name_or_id)
     except (KeyError, IllegalOperationError) as err:
-        cli_utils.error(str(err))
+        cli_utils.exception(err)
     cli_utils.declare(f"Deleted user '{user_name_or_id}'.")

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -200,14 +200,20 @@ def exception(exception: Exception) -> NoReturn:
     Args:
         exception: Input exception.
     """
-    if exception.__str__ is Exception.__str__:
-        # If the exception class overrides the __str__ method, we expect that
-        # to have a reasonable string representation
-        error_message = str(exception)
-    elif exception.args and isinstance(exception.args[0], str):
+    # KeyError add quotes around their error message to handle the case when
+    # someone tried to fetch something with the key '' (empty string). In all
+    # other cases where the key is not empty however, this adds unnecessary
+    # quotes around the error message, which this function removes.
+    if (
+        isinstance(exception, KeyError)
+        and len(exception.args) == 1
+        # If the exception is a KeyError with an empty string as the argument,
+        # we use the default string representation which will print ''
+        and exception.args[0]
+        and isinstance(exception.args[0], str)
+    ):
         error_message = exception.args[0]
     else:
-        # Fallback to the default string representation
         error_message = str(exception)
 
     error(error_message)

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -194,6 +194,25 @@ def error(text: str) -> NoReturn:
     raise StyledClickException(message=error_prefix + error_message)
 
 
+def exception(exception: Exception) -> NoReturn:
+    """Echo an exception string on the CLI.
+
+    Args:
+        exception: Input exception.
+    """
+    if exception.__str__ is Exception.__str__:
+        # If the exception class overrides the __str__ method, we expect that
+        # to have a reasonable string representation
+        error_message = str(exception)
+    elif exception.args and isinstance(exception.args[0], str):
+        error_message = exception.args[0]
+    else:
+        # Fallback to the default string representation
+        error_message = str(exception)
+
+    error(error_message)
+
+
 def warning(
     text: str,
     bold: Optional[bool] = None,


### PR DESCRIPTION
## Describe changes
When converting KeyError to strings, they quote the error message by default:

```python
error = KeyError("Test")
str(error)  # this will be "'test'"
```

This lead to lots of our CLI error messages always having some extra quotes, which this PR solves.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

