### PR TITLE
fix(artifacts): accumulate chunks before writing to ZIP entry

### DIFF
--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -620,14 +620,26 @@ def download_artifact_files_from_response(
                     with artifact_store.open(
                         file_path, mode="rb"
                     ) as store_file:
-                        # Use a loop to read and write chunks of the file
-                        # instead of reading the entire file into memory
+                        # Stream chunks into a single ZIP entry using
+                        # zipf.open() as a writable context manager.
+                        #
+                        # Bug fix (issue #4349): The previous implementation
+                        # called zipf.writestr(file_str, chunk) inside a
+                        # loop, which created a *new* ZIP entry for every
+                        # chunk instead of appending to the same entry.
+                        # Only the last chunk survived in the archive for
+                        # any file larger than CHUNK_SIZE (8 192) bytes.
+                        #
+                        # Fix: open a single writable ZIP entry via
+                        # zipf.open(file_str, 'w') and write each chunk
+                        # into it, so all chunks end up in one entry.
                         CHUNK_SIZE = 8192
-                        while True:
-                            if file_content := store_file.read(CHUNK_SIZE):
-                                zipf.writestr(file_str, file_content)
-                            else:
-                                break
+                        with zipf.open(file_str, "w") as zip_entry:
+                            while True:
+                                file_content = store_file.read(CHUNK_SIZE)
+                                if not file_content:
+                                    break
+                                zip_entry.write(file_content)
         except Exception as e:
             logger.error(
                 f"Failed to save artifact '{artifact.id}' to zip file "


### PR DESCRIPTION
## Description

Fixes #4349

### Problem

 in `src/zenml/artifacts/utils.py` called `zipf.writestr(file_str, chunk)` inside a `while True` read loop. Each call to `writestr` **creates a brand-new ZIP entry** with the same name — it does not append to the existing one. As a result, only the final (often partial) chunk ends up in the archive for any file larger than `CHUNK_SIZE` (8 192 bytes), silently truncating/corrupting larger artifact files.

### Fix

Replaced the `zipf.writestr()`-per-chunk pattern with `zipf.open(file_str, "w")` which returns a writable file-like object that streams all chunks into a **single** ZIP entry, preserving the complete file content regardless of size.

```python
# Before (broken – new entry created each iteration)
while True:
    if file_content := store_file.read(CHUNK_SIZE):
        zipf.writestr(file_str, file_content)   # overwrites!
    else:
        break

# After (correct – one entry, all chunks streamed in)
with zipf.open(file_str, "w") as zip_entry:
    while True:
        file_content = store_file.read(CHUNK_SIZE)
        if not file_content:
            break
        zip_entry.write(file_content)
```

### Impact

- Artifact files > 8 192 bytes downloaded via `download_artifact_files_from_response` were silently truncated / contained only their last chunk.
- The fix is backward-compatible and does not change any public API.

### Tests

The existing integration test in `tests/integration/functional/artifacts/test_utils.py` covers this function. The fix ensures large artifacts (> 8 192 bytes) are now correctly preserved in the downloaded ZIP.