### PR TITLE
Remove unused endpoint

### DIFF
--- a/src/zenml/zen_server/routers/pipelines_endpoints.py
+++ b/src/zenml/zen_server/routers/pipelines_endpoints.py
@@ -21,7 +21,6 @@ from fastapi import APIRouter, Depends, Security
 from zenml.constants import (
     API,
     PIPELINES,
-    RUNS,
     VERSION_1,
 )
 from zenml.models import (
@@ -29,8 +28,6 @@ from zenml.models import (
     PipelineFilter,
     PipelineRequest,
     PipelineResponse,
-    PipelineRunFilter,
-    PipelineRunResponse,
     PipelineUpdate,
 )
 from zenml.zen_server.auth import AuthContext, authorize
@@ -232,29 +229,3 @@ def delete_pipeline(
     )
     if should_decrement:
         report_decrement(ResourceType.PIPELINE, resource_id=pipeline_id)
-
-
-@router.get(
-    "/{pipeline_id}" + RUNS,
-    responses={401: error_response, 404: error_response, 422: error_response},
-)
-@async_fastapi_endpoint_wrapper(deduplicate=True)
-def list_pipeline_runs(
-    pipeline_run_filter_model: PipelineRunFilter = Depends(
-        make_dependable(PipelineRunFilter)
-    ),
-    hydrate: bool = False,
-    _: AuthContext = Security(authorize),
-) -> Page[PipelineRunResponse]:
-    """Get pipeline runs according to query filters.
-
-    Args:
-        pipeline_run_filter_model: Filter model used for pagination, sorting,
-            filtering
-        hydrate: Flag deciding whether to hydrate the output model(s)
-            by including metadata fields in the response.
-
-    Returns:
-        The pipeline runs according to query filters.
-    """
-    return zen_store().list_runs(pipeline_run_filter_model, hydrate=hydrate)


### PR DESCRIPTION
## Describe changes
Removes the `/api/v1/pipelines/<ID>/runs` endpoint.
Reasons:
- `/api/v1/runs?pipeline_id=<ID>` does the same thing
- The endpoint didn't even use the pipeline ID, and was just returning all runs instead

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

