### PR TITLE
Refresh kubernetes credentials while monitoring jobs

### DIFF
--- a/src/zenml/integrations/kubernetes/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/kube_utils.py
@@ -813,8 +813,7 @@ def get_container_termination_reason(
 
 
 def wait_for_job_to_finish(
-    batch_api: k8s_client.BatchV1Api,
-    core_api: k8s_client.CoreV1Api,
+    get_client: Callable[[], k8s_client.ApiClient],
     namespace: str,
     job_name: str,
     backoff_interval: float = 1,
@@ -827,8 +826,7 @@ def wait_for_job_to_finish(
     """Wait for a job to finish.
 
     Args:
-        batch_api: Kubernetes BatchV1Api client.
-        core_api: Kubernetes CoreV1Api client.
+        get_client: A function that returns a Kubernetes API client.
         namespace: Kubernetes namespace.
         job_name: Name of the job for which to wait.
         backoff_interval: The interval to wait between polling the job status.
@@ -847,6 +845,10 @@ def wait_for_job_to_finish(
     finished_pods = set()
 
     while True:
+        client = get_client()
+        batch_api = k8s_client.BatchV1Api(client)
+        core_api = k8s_client.CoreV1Api(client)
+
         job: k8s_client.V1Job = retry_on_api_exception(
             batch_api.read_namespaced_job
         )(name=job_name, namespace=namespace)

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -835,8 +835,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
                                 "Waiting for orchestrator job to finish..."
                             )
                             kube_utils.wait_for_job_to_finish(
-                                batch_api=self._k8s_batch_api,
-                                core_api=self._k8s_core_api,
+                                get_client=self.get_kube_client,
                                 namespace=self.config.kubernetes_namespace,
                                 job_name=job_name,
                                 backoff_interval=settings.job_monitoring_interval,
@@ -945,8 +944,7 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
             job_name,
         )
         kube_utils.wait_for_job_to_finish(
-            batch_api=self._k8s_batch_api,
-            core_api=self._k8s_core_api,
+            get_client=self.get_kube_client,
             namespace=self.config.kubernetes_namespace,
             job_name=job_name,
             fail_on_container_waiting_reasons=settings.fail_on_container_waiting_reasons,

--- a/src/zenml/integrations/kubernetes/step_operators/kubernetes_step_operator.py
+++ b/src/zenml/integrations/kubernetes/step_operators/kubernetes_step_operator.py
@@ -279,8 +279,7 @@ class KubernetesStepOperator(BaseStepOperator):
             job_name,
         )
         kube_utils.wait_for_job_to_finish(
-            batch_api=self._k8s_batch_api,
-            core_api=self._k8s_core_api,
+            get_client=self.get_kube_client,
             namespace=self.config.kubernetes_namespace,
             job_name=job_name,
             fail_on_container_waiting_reasons=settings.fail_on_container_waiting_reasons,


### PR DESCRIPTION
## Describe changes
This PR fixes an issue where Kubernetes credentials issued by service connectors expired while monitoring running jobs.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

