### PR TITLE
Fall back to uv pip freeze when pip is missing

### DIFF
--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -30,6 +30,7 @@ class PythonEnvironmentExportMethod(Enum):
     """Different methods to export the local Python environment."""
 
     PIP_FREEZE = "pip_freeze"
+    UV_FREEZE = "uv_freeze"
     POETRY_EXPORT = "poetry_export"
 
     @property
@@ -44,6 +45,7 @@ class PythonEnvironmentExportMethod(Enum):
         """
         return {
             PythonEnvironmentExportMethod.PIP_FREEZE: "pip freeze",
+            PythonEnvironmentExportMethod.UV_FREEZE: "uv pip freeze",
             PythonEnvironmentExportMethod.POETRY_EXPORT: "poetry export --format=requirements.txt",
         }[self]
 


### PR DESCRIPTION
ZenML calls `pip freeze` during pipeline runs to collect environment metadata. In uv-only environments (where pip is not installed), this raises FileNotFoundError and crashes the run. Now catches that error and falls back to `uv pip freeze`, which works without pip.

Also adds UV_FREEZE as an export method in PythonEnvironmentExportMethod for Docker builds.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

