### PR TITLE
Prevent MLX integration install on Intel Macs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,8 @@ module = [
     "numba.*",
     "uvloop.*",
     "litellm",
+    "mlx",
+    "mlx.*",
     "jsonref",
 ]
 ignore_missing_imports = true

--- a/src/zenml/integrations/mlx/__init__.py
+++ b/src/zenml/integrations/mlx/__init__.py
@@ -20,12 +20,6 @@ from typing import List, Optional
 from zenml.integrations.constants import MLX
 from zenml.integrations.integration import Integration
 
-# MLX can run on Linux, but only with CPU or Cuda devices,
-# see https://ml-explore.github.io/mlx/build/html/install.html#cuda ff.
-# On macOS, MLX only supports Apple Silicon (ARM64), not Intel (x86_64).
-SUPPORTED_PLATFORMS = ("darwin", "linux")
-
-
 def _is_supported_platform() -> bool:
     """Check if the current platform supports MLX.
     

--- a/tests/integration/integrations/mlx/test_mlx_array_materializer.py
+++ b/tests/integration/integrations/mlx/test_mlx_array_materializer.py
@@ -12,19 +12,17 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-import sys
-
 import mlx.core as mx
 import pytest
 
 from tests.unit.test_general import _test_materializer
-from zenml.integrations.mlx import SUPPORTED_PLATFORMS
+from zenml.integrations.mlx import _is_supported_platform
 from zenml.integrations.mlx.materializer import MLXArrayMaterializer
 
 
 @pytest.mark.skipif(
-    sys.platform not in SUPPORTED_PLATFORMS,
-    reason="MLX only runs on Apple and Linux",
+    not _is_supported_platform(),
+    reason="MLX only runs on Apple Silicon and Linux (not Intel Macs)",
 )
 def test_mlx_array_materializer():
     """Test the MLX array materializer."""

--- a/tests/integration/integrations/mlx/test_mlx_array_materializer.py
+++ b/tests/integration/integrations/mlx/test_mlx_array_materializer.py
@@ -12,12 +12,10 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-import mlx.core as mx
 import pytest
 
 from tests.unit.test_general import _test_materializer
 from zenml.integrations.mlx import _is_supported_platform
-from zenml.integrations.mlx.materializer import MLXArrayMaterializer
 
 
 @pytest.mark.skipif(
@@ -26,6 +24,10 @@ from zenml.integrations.mlx.materializer import MLXArrayMaterializer
 )
 def test_mlx_array_materializer():
     """Test the MLX array materializer."""
+    import mlx.core as mx
+
+    from zenml.integrations.mlx.materializer import MLXArrayMaterializer
+
     arr = mx.ones(5)
 
     result = _test_materializer(


### PR DESCRIPTION
MLX wheels are only available for Apple Silicon (ARM64) Macs, not Intel (x86_64). Added architecture detection using `platform.machine()` to `check_installation()` and `get_requirements()` to prevent installation attempts on unsupported Intel Macs.

The integration now properly detects:
- Apple Silicon Macs (arm64/aarch64): Supported
- Intel Macs (x86_64): Not supported
- Linux (any arch): Supported
