### PR TITLE
Test selective CI routing with trivial change

### DIFF
--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -87,7 +87,7 @@ def b64_encode(input_: str) -> str:
 
 
 def b64_decode(input_: str) -> str:
-    """Returns a decoded string of the Base64 encoded input string.
+    """Returns a decoded string of the base 64 encoded input string.
 
     Args:
         input_: Base64 encoded string.


### PR DESCRIPTION
## Summary
- Reverts a docstring capitalization change in `string_utils.py`
- **Purpose**: Validate that the pilot-ci selective testing correctly skips heavy jobs (migrations, server-env) when only a trivial utility file changes

## Expected pilot-ci behavior
- `classify-changes`: should detect only `src/zenml/utils/string_utils.py` changed
- `needs_migrations`: **false** (no migration matcher hit)
- `needs_server_env`: **false** (no server env matcher hit)
- `default_test_scope`: **integration/functional** (narrow scope, no full-scope trigger)
- `sqlite-db-migration-testing-random`: **SKIPPED**
- `ubuntu-latest-integration-test-server`: **SKIPPED**
- `ubuntu-latest-integration-test-default`: runs with `integration/functional` scope

## Test plan
- [ ] Add `pilot-ci` label and confirm classification outputs
- [ ] Verify heavy jobs are skipped
- [ ] Close PR after validation