### PR TITLE
Fix the mount point configuration in the Hashicorp Vault secrets store and add it to helm chart

### DIFF
--- a/docker/zenml-server-hf-spaces.Dockerfile
+++ b/docker/zenml-server-hf-spaces.Dockerfile
@@ -59,6 +59,7 @@ ENV ZENML_SERVER_SECURE_HEADERS_CSP="frame-ancestors *;"
 # ENV ZENML_SECRETS_STORE_VAULT_ADDR=""
 # ENV ZENML_SECRETS_STORE_VAULT_TOKEN=""
 # ENV ZENML_SECRETS_STORE_VAULT_NAMESPACE=""
+# ENV ZENML_SECRETS_STORE_MOUNT_POINT=""
 # ENV ZENML_SECRETS_STORE_MAX_VERSIONS=""
 
 ENTRYPOINT ["uvicorn", "zenml.zen_server.zen_server_api:app", "--log-level", "debug", "--no-server-header"]

--- a/docs/book/getting-started/deploying-zenml/deploy-with-docker.md
+++ b/docs/book/getting-started/deploying-zenml/deploy-with-docker.md
@@ -195,6 +195,7 @@ These configuration options are only relevant if you're using Hashicorp Vault as
 * **ZENML\_SECRETS\_STORE\_VAULT\_ADDR**: The URL of the HashiCorp Vault server to connect to. NOTE: this is the same as setting the `VAULT_ADDR` environment variable.
 * **ZENML\_SECRETS\_STORE\_VAULT\_TOKEN**: The token to use to authenticate with the HashiCorp Vault server. NOTE: this is the same as setting the `VAULT_TOKEN` environment variable.
 * **ZENML\_SECRETS\_STORE\_VAULT\_NAMESPACE**: The Vault Enterprise namespace. Not required for Vault OSS. NOTE: this is the same as setting the `VAULT_NAMESPACE` environment variable.
+* **ZENML\_SECRETS\_STORE\_MOUNT\_POINT**: The mount point to use for the HashiCorp Vault secrets store. If not set, the default value of `secret` will be used.
 * **ZENML\_SECRETS\_STORE\_MAX\_VERSIONS**: The maximum number of secret versions to keep for each Vault secret. If not set, the default value of 1 will be used (only the latest version will be kept).
 {% endtab %}
 

--- a/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
+++ b/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
@@ -530,6 +530,8 @@ To use the HashiCorp Vault service as a Secrets Store back-end, it must be confi
        vault_token: <your Vault token>
        # The Vault Enterprise namespace. Not required for Vault OSS.
        vault_namespace: <your Vault namespace>
+       # The mount point to use for the HashiCorp Vault secrets store. If not set, the default value of `secret` will be used.
+       mount_point: <your Vault mount point>
 ```
 {% endtab %}
 

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -335,6 +335,9 @@ vault_addr: {{ .SecretsStore.hashicorp.vault_addr | quote }}
 {{- if .SecretsStore.hashicorp.vault_namespace }}
 vault_namespace: {{ .SecretsStore.hashicorp.vault_namespace | quote }}
 {{- end }}
+{{- if .SecretsStore.hashicorp.mount_point }}
+mount_point: {{ .SecretsStore.hashicorp.mount_point | quote }}
+{{- end }}
 {{- if .SecretsStore.hashicorp.max_versions }}
 max_versions: {{ .SecretsStore.hashicorp.max_versions | quote }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -702,6 +702,8 @@ zenml:
       vault_token:
       # The Vault Enterprise namespace. Not required for Vault OSS.
       vault_namespace:
+      # The mount point to use (defaults to "secret" if not set)
+      mount_point:
       # The maximum number of secret versions to keep. If not set, the default
       # value of 1 will be used (only the latest version will be kept).
       max_versions:
@@ -962,6 +964,8 @@ zenml:
       vault_token:
       # The Vault Enterprise namespace. Not required for Vault OSS.
       vault_namespace:
+      # The mount point to use (defaults to "secret" if not set)
+      mount_point:
       # The maximum number of secret versions to keep. If not set, the default
       # value of 1 will be used (only the latest version will be kept).
       max_versions:


### PR DESCRIPTION
## Describe changes
Backgrount: the mount point is a way to configure soft isolation in the context of the same Hashicorp Vault  (OSS) or namespace (Enterprise) with the purpose of implementing multi-tenancy. 

This PR fixes the Hashicorp Vault secrets store backend to make proper use of the configured mount point: 
* use the mount point in every call (necessary, previously this was ignored in all API requests to create/read/update/delete secrets)
* add mount point setting to helm chart

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

