### PR TITLE
Fix Bandit security false positives in Kubernetes integration

### DIFF
--- a/src/zenml/integrations/kubernetes/deployers/kubernetes_deployer.py
+++ b/src/zenml/integrations/kubernetes/deployers/kubernetes_deployer.py
@@ -292,7 +292,7 @@ class KubernetesDeployer(ContainerizedDeployer):
                         )
                     if kubernetes_context != active_context:
                         logger.warning(
-                            f"{msg}the Kubernetes context "
+                            f"{msg}the Kubernetes context "  # nosec B608
                             f"'{kubernetes_context}' configured for the "
                             f"Kubernetes deployer is not the same as the "
                             f"active context in the local Kubernetes "

--- a/src/zenml/integrations/kubernetes/template_engine.py
+++ b/src/zenml/integrations/kubernetes/template_engine.py
@@ -69,7 +69,9 @@ class KubernetesTemplateEngine:
             strict_undefined: If True, raise an error for undefined template
                 variables. If False, undefined variables are silently ignored.
         """
-        self.env = Environment(
+        # Autoescape is disabled because we render Kubernetes YAML manifests,
+        # not HTML. XSS is not a concern for YAML configuration files.
+        self.env = Environment(  # nosec B701
             undefined=StrictUndefined if strict_undefined else Undefined,
             autoescape=False,
             trim_blocks=True,


### PR DESCRIPTION
## Summary
Our CI `small-checks` are currently failing. (e.g. https://github.com/zenml-io/zenml/actions/runs/19734254626/job/56542351791?pr=4252)

- Add `# nosec B608` to suppress false positive SQL injection warning in `kubernetes_deployer.py` (it's a logger.warning() f-string, not SQL)
- Add `# nosec B701` to suppress XSS warning in `template_engine.py` (Jinja2 renders YAML manifests, not HTML—autoescape=False is correct)

Both are legitimate false positives where Bandit misidentifies the code context.