### PR TITLE
Add missing index to the snapshot table

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/d1e8c2c4a9ef_add_snapshot_index.py
+++ b/src/zenml/zen_stores/migrations/versions/d1e8c2c4a9ef_add_snapshot_index.py
@@ -1,0 +1,31 @@
+"""add snapshot index [d1e8c2c4a9ef].
+
+Revision ID: d1e8c2c4a9ef
+Revises: 0e5c99d02aa7
+Create Date: 2026-01-23 16:25:05.328420
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d1e8c2c4a9ef"
+down_revision = "0e5c99d02aa7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("pipeline_snapshot", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_pipeline_snapshot_source_snapshot_id",
+            ["source_snapshot_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("pipeline_snapshot", schema=None) as batch_op:
+        batch_op.drop_index("ix_pipeline_snapshot_source_snapshot_id")

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -46,7 +46,10 @@ from zenml.zen_stores.schemas.pipeline_build_schemas import PipelineBuildSchema
 from zenml.zen_stores.schemas.pipeline_schemas import PipelineSchema
 from zenml.zen_stores.schemas.project_schemas import ProjectSchema
 from zenml.zen_stores.schemas.schedule_schema import ScheduleSchema
-from zenml.zen_stores.schemas.schema_utils import build_foreign_key_field
+from zenml.zen_stores.schemas.schema_utils import (
+    build_foreign_key_field,
+    build_index,
+)
 from zenml.zen_stores.schemas.stack_schemas import StackSchema
 from zenml.zen_stores.schemas.tag_schemas import TagSchema
 from zenml.zen_stores.schemas.user_schemas import UserSchema
@@ -74,6 +77,10 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             "pipeline_id",
             "name",
             name="unique_name_for_pipeline_id",
+        ),
+        build_index(
+            table_name=__tablename__,
+            column_names=["source_snapshot_id"],
         ),
     )
 


### PR DESCRIPTION
## Describe changes
When fetching a snapshot, the last run associated with it is also fetched. However, this uses a different column (`source_snapshot_id`) that was previously not configured as an index. On databases with very large number of snapshots, this leads to very high DB query times that impacts ZenML's scalabilty.

This PR adds the missing index.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

