### PR TITLE
Fix dict size change during iteration error

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -258,7 +258,11 @@ class DynamicPipelineRunner:
             start_time = time.time()
             finished_step_runs = []
 
-            for invocation_id, step_run in self._steps_to_monitor.items():
+            # Copy the steps to avoid the dictionary getting modified by
+            # the main thread while we're iterating over it.
+            for invocation_id, step_run in list(
+                self._steps_to_monitor.items()
+            ):
                 infra_status: Optional[ExecutionStatus] = None
                 try:
                     infra_status = self._get_isolated_step_infra_status(


### PR DESCRIPTION
## Describe changes
When running dynamic pipelines, the main thread could potentially modify the `_steps_to_monitor` dictionary while the monitoring thread was iterating over it, which caused an exception.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

