### PR TITLE
Update `.gitignore` to include Codex settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,10 +206,14 @@ examples/computer_vision/test_runs
 #generated folder by zenml
 zenml_tutorial/
 
-# Claude settings
+# Claude
 **/.claude/settings.local.json
 .claude/*
 !.claude/skills/
+
+# Codex
+.codex/*
+AGENTS.override.md
 
 .local/
 # PLEASE KEEP THIS LINE AT THE EOF: never include here src/zenml/zen_server/dashboard, since it is affecting release flow


### PR DESCRIPTION
## Summary
- Gitignore the `.codex/` directory (OpenAI Codex agent config), which is private to each developer — similar to how `.claude/` is already ignored
- Gitignore `AGENTS.override.md`, a local-only file that lets individual developers override the repo's `AGENTS.md` with custom agent instructions without committing their personal preferences
- Minor comment cleanup ("Claude settings" → "Claude")