### PR TITLE
Handle activation exceptions for individual integrations

### DIFF
--- a/src/zenml/integrations/registry.py
+++ b/src/zenml/integrations/registry.py
@@ -97,12 +97,20 @@ class IntegrationRegistry(object):
                 continue
 
     def activate_integrations(self) -> None:
-        """Activate all installed integrations (best effort).
+        """Best-effort eager activation of installed integrations.
 
-        Attempts to activate each installed integration. If an individual
-        integration fails due to an ImportError or OSError (e.g. missing
-        optional dependencies, binary/DLL load failures), the error is
-        logged and activation continues for the remaining integrations.
+        Attempts to activate each integration that passes the
+        metadata-based installation check. Activation imports the
+        integration's runtime modules (materializers, service connectors,
+        etc.) to trigger eager registration. If an individual activation
+        fails due to a broken or incomplete install (ImportError) or
+        native library load failure (OSError), the error is logged and
+        remaining integrations continue.
+
+        Note: activation failure only skips early registration side
+        effects. Later on-demand imports (e.g. loading stored artifacts
+        or stack components) may still attempt to import the same modules
+        and could fail independently.
         """
         self._initialize()
         for name, integration in self._integrations.items():
@@ -110,14 +118,20 @@ class IntegrationRegistry(object):
                 logger.debug(f"Activating integration `{name}`...")
                 try:
                     integration.activate()
-                # ImportError: missing optional dependencies
-                # OSError: binary/DLL load failures (e.g. torch on Windows)
+                # ImportError: broken/incomplete install or undeclared
+                # transitive dependency despite declared requirements
+                # appearing installed.
+                # OSError: native library or binary/DLL load failure
+                # at import time.
                 except (ImportError, OSError) as e:
                     logger.exception(
                         f"Failed to activate integration `{name}`: "
                         f"{type(e).__name__}: {e}. "
-                        "Continuing without this integration; "
-                        "its features will be unavailable."
+                        "Skipping activation-time registration (e.g. "
+                        "materializers, service connectors). Some "
+                        "features may be missing from auto-discovery, "
+                        "and on-demand imports of this integration "
+                        "may also fail."
                     )
                     continue
                 logger.debug(f"Integration `{name}` is activated.")

--- a/tests/unit/integrations/test_registry.py
+++ b/tests/unit/integrations/test_registry.py
@@ -108,7 +108,7 @@ def test_activate_integrations_continues_after_import_error(caplog):
 
 
 def test_activate_integrations_logs_continuation_message(caplog):
-    """The error log must mention that the system continues without the integration."""
+    """The error log must mention that activation-time registration was skipped."""
     registry = IntegrationRegistry()
     registry._initialized = True
     registry._integrations = {
@@ -119,6 +119,6 @@ def test_activate_integrations_logs_continuation_message(caplog):
         registry.activate_integrations()
 
     assert any(
-        "Continuing without this integration" in record.message
+        "Skipping activation-time registration" in record.message
         for record in caplog.records
     )


### PR DESCRIPTION
## Summary

Spun out from #4471 (CI flakiness fix PR) per review — this change needs focused review since it affects the global integration activation path.

- When activating integrations at startup, a single integration failing (e.g., `OSError` from Windows DLL loads, `ImportError` from broken/incomplete installs) would crash the entire activation loop, preventing all subsequent integrations from activating
- Wraps each `integration.activate()` call with a try/except for `ImportError` and `OSError`
- Logs the failure at **ERROR** level with full traceback via `logger.exception()` and continues activating remaining integrations
- The log message explains what was skipped (activation-time registration) and warns that on-demand imports may also fail later

### Changes

| File | What |
|------|------|
| `src/zenml/integrations/registry.py` | try/except around `integration.activate()` in `activate_integrations()` with ERROR-level logging, inline comments explaining exception choices, and updated docstring reflecting best-effort semantics |
| `tests/unit/integrations/test_registry.py` | Unit tests covering OSError resilience, ImportError resilience, and continuation message logging |

### Design decisions

- **ERROR level (not WARNING)**: Aligns with the `_initialize()` method which already uses `logger.exception()` for import failures. When `check_installation()` says "installed" but `activate()` fails, that's an error worth surfacing clearly in CI/ops logs
- **Narrow exception scope**: Only `ImportError` and `OSError` are caught — not `Exception` broadly — to avoid masking real ZenML bugs. These two cover the known failure modes (broken installs, undeclared transitive dependencies, binary/DLL load failures)
- **Precise error messaging**: The log message distinguishes between what was skipped (eager registration of materializers/service connectors) and what may still happen (on-demand imports of the same integration may fail later when loading stored artifacts or stack components). This addresses the reality that ZenML has two import paths: eager (activation-time) and lazy (on-demand)
- **No failure tracking dict (yet)**: A future refinement could add `self._activation_failures: Dict[str, Exception]` to the registry so downstream code can surface "integration X failed earlier" when users hit flavor/materializer-not-found errors. Not included here to keep scope tight

### Key insight: why `check_installation()` passes but `activate()` fails

`check_installation()` verifies declared pip distribution metadata (package names + version specifiers) — it does NOT import runtime modules. So it can report "installed ✓" while the actual import in `activate()` fails because:
- A transitive dependency is not declared in the package's `pyproject.toml`
- The install is broken/partial (metadata exists but C extensions are corrupt)
- A native library or DLL fails to load at import time

### Risk considerations

- Catching `ImportError`/`OSError` broadly *could* hide real failures, but `logger.exception()` (ERROR + full traceback) ensures they are always visible
- The primary use case is Windows CI where torch DLL imports raise `OSError` and poison all subsequent integration activations
- Partial activation means an integration's materializers/service connectors may not register in the eager path, but later on-demand imports (e.g., loading stored artifacts or stack components) will still attempt the same imports and may fail independently — this is strictly better than the previous behavior where ALL subsequent integrations failed

## Test plan

- [x] Unit tests for best-effort activation (OSError, ImportError, continuation message)
- [ ] ci-slow Windows integration tests pass (torch DLL crash no longer poisons other integrations)
- [ ] Linux/macOS integration tests still pass (no behavior change for working integrations)
- [ ] Integration activation failures are visible in logs (not silently swallowed)