### PR TITLE
Add workflow to require release labels on PRs

### DIFF
--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -1,0 +1,24 @@
+# Requires PRs to have either 'release-notes' or 'no-release-notes' label
+# This ensures release notes are considered for every PR before merging.
+# The check is enforced via branch protection rules on develop.
+name: Require Release Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-label:
+    if: github.repository == 'zenml-io/zenml'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for release label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "release-notes, no-release-notes"
+          message: |
+            This PR is missing a release label. Please add one of:
+            - `release-notes` - if this PR has user-facing changes that should appear in the changelog
+            - `no-release-notes` - if this is an internal change (refactoring, tests, CI, etc.)


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that checks every PR for either a `release-notes` or `no-release-notes` label
- Uses the well-maintained `mheap/github-action-required-labels@v5` action
- Creates a status check that can be made required via branch protection

## Why
Part of the release communication system improvements. By requiring every PR to be explicitly tagged as either user-facing (`release-notes`) or internal (`no-release-notes`), we ensure:
1. Release notes are considered at PR time, not at release time
2. Nothing user-facing gets missed in announcements
3. Clear signal to reviewers about what kind of change this is

## After this is merged
Branch protection will be updated on `develop` to require this check. See the working plan at `design/release-wework-nov-2025/working_document_plan.md` task 3.1.

## Test plan
- [ ] Open a PR without labels → check should fail
- [ ] Add `release-notes` label → check should pass
- [ ] Add `no-release-notes` label → check should pass
- [ ] Add both labels → check should fail (mode: exactly + count: 1)