### PR TITLE
Fix deployer dashboard HTML when Jinja2/Starlette template loading breaks

### DIFF
--- a/src/zenml/deployers/server/fastapi/app.py
+++ b/src/zenml/deployers/server/fastapi/app.py
@@ -209,6 +209,13 @@ class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
 
             # everything else is directed to the index.html file that hosts the
             # single-page application - this is to support client-side routing
+
+            # Using get_template + Template.render + HTMLResponse instead of
+            # Jinja2Templates.TemplateResponse. Starlette's _TemplateResponse
+            # path can interact with Jinja 3.1.x template caching around globals
+            # and raise TypeError (e.g. unhashable dict) in some environments.
+            # Explicit load and render preserves the same template context
+            # (request, service_info) that TemplateResponse would set.
             template = templates.get_template("index.html")
             html = template.render(
                 request=request,


### PR DESCRIPTION
## Describe changes
The FastAPI deployment app’s dashboard catch-all route used Jinja2Templates.TemplateResponse(). On some environments (e.g. Kubernetes with newer Jinja2), that path can raise TypeError: unhashable type: 'dict' during template load/render, which prevents the server from starting when the dashboard is enabled.

What changed:
* Replaced `templates.TemplateResponse(...)` with explicit `templates.get_template("index.html")`, `template.render(request=..., service_info=...)`, and `HTMLResponse(content=html)`.
* Behavior for clients is unchanged: same template, same context (request, service_info), same HTML response.

Why this approach: Rendering via `Template.render` and returning `HTMLResponse` avoids Starlette’s `TemplateResponse` wrapper and keeps template loading independent of per-request context being threaded through APIs that interact badly with Jinja’s template cache across Jinja2/Starlette versions.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

