### PR TITLE
Fix release cloudbuild

### DIFF
--- a/release-cloudbuild.yaml
+++ b/release-cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.10 \
@@ -27,7 +27,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.11 \
@@ -52,7 +52,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.12 \
@@ -75,7 +75,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.13 \
@@ -161,7 +161,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.11 \
@@ -179,7 +179,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.11 \
@@ -197,7 +197,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build \
+        docker buildx build \
           --platform linux/amd64 \
           --build-arg ZENML_VERSION=$TAG_NAME \
           --build-arg PYTHON_VERSION=3.11 \


### PR DESCRIPTION
## Describe changes
Cloudbuild uses an old docker version which doesn't use build kit by default yet. This version always builds all targets specified inside a Dockerfile, which causes a failure when trying to build the python 3.13 image (The client image builds just fine, but something in the server dependencies messes it up).

This PR simply uses the `docker buildx` commit to use BuildKit for building those images.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

