### PR TITLE
Pin qwen-agent<0.0.32 to fix CI import error

### DIFF
--- a/examples/agent_framework_integrations/qwen-agent/requirements.txt
+++ b/examples/agent_framework_integrations/qwen-agent/requirements.txt
@@ -1,4 +1,7 @@
-qwen-agent>=0.0.10
+# qwen-agent 0.0.32 has a SyntaxError bug in tools/mcp_manager.py
+# See: https://github.com/QwenLM/Qwen-Agent/issues/768
+# Remove this cap once a fixed version is released
+qwen-agent>=0.0.10,<0.0.32
 openai>=1.0.0
 zenml[local]
 json5>=0.9


### PR DESCRIPTION
## Summary
- Pins `qwen-agent` to `<0.0.32` in the agent examples to fix a CI failure
- The `qwen-agent==0.0.32` release has a SyntaxError bug in `tools/mcp_manager.py`

## Problem
The weekly agent examples CI job failed because `qwen-agent==0.0.32` contains invalid Python syntax:

```python
# In qwen_agent/tools/mcp_manager.py line 142
logger.info(f'Initializing MCP tools from mcp servers: {list(config['mcpServers'].keys())}')
#                                                                    ^^^^^^^^^^
# SyntaxError: f-string: unmatched '['
```

This is a known upstream issue: https://github.com/QwenLM/Qwen-Agent/issues/768

The nested single quotes inside the f-string expression are invalid in Python <3.12 (our CI uses Python 3.11).

## Fix
Added an upper bound to the version constraint in `examples/agent_framework_integrations/qwen-agent/requirements.txt`:

```diff
- qwen-agent>=0.0.10
+ qwen-agent>=0.0.10,<0.0.32
```

This pins to version 0.0.31 (or earlier compatible versions) until the upstream bug is fixed.

## Test plan
- [ ] CI passes with the version pin
- [ ] Remove the cap once qwen-agent releases a fix (tracked via upstream issue)