### PR TITLE
Add `ARG` instructions to Dockerfile for build arguments defined in DockerSettings

### DIFF
--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -731,6 +731,15 @@ class PipelineDockerImageBuilder:
         """
         lines = [f"FROM {parent_image}", f"WORKDIR {DOCKER_IMAGE_WORKDIR}"]
 
+        if (
+            docker_settings.build_config
+            and docker_settings.build_config.build_options
+        ):
+            b_args = docker_settings.build_config.build_options.build_args
+            if b_args:
+                for arg_key in b_args.keys():
+                    lines.append(f"ARG {arg_key}")
+
         for key, value in docker_settings.environment.items():
             lines.append(f"ENV {key.upper()}='{value}'")
 

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -19,6 +19,7 @@ import pytest
 
 from zenml.client import Client
 from zenml.config import DockerSettings
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
 from zenml.integrations.sklearn import SKLEARN, SklearnIntegration
 from zenml.utils.pipeline_docker_image_builder import (
     PipelineDockerImageBuilder,
@@ -228,3 +229,33 @@ def test_dockerfile_needs_to_exist():
             stack=Client().active_stack,
             include_files=True,
         )
+
+
+def test_build_args_are_added_to_dockerfile():
+    """Tests that build args from the Docker settings are added to the
+    Dockerfile."""
+    # No build args specified
+    docker_settings = DockerSettings()
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag",
+            docker_settings,
+        )
+    )
+    assert "ARG" not in generated_dockerfile
+
+    # Build args are specified
+    docker_settings = DockerSettings(
+        build_config=DockerBuildConfig(
+            build_options=DockerBuildOptions(
+                build_args={"ARG1": "VALUE1", "ARG2": "VALUE2"}
+            )
+        )
+    )
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag", docker_settings
+        )
+    )
+    assert "ARG ARG1" in generated_dockerfile
+    assert "ARG ARG2" in generated_dockerfile


### PR DESCRIPTION
## Describe changes

I implemented the addition of `ARG <key>` instructions to the auto-generated Dockerfile for each build argument defined in `DockerSettings`. 

This ensures that build arguments are correctly declared in the Dockerfile during the image build process.

Closes #4599 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
