### PR TITLE
Fix CLI hyperlink wrapping that breaks CMD-click

### DIFF
--- a/src/zenml/cli/deployment.py
+++ b/src/zenml/cli/deployment.py
@@ -272,7 +272,8 @@ def provision_deployment(
             dashboard_url = get_deployment_url(deployment)
             if dashboard_url:
                 cli_utils.declare(
-                    f"\nView in ZenML Cloud: [link]{dashboard_url}[/link]"
+                    f"\nView in ZenML Cloud: [link]{dashboard_url}[/link]",
+                    no_wrap=True,
                 )
 
 

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -491,7 +491,8 @@ def deploy_pipeline(
         dashboard_url = get_deployment_url(deployment)
         if dashboard_url:
             cli_utils.declare(
-                f"\nView in the ZenML UI: [link]{dashboard_url}[/link]"
+                f"\nView in the ZenML UI: [link]{dashboard_url}[/link]",
+                no_wrap=True,
             )
 
         if attach:
@@ -1264,7 +1265,8 @@ def deploy_snapshot(
             dashboard_url = get_deployment_url(deployment)
             if dashboard_url:
                 cli_utils.declare(
-                    f"\nView in the ZenML UI: [link]{dashboard_url}[/link]"
+                    f"\nView in the ZenML UI: [link]{dashboard_url}[/link]",
+                    no_wrap=True,
                 )
 
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -2363,9 +2363,13 @@ def pretty_print_deployment(
     if deployment.url:
         declare("\n[bold]Connection information:[/bold]")
 
-        declare(f"\n[bold]Endpoint URL:[/bold] [link]{deployment.url}[/link]")
         declare(
-            f"[bold]Swagger URL:[/bold] [link]{deployment.url.rstrip('/')}/docs[/link]"
+            f"\n[bold]Endpoint URL:[/bold] [link]{deployment.url}[/link]",
+            no_wrap=True,
+        )
+        declare(
+            f"[bold]Swagger URL:[/bold] [link]{deployment.url.rstrip('/')}/docs[/link]",
+            no_wrap=True,
         )
 
         # Auth key handling with proper security


### PR DESCRIPTION
## Summary
- Fixed CLI hyperlink wrapping that was breaking CMD-click in terminals
- Added `no_wrap=True` to all `declare()` calls that print URLs

## Problem
When ZenML CLI printed dashboard URLs, Rich's console was wrapping long URLs across multiple lines. This broke terminal hyperlink detection (CMD-click on macOS / Ctrl-click on Linux) because terminals couldn't recognize the URL as a single clickable entity.

## Solution
Rich's `Console.print()` accepts `no_wrap=True` which prevents line wrapping. The existing `declare()` function already forwards `**kwargs` to `console.print()`, so we simply added `no_wrap=True` to the specific calls that print URLs:

- `cli/utils.py`: Endpoint URL and Swagger URL in `pretty_print_deployment()`
- `cli/pipeline.py`: Dashboard URL in `deploy_pipeline()` and `deploy_snapshot()`
- `cli/deployment.py`: Dashboard URL in `provision_deployment()`

## Test plan
- [ ] Run any CLI command that prints a dashboard URL (e.g., `zenml pipeline deploy`)
- [ ] Verify the URL stays on a single line
- [ ] Verify CMD-click opens the link in a browser