### PR TITLE
Don't pass pipeline run and step run ids to logs request

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -10247,7 +10247,6 @@ class SqlZenStore(BaseZenStore):
                             source=logs_request.source or "step",
                             artifact_store_id=logs_request.artifact_store_id,
                             log_store_id=logs_request.log_store_id,
-                            pipeline_run_id=step_schema.pipeline_run_id,
                             step_run_id=step_schema.id,
                         ),
                         session=session,


### PR DESCRIPTION
## Describe changes
Don't pass both pipeline run ID and step run ID to the logs request when creating logs as part of a step run. This fixes a client-server compatibility issue with clients `<=0.92.0`

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

