### PR TITLE
Fix typos caught by updated typos CI (v1.43.5)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -7,7 +7,9 @@ extend-exclude = [
     "tests/unit/materializers/test_built_in_materializer.py",
     "tests/integration/functional/cli/test_pipeline.py",
     "src/zenml/zen_server/dashboard/",
-    "examples/llm_finetuning/lit_gpt/"
+    "examples/llm_finetuning/lit_gpt/",
+    "RELEASE_NOTES.md",
+    "docs/book/how-to/manage-zenml-server/migration-guide/",
 ]
 
 [default.extend-identifiers]
@@ -40,6 +42,11 @@ OT = "OT"
 cll = "cll"
 ser = "ser"
 fo = "fo"
+Conveyer = "Conveyer"  # Column name in Steel Plates Faults dataset
+Packt = "Packt"  # Packt Publishing (publisher name)
 
 [default]
 locale = "en-us"
+extend-ignore-re = [
+    "(?Rm)^.*#\\s*typos:\\s*ignore$",
+]

--- a/docs/book/component-guide/orchestrators/skypilot-vm.md
+++ b/docs/book/component-guide/orchestrators/skypilot-vm.md
@@ -333,7 +333,7 @@ For additional configuration of the Skypilot orchestrator, you can pass `Setting
 * `workdir`: Working directory on the local machine to sync to the VM. This is synced to `~/sky_workdir` inside the VM.
 * `task_name`: Human-readable task name shown in SkyPilot for display purposes.
 * `file_mounts`: File and storage mounts configuration to make local or cloud storage paths available inside the remote cluster.
-* `envs`: Environment variables for the task. Accessible in the VMs that Skypilot launches, not in Docker continaers that the steps and pipeline is running on.
+* `envs`: Environment variables for the task. Accessible in the VMs that Skypilot launches, not in Docker containers that the steps and pipeline is running on.
 * `task_settings`: Dictionary of arbitrary settings forwarded to `sky.Task()`. This allows passing future parameters added by SkyPilot without requiring updates to ZenML.
 * `resources_settings`: Dictionary of arbitrary settings forwarded to `sky.Resources()`. This allows passing future parameters added by SkyPilot without requiring updates to ZenML.
 * `launch_settings`: Dictionary of arbitrary settings forwarded to `sky.launch()`. This allows passing future parameters added by SkyPilot without requiring updates to ZenML.

--- a/docs/book/how-to/manage-zenml-server/using-zenml-server-in-prod.md
+++ b/docs/book/how-to/manage-zenml-server/using-zenml-server-in-prod.md
@@ -92,7 +92,7 @@ An important component of the ZenML server deployment is the backing database. W
 
 We would recommend starting out with a simple (single) database instance and then monitoring it to decide if it needs scaling. Some common metrics to look out for:
 
-* CPU Utilization: If the CPU Utilization is consistently above 50%, you may need to scale your database. Some spikes in the utlization are expected but it should not be consistently high.
+* CPU Utilization: If the CPU Utilization is consistently above 50%, you may need to scale your database. Some spikes in the utilization are expected but it should not be consistently high.
 * Freeable Memory: It is natural for the freeable memory to go down with time as your database uses it for caching and buffering but if it drops below 100-200 MB, you may need to scale your database.
 
 ## Setting up an ingress/load balancer

--- a/docs/book/how-to/steps-pipelines/logging.md
+++ b/docs/book/how-to/steps-pipelines/logging.md
@@ -243,7 +243,7 @@ def async_step() -> None:
     thread.join()
 ```
 
-As a workaournd, you can run it under the copied `contextvars` context so
+As a workaround, you can run it under the copied `contextvars` context so
 ZenML can associate the log records with the running step:
 
 ```python

--- a/examples/e2e_nlp/steps/__init__.py
+++ b/examples/e2e_nlp/steps/__init__.py
@@ -28,7 +28,7 @@ from .register import register_model
 from .tokenizer_loader import (
     tokenizer_loader,
 )
-from .tokenzation import (
+from .tokenzation import (  # typos: ignore
     tokenization_step,
 )
 from .training import model_trainer

--- a/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
+++ b/src/zenml/integrations/mlflow/steps/mlflow_deployer.py
@@ -63,7 +63,7 @@ def mlflow_model_deployer_step(
     This step deploys a model logged in the MLflow artifact store to a
     deployment service. The user would typically use this step in a pipeline
     that deploys a model that was already registered in the MLflow model
-    registr either manually or by using the `mlflow_model_registry_step`.
+    registry either manually or by using the `mlflow_model_registry_step`.
 
     Args:
         deploy_decision: whether to deploy the model or not

--- a/src/zenml/integrations/seldon/seldon_client.py
+++ b/src/zenml/integrations/seldon/seldon_client.py
@@ -532,7 +532,7 @@ class SeldonClient:
         """Initialize the Kubernetes clients.
 
         Args:
-            context: a Kubernetes configuratino context to use.
+            context: a Kubernetes configuration context to use.
             kube_client: a Kubernetes client to use.
 
         Raises:

--- a/src/zenml/materializers/cloudpickle_materializer.py
+++ b/src/zenml/materializers/cloudpickle_materializer.py
@@ -37,7 +37,7 @@ class CloudpickleMaterializer(BaseMaterializer):
     """Materializer using cloudpickle.
 
     This materializer can materialize (almost) any object, but does so in a
-    non-reproducble way since artifacts cannot be loaded from other Python
+    non-reproducible way since artifacts cannot be loaded from other Python
     versions. It is recommended to use this materializer only as a last resort.
 
     That is also why it has `SKIP_REGISTRATION` set to True and is currently

--- a/src/zenml/utils/pydantic_utils.py
+++ b/src/zenml/utils/pydantic_utils.py
@@ -278,7 +278,7 @@ def validate_function_args(
         f
     )
 
-    # This raises a pydantic.ValidatonError in case the arguments are not valid
+    # This raises a pydantic.ValidationError in case the arguments are not valid
     validated_function(*args, **kwargs)
 
     return signature.bind(*validated_args, **validated_kwargs).arguments

--- a/tests/integration/examples/seldon/custom_predict/pytorch.py
+++ b/tests/integration/examples/seldon/custom_predict/pytorch.py
@@ -31,8 +31,8 @@ def pre_process(tensor: torch.Tensor) -> dict:
     Returns:
         dict: The processed data, in this case a dictionary with the tensor as value.
     """
-    tansformation = torchvision.transforms.Normalize((0.1307,), (0.3081,))
-    processed_tensor = tansformation(tensor.to(torch.float))
+    transformation = torchvision.transforms.Normalize((0.1307,), (0.3081,))
+    processed_tensor = transformation(tensor.to(torch.float))
     processed_tensor = processed_tensor.unsqueeze(0)
     return processed_tensor.float()
 


### PR DESCRIPTION
## Summary

Separated from #4507 (the dependabot CI actions bump) so typo fixes can be reviewed independently.

The `typos` CI version bump from 1.17.0 to 1.43.5 surfaced several previously undetected spelling errors. This PR:

- **Fixes 8 genuine typos** in docs, docstrings, comments, and a variable name (`continaers`, `reproducble`, `tansformation`, `registr`, `configuratino`, `Validaton`, `workaournd`, `utlization`)
- **Excludes `RELEASE_NOTES.md`** from spell checking (contains PR titles from external contributors)
- **Excludes `migration-guide/`** directory (historical CLI output with truncated column names)
- **Adds `Conveyer` and `Packt`** to the allowed words list (dataset column name and publisher name)
- **Adds `# typos: ignore` inline comment support** via `extend-ignore-re` for cases like the `e2e_nlp` module import where renaming isn't practical

## Test plan

- [x] `typos . --config ./.typos.toml` passes locally with zero errors
- [ ] CI spellcheck job passes