### PR TITLE
Fix O(N) global scan in artifact-version delete

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -5195,9 +5195,10 @@ class Client(metaclass=ClientMetaClass):
         Raises:
             ValueError: If the artifact version is still used in any runs.
         """
-        if artifact_version not in depaginate(
-            self.list_artifact_versions, only_unused=True
-        ):
+        unused_versions = self.list_artifact_versions(
+            id=artifact_version.id, only_unused=True, size=1
+        )
+        if not unused_versions.items:
             raise ValueError(
                 "The metadata of artifact versions that are used in runs "
                 "cannot be deleted. Please delete all runs that use this "


### PR DESCRIPTION
## Summary

- Replaces the global `depaginate(list_artifact_versions, only_unused=True)` membership check in `_delete_artifact_version` with a targeted query that filters by the specific artifact version ID (`id=artifact_version.id, only_unused=True, size=1`)
- This avoids re-listing every unused artifact version on each delete call, which caused O(N) paginated API requests per deletion (see #4684 for profiling data showing ~41s per delete reduced to ~0.6s)

## Test plan

- [ ] Verify `Client.delete_artifact_version()` still raises `ValueError` for in-use artifact versions
- [ ] Verify unused artifact versions are deleted successfully
- [ ] Confirm paginated GET calls are reduced from O(N) to 1 per deletion

Fixes #4684