### PR TITLE
Fix handling of variadic keyword args in pipeline function

### DIFF
--- a/src/zenml/utils/pydantic_utils.py
+++ b/src/zenml/utils/pydantic_utils.py
@@ -281,7 +281,29 @@ def validate_function_args(
     # This raises a pydantic.ValidatonError in case the arguments are not valid
     validated_function(*args, **kwargs)
 
-    return signature.bind(*validated_args, **validated_kwargs).arguments
+    bound_arguments = dict(
+        signature.bind(*validated_args, **validated_kwargs).arguments
+    )
+
+    variadic_keyword_parameter = next(
+        (
+            parameter.name
+            for parameter in signature.parameters.values()
+            if parameter.kind is inspect.Parameter.VAR_KEYWORD
+        ),
+        None,
+    )
+    if variadic_keyword_parameter and isinstance(
+        bound_arguments.get(variadic_keyword_parameter), dict
+    ):
+        # If the function defines a variadic keyword parameter, we expand the
+        # and include them flat in the return dictionary.
+        variadic_keyword_arguments = bound_arguments.pop(
+            variadic_keyword_parameter
+        )
+        bound_arguments.update(variadic_keyword_arguments)
+
+    return bound_arguments
 
 
 def model_validator_data_handler(

--- a/tests/unit/utils/test_pydantic_utils.py
+++ b/tests/unit/utils/test_pydantic_utils.py
@@ -154,3 +154,14 @@ def test_yaml_serialization_mixin(tmp_path):
     yaml_path.write_text(model.yaml())
 
     assert Model.from_yaml(str(yaml_path)) == model
+
+
+def test_validate_function_args_expands_variadic_keyword_arguments():
+    """Tests that the validate_function_args function expands variadic keyword
+    arguments."""
+
+    def f(a: int, **kwargs: int) -> None:
+        pass
+
+    validated = pydantic_utils.validate_function_args(f, None, 1, b="2", c=3)
+    assert validated == {"a": 1, "b": 2, "c": 3}


### PR DESCRIPTION
## Describe changes
Correctly handle variadic keyword arguments in pipeline functions. Previously, the keyword arguments were not flattened before calling the pipeline function. Instead they were being passed in a single dictionary, which would be treated as a single keyword argument.

Example:
```python
@pipeline
def my_pipeline(**kwargs):
  print(kwargs)
```
The above would print  `{'kwargs': {'kwargs': {'a': 1}}}` instead of `{'a': 1}`. (The double nesting was because the faulty internal function was called twice.)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

