### PR TITLE
Fix azure integration dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ connectors-azure = [
     "azure-mgmt-containerregistry>=10.0.0",
     "azure-mgmt-storage>=20.0.0",
     "azure-storage-blob>=12.0.0",
-    "azure-mgmt-resource>=21.0.0",
+    "azure-mgmt-resource>=21.0.0,<25.0.0",
     "kubernetes>=18.20.0",
     "requests>=2.27.11,<3.0.0",
     "marshmallow<4.0.0",

--- a/src/zenml/integrations/azure/__init__.py
+++ b/src/zenml/integrations/azure/__init__.py
@@ -46,6 +46,10 @@ class AzureIntegration(Integration):
         "azure-identity",
         "azureml-core==1.56.0",
         "azure-mgmt-containerservice>=20.0.0",
+        # The 25.0.0 release splits the azure-mgmt-resource package into
+        # multiple packages, some of which don't have a stable (non-prerelease)
+        # version yet. See https://github.com/Azure/azure-sdk-for-python/releases/tag/azure-mgmt-resource_25.0.0
+        "azure-mgmt-resource<25.0.0",
         "azure-storage-blob==12.17.0",  # temporary fix for https://github.com/Azure/azure-sdk-for-python/issues/32056
         "kubernetes",
         "azure-ai-ml==1.23.1",


### PR DESCRIPTION
## Describe changes
The 25.0.0 release splits the `azure-mgmt-resource` package into multiple packages, all of which need to be installed manually to be available. In our case, some of those new packages only have pre-releases available, so I decided to instead  limit the `azure-mgmt-resource` version instead.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

