### PR TITLE
Fix Claude workflow triggers to use `@claude` instead of `/claude`

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/claude /full-review')
+      contains(github.event.comment.body, '@claude /full-review')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,10 @@ jobs:
       needs.check-team-member.outputs.is-team-member == 'true' &&
       github.actor != 'github-actions[bot]' &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/claude /full-review')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/claude') && !contains(github.event.comment.body, '/claude /full-review')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/claude') && !contains(github.event.review.body, '/claude /full-review')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '/claude') || contains(github.event.issue.title, '/claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude /full-review')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude /full-review')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Fixes the Claude Code Action trigger pattern from `/claude` to `@claude` in both workflow files
- The action uses **tag mode** by default and expects `@claude` mentions as the trigger
- The previous `/claude` pattern was being matched by workflow `if:` conditions, but the action's internal trigger detection was failing silently with: `No trigger was met for @claude`

## Background

This fix is based on testing done in the private `zenml-io/gh-action-testing` repo. The Claude Code Action has a two-layer trigger system:
1. **Workflow layer**: Your `if:` condition (e.g., `contains(github.event.comment.body, '@claude')`)
2. **Action layer**: Internal trigger detection that looks for `@claude` mentions

Both layers must align for the action to execute. Previously, only the workflow layer was passing.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/claude.yml` | Updated 8 trigger patterns from `/claude` to `@claude` |
| `.github/workflows/claude-code-review.yml` | Updated trigger from `/claude /full-review` to `@claude /full-review` |

## Test plan

- [x] Tested trigger patterns in `zenml-io/gh-action-testing` (private repo)

## Notes

- The post-comment job fixes from the learnings doc are **not applicable** here since these workflows use the Claude Code Action's built-in commenting via `track_progress: true`
- No Codex workflow exists in this repo, so those learnings don't apply