### PR TITLE
Fix deletion of dynamic pipeline runs

### DIFF
--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -215,7 +215,11 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
     # In dynamic pipelines, the config is dynamically generated and cannot be
     # included in the compiled snapshot. In this case, we link it directly to
     # the step run.
-    dynamic_config: Optional["StepConfigurationSchema"] = Relationship()
+    dynamic_config: Optional["StepConfigurationSchema"] = Relationship(
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+        },
+    )
     # In legacy pipelines (before snapshots, former deployments), the config
     # is stored as a string in the step run.
     step_configuration: str = Field(


### PR DESCRIPTION
## Describe changes
The dynamic step configuration is configured on DB level to be deleted when the step run is deleted. However, SQLAlchemy on the ORM level first issued a `UPDATE step_configuration SET step_run_id=null` before it got to the DB, and this violated the check constraint defined on the `step_configuration` table. This change makes it so that SQLAlchemy issues a DELETE instead.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

