### PR TITLE
fix mlflow env var conflicts with orchestrator-injected values

### DIFF
--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -304,7 +304,26 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
         mlflow.set_tracking_uri("")
 
     def configure_mlflow(self) -> None:
-        """Configures the MLflow tracking URI and any additional credentials."""
+        """Configures the MLflow tracking URI and any additional credentials.
+
+        Clears any pre-existing MLflow environment variables first to
+        prevent conflicts with orchestrator-injected values (e.g. AzureML
+        sets MLFLOW_TRACKING_TOKEN and MLFLOW_RUN_ID which can interfere
+        with ZenML's own credentials).
+        """
+        # Clear MLflow env vars that may have been injected by the
+        # orchestrator environment before we set ZenML's own values.
+        for var in [
+            MLFLOW_TRACKING_URI,
+            MLFLOW_TRACKING_USERNAME,
+            MLFLOW_TRACKING_PASSWORD,
+            MLFLOW_TRACKING_TOKEN,
+            MLFLOW_TRACKING_INSECURE_TLS,
+            "MLFLOW_EXPERIMENT_ID",
+            "MLFLOW_RUN_ID",
+        ]:
+            os.environ.pop(var, None)
+
         tracking_uri = self.get_tracking_uri()
         mlflow.set_tracking_uri(tracking_uri)
 


### PR DESCRIPTION
When running on orchestrators like AzureML, the environment comes pre-loaded with `MLFLOW_*` env vars (`MLFLOW_TRACKING_TOKEN`, `MLFLOW_RUN_ID`, `MLFLOW_EXPERIMENT_ID`, etc.) that are meant for the orchestrator's built-in MLflow instance. `configure_mlflow()` sets ZenML's own credentials via env vars but never clears the pre-existing ones first, so MLflow ends up using the wrong token (401 errors) or trying to resume stale runs (`RESOURCE_DOES_NOT_EXIST`).

The fix clears all relevant `MLFLOW_*` env vars at the top of `configure_mlflow()` before setting ZenML's own values. This way ZenML's credentials always win regardless of what the orchestrator injected.

Added a test that sets fake orchestrator-injected env vars, calls `configure_mlflow()`, and verifies they get cleaned up.

Fixes #4407