### PR TITLE
Allow mapping over artifact lists

### DIFF
--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -123,7 +123,10 @@ def map_reduce():
 ```
 
 Key points:
-- `step.map(...)` fans out a step over sequence-like inputs.
+- `step.map(...)` fans out a step over sequence-like inputs. These inputs can be either
+  - a single list-like output artifact (see the code sample above)
+  - a list of output artifacts.
+  - the output of a `.map(...)` or `.product(...)` call if the respective step only returns a single output artifact
 - Steps can accept lists of artifacts directly as inputs (useful for reducers).
 - You can pass the mapped output directly to a downstream step without loading in the orchestration environment.
 

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -637,6 +637,15 @@ def expand_mapped_inputs(
                 "wrap your input with the `unmapped(...)` function.",
                 key,
             )
+        elif (
+            isinstance(value, Sequence)
+            and value
+            and all(isinstance(item, OutputArtifact) for item in value)
+        ):
+            # List of step output artifacts, in this case the mapping is over
+            # the items of the list
+            mapped_input_names.append(key)
+            mapped_inputs.append(tuple(value))
         elif isinstance(value, Sequence):
             logger.warning(
                 "Received sequence-like data for step input `%s`. Mapping over "


### PR DESCRIPTION
## Describe changes
This PR adds two more items that a `step.map(...)` call works for:
- A list of output artifacts
- The output of a `.map(...)` or `.product(...)` call if the step only returns a single output artifact

**Example:**
```python
from zenml import pipeline, step

@step
def producer() -> int:
  return 1

@step
def worker(a: int) -> int:
  return a * 2

@pipeline(dynamic=True)
def map_example():
  artifact_list = [producer() for _ in range(3)]
  result = worker.map(artifact_list)  # map over list of outputs
  worker.map(result)  # map over output of previous `map(...)` call
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

