### PR TITLE
Enable the oneof operator for referenced entities

### DIFF
--- a/src/zenml/models/v2/base/filter.py
+++ b/src/zenml/models/v2/base/filter.py
@@ -846,7 +846,10 @@ class BaseFilter(BaseModel):
         from sqlmodel import or_
 
         value, operator = BaseFilter._resolve_operator(value)
-        value = str(value)
+        # For the `oneof` operator, the return value here will be a list which
+        # we do not want to convert.
+        if isinstance(value, UUID):
+            value = str(value)
 
         conditions = []
 


### PR DESCRIPTION
## Describe changes
This PR enables the `oneof` operator when trying to filter some entity by a referenced entity (e.g. filter pipeline runs by the stack that they were run on).

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

