### PR TITLE
Fix kubernetes service selector

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -55,6 +55,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Selector labels for server-only resources
+*/}}
+{{- define "zenml.serverSelectorLabels" -}}
+{{ include "zenml.selectorLabels" . }}
+app.kubernetes.io/component: server
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "zenml.serviceAccountName" -}}

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -15,6 +15,8 @@ spec:
   {{- end }}
   selector:
     matchLabels:
+      # TODO: this should also include the server component label, but
+      # adding it now would fail for existing installations.
       {{- include "zenml.selectorLabels" . | nindent 6 }}
   template:
     metadata:

--- a/helm/templates/server-service.yaml
+++ b/helm/templates/server-service.yaml
@@ -16,4 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "zenml.selectorLabels" . | nindent 4 }}
+    {{- include "zenml.serverSelectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Describe changes
Our kubernetes server used a label selector that was too broad, so it selected not only the server pod but also scheduler/executor pods.

This meant the scheduler/executor pods received HTTP requests which they didn't handle, which caused refused connections and 502 errors.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

