### PR TITLE
Fix secret tags and logs for the AWS deployer

### DIFF
--- a/src/zenml/integrations/aws/deployers/aws_deployer.py
+++ b/src/zenml/integrations/aws/deployers/aws_deployer.py
@@ -1630,7 +1630,9 @@ class AWSDeployer(ContainerizedDeployer):
                 )
 
             # App Runner automatically creates CloudWatch log groups
-            log_group_name = f"/aws/apprunner/{service_name}/{service_id}/application"
+            log_group_name = (
+                f"/aws/apprunner/{service_name}/{service_id}/application"
+            )
 
             try:
                 streams_response = self.logs_client.describe_log_streams(


### PR DESCRIPTION
## Describe changes
Fix secret tags and logs for the AWS deployer:

* `Tags` is not an attribute supported by the boto3 secrets manager client `update_secret` method
* the deployer was looking at the wrong log group

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

