### PR TITLE
Add pipeline run stop support for Vertex AI orchestrator

### DIFF
--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -842,6 +842,56 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
         job_name = step_run.run_metadata[STEP_JOB_NAME_METADATA_KEY]
         client.cancel_custom_job(name=job_name)
 
+    def _stop_run(
+        self, run: "PipelineRunResponse", graceful: bool = False
+    ) -> None:
+        """Stops a pipeline run on Vertex AI.
+
+        Args:
+            run: The pipeline run to stop.
+            graceful: If True, does nothing (lets the pipeline finish
+                naturally). If False, cancels the Vertex AI job.
+
+        Raises:
+            ValueError: If the orchestrator run ID cannot be found.
+        """
+        if graceful:
+            logger.info(
+                "Graceful stop requested - letting the Vertex AI pipeline "
+                "finish naturally."
+            )
+            return
+
+        if METADATA_ORCHESTRATOR_RUN_ID in run.run_metadata:
+            run_id = run.run_metadata[METADATA_ORCHESTRATOR_RUN_ID]
+        elif run.orchestrator_run_id is not None:
+            run_id = run.orchestrator_run_id
+        else:
+            raise ValueError(
+                "Cannot find the orchestrator run ID to stop the pipeline."
+            )
+
+        credentials, project_id = self._get_authentication()
+
+        if run.snapshot and run.snapshot.is_dynamic:
+            job = aiplatform.CustomJob.get(
+                run_id,
+                project=project_id,
+                location=self.config.location,
+                credentials=credentials,
+            )
+        else:
+            job = aiplatform.PipelineJob.get(
+                run_id,
+                project=project_id,
+                location=self.config.location,
+                credentials=credentials,
+            )
+
+        logger.info("Cancelling Vertex AI job '%s'...", run_id)
+        job.cancel()
+        logger.info("Successfully requested cancellation of job '%s'.", run_id)
+
     def _upload_and_run_pipeline(
         self,
         pipeline_name: str,

--- a/tests/integration/integrations/gcp/orchestrators/test_vertex_orchestrator.py
+++ b/tests/integration/integrations/gcp/orchestrators/test_vertex_orchestrator.py
@@ -279,3 +279,108 @@ def test_vertex_orchestrator_configure_container_resources(
         return True
 
     assert assert_dict_is_subset(expected_resources, job_spec["resources"])
+
+
+def test_vertex_orchestrator_stop_run_graceful(mocker) -> None:
+    """Tests that graceful stop returns early without cancelling."""
+    orchestrator = _get_vertex_orchestrator(
+        location="europe-west4",
+        pipeline_root="gs://my-bucket/pipeline",
+    )
+
+    mock_run = mocker.MagicMock()
+    mock_run.run_metadata = {"orchestrator_run_id": "test-run-id"}
+    mock_run.orchestrator_run_id = "test-run-id"
+
+    mock_auth = mocker.patch.object(
+        orchestrator, "_get_authentication", return_value=("creds", "project")
+    )
+
+    orchestrator._stop_run(mock_run, graceful=True)
+
+    mock_auth.assert_not_called()
+
+
+def test_vertex_orchestrator_stop_run_forceful_static(mocker) -> None:
+    """Tests that forceful stop cancels a static PipelineJob."""
+    from google.cloud import aiplatform
+
+    orchestrator = _get_vertex_orchestrator(
+        location="europe-west4",
+        pipeline_root="gs://my-bucket/pipeline",
+    )
+
+    mock_run = mocker.MagicMock()
+    mock_run.run_metadata = {"orchestrator_run_id": "test-run-id"}
+    mock_run.orchestrator_run_id = "test-run-id"
+    mock_run.snapshot.is_dynamic = False
+
+    mocker.patch.object(
+        orchestrator, "_get_authentication", return_value=("creds", "project")
+    )
+
+    mock_job = mocker.MagicMock()
+    mock_get = mocker.patch.object(
+        aiplatform.PipelineJob, "get", return_value=mock_job
+    )
+
+    orchestrator._stop_run(mock_run, graceful=False)
+
+    mock_get.assert_called_once_with(
+        "test-run-id",
+        project="project",
+        location="europe-west4",
+        credentials="creds",
+    )
+    mock_job.cancel.assert_called_once()
+
+
+def test_vertex_orchestrator_stop_run_forceful_dynamic(mocker) -> None:
+    """Tests that forceful stop cancels a dynamic CustomJob."""
+    from google.cloud import aiplatform
+
+    orchestrator = _get_vertex_orchestrator(
+        location="europe-west4",
+        pipeline_root="gs://my-bucket/pipeline",
+    )
+
+    mock_run = mocker.MagicMock()
+    mock_run.run_metadata = {"orchestrator_run_id": "test-run-id"}
+    mock_run.orchestrator_run_id = "test-run-id"
+    mock_run.snapshot.is_dynamic = True
+
+    mocker.patch.object(
+        orchestrator, "_get_authentication", return_value=("creds", "project")
+    )
+
+    mock_job = mocker.MagicMock()
+    mock_get = mocker.patch.object(
+        aiplatform.CustomJob, "get", return_value=mock_job
+    )
+
+    orchestrator._stop_run(mock_run, graceful=False)
+
+    mock_get.assert_called_once_with(
+        "test-run-id",
+        project="project",
+        location="europe-west4",
+        credentials="creds",
+    )
+    mock_job.cancel.assert_called_once()
+
+
+def test_vertex_orchestrator_stop_run_missing_run_id(mocker) -> None:
+    """Tests that stop raises ValueError when run ID is missing."""
+    orchestrator = _get_vertex_orchestrator(
+        location="europe-west4",
+        pipeline_root="gs://my-bucket/pipeline",
+    )
+
+    mock_run = mocker.MagicMock()
+    mock_run.run_metadata = {}
+    mock_run.orchestrator_run_id = None
+
+    with pytest.raises(
+        ValueError, match="Cannot find the orchestrator run ID"
+    ):
+        orchestrator._stop_run(mock_run, graceful=False)


### PR DESCRIPTION
## Summary

- Implements `_stop_run()` on `VertexOrchestrator`, enabling users to stop running Vertex AI pipeline runs via CLI (`zenml pipeline runs stop`) or the dashboard
- Handles both static pipelines (`PipelineJob.cancel()`) and dynamic pipelines (`CustomJob.cancel()`)
- Follows the same pattern as the existing Kubernetes orchestrator implementation
- No new dependencies, schema changes, or migrations needed — all infrastructure (CLI, API endpoint, status mapping) already exists

## Test plan

- [x] `mypy` passes on the changed file
- [x] `bash scripts/format.sh` produces no changes
- [x] Unit tests added and passing (graceful stop, forceful static, forceful dynamic, missing run ID)
- [ ] Test stopping a static Vertex AI pipeline run (PipelineJob) on live environment
- [ ] Test stopping a dynamic Vertex AI pipeline run (CustomJob) on live environment
- [ ] Verify dashboard stop button appears and works for Vertex AI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)