### PR TITLE
Report all missing stack integrations at once   

### DIFF
--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -182,10 +182,54 @@ class Stack:
             hydrate=True,
         )
 
-        stack_components = {
-            model.type: StackComponent.from_model(model)
-            for model in component_models
-        }
+        stack_components = {}
+        missing_integrations: Dict[str, str] = {}
+        for model in component_models:
+            try:
+                stack_components[model.type] = StackComponent.from_model(
+                    model
+                )
+            except ImportError:
+                from zenml.integrations.registry import (
+                    integration_registry,
+                )
+
+                flavor_model = model.flavor
+                if (
+                    flavor_model.integration
+                    and not integration_registry.is_installed(
+                        flavor_model.integration
+                    )
+                ):
+                    missing_integrations[flavor_model.integration] = (
+                        flavor_model.name
+                    )
+                else:
+                    raise
+
+        if missing_integrations:
+            from zenml.integrations.registry import integration_registry
+
+            all_integrations = " ".join(missing_integrations.keys())
+            all_requirements = " ".join(
+                f"'{req}'"
+                for integration in missing_integrations
+                for req in integration_registry.select_integration_requirements(
+                    integration
+                )
+            )
+            component_details = ", ".join(
+                f"`{flavor}` ({integration})"
+                for integration, flavor in missing_integrations.items()
+            )
+            raise ImportError(
+                f"Your active stack requires the following integrations "
+                f"which are not installed: {component_details}. "
+                f"You can install all of them at once using the CLI:\n\n"
+                f"  zenml integration install {all_integrations}\n\n"
+                f"Or by manually installing the requirements:\n\n"
+                f"  pip install {all_requirements}\n"
+            )
         stack = Stack.from_components(
             id=stack_model.id,
             name=stack_model.name,


### PR DESCRIPTION
Summary         

  - When a stack has multiple uninstalled integrations, Stack.from_model() previously failed on the first missing one
   and stopped. Users had to install integrations one at a time across repeated failed pipeline runs.
  - Now all component imports are attempted, missing integrations are collected, and a single actionable error is
  raised listing everything that needs to be installed — with copy-pasteable commands for both zenml integration
  install and pip install (shell-safe with quoted version specifiers).

  Before:
  ImportError: No module named 's3fs'
  The `s3` integration that you are trying to use is not installed...
  (fix, re-run, hit next missing integration, repeat)

  After:
  ImportError: Your active stack requires the following integrations
  which are not installed: `s3fs` (s3), `kubeflow` (kubeflow), `mlflow` (mlflow).
  You can install all of them at once using the CLI:

    zenml integration install s3 kubeflow mlflow

  Or by manually installing the requirements:

    pip install 's3fs>2022.3.0,!=2025.3.1' 'boto3' 'kfp>=2.6.0' ...

  Test plan

  - Set up a stack with multiple integration-based components (e.g., s3 artifact store + kubeflow orchestrator)
  without installing either integration
  - Run a pipeline and verify the error message lists all missing integrations in a single error
  - Verify the suggested zenml integration install command installs everything needed
  - Verify that a stack with only built-in components (no integrations) still works without changes
  - Verify that a non-integration ImportError (e.g., broken built-in component) is still raised immediately