### PR TITLE
Fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - name: Test migrations across versions
         run: bash scripts/test-migrations.sh sqlite latest
   mariadb-db-migration-testing:

--- a/.github/workflows/release_finalize.yml
+++ b/.github/workflows/release_finalize.yml
@@ -117,5 +117,5 @@ jobs:
           gh pr create --title "Add version ${{ github.event.inputs.latest_version }} to legacy docs" \
                       --body "This PR adds version ${{ github.event.inputs.latest_version }} to the legacy documentation reference table." \
                       --base develop \
-                      --head legacy_docs_update_${{ github.event.inputs.latest_version }}
+                      --head legacy_docs_update_${{ github.event.inputs.latest_version }} \
                       --label "no-release-notes"

--- a/scripts/add-migration-test-version.sh
+++ b/scripts/add-migration-test-version.sh
@@ -37,7 +37,7 @@ else
     gh pr create --base "develop" --head "$NEW_BRANCH" \
       --title "Add $NEW_VERSION to the migration tests" \
       --body "This PR adds $NEW_VERSION to the list of version in the migration test script." \
-      --label "internal"
+      --label "internal" \
       --label "no-release-notes"
     exit 0
 fi


### PR DESCRIPTION
## Describe changes
- Add missing `\` so the labels get added correctly when creating github prs
- Switch the python 3.10 for the release sqlite db migration tests. This mirrors all the other CI tests that we have, and limits the sklearn version which causes an issue on 3.11.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

