### PR TITLE
Only group minor/patch dependabot action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,10 @@ updates:
     reviewers: [strickvl]
     labels: [dependencies, internal, no-release-notes]
     groups:
-      all-actions:
+      minor-and-patch:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     target-branch: develop


### PR DESCRIPTION
## Summary
- Changes the dependabot GitHub Actions grouping strategy so only minor and patch updates are grouped together
- Major version bumps will now create individual PRs, making them easier to review and assess for breaking changes
- This addresses the issue where all 31 action updates were bundled into a single massive PR (#4643)

## Test plan
- [ ] Verify dependabot picks up the new config on next scheduled run (Tuesday 07:00 CET)
- [ ] Confirm minor/patch updates still arrive as a single grouped PR
- [ ] Confirm major version bumps arrive as separate individual PRs