### PR TITLE
Backport: Schedule management documentation (#4396)

### DIFF
--- a/docs/book/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/component-guide/orchestrators/kubernetes.md
@@ -411,17 +411,40 @@ To view your scheduled jobs and their status:
 kubectl get cronjobs -n zenml
 ```
 
-To update a schedule, use the following command:
+To update a schedule's cron expression:
 ```bash
-# This deletes both the schedule metadata in ZenML as well as the underlying CronJob
 zenml pipeline schedule update <SCHEDULE_NAME_OR_ID> --cron-expression='0 4 * * *'
+```
+
+#### Pausing and resuming a scheduled pipeline
+
+You can temporarily pause a scheduled pipeline without deleting it using the deactivate command. This sets the CronJob's `suspend` field to `true`, preventing any new executions while preserving the CronJob resource:
+
+```bash
+# Pause the schedule (sets suspend=true on the CronJob)
+zenml pipeline schedule deactivate <SCHEDULE_NAME_OR_ID>
+
+# Resume the schedule (sets suspend=false on the CronJob)
+zenml pipeline schedule activate <SCHEDULE_NAME_OR_ID>
+```
+
+You can verify the suspend status using kubectl:
+```shell
+kubectl get cronjob <cronjob-name> -n zenml -o jsonpath='{.spec.suspend}'
+```
 
 #### Deleting a scheduled pipeline
 
-When you no longer need a scheduled pipeline, you can delete the schedule as follows:
+When you no longer need a scheduled pipeline, you can delete the schedule. By default, deletion archives the schedule (soft delete), which preserves references in historical pipeline runs:
+
 ```bash
-# This deletes both the schedule metadata in ZenML as well as the underlying CronJob
+# Archive the schedule (soft delete - default)
+# This removes the CronJob from Kubernetes and archives the schedule in ZenML
 zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID>
+
+# Permanently delete the schedule (hard delete)
+# This removes the CronJob and permanently deletes all schedule references
+zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID> --hard
 ```
 
 #### Troubleshooting

--- a/docs/book/component-guide/orchestrators/sagemaker.md
+++ b/docs/book/component-guide/orchestrators/sagemaker.md
@@ -269,7 +269,7 @@ Alternatively, for a more detailed view of log messages during SageMaker pipelin
 
 When running your ZenML pipeline with the Sagemaker orchestrator, the configuration set when configuring the orchestrator as a ZenML component will be used by default. However, it is possible to provide additional configuration at the pipeline or step level. This allows you to run whole pipelines or individual steps with alternative configurations. For example, this allows you to run the training process with a heavier, GPU-enabled instance type, while running other steps with lighter instances.
 
-Additional configuration for the Sagemaker orchestrator can be passed via `SagemakerOrchestratorSettings`. Here, it is possible to configure `processor_args`, which is a dictionary of arguments for the Processor. For available arguments, see the [Sagemaker documentation](https://sagemaker.readthedocs.io/en/stable/api/training/processing.html#sagemaker.processing.Processor) . Currently, it is not possible to provide custom configuration for the following attributes:
+Additional configuration for the Sagemaker orchestrator can be passed via `SagemakerOrchestratorSettings`. Here, it is possible to configure `processor_args`, which is a dictionary of arguments for the Processor. For available arguments, see the [Sagemaker documentation](https://sagemaker.readthedocs.io/en/v2/api/training/processing.html#sagemaker.processing.Processor) . Currently, it is not possible to provide custom configuration for the following attributes:
 
 * `image_uri`
 * `instance_count`

--- a/docs/book/how-to/steps-pipelines/scheduling.md
+++ b/docs/book/how-to/steps-pipelines/scheduling.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to set, pause and stop a schedule for pipelines.
+description: Learn how to create, update, activate, deactivate, and delete schedules for pipelines.
 ---
 
 # Schedule a pipeline
@@ -54,19 +54,48 @@ my_pipeline()
 Check out our [SDK docs](https://sdkdocs.zenml.io/latest/core_code_docs/core-config.html#zenml.config.schedule) to learn more about the different scheduling options.
 {% endhint %}
 
-### Update/Pause/Stop a schedule
+### Update a schedule
 
-You can update or delete your schedules using the following CLI commands:
+You can update your schedule's cron expression:
 ```bash
-# Update the cron expression of the schedule
 zenml pipeline schedule update <SCHEDULE_NAME_OR_ID> --cron-expression='* * * * *'
-
-# Delete a schedule
-zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID>
 ```
 
-The functionality of these commands changes depending on whether the orchestrator that is running the schedule
-supports schedule updates/deletions:
+### Activate and deactivate a schedule
+
+You can temporarily pause a schedule without deleting it using the deactivate command, and resume it later with activate:
+
+```bash
+# Pause a schedule (stops future executions)
+zenml pipeline schedule deactivate <SCHEDULE_NAME_OR_ID>
+
+# Resume a paused schedule
+zenml pipeline schedule activate <SCHEDULE_NAME_OR_ID>
+```
+
+{% hint style="info" %}
+For the Kubernetes orchestrator, activate/deactivate controls the CronJob's `suspend` field - this is a native Kubernetes feature that pauses schedule execution without removing the CronJob resource.
+{% endhint %}
+
+### Delete a schedule
+
+Deleting a schedule archives it by default (soft delete), which preserves references in historical pipeline runs that were triggered by this schedule:
+
+```bash
+# Archive a schedule (soft delete - default behavior)
+zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID>
+
+# Permanently delete a schedule and remove all references (hard delete)
+zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID> --hard
+```
+
+{% hint style="warning" %}
+Using `--hard` permanently removes the schedule and any historical references to it. Pipeline runs that were triggered by this schedule will no longer show the schedule association.
+{% endhint %}
+
+### Orchestrator support for schedule management
+
+The functionality of these commands changes depending on whether the orchestrator supports schedule updates/deletions:
 - If the orchestrator supports it, this will update/delete the actual schedule as well as the schedule information stored in ZenML
 - If the orchestrator does not support it, this will only update/delete the schedule information stored in ZenML
 

--- a/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
+++ b/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
@@ -187,22 +187,22 @@ Sometimes we need to modify an existing schedule. Since ZenML doesn't support di
 
 #### Step 4.1: Delete the Existing Schedule
 
-First, delete the schedule from ZenML:
+First, delete the schedule from ZenML (this archives the schedule by default):
 
 ```python
-# Delete from ZenML
+# Archive the schedule from ZenML
 client.delete_schedule("daily-data-processing")
 ```
 
 Using the CLI:
 
 ```bash
-# Delete a specific schedule
+# Archive a specific schedule (soft delete)
 zenml pipeline schedule delete daily-data-processing
 ```
 
 {% hint style="warning" %}
-**Important**: You must also delete the schedule from the orchestrator. ZenML's delete command never removes the underlying orchestrator schedule.
+**Important**: For orchestrators that don't support native schedule deletion (like Vertex AI), you must also manually delete the schedule from the orchestrator. For orchestrators that do support it (like Kubernetes), ZenML will handle the orchestrator-side deletion automatically.
 {% endhint %}
 
 For Vertex AI, you need to delete the orchestrator schedule:
@@ -299,17 +299,28 @@ When you're done with a scheduled pipeline, proper cleanup is essential to preve
 
 #### Step 6.1: Delete the Schedule from ZenML
 
-First, let's delete the schedule from ZenML:
+First, let's delete the schedule from ZenML. By default, deletion archives the schedule (soft delete), which preserves references in historical pipeline runs:
 
 ```python
+# Archive the schedule (soft delete - preserves historical references)
 client.delete_schedule("daily-data-processing")
 
 # Verify deletion from ZenML
 schedules = client.list_schedules()
 if not any(s.name == "daily-data-processing" for s in schedules):
-    print("Schedule deleted successfully from ZenML!")
+    print("Schedule archived successfully in ZenML!")
 else:
     print("Schedule still exists in ZenML!")
+```
+
+Using the CLI, you can also perform a hard delete if you want to permanently remove all references:
+
+```bash
+# Soft delete (archive) - default behavior
+zenml pipeline schedule delete daily-data-processing
+
+# Hard delete - permanently removes all references
+zenml pipeline schedule delete daily-data-processing --hard
 ```
 
 #### Step 6.2: Delete the Schedule from the Orchestrator (Required)


### PR DESCRIPTION
## Summary

Backports PR #4396 from develop to release/0.93.1.

### Original PR: #4396 - Add documentation for schedule activate/deactivate and archiving

Documents new schedule management features:
- **Activate/Deactivate commands**: CLI commands for pausing and resuming schedules
- **Schedule archiving**: Soft-delete as default deletion behavior
- **Hard delete option**: `--hard` flag for permanent deletion
- Fixes broken SageMaker docs link

## Files changed
- `docs/book/component-guide/orchestrators/kubernetes.md`
- `docs/book/component-guide/orchestrators/sagemaker.md`
- `docs/book/how-to/steps-pipelines/scheduling.md`
- `docs/book/user-guide/tutorial/managing-scheduled-pipelines.md`

(cherry picked from commit 09ca399b8bd7a00028c2bf62b8628035057e934f)