### PR TITLE
Include git submodule files in code archive

### DIFF
--- a/src/zenml/utils/code_utils.py
+++ b/src/zenml/utils/code_utils.py
@@ -109,13 +109,21 @@ class CodeArchive(Archivable):
 
         if repo := self.git_repo:
             try:
-                result = repo.git.ls_files(
+                # Split into two calls because --recurse-submodules is only
+                # compatible with --cached, not with --others or --modified.
+                tracked = repo.git.ls_files(
                     "--cached",
+                    "--recurse-submodules",
+                    "--exclude-standard",
+                    self._root,
+                )
+                untracked_and_modified = repo.git.ls_files(
                     "--others",
                     "--modified",
                     "--exclude-standard",
                     self._root,
                 )
+                result = tracked + "\n" + untracked_and_modified
             except Exception as e:
                 logger.warning(
                     "Failed to get non-ignored files from git: %s", str(e)
@@ -123,6 +131,8 @@ class CodeArchive(Archivable):
                 all_files = self._get_all_files(archive_root=self._root)
             else:
                 for file in result.split():
+                    if not file:
+                        continue
                     file_path = os.path.join(repo.working_dir, file)
                     path_in_archive = os.path.relpath(file_path, self._root)
 

--- a/tests/unit/utils/test_code_utils.py
+++ b/tests/unit/utils/test_code_utils.py
@@ -1,0 +1,115 @@
+#  Copyright (c) ZenML GmbH 2024. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for code_utils.py."""
+
+import os
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from zenml.utils.code_utils import CodeArchive
+
+
+def test_get_files_uses_recurse_submodules(tmp_path):
+    """Verify that git ls-files is called with --recurse-submodules for
+    tracked files and a separate call for untracked/modified files."""
+    # Create a file on disk so os.path.exists passes
+    test_file = tmp_path / "main.py"
+    test_file.write_text("print('hello')")
+    submodule_file = tmp_path / "external" / "lib.py"
+    submodule_file.parent.mkdir()
+    submodule_file.write_text("x = 1")
+
+    mock_repo = MagicMock()
+    mock_repo.working_dir = str(tmp_path)
+
+    # First call: --cached --recurse-submodules returns tracked + submodule
+    # Second call: --others --modified returns nothing extra
+    mock_repo.git.ls_files = MagicMock(
+        side_effect=[
+            "main.py\nexternal/lib.py",
+            "",
+        ]
+    )
+
+    archive = CodeArchive(root=str(tmp_path))
+
+    with patch.object(
+        CodeArchive, "git_repo", new_callable=PropertyMock
+    ) as mock_git_repo:
+        mock_git_repo.return_value = mock_repo
+        files = archive.get_files()
+
+    # Both tracked calls should have been made
+    assert mock_repo.git.ls_files.call_count == 2
+
+    first_call_args = mock_repo.git.ls_files.call_args_list[0][0]
+    assert "--recurse-submodules" in first_call_args
+    assert "--cached" in first_call_args
+
+    second_call_args = mock_repo.git.ls_files.call_args_list[1][0]
+    assert "--others" in second_call_args
+    assert "--modified" in second_call_args
+    assert "--recurse-submodules" not in second_call_args
+
+    assert "main.py" in files
+    assert os.path.join("external", "lib.py") in files
+
+
+def test_get_files_includes_untracked_files(tmp_path):
+    """Verify that untracked/modified files from the second ls-files call
+    are included in the archive."""
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("tracked")
+    untracked = tmp_path / "new_file.py"
+    untracked.write_text("untracked")
+
+    mock_repo = MagicMock()
+    mock_repo.working_dir = str(tmp_path)
+    mock_repo.git.ls_files = MagicMock(
+        side_effect=[
+            "tracked.py",
+            "new_file.py",
+        ]
+    )
+
+    archive = CodeArchive(root=str(tmp_path))
+
+    with patch.object(
+        CodeArchive, "git_repo", new_callable=PropertyMock
+    ) as mock_git_repo:
+        mock_git_repo.return_value = mock_repo
+        files = archive.get_files()
+
+    assert "tracked.py" in files
+    assert "new_file.py" in files
+
+
+def test_get_files_falls_back_on_git_error(tmp_path):
+    """Verify that if git ls-files fails, all files are included via
+    the filesystem fallback."""
+    test_file = tmp_path / "fallback.py"
+    test_file.write_text("fallback")
+
+    mock_repo = MagicMock()
+    mock_repo.working_dir = str(tmp_path)
+    mock_repo.git.ls_files = MagicMock(side_effect=Exception("git error"))
+
+    archive = CodeArchive(root=str(tmp_path))
+
+    with patch.object(
+        CodeArchive, "git_repo", new_callable=PropertyMock
+    ) as mock_git_repo:
+        mock_git_repo.return_value = mock_repo
+        files = archive.get_files()
+
+    assert "fallback.py" in files


### PR DESCRIPTION
## Summary
- Split the `git ls-files` call in `CodeArchive.get_files()` into two separate calls: one with `--recurse-submodules` for tracked files (including submodule contents) and one for untracked/modified files
- This is necessary because `--recurse-submodules` is only compatible with `--cached` mode per git documentation
- Backwards compatible: repos without submodules work exactly as before
- Only affects the artifact store upload path (`allow_download_from_artifact_store`), not the code repository download path

Fixes #4408

## Test plan
- [x] Unit tests verifying `--recurse-submodules` is passed in the tracked-files call
- [x] Unit tests verifying untracked/modified files are still included via the second call
- [x] Unit test verifying fallback behavior when git commands fail
- [ ] Manual verification with a repo containing git submodules and `allow_download_from_artifact_store: true`