### PR TITLE
fix: replace bare except with except BaseException in kaniko image builder

### DIFF
--- a/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
+++ b/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
@@ -291,7 +291,7 @@ class KanikoImageBuilder(BaseImageBuilder):
 
             try:
                 return_code = p.wait()
-            except:
+            except BaseException:
                 p.kill()
                 raise
 


### PR DESCRIPTION
## Summary

Replace a bare `except:` clause with `except BaseException:` in `kaniko_image_builder.py`.

**Change:**
```python
# Before
try:
    return_code = p.wait()
except:
    p.kill()
    raise

# After
try:
    return_code = p.wait()
except BaseException:
    p.kill()
    raise
```

The bare `except:` was intentional (catch-all before killing the process and re-raising), but using explicit `except BaseException:` makes the intent clear and avoids linter warnings without suppression. Behavior is identical.