### PR TITLE
Add changelog notification workflow

### DIFF
--- a/.github/workflows/notify-changelog.yml
+++ b/.github/workflows/notify-changelog.yml
@@ -1,20 +1,20 @@
+---
 name: Notify Changelog Repo
-
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag (e.g., 0.92.0)'
+        description: Release tag (e.g., 0.92.0)
         required: true
         type: string
-
 jobs:
   notify:
     runs-on: ubuntu-latest
     # Only trigger for non-prerelease, non-draft releases (auto) or manual dispatch
-    if: github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease && !github.event.release.draft)
+    if: github.event_name == 'workflow_dispatch' || (!github.event.release.prerelease
+      && !github.event.release.draft)
     steps:
       - name: Get release info
         id: release_info
@@ -35,21 +35,19 @@ jobs:
               // Automatic trigger: use event payload
               release = context.payload.release;
             }
-            
             core.setOutput('tag', release.tag_name);
             core.setOutput('name', release.name || release.tag_name);
             core.setOutput('url', release.html_url);
             core.setOutput('body', JSON.stringify(release.body || ''));
             core.setOutput('published_at', release.published_at);
             core.setOutput('prerelease', release.prerelease);
-
       - name: Send repository dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CHANGELOG_DISPATCH_TOKEN }}
           repository: zenml-io/zenml-changelog
           event-type: release-published
-          client-payload: |
+          client-payload: |-
             {
               "repo": "${{ github.repository }}",
               "repo_name": "${{ github.event.repository.name }}",

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -1,12 +1,11 @@
+---
 # Requires PRs to have either 'release-notes' or 'no-release-notes' label
 # This ensures release notes are considered for every PR before merging.
 # The check is enforced via branch protection rules on develop.
 name: Require Release Label
-
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-
 jobs:
   check-label:
     if: github.repository == 'zenml-io/zenml'
@@ -17,8 +16,8 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "release-notes, no-release-notes"
-          message: |
+          labels: release-notes, no-release-notes
+          message: |-
             This PR is missing a release label. Please add one of:
             - `release-notes` - if this PR has user-facing changes that should appear in the changelog
             - `no-release-notes` - if this is an internal change (refactoring, tests, CI, etc.)


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that notifies `zenml-io/zenml-changelog` when a release is published
- Enables automated changelog generation from PRs with the `release-notes` label

## How It Works
1. When a GitHub Release is published (Step 10 of our release process), this workflow fires
2. It sends a `repository_dispatch` event to `zenml-io/zenml-changelog` with release metadata
3. The changelog repo then generates entries and opens a PR for review

## Trigger
- **Automatic**: Fires on `release: [published]` events (non-draft, non-prerelease)
- **Manual**: Supports `workflow_dispatch` to re-trigger for past releases

## Required Secret
The `CHANGELOG_DISPATCH_TOKEN` secret must be configured (org-level or repo-level) with:
- `repo` scope
- Write access to `zenml-io/zenml-changelog`

## Test plan
- [ ] Verify `CHANGELOG_DISPATCH_TOKEN` secret exists
- [ ] After merge, test with manual trigger using an existing release tag (e.g., `0.92.0`)
- [ ] Verify `zenml-io/zenml-changelog` receives the dispatch event