### PR TITLE
Add snapshot delete command to CLI

### DIFF
--- a/docs/book/how-to/snapshots/snapshots.md
+++ b/docs/book/how-to/snapshots/snapshots.md
@@ -197,6 +197,20 @@ Learn how to get a bearer token for the curl commands:
 - For Pro management API (`cloudapi.zenml.io`): use [Pro API tokens](https://docs.zenml.io/api-reference/pro-api/getting-started#programmatic-access-with-api-tokens).
 {% endhint %}
 
+## Deleting Pipeline Snapshots
+
+You can delete a snapshot using the CLI:
+```bash
+zenml pipeline snapshot delete <SNAPSHOT-NAME-OR-ID>
+```
+
+You can also delete a snapshot using the Python SDK:
+```python
+from zenml.client import Client
+
+Client().delete_snapshot(name_id_or_prefix=<SNAPSHOT-NAME-OR-ID>)
+```
+
 ## Advanced Usage: Running Snapshots from Other Pipelines
 
 You can run snapshots from within other pipelines, enabling complex workflows. There are two ways to do this:

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -1276,3 +1276,36 @@ def list_pipeline_snapshots(**kwargs: Any) -> None:
                 "code_path",
             ],
         )
+
+
+@snapshot.command("delete", help="Delete a pipeline snapshot.")
+@click.argument("snapshot_name_or_id", type=str, required=True)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Don't ask for confirmation.",
+)
+def delete_pipeline_snapshot(
+    snapshot_name_or_id: str, yes: bool = False
+) -> None:
+    """Delete a pipeline snapshot.
+
+    Args:
+        snapshot_name_or_id: The name or ID of the snapshot to delete.
+        yes: If set, don't ask for confirmation.
+    """
+    if not yes:
+        confirmation = cli_utils.confirmation(
+            f"Are you sure you want to delete snapshot `{snapshot_name_or_id}`?"
+        )
+        if not confirmation:
+            cli_utils.declare("Snapshot deletion canceled.")
+            return
+
+    try:
+        Client().delete_snapshot(name_id_or_prefix=snapshot_name_or_id)
+    except KeyError as e:
+        cli_utils.exception(e)
+    else:
+        cli_utils.declare(f"Deleted snapshot '{snapshot_name_or_id}'.")

--- a/tests/integration/functional/cli/test_pipeline.py
+++ b/tests/integration/functional/cli/test_pipeline.py
@@ -482,3 +482,16 @@ def test_pipeline_build_delete(clean_client: "Client"):
 
     # this now fails because the build doesn't exist anymore
     assert runner.invoke(delete_command, [str(build_id), "-y"]).exit_code == 1
+
+
+def test_pipeline_snapshot_delete(clean_client: "Client"):
+    """Test that `zenml pipeline snapshots delete` works as expected."""
+    snapshot_id = pipeline_instance.create_snapshot(name="test_snapshot").id
+    runner = CliRunner()
+    delete_command = (
+        cli.commands["pipeline"].commands["snapshot"].commands["delete"]
+    )
+    result = runner.invoke(delete_command, [str(snapshot_id), "-y"])
+    assert result.exit_code == 0
+    with pytest.raises(KeyError):
+        clean_client.get_snapshot(str(snapshot_id))


### PR DESCRIPTION
Added:

- the `zenml pipeline snapshot delete` CLI command
- a test for that CLI command
- a docs section covering the new CLI command as well as how to do it with the Python SDK.