### PR TITLE
Fixes for timestamps in logs

### DIFF
--- a/src/zenml/logging/step_logging.py
+++ b/src/zenml/logging/step_logging.py
@@ -159,7 +159,7 @@ class ArtifactStoreHandler(logging.Handler):
                     message=message,
                     name=record.name,
                     level=level,
-                    timestamp=utc_now(),
+                    timestamp=utc_now(tz_aware=True),
                     module=record.module,
                     filename=record.filename,
                     lineno=record.lineno,
@@ -178,7 +178,7 @@ class ArtifactStoreHandler(logging.Handler):
                         module=record.module,
                         filename=record.filename,
                         lineno=record.lineno,
-                        timestamp=utc_now(),
+                        timestamp=utc_now(tz_aware=True),
                         chunk_index=i,
                         total_chunks=len(chunks),
                         id=entry_id,
@@ -275,7 +275,7 @@ def parse_log_entry(log_line: str) -> Optional[LogEntry]:
 
     timestamp = None
     if old_format:
-        timestamp = old_format.group(1)
+        timestamp = old_format.group(1) + "Z"
         line = line.replace(old_format.group(0), "").strip()
 
     return LogEntry(


### PR DESCRIPTION
## Describe changes
Now we save timestamps for logs in a tz_aware manner and when we fetch the logs from older ZenML versions, when we respect the UTC.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

