### PR TITLE
Fix weave import side-effects when `enable_weave=False`

### DIFF
--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -180,12 +180,3 @@ class WandbExperimentTracker(BaseExperimentTracker):
                     "Weave enabled but no project_name specified. "
                     "Skipping weave initialization."
                 )
-        else:
-            import weave
-
-            if self.config.project_name:
-                logger.info("Disabling weave")
-                weave.init(
-                    project_name=self.config.project_name,
-                    settings={"disabled": True},
-                )


### PR DESCRIPTION
## Summary

- Fixes weave import triggering `wandb_init_hook` and remote project creation even when `enable_weave=False`
- Removes unnecessary `else` branch that imported weave and called `weave.init(..., settings={"disabled": True})`
- Prevents `PERMISSION_ERROR` for users not logged into W&B who have Weave disabled

## Problem

With wandb 0.23.0 + weave 0.52.17+, runs fail even when Weave is explicitly disabled. The root cause:

1. The old code imported `weave` in both branches (enabled and disabled)
2. With newer weave versions, `import weave` alone loads ~548 modules including `weave.trace.autopatch`
3. This triggers `wandb_init_hook` which attempts remote project creation
4. Users without credentials get `PERMISSION_ERROR` despite having `enable_weave=False`

## Solution

Simply remove the `else` branch. When `enable_weave=False`, we don't import or interact with weave at all. Not importing a library is the ultimate way to disable it.

```diff
         if settings.enable_weave:
             import weave
             if self.config.project_name:
                 weave.init(project_name=self.config.project_name)
-        else:
-            import weave
-            if self.config.project_name:
-                weave.init(project_name=..., settings={"disabled": True})
```

## Test plan

- [x] Verified fix with wandb 0.23.0 + weave 0.52.20 in isolated venv
- [x] Confirmed `import weave` loads 548 modules with potential side-effects
- [x] Confirmed the fix prevents any weave-related code when disabled
- [ ] Manual testing with ZenML pipeline using wandb tracker with `enable_weave=False`