### PR TITLE
Fix Claude GitHub Actions workflow configuration

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |
             You are reviewing code changes with git diffs included in the prompt. Focus on ensuring the changes are sound, clean, intentional, and void of regressions.
@@ -109,6 +111,6 @@ jobs:
             Be constructive and helpful in your feedback.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
             issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
             pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,9 +36,9 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude /full-review')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
@@ -60,8 +60,10 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
 
           # This is an optional setting that allows Claude to read CI results on PRs
@@ -73,6 +75,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: --max-turns 5 --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
+          claude_args: --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh
             issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh
             pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(bash scripts/format.sh:*)"


### PR DESCRIPTION
## Summary
This PR fixes several issues with the Claude GitHub Actions workflows to improve reliability and prevent duplicate workflow runs.

## Changes

### API Key Management
- Renamed `CLAUDE_GITHUB_ACTIONS_ANTHROPIC_KEY` secret to `ANTHROPIC_API_KEY` for consistency with standard naming conventions
- Added `ANTHROPIC_API_KEY` as an explicit environment variable for both Claude workflow steps in addition to passing it as a parameter

### Workflow Trigger Logic
- Updated `claude.yml` to exclude `@claude /full-review` commands from triggering
- This prevents duplication since `claude-code-review.yml` specifically handles `/full-review` requests
- Applied the exclusion to all relevant event types: `issue_comment`, `pull_request_review_comment`, and `pull_request_review`

### Configuration Optimization
- Removed `--max-turns` limits from both workflows to allow Claude more flexibility in completing complex tasks

## Test Plan
- ✅ Formatting script passed
- The changes should be tested by:
  - Triggering a regular `@claude` command (should use claude.yml)
  - Triggering an `@claude /full-review` command (should only use claude-code-review.yml, not both)

## Related Issues
Part of the ongoing Claude bot improvements.