### PR TITLE
Make init_logging() idempotent on re-entry

### DIFF
--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -361,11 +361,16 @@ def init_logging() -> None:
     # Add both handlers to the root logger
     root_logger = logging.getLogger()
 
-    # Console handler - writes to original stdout
-    root_logger.addHandler(get_console_handler())
+    # Skip re-adding handlers if init_logging() has already been called.
+    # Re-entry would otherwise attach duplicate ConsoleHandler/ZenMLLoggingHandler
+    # instances to the root logger and cause duplicate log output.
+    existing_handler_types = {type(h) for h in root_logger.handlers}
+    if ZenMLLoggingHandler not in existing_handler_types:
+        # Console handler - writes to original stdout
+        root_logger.addHandler(get_console_handler())
 
-    # ZenML handler - routes through LoggingContext
-    root_logger.addHandler(get_zenml_handler())
+        # ZenML handler - routes through LoggingContext
+        root_logger.addHandler(get_zenml_handler())
 
     # Mute tensorflow cuda warnings
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"


### PR DESCRIPTION
`init_logging()` unconditionally attaches a `ConsoleHandler` and a `ZenMLLoggingHandler` to the root logger each time it is called. If something triggers it more than once in the same process (tests, nested imports, reloaders), each call stacks another pair of handlers, causing duplicate output for every log record.

This patch checks for an existing `ZenMLLoggingHandler` on the root logger before adding handlers, so subsequent calls are a no-op for the handler set.

Fixes #4683