### PR TITLE
Fix for SDK docs release

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Get the version from the github branch name
         id: get_version
         run: |
-          BRANCH="${GITHUB_REF_NAME}""
+          BRANCH="${GITHUB_REF_NAME}"
           echo ::set-output name=VERSION::${BRANCH#release/}
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8  # v4.0.1
         with:


### PR DESCRIPTION
## Describe changes
Going from 0.93.1 to 0.93.2, we switched the ref name from GitHub expression syntax `${{ github.ref_name }}` to shell syntax `${GITHUB_REF_NAME}`, but kept single quotes, which prevented shell expansion. As a result, the workflow passed the literal string ${GITHUB_REF_NAME} to docs publishing instead of the release branch version.

We still need to remove this version, and probably add the missing `0.93.2` and `0.93.3` versions.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

