### PR TITLE
Remove wrong error message when running dynamic snapshots

### DIFF
--- a/src/zenml/zen_server/pipeline_execution/utils.py
+++ b/src/zenml/zen_server/pipeline_execution/utils.py
@@ -175,11 +175,6 @@ def run_snapshot(
                 "not have an associated build. This is probably because the "
                 "build has been deleted."
             )
-        if snapshot.is_dynamic:
-            raise ValueError(
-                "Snapshots of dynamic pipelines can not be run via the server "
-                "yet."
-            )
 
         raise ValueError("This snapshot can not be run via the server.")
 


### PR DESCRIPTION
## Describe changes
This PR removes one remaining exception when running a snapshot of a dynamic pipeline.
Running dynamic snapshots has been possible for some time, but this exception was missed. It didn't actually prevent any execution (even for static pipelines the next line would raise an exception), it was just giving users a misleading message.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

