### PR TITLE
fix: replace bare `except:` with `except BaseException:` in kaniko_image_builder.py

### DIFF
--- a/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
+++ b/src/zenml/integrations/kaniko/image_builders/kaniko_image_builder.py
@@ -291,7 +291,7 @@ class KanikoImageBuilder(BaseImageBuilder):
 
             try:
                 return_code = p.wait()
-            except:
+            except BaseException:
                 p.kill()
                 raise
 


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except BaseException:` in `kaniko_image_builder.py` to comply with PEP 8 E722.

The bare `except` clause catches everything including `KeyboardInterrupt` and `SystemExit`. Since this block performs cleanup (`p.kill()`) and then re-raises, `except BaseException:` is the correct explicit replacement.

**Change:**
```python
# Before
except:
    p.kill()
    raise

# After
except BaseException:
    p.kill()
    raise
```

## Testing
No behavior change — bare `except:` is equivalent to `except BaseException:`, this just makes the intent explicit.