### PR TITLE
Backport: Add ZenML Quick Wins skill for Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,11 +207,8 @@ zenml_tutorial/
 
 # Claude settings
 **/.claude/settings.local.json
-.claude/
-!.claude/agents/**
-!.claude/commands/**
-!.claude/settings.json
-!.claude/skills/**
+.claude/*
+!.claude/skills/
 
 .local/
 # PLEASE KEEP THIS LINE AT THE EOF: never include here src/zenml/zen_server/dashboard, since it is affecting release flow

--- a/docs/book/reference/llms-txt.md
+++ b/docs/book/reference/llms-txt.md
@@ -1,7 +1,15 @@
 ---
 icon: robot
-description: Access ZenML documentation via MCP server or llms.txt
+description: LLM tooling for ZenML - MCP servers, llms.txt, and Agent Skills
 ---
+
+# LLM Tooling
+
+ZenML provides multiple ways to enhance your AI-assisted development workflow:
+
+- **MCP servers** for real-time doc queries and server interaction
+- **llms.txt** for grounding LLMs with ZenML documentation
+- **Agent Skills** for guided implementation of ZenML features
 
 ## About llms.txt
 The llms.txt file format was proposed by [llmstxt.org](https://llmstxt.org/) as a standard way to provide information to help LLMs answer questions about a product/website. From their website:
@@ -80,3 +88,90 @@ following tools:
 - [GitMCP](https://gitmcp.io/) - A way to quickly create an MCP server for a github repository (e.g. for `zenml-io/zenml`)
 - [mcp-llms](https://github.com/parlance-labs/mcp-llms.txt/) - This shows how to use an MCP server to iteratively explore the llms.txt file with your MCP client
 - [mcp-llms-txt-explorer](https://github.com/thedaviddias/mcp-llms-txt-explorer) -  A tool to help you explore and discover websites that have llms.txt files
+
+## ZenML Agent Skills
+
+Agent Skills are modular capabilities that help AI coding agents perform specific tasks. ZenML publishes skills through a plugin marketplace that works with many popular agentic coding tools.
+
+### Supported tools
+
+ZenML skills work with tools that support the Agent Skills format:
+
+| Tool | Type | Skills support |
+|------|------|----------------|
+| [Claude Code](https://code.claude.com/) | Anthropic's CLI agent | Native plugin marketplace |
+| [OpenAI Codex CLI](https://github.com/openai/codex) | OpenAI's terminal agent | Native skills support |
+| [GitHub Copilot](https://github.com/features/copilot) | IDE coding assistant | Agent Skills integration |
+| [OpenCode](https://github.com/opencode-ai/opencode) | Open source AI agent | Native skills support |
+| [Amp](https://amp.dev) | AI coding assistant | Agent Skills integration |
+| [Cursor](https://cursor.sh) | AI-powered IDE | Via settings configuration |
+| [Gemini CLI](https://github.com/google/gemini-cli) | Google's terminal agent | Skills support |
+
+### Installing ZenML skills
+
+#### Claude Code
+
+```bash
+# Add the ZenML marketplace (one-time setup)
+/plugin marketplace add zenml-io/skills
+
+# Install available skills
+/plugin install zenml-quick-wins@zenml
+```
+
+#### OpenAI Codex CLI
+
+```bash
+# Add the ZenML marketplace
+codex plugin add zenml-io/skills
+
+# Install skills
+codex plugin install zenml-quick-wins@zenml
+```
+
+### Available skills
+
+#### `zenml-quick-wins`
+
+Guides you through discovering and implementing high-impact ZenML features. The skill investigates your current setup, recommends priorities based on your stack, and helps implement improvements interactively.
+
+**Use when:**
+- You want to improve your ZenML setup
+- You're looking for MLOps best practices to adopt
+- You need help with features like experiment tracking, alerting, scheduling, or model governance
+
+**What it does:**
+1. **Investigate** - Analyzes your stack configuration and codebase
+2. **Recommend** - Prioritizes quick wins based on your current setup
+3. **Implement** - Helps you apply selected improvements
+4. **Verify** - Confirms the implementation works
+
+**Example prompts:**
+```
+Use zenml-quick-wins to analyze this repo and recommend the top 3 quick wins.
+
+Implement metadata logging and tags across my pipelines.
+
+Set up Slack alerts for pipeline failures.
+```
+
+See the [Quick Wins guide](../user-guide/best-practices/quick-wins.md) for the full catalog of improvements this skill can help implement.
+
+### Coming soon
+
+We're developing additional skills to help with common ZenML workflows:
+
+- **Pipeline creation** - Scaffolding new pipelines from templates
+- **Stack setup** - Guided stack component configuration
+- **Debugging** - Investigating pipeline failures and performance issues
+- **Migration** - Migrating from other MLOps platforms and orchestrators to ZenML
+
+### Combining MCP + Skills
+
+For the best AI-assisted ZenML development experience, combine:
+
+1. **GitBook MCP server** (`https://docs.zenml.io/~gitbook/mcp`) - For doc-grounded answers
+2. **ZenML server MCP** ([setup guide](../user-guide/best-practices/mcp-chat-with-server.md)) - For querying your live pipelines, runs, and stacks
+3. **Agent Skills** - For guided implementation of features
+
+This gives your AI assistant access to documentation, your actual ZenML data, and structured workflows for making changes.

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -65,7 +65,7 @@
 
 * [Community & content](reference/community-and-content.md)
 * [Environment Variables](reference/environment-variables.md)
-* [MCP Docs & llms.txt](reference/llms-txt.md)
+* [LLM Tooling](reference/llms-txt.md)
 * [FAQ](reference/faq.md)
 * [Global settings](reference/global-settings.md)
 * [Legacy docs](reference/legacy-docs.md)

--- a/docs/book/user-guide/best-practices/quick-wins.md
+++ b/docs/book/user-guide/best-practices/quick-wins.md
@@ -9,6 +9,22 @@ Below is a menu of 5-minute quick wins you can sprinkle into an existing ZenML
 project with almost no code changes. Each entry explains why it matters, the
 micro-setup (under 5 minutes) and any tips or gotchas to anticipate.
 
+{% hint style="info" %}
+**Automate with AI coding agents:** If you use an agentic coding tool (Claude Code, OpenAI Codex, GitHub Copilot, OpenCode, Amp, Cursor, etc.), install the `zenml-quick-wins` skill to analyze your repo and stack, get personalized recommendations, and implement quick wins interactively.
+
+```bash
+# Example for Claude Code - add the ZenML marketplace (one-time)
+/plugin marketplace add zenml-io/skills
+
+# Install the skill
+/plugin install zenml-quick-wins@zenml
+```
+
+Then ask: *"Use zenml-quick-wins to analyze this repo and recommend the top 3 quick wins to implement."*
+
+See [LLM tooling](../../reference/llms-txt.md) for setup instructions across different tools.
+{% endhint %}
+
 | Quick Win | What it does | Why you need it |
 |-----------|--------------|----------------|
 | [Log rich metadata](#id-1-log-rich-metadata-on-every-run) | Track params, metrics, and properties on every run | Foundation for reproducibility and analytics |


### PR DESCRIPTION
## Summary

Backports commit 6a6449eae from `develop` to `release/0.93.1`.

**Original PR:** #4426

## Changes

- Adds documentation for the ZenML Quick Wins Claude Code skill
- Updates `llms-txt.md` with skill usage instructions
- Adds `quick-wins.md` guide to best practices section

## Notes

This is a docs-only backport to make the new skill documentation available on the live docs site.

(cherry picked from commit 6a6449eae5a53db4e7eea6555a751e59a479da26)