### PR TITLE
Fix applying default kubernetes resources

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kube_utils.py
@@ -1159,12 +1159,7 @@ def apply_default_resource_requests(
     if not pod_settings:
         pod_settings = KubernetesPodSettings(resources=resources)
     elif not pod_settings.resources:
-        # We can't update the pod settings in place (because it's a frozen
-        # pydantic model), so we have to create a new one.
-        pod_settings = KubernetesPodSettings(
-            **pod_settings.model_dump(exclude_unset=True),
-            resources=resources,
-        )
+        pod_settings = pod_settings.model_copy(update={"resources": resources})
     else:
         set_requests = pod_settings.resources.get("requests", {})
         resources["requests"].update(set_requests)


### PR DESCRIPTION
## Describe changes
The `apply_default_resource_requests(...)` function used `exclude_unset=True` when modifying existing pod settings. In cases where the orchestrator is configured to pass the token as a secret, we modify the pod settings env like this:
```python
pod_settings.env.append(...)
```
If the pod settings had the default value (empty list) before, this attribute would still be "unset" and therefore removed when applying the default resource requests. This removes the env variable specification for the token and causes the orchestrator pod to fail.

Why this didn't fail ealier: Previously we first applied the default resource requests, and then appended to the environment list. My PR for dynamic pipelines (#4074) reworked the orchestrator and swapped the order, which now causes a failure for certain configurations of the orchestrator.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

