### PR TITLE
Fix KFP related requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ sagemaker = [
 vertex = [
     "google-cloud-aiplatform>=1.34.0",
     "kfp>=2.6.0",
+    "urllib3<2.6.0",
     "google-cloud-pipeline-components>=2.19.0",
 ]
 azureml = [

--- a/src/zenml/integrations/gcp/__init__.py
+++ b/src/zenml/integrations/gcp/__init__.py
@@ -49,6 +49,7 @@ class GcpIntegration(Integration):
     # removed once the issue is resolved.
     REQUIREMENTS = [
         "kfp>=2.6.0",
+        "urllib3<2.6.0",
         "gcsfs!=2025.5.0,!=2025.5.0.post1,<=2024.12.0",
         "google-cloud-secret-manager",
         "google-cloud-container>=2.21.0",


### PR DESCRIPTION
## Describe changes

Two unrelated conditions combined together and created a situation that results in failures in the ZenML server related to the kubernetes service connector: 

1. [A recent update of urllib3](https://pypi.org/project/urllib3/2.6.0/) removed some deprecated methods, some of which are still used by older versions of the kubernetes Python client library (e.g. `30.0.1`)
2. the KFP package (required in the zenml server container because it is part of the GCP/Vertex integration) depends on a very old version of kubernetes (yes, you guessed it, it's `30.0.1`)

The result: the recent urllib3 2.6.0 version breaks our kubernetes service connector functionality server-side, leading to errors such as the following when using service connectors to authenticate to any type of kubernetes cluster (e.g. EKS/GKE):

```
2025-12-05 19:29:39,666 - zenml.zen_server.utils - ERROR - API error (utils.py:412)
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/utils.py", line 402, in decorated
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/routers/service_connectors_endpoints.py", line 412, in get_service_connector_client
    return zen_store().get_service_connector_client(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_stores/sql_zen_store.py", line 9190, in get_service_connector_client
    connector_client = connector_instance.get_connector_client(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/service_connectors/service_connector.py", line 1345, in get_connector_client
    connector_client._verify(
  File "/opt/venv/lib/python3.11/site-packages/zenml/integrations/kubernetes/service_connectors/kubernetes_service_connector.py", line 574, in _verify
    client.call_api(
  File "/opt/venv/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 348, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/kubernetes/client/api_client.py", line 200, in __call_api
    response_data.getheaders())
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/kubernetes/client/rest.py", line 44, in getheaders
    return self.urllib3_response.getheaders()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'HTTPResponse' object has no attribute 'getheaders'
```

The solution is to pin urllib to be lower than 2.6.0.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

