### PR TITLE
Add container-level security context support for Kubernetes orchestrator

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -26,7 +26,6 @@ from zenml.constants import ENV_ZENML_ENABLE_REPO_INIT_WARNINGS
 from zenml.integrations.airflow.orchestrators.dag_generator import (
     ENV_ZENML_LOCAL_STORES_PATH,
 )
-from zenml.integrations.kubernetes import serialization_utils
 from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
 from zenml.logger import get_logger
 
@@ -238,11 +237,7 @@ def add_pod_settings(
         if settings.container_security_context:
             existing_dict = container.security_context.to_dict()
             existing_dict.update(settings.container_security_context)
-            container.security_context = (
-                serialization_utils.deserialize_kubernetes_model(
-                    existing_dict, "V1SecurityContext"
-                )
-            )
+            container.security_context = existing_dict
 
     if settings.volumes:
         if pod_spec.volumes:

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -26,6 +26,7 @@ from zenml.constants import ENV_ZENML_ENABLE_REPO_INIT_WARNINGS
 from zenml.integrations.airflow.orchestrators.dag_generator import (
     ENV_ZENML_LOCAL_STORES_PATH,
 )
+from zenml.integrations.kubernetes import serialization_utils
 from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
 from zenml.logger import get_logger
 
@@ -235,8 +236,6 @@ def add_pod_settings(
                 container.env_from = settings.env_from
 
         if settings.container_security_context:
-            from zenml.integrations.kubernetes import serialization_utils
-
             if container.security_context:
                 existing_dict = (
                     container.security_context.to_dict()

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -237,30 +237,25 @@ def add_pod_settings(
         if settings.container_security_context:
             from zenml.integrations.kubernetes import serialization_utils
 
-            # Deserialize the security context settings
-            security_context_dict = (
-                serialization_utils.deserialize_kubernetes_model(
-                    settings.container_security_context, "V1SecurityContext"
-                )
-            )
-
-            # Merge with existing security context if it exists
             if container.security_context:
-                # Get existing security context as dict
                 existing_dict = (
                     container.security_context.to_dict()
                     if hasattr(container.security_context, "to_dict")
                     else {}
                 )
-                # Merge the dictionaries, with new settings taking precedence
-                existing_dict.update(security_context_dict.to_dict())
+                existing_dict.update(settings.container_security_context)
                 container.security_context = (
                     serialization_utils.deserialize_kubernetes_model(
                         existing_dict, "V1SecurityContext"
                     )
                 )
             else:
-                container.security_context = security_context_dict
+                container.security_context = (
+                    serialization_utils.deserialize_kubernetes_model(
+                        settings.container_security_context,
+                        "V1SecurityContext",
+                    )
+                )
 
     if settings.volumes:
         if pod_spec.volumes:

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -235,9 +235,14 @@ def add_pod_settings(
                 container.env_from = settings.env_from
 
         if settings.container_security_context:
-            existing_dict = container.security_context.to_dict()
-            existing_dict.update(settings.container_security_context)
-            container.security_context = existing_dict
+            if container.security_context:
+                existing_dict = container.security_context.to_dict()
+                existing_dict.update(settings.container_security_context)
+                container.security_context = existing_dict
+            else:
+                container.security_context = (
+                    settings.container_security_context
+                )
 
     if settings.volumes:
         if pod_spec.volumes:

--- a/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/manifest_utils.py
@@ -236,25 +236,13 @@ def add_pod_settings(
                 container.env_from = settings.env_from
 
         if settings.container_security_context:
-            if container.security_context:
-                existing_dict = (
-                    container.security_context.to_dict()
-                    if hasattr(container.security_context, "to_dict")
-                    else {}
+            existing_dict = container.security_context.to_dict()
+            existing_dict.update(settings.container_security_context)
+            container.security_context = (
+                serialization_utils.deserialize_kubernetes_model(
+                    existing_dict, "V1SecurityContext"
                 )
-                existing_dict.update(settings.container_security_context)
-                container.security_context = (
-                    serialization_utils.deserialize_kubernetes_model(
-                        existing_dict, "V1SecurityContext"
-                    )
-                )
-            else:
-                container.security_context = (
-                    serialization_utils.deserialize_kubernetes_model(
-                        settings.container_security_context,
-                        "V1SecurityContext",
-                    )
-                )
+            )
 
     if settings.volumes:
         if pod_spec.volumes:

--- a/src/zenml/integrations/kubernetes/pod_settings.py
+++ b/src/zenml/integrations/kubernetes/pod_settings.py
@@ -71,7 +71,9 @@ class KubernetesPodSettings(BaseSettings):
         container_security_context: Security context settings to apply to all
             containers in the pod. This allows specifying container-level security
             attributes such as runAsUser, runAsNonRoot, allowPrivilegeEscalation,
-            etc.
+            etc. Note: This is different from pod-level security context (which can
+            be set via additional_pod_spec_args) as some admission policies require
+            container-level security settings.
         additional_pod_spec_args: Additional arguments to pass to the pod. These
             will be applied to the pod spec.
     """


### PR DESCRIPTION
Previously, only pod-level security context settings could be configured, and container-level settings were limited to the privileged flag. This caused issues in restricted environments that enforce container security policies like runAsNonRoot and allowPrivilegeEscalation.

This change adds a container_security_context field to KubernetesPodSettings that allows users to specify container-level security attributes:
- runAsUser
- runAsNonRoot
- allowPrivilegeEscalation
- and other V1SecurityContext attributes

The settings are applied to all containers in the pod and are properly merged with existing security context settings (like the privileged flag).

Fixes #4141

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

