### PR TITLE
Removing 3.9 & Adding 3.13

### DIFF
--- a/.github/workflows/base-package-functionality.yml
+++ b/.github/workflows/base-package-functionality.yml
@@ -27,7 +27,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       git-ref:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -43,10 +43,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Test migrations across versions
         run: bash scripts/test-migrations.sh sqlite random
   spellcheck:
@@ -79,7 +79,7 @@ jobs:
       == false
     uses: ./.github/workflows/update-templates-to-examples.yml
     with:
-      python-version: '3.9'
+      python-version: '3.11'
       os: ubuntu-latest
     secrets: inherit
   linting:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -50,10 +50,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -73,10 +73,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -97,10 +97,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Test migrations across versions
         run: bash scripts/test-migrations.sh sqlite full
   mariadb-db-migration-testing:
@@ -114,10 +114,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -177,7 +177,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.12']
+        python-version: ['3.10', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/linting.yml
     with:
@@ -190,7 +190,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.12']
+        python-version: ['3.10', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
     with:
@@ -203,7 +203,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/linting.yml
     with:
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
     with:
@@ -229,7 +229,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/linting.yml
     with:
@@ -242,7 +242,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     uses: ./.github/workflows/unit-test.yml
     with:
@@ -255,7 +255,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         test_environment: [default]
       fail-fast: false
     uses: ./.github/workflows/integration-test-slow.yml
@@ -270,7 +270,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         test_environment: [default]
       fail-fast: false
     uses: ./.github/workflows/integration-test-slow.yml
@@ -285,25 +285,25 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.12']
+        python-version: ['3.10', '3.12', '3.13']
         test_environment:
           - default
           - docker-server-docker-orchestrator-mysql
           - docker-server-docker-orchestrator-mariadb
         exclude:
-          # docker is time-consuming to run, so we only run it on 3.9
-          - test_environment: docker-server-docker-orchestrator-mysql
-            python-version: '3.9'
+          # docker is time-consuming to run, so we only run it on 3.11
           - test_environment: docker-server-docker-orchestrator-mysql
             python-version: '3.10'
           - test_environment: docker-server-docker-orchestrator-mysql
             python-version: '3.12'
-          - test_environment: docker-server-docker-orchestrator-mariadb
-            python-version: '3.9'
+          - test_environment: docker-server-docker-orchestrator-mysql
+            python-version: '3.13'
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.10'
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.12'
+          - test_environment: docker-server-docker-orchestrator-mariadb
+            python-version: '3.13'
       fail-fast: false
     uses: ./.github/workflows/integration-test-slow.yml
     with:

--- a/.github/workflows/integration-test-fast-services.yml
+++ b/.github/workflows/integration-test-fast-services.yml
@@ -41,7 +41,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       test_environment:

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -41,7 +41,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       test_environment:

--- a/.github/workflows/integration-test-slow-services.yml
+++ b/.github/workflows/integration-test-slow-services.yml
@@ -41,7 +41,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       test_environment:
@@ -152,7 +152,7 @@ jobs:
       - name: Install MacOS System Dependencies
         if: runner.os=='macOS'
         run: brew install libomp
-      - name: Unbreak Python in GHA for 3.9-3.10
+      - name: Unbreak Python in GHA for 3.10
         if: runner.os=='macOS' && inputs.python-version != '3.11'
         # github actions overwrites brew's python. Force it to reassert itself, by
         # running in a separate step.

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -41,7 +41,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       test_environment:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,7 +37,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       enable_tmate:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
-      python-version: '3.9'
+      python-version: '3.11'
       git-ref: develop
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install Poetry
         uses: snok/install-poetry@v1.3.4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     uses: ./.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
-      python-version: '3.9'
+      python-version: '3.11'
     secrets: inherit
   mysql-db-migration-testing:
     runs-on: ubuntu-latest
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -41,10 +41,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Test migrations across versions
         run: bash scripts/test-migrations.sh sqlite
   mariadb-db-migration-testing:
@@ -57,10 +57,10 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4.8.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -94,10 +94,10 @@ jobs:
       - name: Get the version from the github tag ref
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      - name: Set up Python
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -22,7 +22,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,7 +42,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
       enable_tmate:

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -22,7 +22,7 @@ on:
       python-version:
         description: Python version
         type: choice
-        options: ['3.9', '3.10', '3.11', '3.12']
+        options: ['3.10', '3.11', '3.12', '3.13']
         required: false
         default: '3.11'
 jobs:

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -9,7 +9,7 @@ icon: cauldron
 {% step %}
 #### Install ZenML
 
-ZenML currently supports **Python 3.9, 3.10, 3.11, and 3.12**. Please make sure that you are using a supported Python version.
+ZenML currently supports **Python 3.10, 3.11, 3.12, and 3.13**. Please make sure that you are using a supported Python version.
 
 {% tabs %}
 {% tab title="Base package" %}

--- a/docs/book/how-to/containerization/containerization.md
+++ b/docs/book/how-to/containerization/containerization.md
@@ -104,7 +104,7 @@ Define settings in a YAML configuration file for better separation of code and c
 ```yaml
 settings:
     docker:
-        parent_image: python:3.9-slim
+        parent_image: python:3.11-slim
         apt_packages:
           - git
           - curl

--- a/docs/book/user-guide/best-practices/debug-and-solve-issues.md
+++ b/docs/book/user-guide/best-practices/debug-and-solve-issues.md
@@ -44,15 +44,15 @@ zenml info -p tensorflow
 The output should look something like this:
 
 ```yaml
-ZENML_LOCAL_VERSION: 0.40.2
-ZENML_SERVER_VERSION: 0.40.2
+ZENML_LOCAL_VERSION: 0.90.0
+ZENML_SERVER_VERSION: 0.90.0
 ZENML_SERVER_DATABASE: mysql
 ZENML_SERVER_DEPLOYMENT_TYPE: alpha
 ZENML_CONFIG_DIR: /Users/my_username/Library/Application Support/zenml
 ZENML_LOCAL_STORE_DIR: /Users/my_username/Library/Application Support/zenml/local_stores
 ZENML_SERVER_URL: https://someserver.zenml.io
 ZENML_ACTIVE_REPOSITORY_ROOT: /Users/my_username/coding/zenml/repos/zenml
-PYTHON_VERSION: 3.9.13
+PYTHON_VERSION: 3.11.3
 ENVIRONMENT: native
 SYSTEM_INFO: {'os': 'mac', 'mac_version': '13.2'}
 ACTIVE_STACK: default

--- a/docs/book/user-guide/best-practices/quick-wins.md
+++ b/docs/book/user-guide/best-practices/quick-wins.md
@@ -710,7 +710,7 @@ Learn more: [Models](https://docs.zenml.io/concepts/models#tracking-metrics-and-
 ```bash
 # 1. Create a Dockerfile for your parent image
 cat > Dockerfile.parent << EOF
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docs/book/user-guide/production-guide/ci-cd.md
+++ b/docs/book/user-guide/production-guide/ci-cd.md
@@ -113,7 +113,7 @@ steps:
 
   - uses: actions/setup-python@v4
     with:
-      python-version: '3.9'
+      python-version: '3.11'
 
   - name: Install requirements
     run: |

--- a/docs/book/user-guide/tutorial/trigger-pipelines-from-external-systems.md
+++ b/docs/book/user-guide/tutorial/trigger-pipelines-from-external-systems.md
@@ -576,7 +576,7 @@ if __name__ == "__main__":
 Create a `Dockerfile` to containerize your API:
 
 ```dockerfile
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,15 +17,15 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Distributed Computing",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
     "click>=8.0.1,<=8.2.1",
@@ -219,8 +219,8 @@ exclude = [
 ]
 
 src = ["src", "test"]
-# use Python 3.9 as the minimum version for autofixing
-target-version = "py39"
+# use Python 3.10 as the minimum version for autofixing
+target-version = "py310"
 
 
 [tool.ruff.format]

--- a/release-cloudbuild.yaml
+++ b/release-cloudbuild.yaml
@@ -1,27 +1,4 @@
 steps:
-  # build client base image - python 3.9
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - '-c'
-      - |
-        docker build \
-          --platform linux/amd64 \
-          --build-arg ZENML_VERSION=$TAG_NAME \
-          --build-arg PYTHON_VERSION=3.9 \
-          --target client \
-          -f docker/base.Dockerfile . \
-          -t $$USERNAME/zenml:$TAG_NAME-py3.9
-
-        # use latest tags only for official releases
-        if [[ $TAG_NAME =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-          docker tag $$USERNAME/zenml:$TAG_NAME-py3.9 $$USERNAME/zenml:py3.9
-        fi
-    id: build-base-3.9
-    waitFor: ['-']
-    entrypoint: bash
-    secretEnv:
-      - USERNAME
-
   # build client base image - python 3.10
   - name: gcr.io/cloud-builders/docker
     args:
@@ -93,6 +70,29 @@ steps:
     secretEnv:
       - USERNAME
 
+  # build client base image - python 3.13
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - '-c'
+      - |
+        docker build \
+          --platform linux/amd64 \
+          --build-arg ZENML_VERSION=$TAG_NAME \
+          --build-arg PYTHON_VERSION=3.13 \
+          --target client \
+          -f docker/base.Dockerfile . \
+          -t $$USERNAME/zenml:$TAG_NAME-py3.13
+
+        # use latest tags only for official releases
+        if [[ $TAG_NAME =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+          docker tag $$USERNAME/zenml:$TAG_NAME-py3.13 $$USERNAME/zenml:py3.13
+        fi
+    id: build-base-3.13
+    waitFor: ['-']
+    entrypoint: bash
+    secretEnv:
+      - USERNAME
+
   # build server image - python 3.11 only
   - name: gcr.io/cloud-builders/docker
     args:
@@ -135,10 +135,10 @@ steps:
     id: push-base
     waitFor:
       - docker-login
-      - build-base-3.9
       - build-base-3.10
       - build-base-3.11
       - build-base-3.12
+      - build-base-3.13
     entrypoint: bash
     secretEnv:
       - USERNAME

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -246,14 +246,6 @@ function test_upgrade_to_version() {
     # Get the major and minor version of Python
     PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 
-    # Check if the Python version is 3.9 and VERSION is > 0.44.0 and < 0.53.0
-    if [[ "$PYTHON_VERSION" == "3.9" ]]; then
-        if [ "$(version_compare "$VERSION" "0.44.0")" == ">" ] && [ "$(version_compare "$VERSION" "0.53.0")" == "<" ]; then
-            # Install importlib_metadata for Python 3.9 and versions > 0.44.0 and < 0.53.0
-            uv pip install importlib_metadata
-        fi
-    fi
-
     if [ "$DB" == "mysql" ] || [ "$DB" == "mariadb" ]; then
 
         if [ "$(version_compare "$VERSION" "0.68.1")" == ">" ]; then


### PR DESCRIPTION
## Describe changes
Python 3.9 reached its EOL already so I am removing support for it. Additionally, I have added support for 3.13. Made the necessary CI and docs changes as well.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

