### PR TITLE
Fix Azure ML compute cluster validation typo

### DIFF
--- a/src/zenml/integrations/azure/azureml_utils.py
+++ b/src/zenml/integrations/azure/azureml_utils.py
@@ -122,7 +122,7 @@ def create_or_get_compute(
                 compute=compute,
             )
 
-        elif compute_type == "amIcompute":  # Compute Cluster
+        elif compute_type == "amlcompute":  # Compute Cluster
             if settings.mode != AzureMLComputeTypes.COMPUTE_CLUSTER:
                 raise RuntimeError(
                     "The mode of operation for the compute target defined "


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the Azure ML orchestrator compute type validation that was preventing users from successfully using compute cluster mode.

## What is the problem?

When users configured the Azure ML orchestrator with `mode="compute-cluster"`, the system would fail with:
> RuntimeError: Unsupported compute type: amlcompute

## Root Cause

Line 125 of `azureml_utils.py` contained a typo in the compute type validation:
- **Incorrect:** `elif compute_type == "amIcompute":`  (capital I)
- **Correct:** `elif compute_type == "amlcompute":`  (lowercase l)

This mismatch caused the Azure ML SDK's actual compute type identifier to not be recognized, triggering the "unsupported" error path.

## Solution

Corrected the string comparison to match the actual compute type identifier (`"amlcompute"`) returned by the Azure ML SDK.

## Testing

- Issue reporter confirmed this fix enables successful execution
- No new tests added (external integration, follows existing testing approach)
- Code formatting passed via `scripts/format.sh`

Fixes #4222

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

