### PR TITLE
Add `concurrency_policy` and `starting_deadline_seconds` to K8s `CronJob` config

### DIFF
--- a/docs/book/how-to/steps-pipelines/scheduling.md
+++ b/docs/book/how-to/steps-pipelines/scheduling.md
@@ -97,6 +97,15 @@ zenml pipeline schedule delete <SCHEDULE_NAME_OR_ID> --hard
 Using `--hard` permanently removes the schedule and any historical references to it. Pipeline runs that were triggered by this schedule will no longer show the schedule association.
 {% endhint %}
 
+### Kubernetes CronJob advanced configuration
+
+When using the Kubernetes orchestrator, scheduled pipelines are backed by Kubernetes CronJobs. You can customize CronJob-specific behavior through `KubernetesOrchestratorSettings`:
+
+- **`concurrency_policy`**: Controls whether concurrent job executions are allowed (`Allow`, `Forbid`, `Replace`)
+- **`starting_deadline_seconds`**: If a scheduled run misses its trigger time, it can still start within this window (in seconds)
+
+These settings are in addition to Job-level settings like `active_deadline_seconds` (runtime timeout), `ttl_seconds_after_finished` (cleanup delay), and history limits. See the [Kubernetes orchestrator docs](../component-guide/orchestrators/kubernetes.md) for the full list and examples.
+
 ### Orchestrator support for schedule management
 
 The functionality of these commands changes depending on whether the orchestrator supports schedule updates/deletions (see the "Native Schedule Management" column in the table above):

--- a/src/zenml/integrations/kubernetes/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/manifest_utils.py
@@ -486,6 +486,8 @@ def build_cron_job_manifest(
     cron_expression: str,
     successful_jobs_history_limit: Optional[int] = None,
     failed_jobs_history_limit: Optional[int] = None,
+    concurrency_policy: Optional[str] = None,
+    starting_deadline_seconds: Optional[int] = None,
 ) -> k8s_client.V1CronJob:
     """Build a Kubernetes cron job manifest.
 
@@ -494,6 +496,10 @@ def build_cron_job_manifest(
         cron_expression: The cron expression to use for the cron job.
         successful_jobs_history_limit: The number of successful jobs to keep.
         failed_jobs_history_limit: The number of failed jobs to keep.
+        concurrency_policy: The concurrency policy for the cron job
+            (Allow, Forbid, or Replace).
+        starting_deadline_seconds: The deadline in seconds for starting
+            a job if it misses its scheduled time.
 
     Returns:
         The Kubernetes cron job manifest.
@@ -502,6 +508,8 @@ def build_cron_job_manifest(
         schedule=cron_expression,
         successful_jobs_history_limit=successful_jobs_history_limit,
         failed_jobs_history_limit=failed_jobs_history_limit,
+        concurrency_policy=concurrency_policy,
+        starting_deadline_seconds=starting_deadline_seconds,
         job_template=job_template,
     )
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -804,6 +804,8 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                         ),
                         successful_jobs_history_limit=settings.successful_jobs_history_limit,
                         failed_jobs_history_limit=settings.failed_jobs_history_limit,
+                        concurrency_policy=settings.concurrency_policy,
+                        starting_deadline_seconds=settings.starting_deadline_seconds,
                     )
 
                     cron_job = self._k8s_batch_api.create_namespaced_cron_job(

--- a/tests/integration/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
+++ b/tests/integration/integrations/kubernetes/orchestrators/test_kubernetes_orchestrator.py
@@ -185,3 +185,34 @@ def test_kubernetes_orchestrator_uses_service_account_from_settings(mocker):
         orchestrator._get_service_account_name(settings)
         == service_account_name
     )
+
+
+@pytest.mark.parametrize(
+    "input_value,expected",
+    [
+        ("Allow", "Allow"),
+        ("Forbid", "Forbid"),
+        ("Replace", "Replace"),
+        ("allow", "Allow"),
+        ("forbid", "Forbid"),
+        ("REPLACE", "Replace"),
+        ("  Forbid  ", "Forbid"),
+        (None, None),
+    ],
+)
+def test_concurrency_policy_validation_accepts_valid_values(
+    input_value, expected
+):
+    """Test that concurrency_policy validator normalizes valid values."""
+    settings = KubernetesOrchestratorSettings(concurrency_policy=input_value)
+    assert settings.concurrency_policy == expected
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    ["Invalid", "never", "always", ""],
+)
+def test_concurrency_policy_validation_rejects_invalid_values(input_value):
+    """Test that concurrency_policy validator rejects invalid values."""
+    with pytest.raises(Exception):
+        KubernetesOrchestratorSettings(concurrency_policy=input_value)


### PR DESCRIPTION
## Summary

- Expose `concurrency_policy` and `starting_deadline_seconds` as optional fields in `KubernetesOrchestratorSettings` for scheduled pipelines backed by Kubernetes CronJobs
- Add a Pydantic validator that normalizes `concurrency_policy` casing (e.g. `"forbid"` → `"Forbid"`) and rejects invalid values early
- Wire both fields through `build_cron_job_manifest()` into the `V1CronJobSpec` constructor
- Update Kubernetes orchestrator and scheduling docs with new settings and usage examples
- Add manifest builder and validator tests

Closes #4480

## Test plan

- [ ] CI passes (formatting, mypy, tests)
- [ ] New tests in `test_manifest_utils.py` verify CronJob manifest fields are set correctly and default to `None`
- [ ] New tests in `test_kubernetes_orchestrator.py` verify the `concurrency_policy` validator accepts valid values (case-insensitive) and rejects invalid ones
- [ ] Manual: deploy a scheduled pipeline with `concurrency_policy="Forbid"` and `starting_deadline_seconds=20`, verify the CronJob spec via `kubectl get cronjob <name> -o yaml`