### PR TITLE
Reject cookies of local user accounts when enrolled in ZenML Pro

### DIFF
--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -311,6 +311,18 @@ def authenticate_credentials(
             logger.error(error)
             raise CredentialsNotValid(error)
 
+        if (
+            server_config().auth_scheme == AuthScheme.EXTERNAL
+            and not user_model.external_user_id
+            and not user_model.is_service_account
+        ):
+            error = (
+                f"Authentication error: local account {user_model.name} is not "
+                f"allowed to authenticate with external authentication"
+            )
+            logger.error(error)
+            raise CredentialsNotValid(error)
+
         api_key_model: Optional[APIKeyInternalResponse] = None
         if decoded_token.api_key_id:
             # The API token was generated from an API key. We still have to


### PR DESCRIPTION
## Describe changes
When a ZenML OSS server is migrated to ZenML Pro by means of organization enrollment, the local user accounts are left behind and, if cookies are not cleared from the browser, the ZenML Pro UI will try to use them instead of issuing new ones that belong to the currently logged in ZenML Pro user. The local user account will obviously not be allowed to access any resources, so an error will be raised and the UI will not show any of the migrated resources (stacks, projects, etc.):

```
2026-02-06 17:58:41,577 - zenml.zen_server.utils - ERROR - API error (utils.py:412)
Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/utils.py", line 402, in decorated
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/routers/projects_endpoints.py", line 103, in list_projects
    return verify_permissions_and_list_entities(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/rbac/endpoint_utils.py", line 257, in verify_permissions_and_list_entities
    allowed_ids = get_allowed_resource_ids(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/rbac/utils.py", line 350, in get_allowed_resource_ids
    ) = rbac().list_allowed_resource_ids(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/zenml/zen_server/rbac/zenml_cloud_rbac.py", line 108, in list_allowed_resource_ids
    assert user.external_user_id
           ^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

This PR fixes that by rejecting session tokens of accounts that:

* are user accounts (service accounts are still allowed for backwards compatibility, even though deprecated)
* are local accounts (no external i.e. Pro account associated)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

