### PR TITLE
Don't block while waiting for concurrent step inputs

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -14,6 +14,7 @@
 """Future registry for dynamic pipeline execution."""
 
 import threading
+import time
 from typing import Dict, List, Optional, Union
 
 from zenml.execution.pipeline.dynamic.outputs import (
@@ -188,12 +189,30 @@ class FutureRegistry:
             ]
 
     def await_all_no_raise(self) -> None:
-        """Wait for all tracked futures to finish without raising.
+        """Wait for all tracked futures to finish without raising."""
+        futures = self.get_all_futures()
 
-        This is used during runner cleanup so secondary step failures do not
-        replace the primary pipeline outcome.
-        """
-        for future in self.get_all_futures():
+        # Poll all futures concurrently before awaiting each of them. This
+        # avoids long cumulative waits when individual futures use backoff-based
+        # polling internally.
+        poll_interval_seconds = 2.0
+        while True:
+            any_running = False
+            for future in futures:
+                try:
+                    if future.running():
+                        any_running = True
+                        break
+                except Exception:
+                    # We still fall back to `wait()` below for this future.
+                    continue
+
+            if not any_running:
+                break
+
+            time.sleep(poll_interval_seconds)
+
+        for future in futures:
             try:
                 future.wait()
             except Exception:

--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -21,6 +21,9 @@ from zenml.execution.pipeline.dynamic.outputs import (
     StepExecutionFuture,
     StepFuture,
 )
+from zenml.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class StartupCancelled(Exception):
@@ -188,6 +191,18 @@ class FutureRegistry:
         """Wait for all tracked futures to finish."""
         for future in self._get_all_futures():
             future.wait()
+
+    def await_all_no_raise(self) -> None:
+        """Wait for all tracked futures to finish without raising.
+
+        This is used during runner cleanup so secondary step failures do not
+        replace the primary pipeline outcome.
+        """
+        for future in self._get_all_futures():
+            try:
+                future.wait()
+            except Exception:
+                pass
 
     def has_in_progress_work(self) -> bool:
         """Check whether any tracked future is still running.

--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -1,0 +1,226 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Future registry for dynamic pipeline execution."""
+
+import threading
+from typing import Dict, List, Union
+
+from zenml.execution.pipeline.dynamic.outputs import (
+    MapResultsFuture,
+    StepExecutionFuture,
+    StepFuture,
+)
+
+
+class StartupCancelled(Exception):
+    """Exception raised when an invocation startup is cancelled."""
+
+
+class FutureRegistry:
+    """Registry for user futures."""
+
+    def __init__(self) -> None:
+        """Initialize the future registry."""
+        self._lock = threading.RLock()
+        self._step_futures: Dict[str, StepFuture] = {}
+        self._map_futures: Dict[str, MapResultsFuture] = {}
+
+    def register_step_future(
+        self,
+        invocation_id: str,
+        future: StepFuture,
+    ) -> StepFuture:
+        """Register a step invocation future.
+
+        Args:
+            invocation_id: The step invocation ID.
+            future: The step future.
+
+        Raises:
+            RuntimeError: If a future already exists for the invocation.
+
+        Returns:
+            The registered step future.
+        """
+        with self._lock:
+            if invocation_id in self._step_futures:
+                raise RuntimeError(
+                    f"Step future for invocation `{invocation_id}` already exists."
+                )
+
+            self._step_futures[invocation_id] = future
+            return future
+
+    def register_map_future(
+        self, map_id: str, future: MapResultsFuture
+    ) -> MapResultsFuture:
+        """Register the future for a map invocation.
+
+        Args:
+            map_id: The map ID.
+            future: The map future.
+
+        Raises:
+            RuntimeError: If a future already exists for the map.
+
+        Returns:
+            The registered map future.
+        """
+        with self._lock:
+            if map_id in self._map_futures:
+                raise RuntimeError(
+                    f"Map future for map `{map_id}` already exists."
+                )
+
+            self._map_futures[map_id] = future
+            return future
+
+    def get_step_future(self, invocation_id: str) -> StepFuture:
+        """Get a step future.
+
+        Args:
+            invocation_id: The step invocation ID.
+
+        Raises:
+            KeyError: If the future does not exist.
+
+        Returns:
+            The step future.
+        """
+        with self._lock:
+            future = self._step_futures.get(invocation_id)
+            if future is None:
+                raise KeyError(f"Unknown step future `{invocation_id}`.")
+            return future
+
+    def get_map_future(self, map_id: str) -> MapResultsFuture:
+        """Get a map future.
+
+        Args:
+            map_id: The map ID.
+
+        Raises:
+            KeyError: If the future does not exist.
+
+        Returns:
+            The map future.
+        """
+        with self._lock:
+            future = self._map_futures.get(map_id)
+            if future is None:
+                raise KeyError(f"Unknown map future `{map_id}`.")
+            return future
+
+    def bind_step_execution_future(
+        self, invocation_id: str, future: StepExecutionFuture
+    ) -> None:
+        """Bind the step execution future to a step invocation.
+
+        Args:
+            invocation_id: The step invocation ID.
+            future: The future that represents the started step execution.
+        """
+        with self._lock:
+            step_future = self.get_step_future(invocation_id=invocation_id)
+            step_future._set_startup_result(future)
+
+    def fail_step_startup(
+        self, invocation_id: str, exception: BaseException
+    ) -> None:
+        """Store a startup failure for a step invocation.
+
+        Args:
+            invocation_id: The step invocation ID.
+            exception: The startup exception.
+        """
+        with self._lock:
+            future = self.get_step_future(invocation_id=invocation_id)
+            future._set_startup_failed(exception)
+
+    def bind_map_child_futures(
+        self, map_id: str, child_futures: List[StepFuture]
+    ) -> None:
+        """Bind expanded child futures to a map.
+
+        Args:
+            map_id: The map ID.
+            child_futures: The child step futures created for the map.
+        """
+        with self._lock:
+            future = self.get_map_future(map_id=map_id)
+            future._set_startup_result(child_futures)
+
+    def fail_map_startup(self, map_id: str, exception: BaseException) -> None:
+        """Store a startup failure for a map.
+
+        Args:
+            map_id: The map ID.
+            exception: The startup exception.
+        """
+        with self._lock:
+            future = self.get_map_future(map_id=map_id)
+            future._set_startup_failed(exception)
+
+    def _get_all_futures(self) -> List[Union[StepFuture, MapResultsFuture]]:
+        """Return all tracked futures.
+
+        Returns:
+            The tracked futures.
+        """
+        with self._lock:
+            return [
+                *self._step_futures.values(),
+                *self._map_futures.values(),
+            ]
+
+    def await_all(self) -> None:
+        """Wait for all tracked futures to finish."""
+        for future in self._get_all_futures():
+            future.wait()
+
+    def has_in_progress_work(self) -> bool:
+        """Check whether any tracked future is still running.
+
+        Returns:
+            True if any tracked future is still running, False otherwise.
+        """
+        return any(future.running() for future in self._get_all_futures())
+
+    def cancel_step_startup(self, invocation_id: str) -> None:
+        """Cancel startup for a specific step invocation.
+
+        Args:
+            invocation_id: The step invocation ID.
+        """
+        with self._lock:
+            step_future = self.get_step_future(invocation_id=invocation_id)
+            step_future._cancel_startup(
+                StartupCancelled(
+                    f"Startup for step `{invocation_id}` was cancelled."
+                )
+            )
+
+    def cancel_map_startup(self, map_id: str) -> None:
+        """Cancel startup for a specific map expansion.
+
+        Args:
+            map_id: The map ID.
+        """
+        with self._lock:
+            map_future = self.get_map_future(map_id=map_id)
+            map_future._cancel_startup(
+                StartupCancelled(
+                    f"Startup for map expansion `{map_id}` was cancelled."
+                )
+            )

--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -14,7 +14,7 @@
 """Future registry for dynamic pipeline execution."""
 
 import threading
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from zenml.execution.pipeline.dynamic.outputs import (
     MapResultsFuture,
@@ -175,11 +175,11 @@ class FutureRegistry:
             future = self.get_map_future(map_id=map_id)
             future._set_startup_failed(exception)
 
-    def _get_all_futures(self) -> List[Union[StepFuture, MapResultsFuture]]:
+    def get_all_futures(self) -> List[Union[StepFuture, MapResultsFuture]]:
         """Return all tracked futures.
 
         Returns:
-            The tracked futures.
+            A snapshot of all tracked futures.
         """
         with self._lock:
             return [
@@ -187,18 +187,13 @@ class FutureRegistry:
                 *self._map_futures.values(),
             ]
 
-    def await_all(self) -> None:
-        """Wait for all tracked futures to finish."""
-        for future in self._get_all_futures():
-            future.wait()
-
     def await_all_no_raise(self) -> None:
         """Wait for all tracked futures to finish without raising.
 
         This is used during runner cleanup so secondary step failures do not
         replace the primary pipeline outcome.
         """
-        for future in self._get_all_futures():
+        for future in self.get_all_futures():
             try:
                 future.wait()
             except Exception:
@@ -210,32 +205,42 @@ class FutureRegistry:
         Returns:
             True if any tracked future is still running, False otherwise.
         """
-        return any(future.running() for future in self._get_all_futures())
+        return any(future.running() for future in self.get_all_futures())
 
-    def cancel_step_startup(self, invocation_id: str) -> None:
+    def cancel_step_startup(
+        self,
+        invocation_id: str,
+        exception: Optional[StartupCancelled] = None,
+    ) -> None:
         """Cancel startup for a specific step invocation.
 
         Args:
             invocation_id: The step invocation ID.
+            exception: Optional exception to set on the future. If not
+                provided, a generic cancellation exception is used.
         """
+        exception = exception or StartupCancelled(
+            f"Startup for step `{invocation_id}` was cancelled."
+        )
         with self._lock:
             step_future = self.get_step_future(invocation_id=invocation_id)
-            step_future._cancel_startup(
-                StartupCancelled(
-                    f"Startup for step `{invocation_id}` was cancelled."
-                )
-            )
+            step_future._cancel_startup(exception)
 
-    def cancel_map_startup(self, map_id: str) -> None:
+    def cancel_map_startup(
+        self,
+        map_id: str,
+        exception: Optional[StartupCancelled] = None,
+    ) -> None:
         """Cancel startup for a specific map expansion.
 
         Args:
             map_id: The map ID.
+            exception: Optional exception to set on the future. If not
+                provided, a generic cancellation exception is used.
         """
+        exception = exception or StartupCancelled(
+            f"Startup for map expansion `{map_id}` was cancelled."
+        )
         with self._lock:
             map_future = self.get_map_future(map_id=map_id)
-            map_future._cancel_startup(
-                StartupCancelled(
-                    f"Startup for map expansion `{map_id}` was cancelled."
-                )
-            )
+            map_future._cancel_startup(exception)

--- a/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
+++ b/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
@@ -1,0 +1,545 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Invocation dependency graph."""
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Collection, Dict, List, Optional, Sequence, Set, Union
+
+from zenml.config.step_configurations import StepConfigurationUpdate
+from zenml.execution.pipeline.dynamic.outputs import AnyStepFuture
+from zenml.logger import get_logger
+from zenml.steps import BaseStep
+from zenml.utils.enum_utils import StrEnum
+
+logger = get_logger(__name__)
+
+
+class NodeState(StrEnum):
+    """Invocation dependency graph node state."""
+
+    PENDING = "pending"
+    READY = "ready"
+    STARTING = "starting"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the state is terminal.
+
+        Returns:
+            True if the state is terminal, False otherwise.
+        """
+        return self in {
+            NodeState.SUCCEEDED,
+            NodeState.FAILED,
+        }
+
+
+@dataclass(kw_only=True)
+class BaseNode:
+    """Base node in the dependency graph."""
+
+    node_id: str
+    state: NodeState = NodeState.PENDING
+    upstream_ids: Set[str] = field(default_factory=set)
+    downstream_ids: Set[str] = field(default_factory=set)
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the node is terminal.
+
+        Returns:
+            True if the node is terminal, False otherwise.
+        """
+        return self.state.is_terminal
+
+
+@dataclass(kw_only=True)
+class StepNode(BaseNode):
+    """Step graph node."""
+
+    parent_id: Optional[str] = None
+    step: Optional[BaseStep] = None
+    inputs: Optional[Dict[str, Any]] = None
+    after: Optional[Union[AnyStepFuture, Sequence[AnyStepFuture]]] = None
+    config_overrides: Optional["StepConfigurationUpdate"] = None
+
+
+@dataclass(kw_only=True)
+class MapNode(BaseNode):
+    """Map graph node."""
+
+    child_node_ids: Set[str] = field(default_factory=set)
+    step: BaseStep
+    inputs: Dict[str, Any]
+    after: Union[AnyStepFuture, Sequence[AnyStepFuture], None]
+    product: bool
+
+
+AnyNode = Union[StepNode, MapNode]
+
+
+class InvocationDependencyGraph:
+    """Invocation dependency graph."""
+
+    def __init__(self) -> None:
+        """Initialize the graph."""
+        self._lock = threading.RLock()
+        self._nodes: Dict[str, AnyNode] = {}
+
+    def register_step_node(
+        self,
+        node_id: str,
+        upstream_ids: Optional[Sequence[str]] = None,
+        state: Optional[NodeState] = None,
+        step: Optional[BaseStep] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        after: Optional[Union[AnyStepFuture, Sequence[AnyStepFuture]]] = None,
+        config_overrides: Optional["StepConfigurationUpdate"] = None,
+    ) -> bool:
+        """Register a step node.
+
+        Args:
+            node_id: The node ID.
+            upstream_ids: Optional upstream node IDs.
+            state: Optional initial state for the node.
+            step: Optional step payload for startup.
+            inputs: Optional input payload for startup.
+            after: Optional `after` payload for startup.
+            config_overrides: Optional config overrides for startup.
+
+        Returns:
+            Whether the registration caused any newly ready nodes.
+        """
+        node = StepNode(
+            node_id=node_id,
+            state=state or NodeState.PENDING,
+            step=step,
+            inputs=inputs,
+            after=after,
+            config_overrides=config_overrides,
+        )
+        return self._register_node(node=node, upstream_ids=upstream_ids)
+
+    def register_map_node(
+        self,
+        node_id: str,
+        step: BaseStep,
+        inputs: Dict[str, Any],
+        product: bool,
+        upstream_ids: Optional[Sequence[str]] = None,
+        state: Optional[NodeState] = None,
+        after: Optional[Union[AnyStepFuture, Sequence[AnyStepFuture]]] = None,
+    ) -> bool:
+        """Register a map aggregate node.
+
+        Args:
+            node_id: The graph node ID.
+            upstream_ids: Optional upstream node IDs.
+            state: Optional initial state for the node.
+            step: The mapped step payload for startup.
+            inputs: The input payload for startup.
+            after: Optional `after` payload for startup.
+            product: The map expansion mode.
+
+        Returns:
+            Whether the registration caused any newly ready nodes.
+        """
+        node = MapNode(
+            node_id=node_id,
+            state=state or NodeState.PENDING,
+            step=step,
+            inputs=inputs,
+            after=after,
+            product=product,
+        )
+        return self._register_node(node=node, upstream_ids=upstream_ids)
+
+    def get_step_node(self, node_id: str) -> StepNode:
+        """Get a step node by ID.
+
+        Args:
+            node_id: The node ID.
+
+        Raises:
+            RuntimeError: If the node does not exist or is not a step node.
+
+        Returns:
+            The step node.
+        """
+        with self._lock:
+            node = self._get_node(node_id=node_id)
+            if not isinstance(node, StepNode):
+                raise RuntimeError(f"Node `{node_id}` is not a step node.")
+            return node
+
+    def get_map_node(self, node_id: str) -> MapNode:
+        """Get a map node by ID.
+
+        Args:
+            node_id: The node ID.
+
+        Raises:
+            RuntimeError: If the node does not exist or is not a map node.
+
+        Returns:
+            The map node.
+        """
+        with self._lock:
+            node = self._get_node(node_id=node_id)
+            if not isinstance(node, MapNode):
+                raise RuntimeError(f"Node `{node_id}` is not a map node.")
+            return node
+
+    def attach_map_children(
+        self, map_node_id: str, child_node_ids: Sequence[str]
+    ) -> bool:
+        """Attach expanded child nodes to a map node.
+
+        Args:
+            map_node_id: The map node ID.
+            child_node_ids: The child step node IDs created by the expansion.
+
+        Returns:
+            Whether the attachment caused any newly ready nodes.
+        """
+        with self._lock:
+            map_node = self.get_map_node(node_id=map_node_id)
+            should_wake_startup_loop = False
+
+            if map_node.state in {NodeState.READY, NodeState.STARTING}:
+                self._set_node_state(
+                    node_id=map_node_id, state=NodeState.RUNNING
+                )
+
+            for child_node_id in child_node_ids:
+                child_node = self.get_step_node(node_id=child_node_id)
+                map_node.child_node_ids.add(child_node_id)
+                child_node.parent_id = map_node_id
+
+            if not child_node_ids:
+                should_wake_startup_loop = self._set_node_state(
+                    node_id=map_node_id, state=NodeState.SUCCEEDED
+                )
+            else:
+                should_wake_startup_loop = self._maybe_finalize_map_node(
+                    map_node_id=map_node_id
+                )
+
+            return should_wake_startup_loop
+
+    def list_nodes(
+        self, states: Optional[Collection[NodeState]] = None
+    ) -> List[AnyNode]:
+        """List graph nodes in insertion order.
+
+        Args:
+            states: Optional node states to filter by.
+
+        Returns:
+            The graph nodes in insertion order.
+        """
+        with self._lock:
+            return [
+                node
+                for node in self._nodes.values()
+                if states is None or node.state in states
+            ]
+
+    def list_ready_step_node_ids(self) -> List[str]:
+        """List all ready step node IDs.
+
+        Returns:
+            The ready step node IDs in insertion order.
+        """
+        with self._lock:
+            return [
+                node_id
+                for node_id, node in self._nodes.items()
+                if isinstance(node, StepNode) and node.state == NodeState.READY
+            ]
+
+    def list_ready_map_node_ids(self) -> List[str]:
+        """List all ready map node IDs.
+
+        Returns:
+            The ready map node IDs in insertion order.
+        """
+        with self._lock:
+            return [
+                node_id
+                for node_id, node in self._nodes.items()
+                if isinstance(node, MapNode) and node.state == NodeState.READY
+            ]
+
+    def mark_node_starting(self, node_id: str) -> bool:
+        """Mark a node as starting.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        return self._set_node_state(node_id=node_id, state=NodeState.STARTING)
+
+    def mark_node_running(self, node_id: str) -> bool:
+        """Mark a node as running.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        return self._set_node_state(node_id=node_id, state=NodeState.RUNNING)
+
+    def mark_node_succeeded(self, node_id: str) -> bool:
+        """Mark a node as successful.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        return self._set_node_state(node_id=node_id, state=NodeState.SUCCEEDED)
+
+    def mark_node_failed(self, node_id: str) -> bool:
+        """Mark a node as failed.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        return self._set_node_state(node_id=node_id, state=NodeState.FAILED)
+
+    def _register_node(
+        self,
+        node: AnyNode,
+        upstream_ids: Optional[Sequence[str]],
+    ) -> bool:
+        """Register a graph node.
+
+        Args:
+            node: The node to register.
+            upstream_ids: Optional upstream node IDs.
+
+        Raises:
+            RuntimeError: If an upstream node is unknown or a node with the same
+                ID but a different node type already exists.
+
+        Returns:
+            Whether the registration caused any newly ready nodes.
+        """
+        with self._lock:
+            if existing_node := self._nodes.get(node.node_id):
+                if type(existing_node) is not type(node):
+                    raise RuntimeError(
+                        f"Node `{node.node_id}` already exists as a different "
+                        "node type."
+                    )
+                return False
+
+            self._nodes[node.node_id] = node
+
+            for upstream_id in upstream_ids or []:
+                self._get_node(node_id=upstream_id)
+                node.upstream_ids.add(upstream_id)
+                self._nodes[upstream_id].downstream_ids.add(node.node_id)
+
+            if node.state == NodeState.READY:
+                return True
+
+            if node.state.is_terminal:
+                return self._handle_terminal_node_transition(
+                    node_id=node.node_id
+                )
+
+            return self._maybe_mark_node_ready(node_id=node.node_id)
+
+    def _validate_node_state_transition(
+        self, old_state: NodeState, new_state: NodeState
+    ) -> NodeState:
+        """Validate a node state transition.
+
+        Args:
+            old_state: The old state.
+            new_state: The new state.
+
+        Raises:
+            RuntimeError: If the state transition is invalid.
+
+        Returns:
+            The validated new state.
+        """
+        if old_state == new_state:
+            return new_state
+
+        if old_state.is_terminal and new_state == NodeState.RUNNING:
+            # Ignore potentially late updates that can happen if concurrent
+            # execution finishes first.
+            logger.debug(
+                "Ignore state transition from terminal state `%s` to `%s`.",
+                old_state,
+                new_state,
+            )
+            return old_state
+
+        if old_state.is_terminal:
+            raise RuntimeError(
+                f"Invalid state transition from `{old_state}` to `{new_state}`."
+            )
+
+        if new_state == NodeState.STARTING and old_state != NodeState.READY:
+            raise RuntimeError(
+                f"Invalid state transition from `{old_state}` to `{new_state}`."
+            )
+
+        if new_state == NodeState.RUNNING and old_state != NodeState.STARTING:
+            raise RuntimeError(
+                f"Invalid state transition from `{old_state}` to `{new_state}`."
+            )
+
+        return new_state
+
+    def _set_node_state(self, node_id: str, state: NodeState) -> bool:
+        """Set a node state and propagate side effects.
+
+        Args:
+            node_id: The node ID.
+            state: The target state.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        with self._lock:
+            node = self._get_node(node_id=node_id)
+            old_state = node.state
+
+            node.state = self._validate_node_state_transition(
+                old_state=old_state, new_state=state
+            )
+
+            if node.state == old_state:
+                return False
+
+            if node.state.is_terminal:
+                return self._handle_terminal_node_transition(node_id=node_id)
+
+            return node.state == NodeState.READY
+
+    def _handle_terminal_node_transition(self, node_id: str) -> bool:
+        """Handle a terminal node transition.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the transition caused any newly ready nodes.
+        """
+        node = self._get_node(node_id=node_id)
+
+        new_nodes_ready = False
+
+        parent_map_id = node.parent_id if isinstance(node, StepNode) else None
+        if parent_map_id:
+            new_nodes_ready = self._maybe_finalize_map_node(
+                map_node_id=parent_map_id
+            )
+
+        for downstream_id in node.downstream_ids:
+            new_nodes_ready = (
+                self._maybe_mark_node_ready(node_id=downstream_id)
+                or new_nodes_ready
+            )
+
+        return new_nodes_ready
+
+    def _maybe_finalize_map_node(self, map_node_id: str) -> bool:
+        """Finalize a map node once all child nodes are terminal.
+
+        Args:
+            map_node_id: The map node ID.
+
+        Returns:
+            Whether finalizing the map node caused any newly ready nodes.
+        """
+        map_node = self.get_map_node(node_id=map_node_id)
+
+        if map_node.state.is_terminal:
+            return False
+
+        if not map_node.child_node_ids:
+            return False
+
+        child_nodes = [
+            self._get_node(node_id=child_node_id)
+            for child_node_id in map_node.child_node_ids
+        ]
+        if not all(child_node.is_terminal for child_node in child_nodes):
+            return False
+
+        if any(
+            child_node.state == NodeState.FAILED for child_node in child_nodes
+        ):
+            aggregate_state = NodeState.FAILED
+        else:
+            aggregate_state = NodeState.SUCCEEDED
+
+        return self._set_node_state(node_id=map_node_id, state=aggregate_state)
+
+    def _maybe_mark_node_ready(self, node_id: str) -> bool:
+        """Mark a pending node as ready when all upstream nodes are terminal.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether the node became ready.
+        """
+        node = self._get_node(node_id=node_id)
+        if node.state != NodeState.PENDING:
+            return False
+
+        if not all(
+            self._get_node(node_id=upstream_id).is_terminal
+            for upstream_id in node.upstream_ids
+        ):
+            return False
+
+        self._set_node_state(node_id=node_id, state=NodeState.READY)
+        return True
+
+    def _get_node(self, node_id: str) -> AnyNode:
+        """Get a node without acquiring the lock.
+
+        Args:
+            node_id: The node ID.
+
+        Raises:
+            RuntimeError: If the node does not exist.
+
+        Returns:
+            The graph node.
+        """
+        node = self._nodes.get(node_id)
+        if not node:
+            raise RuntimeError(f"Unknown graph node `{node_id}`.")
+        return node

--- a/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
+++ b/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
@@ -260,31 +260,25 @@ class InvocationDependencyGraph:
                 if states is None or node.state in states
             ]
 
-    def list_ready_step_node_ids(self) -> List[str]:
-        """List all ready step node IDs.
+    def get_ready_node(self) -> Optional[AnyNode]:
+        """Get one ready node in insertion order.
+
+        Step nodes are prioritized over map nodes.
 
         Returns:
-            The ready step node IDs in insertion order.
+            A ready node if one exists, otherwise `None`.
         """
         with self._lock:
-            return [
-                node_id
-                for node_id, node in self._nodes.items()
-                if isinstance(node, StepNode) and node.state == NodeState.READY
-            ]
+            ready_map_node: Optional[MapNode] = None
+            for node in self._nodes.values():
+                if node.state != NodeState.READY:
+                    continue
+                if isinstance(node, StepNode):
+                    return node
+                if isinstance(node, MapNode) and ready_map_node is None:
+                    ready_map_node = node
 
-    def list_ready_map_node_ids(self) -> List[str]:
-        """List all ready map node IDs.
-
-        Returns:
-            The ready map node IDs in insertion order.
-        """
-        with self._lock:
-            return [
-                node_id
-                for node_id, node in self._nodes.items()
-                if isinstance(node, MapNode) and node.state == NodeState.READY
-            ]
+            return ready_map_node
 
     def mark_node_starting(self, node_id: str) -> bool:
         """Mark a node as starting.
@@ -506,7 +500,7 @@ class InvocationDependencyGraph:
         return self._set_node_state(node_id=map_node_id, state=aggregate_state)
 
     def _maybe_mark_node_ready(self, node_id: str) -> bool:
-        """Mark a pending node as ready when all upstream nodes are terminal.
+        """Mark a pending node as ready when all upstream nodes succeeded.
 
         Args:
             node_id: The node ID.
@@ -519,7 +513,7 @@ class InvocationDependencyGraph:
             return False
 
         if not all(
-            self._get_node(node_id=upstream_id).is_terminal
+            self._get_node(node_id=upstream_id).state == NodeState.SUCCEEDED
             for upstream_id in node.upstream_ids
         ):
             return False

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -13,9 +13,20 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline execution outputs."""
 
+import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from typing import Any, Iterator, List, Optional, Tuple, Union, overload
+from typing import (
+    Any,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    overload,
+)
 from uuid import UUID
 
 from zenml.logger import get_logger
@@ -23,6 +34,8 @@ from zenml.models import ArtifactVersionResponse, StepRunResponse
 from zenml.utils import exception_utils
 
 logger = get_logger(__name__)
+
+T = TypeVar("T")
 
 
 class OutputArtifact(ArtifactVersionResponse):
@@ -124,7 +137,7 @@ class _InlineStepFuture(BaseFuture):
 
 
 class _IsolatedStepFuture(BaseFuture):
-    """Future for an inline step run."""
+    """Future for an isolated step run."""
 
     def __init__(
         self,
@@ -140,6 +153,7 @@ class _IsolatedStepFuture(BaseFuture):
             wrapped: Optional future to wait for that submits the step run.
         """
         self._wrapped = wrapped
+        self._finished_step_run: Optional[StepRunResponse] = None
         self.pipeline_run_id = pipeline_run_id
         self.invocation_id = invocation_id
 
@@ -151,12 +165,17 @@ class _IsolatedStepFuture(BaseFuture):
         """
         from zenml.execution.pipeline.dynamic.utils import get_latest_step_run
 
+        if self._finished_step_run is not None:
+            return False
+
         if self._wrapped and not self._wrapped.done():
             return True
 
         step_run = get_latest_step_run(
             self.pipeline_run_id, self.invocation_id, hydrate=False
         )
+        if step_run.status.is_finished:
+            self._finished_step_run = step_run
 
         return not step_run.status.is_finished
 
@@ -174,14 +193,19 @@ class _IsolatedStepFuture(BaseFuture):
             wait_for_step_to_finish,
         )
 
-        if self._wrapped:
-            # We first wait until the step run is submitted and only then
-            # start monitoring the actual step.
-            self._wrapped.result()
+        if self._finished_step_run is not None:
+            step_run = self._finished_step_run
+        else:
+            if self._wrapped:
+                # We first wait until the step run is submitted and only then
+                # start monitoring the actual step.
+                self._wrapped.result()
 
-        step_run = wait_for_step_to_finish(
-            pipeline_run_id=self.pipeline_run_id, step_name=self.invocation_id
-        )
+            step_run = wait_for_step_to_finish(
+                pipeline_run_id=self.pipeline_run_id,
+                step_name=self.invocation_id,
+            )
+            self._finished_step_run = step_run
 
         if step_run.status.is_failed:
             raise exception_utils.reconstruct_exception(
@@ -195,21 +219,81 @@ class _IsolatedStepFuture(BaseFuture):
         return step_run
 
 
-class BaseStepFuture(BaseFuture):
+StepExecutionFuture = Union[_InlineStepFuture, _IsolatedStepFuture]
+
+
+class _StartupResult(Generic[T]):
+    """Container for a startup result or startup exception."""
+
+    def __init__(self) -> None:
+        """Initialize the startup result."""
+        self._lock = threading.Lock()
+        self._future: Future[T] = Future()
+
+    def done(self) -> bool:
+        """Whether the startup completed.
+
+        Returns:
+            Whether the startup completed.
+        """
+        return self._future.done()
+
+    def failed(self) -> bool:
+        """Whether the startup failed.
+
+        Returns:
+            Whether the startup failed.
+        """
+        return self._future.done() and self._future.exception() is not None
+
+    def result(self) -> T:
+        """Get the startup result.
+
+        Returns:
+            The startup result.
+        """
+        return self._future.result()
+
+    def set_result(self, value: T) -> None:
+        """Store the startup result if it is still unresolved.
+
+        Args:
+            value: The startup result.
+        """
+        with self._lock:
+            if self._future.done():
+                return
+
+            self._future.set_result(value)
+
+    def set_exception(self, exception: BaseException) -> None:
+        """Store the startup exception if it is still unresolved.
+
+        Args:
+            exception: The startup exception.
+        """
+        with self._lock:
+            if self._future.done():
+                return
+
+            self._future.set_exception(exception)
+
+
+class BaseStepFuture(BaseFuture, ABC):
     """Base step future."""
 
     def __init__(
         self,
-        wrapped: Union[_InlineStepFuture, _IsolatedStepFuture],
+        invocation_id: str,
         **kwargs: Any,
     ) -> None:
         """Initialize the dynamic step run future.
 
         Args:
-            wrapped: The wrapped future object.
+            invocation_id: The invocation ID of the future.
             **kwargs: Additional keyword arguments.
         """
-        self._wrapped = wrapped
+        self._invocation_id = invocation_id
 
     @property
     def invocation_id(self) -> str:
@@ -218,15 +302,11 @@ class BaseStepFuture(BaseFuture):
         Returns:
             The step run invocation ID.
         """
-        return self._wrapped.invocation_id
+        return self._invocation_id
 
-    def running(self) -> bool:
-        """Check if the step run future is running.
-
-        Returns:
-            True if the step run future is running, False otherwise.
-        """
-        return self._wrapped.running()
+    @abstractmethod
+    def wait(self) -> None:
+        """Wait for the future to finish."""
 
 
 class ArtifactFuture(BaseStepFuture):
@@ -234,17 +314,26 @@ class ArtifactFuture(BaseStepFuture):
 
     def __init__(
         self,
-        wrapped: Union[_InlineStepFuture, _IsolatedStepFuture],
+        parent: "StepFuture",
         index: int,
     ) -> None:
         """Initialize the future.
 
         Args:
-            wrapped: The wrapped future object.
+            parent: The parent step future object.
             index: The index of the output artifact.
         """
-        super().__init__(wrapped=wrapped)
+        super().__init__(invocation_id=parent.invocation_id)
         self._index = index
+        self._parent = parent
+
+    def running(self) -> bool:
+        """Check if the artifact future is running.
+
+        Returns:
+            True if the artifact future is running, False otherwise.
+        """
+        return self._parent.running()
 
     def result(self) -> OutputArtifact:
         """Get the output artifact this future represents.
@@ -255,11 +344,11 @@ class ArtifactFuture(BaseStepFuture):
         Returns:
             The output artifact.
         """
-        step_run = self._wrapped.result()
         from zenml.execution.pipeline.dynamic.utils import (
             load_step_run_outputs,
         )
 
+        step_run = self._parent._wait()
         result = load_step_run_outputs(step_run.id)
 
         if isinstance(result, OutputArtifact):
@@ -297,22 +386,32 @@ class ArtifactFuture(BaseStepFuture):
         """
         return self.result().chunk(index=index)
 
+    def wait(self) -> None:
+        """Wait for the artifact future to complete."""
+        self._parent.wait()
+
 
 class StepFuture(BaseStepFuture):
     """Future for a step run output."""
 
     def __init__(
         self,
-        wrapped: Union[_InlineStepFuture, _IsolatedStepFuture],
+        invocation_id: str,
         output_keys: List[str],
+        execution_future: Optional[StepExecutionFuture] = None,
     ) -> None:
         """Initialize the future.
 
         Args:
-            wrapped: The wrapped future object.
+            invocation_id: The invocation ID of the step run.
             output_keys: The output keys of the step run.
+            execution_future: Optional execution future if the startup has
+                already completed.
         """
-        super().__init__(wrapped=wrapped)
+        super().__init__(invocation_id=invocation_id)
+        self._startup = _StartupResult[StepExecutionFuture]()
+        if execution_future is not None:
+            self._startup.set_result(execution_future)
         self._output_keys = output_keys
 
     def get_artifact(self, key: str) -> ArtifactFuture:
@@ -334,13 +433,27 @@ class StepFuture(BaseStepFuture):
             )
 
         return ArtifactFuture(
-            wrapped=self._wrapped,
+            parent=self,
             index=self._output_keys.index(key),
         )
 
+    def running(self) -> bool:
+        """Check if the step future is running.
+
+        Returns:
+            True if the step future is running, False otherwise.
+        """
+        if not self._startup.done():
+            return True
+
+        if self._startup.failed():
+            return False
+
+        return self._startup.result().running()
+
     def wait(self) -> None:
         """Wait for the step to finish."""
-        self._wrapped.result()
+        self._wait()
 
     def artifacts(self) -> StepRunOutputs:
         """Get the step run output artifacts.
@@ -360,7 +473,7 @@ class StepFuture(BaseStepFuture):
             load_step_run_outputs,
         )
 
-        step_run = self._wrapped.result()
+        step_run = self._wait()
         return load_step_run_outputs(step_run.id)
 
     def load(self, disable_cache: bool = False) -> Any:
@@ -412,14 +525,14 @@ class StepFuture(BaseStepFuture):
             output_key = self._output_keys[key]
 
             return ArtifactFuture(
-                wrapped=self._wrapped,
+                parent=self,
                 index=self._output_keys.index(output_key),
             )
         elif isinstance(key, slice):
             output_keys = self._output_keys[key]
             return tuple(
                 ArtifactFuture(
-                    wrapped=self._wrapped,
+                    parent=self,
                     index=self._output_keys.index(output_key),
                 )
                 for output_key in output_keys
@@ -443,7 +556,7 @@ class StepFuture(BaseStepFuture):
 
         for index in range(len(self._output_keys)):
             yield ArtifactFuture(
-                wrapped=self._wrapped,
+                parent=self,
                 index=index,
             )
 
@@ -455,17 +568,112 @@ class StepFuture(BaseStepFuture):
         """
         return len(self._output_keys)
 
+    def _wait(self) -> StepRunResponse:
+        """Wait for the step to finish.
+
+        Returns:
+            The step run response.
+        """
+        return self._startup.result().result()
+
+    def _set_startup_result(
+        self, wrapped: Union[_InlineStepFuture, _IsolatedStepFuture]
+    ) -> None:
+        """Store the future that represents the started step.
+
+        Args:
+            wrapped: The future that represents the started step.
+        """
+        self._startup.set_result(wrapped)
+
+    def _set_startup_failed(self, exception: BaseException) -> None:
+        """Store a startup exception for the step.
+
+        Args:
+            exception: The startup exception.
+        """
+        self._startup.set_exception(exception)
+
+    def _cancel_startup(self, exception: BaseException) -> None:
+        """Cancel step startup if it has not been resolved yet.
+
+        Args:
+            exception: The cancellation exception to store.
+        """
+        self._set_startup_failed(exception)
+
 
 class MapResultsFuture(BaseFuture):
     """Future that represents the results of a `step.map/product(...)` call."""
 
-    def __init__(self, futures: List[StepFuture]) -> None:
-        """Initialize the map results future.
+    def __init__(self, invocation_id: str) -> None:
+        """Initialize an empty map results future.
 
         Args:
-            futures: The step run futures.
+            invocation_id: Stable invocation ID for the map expansion.
         """
-        self.futures = futures
+        self._invocation_id = invocation_id
+        self._startup = _StartupResult[List[StepFuture]]()
+
+    @property
+    def invocation_id(self) -> str:
+        """Stable invocation ID for this map expansion.
+
+        Returns:
+            The invocation ID.
+        """
+        return self._invocation_id
+
+    @property
+    def startup_succeeded(self) -> bool:
+        """Whether map startup completed successfully with child futures.
+
+        Returns:
+            Whether the  startup completed successfully.
+        """
+        return self._startup.done() and not self._startup.failed()
+
+    @property
+    def startup_failed(self) -> bool:
+        """Whether the map startup failed.
+
+        Returns:
+            Whether the map startup failed.
+        """
+        return self._startup.failed()
+
+    def _set_startup_result(self, futures: List[StepFuture]) -> None:
+        """Store the child step futures created for the map.
+
+        Args:
+            futures: The child step futures created for the map.
+        """
+        self._startup.set_result(futures)
+
+    def _set_startup_failed(self, exception: BaseException) -> None:
+        """Store a startup exception for the map.
+
+        Args:
+            exception: The startup exception.
+        """
+        self._startup.set_exception(exception)
+
+    def _cancel_startup(self, exception: BaseException) -> None:
+        """Cancel map startup if it has not been resolved yet.
+
+        Args:
+            exception: The cancellation exception to store.
+        """
+        self._set_startup_failed(exception)
+
+    @property
+    def futures(self) -> List[StepFuture]:
+        """Get the child step futures for the map.
+
+        Returns:
+            The child step futures.
+        """
+        return self._startup.result()
 
     def running(self) -> bool:
         """Check if the map results future is running.
@@ -473,7 +681,16 @@ class MapResultsFuture(BaseFuture):
         Returns:
             True if the map results future is running, False otherwise.
         """
+        if not self._startup.done():
+            return True
+        if self._startup.failed():
+            return False
         return any(future.running() for future in self.futures)
+
+    def wait(self) -> None:
+        """Wait for the map results future to complete."""
+        for future in self.futures:
+            future.wait()
 
     def result(self) -> List[StepRunOutputs]:
         """Get the step run outputs this future represents.

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -29,6 +29,7 @@ from typing import (
 )
 from uuid import UUID
 
+from zenml.enums import ExecutionStatus
 from zenml.logger import get_logger
 from zenml.models import ArtifactVersionResponse, StepRunResponse
 from zenml.utils import exception_utils
@@ -168,8 +169,16 @@ class _IsolatedStepFuture(BaseFuture):
         if self._finished_step_run is not None:
             return False
 
-        if self._wrapped and not self._wrapped.done():
-            return True
+        if self._wrapped:
+            if not self._wrapped.done():
+                # Waiting for the step run to be launched.
+                return True
+
+            try:
+                self._wrapped.result()
+            except BaseException:
+                # Launching the step run failed or was cancelled.
+                return False
 
         step_run = get_latest_step_run(
             self.pipeline_run_id, self.invocation_id, hydrate=False
@@ -185,6 +194,7 @@ class _IsolatedStepFuture(BaseFuture):
         Raises:
             BaseException: Any exception that happened while waiting for the
                 step to finish.
+            RuntimeError: If the step was stopped.
 
         Returns:
             The result of the step future.
@@ -207,7 +217,10 @@ class _IsolatedStepFuture(BaseFuture):
             )
             self._finished_step_run = step_run
 
-        if step_run.status.is_failed:
+        if (
+            step_run.status.is_failed
+            or step_run.status == ExecutionStatus.STOPPED
+        ):
             raise exception_utils.reconstruct_exception(
                 exception_info=step_run.exception_info,
                 fallback_message=(

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -70,17 +70,27 @@ from zenml.enums import (
     RunWaitConditionType,
     StepRuntime,
 )
+from zenml.execution.pipeline.dynamic.future_registry import (
+    FutureRegistry,
+    StartupCancelled,
+)
 from zenml.execution.pipeline.dynamic.interactive_input_utils import (
     maybe_enable_interactive_wait_prompt,
     poll_interactive_wait_condition_input,
 )
+from zenml.execution.pipeline.dynamic.invocation_dependency_graph import (
+    InvocationDependencyGraph,
+    MapNode,
+    NodeState,
+    StepNode,
+)
 from zenml.execution.pipeline.dynamic.outputs import (
     AnyStepFuture,
     ArtifactFuture,
-    BaseFuture,
     BaseStepFuture,
     MapResultsFuture,
     OutputArtifact,
+    StepExecutionFuture,
     StepFuture,
     StepRunOutputs,
     _InlineStepFuture,
@@ -91,6 +101,7 @@ from zenml.execution.pipeline.dynamic.run_context import (
 )
 from zenml.execution.pipeline.dynamic.utils import (
     _Unmapped,
+    collect_futures,
     load_step_run_outputs,
 )
 from zenml.execution.pipeline.utils import compute_invocation_id
@@ -117,6 +128,7 @@ from zenml.orchestrators.publish_utils import (
 from zenml.pipelines.dynamic.pipeline_definition import DynamicPipeline
 from zenml.pipelines.run_utils import create_placeholder_run
 from zenml.stack import Stack
+from zenml.steps import BaseStep
 from zenml.steps.entrypoint_function_utils import StepArtifact
 from zenml.steps.step_invocation import StepInvocation
 from zenml.steps.utils import OutputSignature
@@ -136,7 +148,6 @@ from zenml.utils.logging_utils import (
 if TYPE_CHECKING:
     from zenml.config import DockerSettings
     from zenml.orchestrators import BaseOrchestrator
-    from zenml.steps import BaseStep
 
 
 logger = get_logger(__name__)
@@ -207,14 +218,19 @@ class DynamicPipelineRunner:
             self._orchestrator = Stack.from_model(snapshot.stack).orchestrator
 
         self._step_operator = Stack.from_model(snapshot.stack).step_operator
-        self._futures: Dict[str, "StepFuture"] = {}
+        self._invocation_id_lock = threading.Lock()
         self._invocation_ids: Set[str] = set()
 
         self._run, self._orchestrator_run_id = self._prepare_run(run)
         self._existing_step_runs = self._run.steps
 
         self._steps_to_monitor: Dict[str, "StepRunResponse"] = {}
-        self._shutdown_event = threading.Event()
+
+        self._shutdown_requested = False
+        self._monitoring_event = threading.Event()
+        self._startup_event = threading.Event()
+        self._dependency_graph = InvocationDependencyGraph()
+        self._future_registry = FutureRegistry()
 
     def _prepare_run(
         self, run: Optional["PipelineRunResponse"]
@@ -300,9 +316,8 @@ class DynamicPipelineRunner:
             ENV_ZENML_DYNAMIC_PIPELINE_MONITORING_DELAY, default=0.1
         )
 
-        while not self._shutdown_event.is_set():
+        while not self._shutdown_requested:
             start_time = time.time()
-            finished_step_runs = []
 
             # Copy the steps to avoid the dictionary getting modified by
             # the main thread while we're iterating over it.
@@ -352,7 +367,7 @@ class DynamicPipelineRunner:
                     # monitoring interval to check again.
                     continue
 
-                finished_step_runs.append(invocation_id)
+                self._steps_to_monitor.pop(invocation_id, None)
 
                 if db_status == ExecutionStatus.STOPPING:
                     # The step runner sets the status to STOPPING when receiving
@@ -394,6 +409,7 @@ class DynamicPipelineRunner:
                             "Step `%s` finished successfully.",
                             invocation_id,
                         )
+                    self._on_step_finished(step_run=step_run)
                 elif db_status.is_failed:
                     if duration_string:
                         logger.error(
@@ -406,6 +422,7 @@ class DynamicPipelineRunner:
                             "Step `%s` failed.",
                             invocation_id,
                         )
+                    self._on_step_finished(step_run=step_run)
                 elif db_status == ExecutionStatus.STOPPED:
                     if duration_string:
                         logger.info(
@@ -415,6 +432,7 @@ class DynamicPipelineRunner:
                         )
                     else:
                         logger.info("Step `%s` stopped.", invocation_id)
+                    self._on_step_finished(step_run=step_run)
                 elif db_status == ExecutionStatus.RETRYING:
                     # The server set the status of the step run to retrying ->
                     # The server expects the step to be retried.
@@ -446,12 +464,104 @@ class DynamicPipelineRunner:
 
                 time.sleep(monitoring_delay)
 
-            for invocation_id in finished_step_runs:
-                self._steps_to_monitor.pop(invocation_id)
-
             duration = time.time() - start_time
             time_to_sleep = max(0, monitoring_interval - duration)
-            self._shutdown_event.wait(timeout=time_to_sleep)
+            self._monitoring_event.wait(timeout=time_to_sleep)
+
+    def _start_monitoring_loop(self) -> threading.Thread:
+        """Start the monitoring loop.
+
+        Returns:
+            The monitoring thread.
+        """
+        monitoring_thread = threading.Thread(
+            name="DynamicPipelineRunner-Monitoring-Loop",
+            target=lambda: context_utils.run_in_current_context(
+                self._monitoring_loop
+            ),
+            daemon=True,
+        )
+        monitoring_thread.start()
+        return monitoring_thread
+
+    def _startup_loop(self) -> None:
+        """Startup loop."""
+        fail_fast = (
+            self._snapshot.pipeline_configuration.execution_mode
+            == ExecutionMode.FAIL_FAST
+        )
+        while not self._shutdown_requested:
+            self._startup_event.clear()
+
+            ready_step_node_ids = (
+                self._dependency_graph.list_ready_step_node_ids()
+            )
+            if ready_step_node_ids:
+                logger.debug(
+                    "Startup loop picked ready step nodes: %s",
+                    ready_step_node_ids,
+                )
+
+            for node_id in ready_step_node_ids:
+                step_node = self._dependency_graph.get_step_node(
+                    node_id=node_id
+                )
+                try:
+                    self._handle_step_ready(node=step_node)
+                except Exception as e:
+                    self._handle_step_startup_failed(
+                        invocation_id=node_id, exception=e
+                    )
+                    logger.exception(
+                        "Failed to start concurrent step `%s`.",
+                        node_id,
+                    )
+                    if fail_fast:
+                        self._shutdown()
+                        return
+
+            ready_map_node_ids = (
+                self._dependency_graph.list_ready_map_node_ids()
+            )
+            if ready_map_node_ids:
+                logger.debug(
+                    "Startup loop picked ready map nodes: %s",
+                    ready_map_node_ids,
+                )
+
+            for node_id in ready_map_node_ids:
+                map_node = self._dependency_graph.get_map_node(node_id=node_id)
+                try:
+                    self._handle_map_ready(node=map_node)
+                except Exception as e:
+                    self._handle_map_expansion_failed(
+                        map_id=node_id, exception=e
+                    )
+                    logger.exception(
+                        "Failed to start concurrent map `%s`.",
+                        node_id,
+                    )
+                    if fail_fast:
+                        self._shutdown()
+                        return
+
+            self._startup_event.wait(timeout=None)
+
+    def _start_startup_loop(self) -> threading.Thread:
+        """Start the startup loop.
+
+        Returns:
+            The startup thread.
+        """
+        startup_thread = threading.Thread(
+            name="DynamicPipelineRunner-Startup-Loop",
+            target=lambda: context_utils.run_in_current_context(
+                self._startup_loop
+            ),
+            daemon=True,
+        )
+        startup_thread.start()
+        return startup_thread
 
     def _maybe_stop_isolated_steps(self) -> None:
         """Maybe stop all isolated in progress steps.
@@ -560,30 +670,22 @@ class DynamicPipelineRunner:
                     runner=self,
                 ),
             ):
-                monitoring_thread = threading.Thread(
-                    name="DynamicPipelineRunner-Monitoring-Loop",
-                    target=lambda: context_utils.run_in_current_context(
-                        self._monitoring_loop
-                    ),
-                    daemon=True,
-                )
-                monitoring_thread.start()
+                monitoring_thread = self._start_monitoring_loop()
+                startup_thread = self._start_startup_loop()
+
                 if not self._run.triggered_by_deployment:
                     # Only run the init hook if the run is not triggered by
                     # a deployment, as the deployment service will have
                     # already run the init hook.
                     self._orchestrator.run_init_hook(snapshot=self._snapshot)
 
+                params = self.pipeline.configuration.parameters or {}
                 try:
-                    # TODO: what should be allowed as pipeline returns?
-                    #  (artifacts, json serializable, anything?)
-                    #  how do we show it in the UI?
-                    params = self.pipeline.configuration.parameters or {}
                     self.pipeline._call_entrypoint(**params)
                     # The pipeline function finished successfully, but some
                     # steps might still be running. We now wait for all of
                     # them and raise any exceptions that occurred.
-                    self.await_all_step_futures()
+                    self.await_all_futures()
                 except _WaitConditionPollTimeout:
                     logger.info("Pausing pipeline run `%s`.", self._run.id)
                 except _WaitConditionAborted:
@@ -607,7 +709,7 @@ class DynamicPipelineRunner:
                     )
                     raise
                 finally:
-                    self._shutdown_event.set()
+                    self._shutdown()
 
                     if not self._run.triggered_by_deployment:
                         # Only run the cleanup hook if the run is not
@@ -617,9 +719,10 @@ class DynamicPipelineRunner:
                             snapshot=self._snapshot
                         )
 
-                    self._maybe_stop_isolated_steps()
                     self._executor.shutdown(wait=True, cancel_futures=True)
+                    self._maybe_stop_isolated_steps()
                     monitoring_thread.join()
+                    startup_thread.join()
 
                 self._run = Client().zen_store.get_run(
                     self._run.id, hydrate=False
@@ -627,6 +730,40 @@ class DynamicPipelineRunner:
                 if self._run.status == ExecutionStatus.RUNNING:
                     publish_successful_pipeline_run(self._run.id)
                     logger.info("Pipeline completed successfully.")
+
+    def _handle_graph_update(self, new_nodes_ready: bool) -> None:
+        """Handle a graph update.
+
+        Args:
+            new_nodes_ready: Whether any new nodes are ready.
+        """
+        if new_nodes_ready:
+            self._startup_event.set()
+
+    def _allocate_invocation_id(
+        self, step: "BaseStep", custom_id: Optional[str], allow_suffix: bool
+    ) -> str:
+        """Allocate a new invocation ID.
+
+        Args:
+            step: The step to allocate an invocation ID for.
+            custom_id: A custom invocation ID to use.
+            allow_suffix: Whether to allow suffixing the invocation ID.
+
+        Returns:
+            The allocated invocation ID.
+        """
+        # TODO: maybe prevent `map:` prefixes for invocation IDs
+        with self._invocation_id_lock:
+            invocation_id = compute_invocation_id(
+                existing_invocations=self._invocation_ids,
+                step=step,
+                custom_id=custom_id,
+                allow_suffix=allow_suffix,
+            )
+            self._invocation_ids.add(invocation_id)
+
+        return invocation_id
 
     @overload
     def launch_step(
@@ -680,101 +817,40 @@ class DynamicPipelineRunner:
             The step run outputs or a future for the step run outputs.
         """  # noqa: DOC502, DOC503
         step = step.copy()
-        step_config = None
-        if self._run and self._run.triggered_by_deployment:
-            # Deployment-specific step overrides
-            step_config = StepConfigurationUpdate(
-                enable_cache=False,
-                step_operator=None,
-                parameters={},
-                runtime=StepRuntime.INLINE,
-                group=group,
-            )
-        elif group:
-            step_config = StepConfigurationUpdate(
-                group=group,
-            )
 
-        inputs = convert_to_keyword_arguments(step.entrypoint, args, kwargs)
-
-        invocation_id = compute_invocation_id(
-            existing_invocations=self._invocation_ids,
-            step=step,
-            custom_id=id,
-            allow_suffix=not id,
-        )
-        self._invocation_ids.add(invocation_id)
-
-        if waiting_for_steps := _get_running_upstream_steps(inputs, after):
-            logger.info(
-                "Waiting for step(s) `%s` to finish before executing step `%s`.",
-                ", ".join(waiting_for_steps),
-                invocation_id,
-            )
-
-        compiled_step = compile_dynamic_step_invocation(
-            snapshot=self._snapshot,
-            pipeline=self.pipeline,
-            step=step,
-            invocation_id=invocation_id,
-            inputs=inputs,
-            pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
-            after=after,
-            config=step_config,
+        invocation_id = self._allocate_invocation_id(
+            step=step, custom_id=id, allow_suffix=not id
         )
 
-        step_run = self._existing_step_runs.get(invocation_id)
-        runtime = get_step_runtime(
-            step_config=compiled_step.config,
-            pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
-            orchestrator=self._orchestrator,
-        )
         remaining_retries = None
-
-        if step_run:
-            old_config = step_run.config.model_copy(deep=True)
-            # The server includes the date/time substitutions based on the
-            # actual DB start time of the pipeline run. We want to compare this
-            # to the newly compiled step config, so we remove them.
-            old_config.substitutions.pop("date")
-            old_config.substitutions.pop("time")
-
-            if (
-                old_config.model_dump_json()
-                != compiled_step.config.model_dump_json()
-            ):
-                # We use the old config here to keep the behavior aligned across
-                # all step retries: When the orchestration environment is
-                # restarted while an isolated step is running, the code below
-                # will start monitoring that existing execution. If that step
-                # then fails, the monitoring loop will restart it with the
-                # configuration of the step run that just failed, which is the
-                # old (=compiled in previous orchestration environment) config.
-                compiled_step = Step(
-                    spec=step_run.spec,
-                    config=old_config,
-                    step_config_overrides=old_config,
-                )
-                logger.warning(
-                    "Configuration for step `%s` changed since the "
-                    "orchestration environment was restarted. If the step "
-                    "needs to be retried, it will use the old configuration.",
-                    step_run.name,
-                )
+        if step_run := self._existing_step_runs.get(invocation_id):
+            runtime = get_step_runtime(
+                step_config=step_run.config,
+                pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
+                orchestrator=self._orchestrator,
+            )
 
             if step_run.status.is_successful:
                 # The step finished successfully, but we still need to return
                 # a future in case the step was launched concurrently so the
                 # caller gets the correct object back.
                 if concurrent:
-                    future = StepFuture(
-                        wrapped=_IsolatedStepFuture(
-                            pipeline_run_id=self._run.id,
-                            invocation_id=invocation_id,
-                        ),
-                        output_keys=list(compiled_step.config.outputs),
+                    execution_future = _IsolatedStepFuture(
+                        pipeline_run_id=self._run.id,
+                        invocation_id=invocation_id,
                     )
-                    self._futures[invocation_id] = future
+                    future = StepFuture(
+                        invocation_id=invocation_id,
+                        execution_future=execution_future,
+                        output_keys=list(step_run.config.outputs),
+                    )
+                    self._register_concurrent_step_invocation(
+                        future=future,
+                        initial_state=NodeState.SUCCEEDED,
+                    )
+                    self._handle_step_execution_succeeded(
+                        invocation_id=invocation_id
+                    )
                     return future
                 else:
                     return load_step_run_outputs(step_run.id)
@@ -790,19 +866,30 @@ class DynamicPipelineRunner:
                 # orchestration environment, so we mark them as failed and
                 # potentially restart them depending on the retry config.
                 step_run = publish_failed_step_run(step_run.id)
+                # Store the updated step run so we can compute the remaining
+                # retries in the async submission flow.
+                self._existing_step_runs[invocation_id] = step_run
 
             if step_run.status.is_failed:
                 # If the step is running concurrently, we only raise the
                 # exception once the future is awaited.
                 if concurrent:
-                    future = StepFuture(
-                        wrapped=_IsolatedStepFuture(
-                            pipeline_run_id=self._run.id,
-                            invocation_id=invocation_id,
-                        ),
-                        output_keys=list(compiled_step.config.outputs),
+                    execution_future = _IsolatedStepFuture(
+                        pipeline_run_id=self._run.id,
+                        invocation_id=invocation_id,
                     )
-                    self._futures[invocation_id] = future
+                    future = StepFuture(
+                        invocation_id=invocation_id,
+                        execution_future=execution_future,
+                        output_keys=list(step_run.config.outputs),
+                    )
+                    self._register_concurrent_step_invocation(
+                        future=future,
+                        initial_state=NodeState.FAILED,
+                    )
+                    self._handle_step_execution_failed(
+                        invocation_id=invocation_id
+                    )
                     return future
                 else:
                     raise exception_utils.reconstruct_exception(
@@ -824,95 +911,79 @@ class DynamicPipelineRunner:
                     remaining_retries,
                 )
                 self._steps_to_monitor[invocation_id] = step_run
-                monitoring_future = StepFuture(
-                    wrapped=_IsolatedStepFuture(
-                        pipeline_run_id=self._run.id,
-                        invocation_id=invocation_id,
-                    ),
-                    output_keys=list(compiled_step.config.outputs),
+                execution_future = _IsolatedStepFuture(
+                    pipeline_run_id=self._run.id,
+                    invocation_id=invocation_id,
                 )
-                self._futures[invocation_id] = monitoring_future
-                return monitoring_future
+                monitoring_future = StepFuture(
+                    invocation_id=invocation_id,
+                    execution_future=execution_future,
+                    output_keys=list(step_run.config.outputs),
+                )
+                self._register_concurrent_step_invocation(
+                    future=monitoring_future,
+                    initial_state=NodeState.RUNNING,
+                )
+                self._handle_step_running(invocation_id=invocation_id)
+                if concurrent:
+                    return monitoring_future
+                else:
+                    return monitoring_future.result()
 
-        if not concurrent:
+        inputs = convert_to_keyword_arguments(step.entrypoint, args, kwargs)
+
+        config_overrides = None
+        if self._run and self._run.triggered_by_deployment:
+            # Deployment-specific step overrides
+            config_overrides = StepConfigurationUpdate(
+                enable_cache=False,
+                step_operator=None,
+                parameters={},
+                runtime=StepRuntime.INLINE,
+                group=group,
+            )
+        elif group:
+            config_overrides = StepConfigurationUpdate(
+                group=group,
+            )
+
+        if concurrent:
+            future = StepFuture(
+                invocation_id=invocation_id,
+                output_keys=list(step.entrypoint_definition.outputs),
+            )
+            self._register_concurrent_step_invocation(
+                future=future,
+                step=step,
+                inputs=inputs,
+                after=after,
+                config_overrides=config_overrides,
+            )
+            return future
+        else:
+            if (
+                running_upstream_dependencies
+                := _get_running_upstream_dependencies(inputs, after)
+            ):
+                logger.info(
+                    "Waiting for upstream dependencies `%s` to finish before "
+                    "executing step `%s`.",
+                    ", ".join(running_upstream_dependencies),
+                    invocation_id,
+                )
+
+            compiled_step = self._compile_or_reuse(
+                step=step,
+                invocation_id=invocation_id,
+                inputs=inputs,
+                after=after,
+                config=config_overrides,
+            )
+
             step_run = self._run_sync_step(
                 step=compiled_step, remaining_retries=remaining_retries
             )
             return load_step_run_outputs(step_run.id)
-        elif runtime == StepRuntime.INLINE:
-            return self._queue_concurrent_inline_step(
-                step=compiled_step, remaining_retries=remaining_retries
-            )
-        else:
-            return self._queue_concurrent_isolated_step(step=compiled_step)
-
-    def _queue_concurrent_isolated_step(self, step: "Step") -> StepFuture:
-        """Queue a concurrent isolated step.
-
-        Args:
-            step: The step to queue.
-
-        Returns:
-            The step future.
-        """
-
-        def _launch_no_wait() -> StepRunResponse:
-            step_run = launch_step(
-                snapshot=self._snapshot,
-                step=step,
-                orchestrator_run_id=self._orchestrator_run_id,
-                # The monitoring loop is responsible for monitoring and retrying
-                # steps.
-                wait=False,
-                retry=False,
-            )
-            self._steps_to_monitor[step.spec.invocation_id] = step_run
-            return step_run
-
-        concurrent_future = self._executor.submit(
-            context_utils.run_in_current_context, _launch_no_wait
-        )
-        future = StepFuture(
-            wrapped=_IsolatedStepFuture(
-                wrapped=concurrent_future,
-                pipeline_run_id=self._run.id,
-                invocation_id=step.spec.invocation_id,
-            ),
-            output_keys=list(step.config.outputs),
-        )
-        self._futures[step.spec.invocation_id] = future
-        return future
-
-    def _queue_concurrent_inline_step(
-        self, step: "Step", remaining_retries: Optional[int] = None
-    ) -> StepFuture:
-        """Queue a concurrent inline step.
-
-        Args:
-            step: The step to queue.
-            remaining_retries: The remaining retries for the step.
-
-        Returns:
-            The step future.
-        """
-
-        def _launch_and_wait() -> StepRunResponse:
-            return self._run_sync_step(
-                step=step, remaining_retries=remaining_retries
-            )
-
-        concurrent_future = self._executor.submit(
-            context_utils.run_in_current_context, _launch_and_wait
-        )
-        future = StepFuture(
-            wrapped=_InlineStepFuture(
-                wrapped=concurrent_future,
-                invocation_id=step.spec.invocation_id,
-            ),
-            output_keys=list(step.config.outputs),
-        )
-        self._futures[step.spec.invocation_id] = future
-        return future
 
     def _run_sync_step(
         self,
@@ -937,6 +1008,46 @@ class DynamicPipelineRunner:
             remaining_retries=remaining_retries,
         )
 
+    def _compile_or_reuse(
+        self,
+        step: "BaseStep",
+        invocation_id: str,
+        inputs: Dict[str, Any],
+        after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = None,
+        config: Optional["StepConfigurationUpdate"] = None,
+    ) -> "Step":
+        """Compile a step invocation or reuse from existing step run.
+
+        Args:
+            step: The step to compile.
+            invocation_id: The invocation ID of the step.
+            inputs: The step inputs.
+            after: Optional upstream futures for the step.
+            config: Optional config overrides for compilation.
+
+        Returns:
+            The compiled step.
+        """
+        if existing_step_run := self._existing_step_runs.get(invocation_id):
+            compiled_step = Step(
+                spec=existing_step_run.spec,
+                config=existing_step_run.config,
+                step_config_overrides=existing_step_run.config,
+            )
+        else:
+            compiled_step = compile_dynamic_step_invocation(
+                snapshot=self._snapshot,
+                pipeline=self.pipeline,
+                step=step,
+                invocation_id=invocation_id,
+                inputs=inputs,
+                pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
+                after=after,
+                config=config,
+            )
+
+        return compiled_step
+
     def map(
         self,
         step: "BaseStep",
@@ -959,33 +1070,20 @@ class DynamicPipelineRunner:
         Returns:
             A future that represents the map results.
         """
-        kwargs = convert_to_keyword_arguments(step.entrypoint, args, kwargs)
-        kwargs = await_step_inputs(kwargs)
-        step_inputs = expand_mapped_inputs(kwargs, product=product)
-
-        # This will overwrite any user-configured groups for the step, but
-        # capturing the mapping information is more important until we introduce
-        # a more flexible group system.
-        group_info = GroupInfo(
-            id=str(uuid4()),
-            name=step.name,
-            type=GroupType.MAP,
+        step = step.copy()
+        inputs = convert_to_keyword_arguments(step.entrypoint, args, kwargs)
+        invocation_id = self._allocate_invocation_id(
+            step=step, custom_id=None, allow_suffix=True
         )
-
-        step_futures = [
-            self.launch_step(
-                step,
-                id=None,
-                args=(),
-                kwargs=inputs,
-                after=after,
-                group=group_info,
-                concurrent=True,
-            )
-            for inputs in step_inputs
-        ]
-
-        return MapResultsFuture(futures=step_futures)
+        map_future = MapResultsFuture(invocation_id=invocation_id)
+        self._register_map_invocation(
+            future=map_future,
+            step=step,
+            inputs=inputs,
+            after=after,
+            product=product,
+        )
+        return map_future
 
     @overload
     def wait(
@@ -1066,18 +1164,8 @@ class DynamicPipelineRunner:
 
         wait_condition_name = name or context.next_wait_condition_name()
 
-        if isinstance(after, BaseStepFuture):
-            after.result()
-        elif isinstance(after, MapResultsFuture):
-            for future in after:
-                future.result()
-        elif isinstance(after, Sequence):
-            for item in after:
-                if isinstance(item, BaseStepFuture):
-                    item.result()
-                elif isinstance(item, MapResultsFuture):
-                    for future in item:
-                        future.result()
+        for future in collect_futures(after=after, expand_map_results=True):
+            future.wait()
 
         condition = Client().zen_store.create_run_wait_condition(
             RunWaitConditionRequest(
@@ -1120,7 +1208,8 @@ class DynamicPipelineRunner:
             ) as interactive_prompting_enabled:
                 # We keep polling until the deadline is reached and all ongoing
                 # steps have finished.
-                while time.time() < deadline or self.has_in_progress_steps():
+                while time.time() < deadline or self.has_in_progress_work():
+                    # TODO: catch pipeline failure here and handle it.
                     lease_now = utc_now()
                     status = (
                         Client().zen_store.update_run_wait_condition_lease(
@@ -1246,40 +1335,432 @@ class DynamicPipelineRunner:
             value=TypeAdapter(schema).validate_python(condition.result),
         )
 
-    def await_all_step_futures(self) -> None:
-        """Await all scheduled step futures.
+    def await_all_futures(self) -> None:
+        """Await all tracked futures."""
+        self._future_registry.await_all()
 
-        Raises:
-            RuntimeError: If one or more step futures failed while waiting.
-        """
-        failed_steps = []
-        for future in list(self._futures.values()):
-            try:
-                future.wait()
-            except Exception as e:
-                logger.warning(
-                    "Failed to run step `%s`: %s", future.invocation_id, str(e)
-                )
-                failed_steps.append(future.invocation_id)
-
-        self._futures = {}
-
-        if failed_steps:
-            # TODO: This should depend on the execution mode.
-            # We only fail after all futures have been awaited. Otherwise, we
-            # will mark the pipeline run as failed which invalidates the token
-            # and other steps won't be able to report their status back.
-            raise RuntimeError(
-                f"Failed to run step(s): {', '.join(failed_steps)}"
-            )
-
-    def has_in_progress_steps(self) -> bool:
-        """Check if there are any in-progress steps.
+    def has_in_progress_work(self) -> bool:
+        """Check if there is any in-progress tracked work.
 
         Returns:
-            True if there are any in-progress steps, False otherwise.
+            True if there is any in-progress tracked work, False otherwise.
         """
-        return any(future.running() for future in list(self._futures.values()))
+        return self._future_registry.has_in_progress_work()
+
+    def _shutdown(self) -> None:
+        """Shutdown the runner.
+
+        This wakes any background loops so they can observe the shutdown flag
+        and exit cleanly.
+        """
+        if self._shutdown_requested:
+            return
+
+        self._shutdown_requested = True
+
+        for node in self._dependency_graph.list_nodes(
+            states={NodeState.PENDING, NodeState.READY}
+        ):
+            if isinstance(node, StepNode):
+                self._future_registry.cancel_step_startup(
+                    invocation_id=node.node_id
+                )
+            elif isinstance(node, MapNode):
+                self._future_registry.cancel_map_startup(map_id=node.node_id)
+
+        self._startup_event.set()
+        self._monitoring_event.set()
+
+    def _raise_if_startup_cancelled(self) -> None:
+        """Abort startup work once runner shutdown has started.
+
+        Raises:
+            StartupCancelled: If the runner is shutting down.
+        """
+        if self._shutdown_requested:
+            raise StartupCancelled("Dynamic pipeline runner is shutting down.")
+
+    # Concurrent step lifecycle
+
+    def _register_concurrent_step_invocation(
+        self,
+        future: StepFuture,
+        initial_state: Optional[NodeState] = None,
+        step: Optional[BaseStep] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        after: Union[AnyStepFuture, Sequence[AnyStepFuture], None] = None,
+        config_overrides: Optional["StepConfigurationUpdate"] = None,
+    ) -> None:
+        """Register a concurrent step invocation.
+
+        Args:
+            future: The step future.
+            initial_state: Optional initial graph state for the node.
+            step: Optional step payload for startup.
+            inputs: Optional input payload for startup.
+            after: Optional upstream futures for startup.
+            config_overrides: Optional config overrides for the step.
+        """
+        if inputs is not None:
+            upstream_node_ids = _collect_upstream_node_ids(
+                inputs=inputs, after=after
+            )
+        else:
+            upstream_node_ids = None
+
+        self._future_registry.register_step_future(
+            invocation_id=future.invocation_id, future=future
+        )
+        nodes_ready = self._dependency_graph.register_step_node(
+            node_id=future.invocation_id,
+            upstream_ids=upstream_node_ids,
+            state=initial_state,
+            step=step,
+            inputs=inputs,
+            after=after,
+            config_overrides=config_overrides,
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_step_starting(self, invocation_id: str) -> None:
+        """Mark a step node as starting in the dependency graph.
+
+        Args:
+            invocation_id: The step invocation ID.
+        """
+        nodes_ready = self._dependency_graph.mark_node_starting(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_step_ready(self, node: StepNode) -> None:
+        """Handle a ready step node.
+
+        Args:
+            node: The step node.
+
+        Raises:
+            RuntimeError: If the step node is missing startup payload.
+        """
+        if node.step is None or node.inputs is None:
+            raise RuntimeError(
+                f"Missing startup payload for step node `{node.node_id}`."
+            )
+
+        self._handle_step_starting(invocation_id=node.node_id)
+
+        compiled_step = self._compile_or_reuse(
+            step=node.step,
+            invocation_id=node.node_id,
+            inputs=node.inputs,
+            after=node.after,
+            config=node.config_overrides,
+        )
+
+        runtime = get_step_runtime(
+            step_config=compiled_step.config,
+            pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
+            orchestrator=self._orchestrator,
+        )
+
+        self._raise_if_startup_cancelled()
+
+        execution_future: StepExecutionFuture
+
+        if runtime == StepRuntime.INLINE:
+            remaining_retries = None
+            if step_run := self._existing_step_runs.get(node.node_id):
+                remaining_retries = get_remaining_retries(step_run=step_run)
+
+            execution_future = self._queue_concurrent_inline_step(
+                step=compiled_step, remaining_retries=remaining_retries
+            )
+        else:
+            execution_future = self._queue_concurrent_isolated_step(
+                step=compiled_step
+            )
+
+        self._handle_step_startup_succeeded(
+            invocation_id=node.node_id,
+            execution_future=execution_future,
+        )
+
+    def _queue_concurrent_isolated_step(
+        self, step: "Step"
+    ) -> _IsolatedStepFuture:
+        """Queue a concurrent isolated step.
+
+        Args:
+            step: The step to queue.
+
+        Returns:
+            The step future.
+        """
+
+        def _launch_no_wait() -> StepRunResponse:
+            step_run = launch_step(
+                snapshot=self._snapshot,
+                step=step,
+                orchestrator_run_id=self._orchestrator_run_id,
+                # The monitoring loop is responsible for monitoring and retrying
+                # steps.
+                wait=False,
+                retry=False,
+            )
+            self._steps_to_monitor[step.spec.invocation_id] = step_run
+            return step_run
+
+        concurrent_future = self._executor.submit(
+            context_utils.run_in_current_context, _launch_no_wait
+        )
+        return _IsolatedStepFuture(
+            wrapped=concurrent_future,
+            pipeline_run_id=self._run.id,
+            invocation_id=step.spec.invocation_id,
+        )
+
+    def _queue_concurrent_inline_step(
+        self, step: "Step", remaining_retries: Optional[int] = None
+    ) -> _InlineStepFuture:
+        """Queue a concurrent inline step.
+
+        Args:
+            step: The step to queue.
+            remaining_retries: The remaining retries for the step.
+
+        Returns:
+            The step future.
+        """
+
+        def _launch_and_wait() -> StepRunResponse:
+            step_run = self._run_sync_step(
+                step=step, remaining_retries=remaining_retries
+            )
+            self._on_step_finished(step_run=step_run)
+            return step_run
+
+        concurrent_future = self._executor.submit(
+            context_utils.run_in_current_context, _launch_and_wait
+        )
+        return _InlineStepFuture(
+            wrapped=concurrent_future,
+            invocation_id=step.spec.invocation_id,
+        )
+
+    def _handle_step_running(self, invocation_id: str) -> None:
+        """Mark a step node as running in the dependency graph.
+
+        Args:
+            invocation_id: The step invocation ID.
+        """
+        nodes_ready = self._dependency_graph.mark_node_running(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_step_startup_succeeded(
+        self, invocation_id: str, execution_future: StepExecutionFuture
+    ) -> None:
+        """Store a successful step startup in the registry and graph.
+
+        Args:
+            invocation_id: The step invocation ID.
+            execution_future: The future for the started step execution.
+        """
+        self._future_registry.bind_step_execution_future(
+            invocation_id=invocation_id, future=execution_future
+        )
+        nodes_ready = self._dependency_graph.mark_node_running(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_step_startup_failed(
+        self, invocation_id: str, exception: BaseException
+    ) -> None:
+        """Store a failed step startup in the registry and graph.
+
+        Args:
+            invocation_id: The step invocation ID.
+            exception: The startup exception.
+        """
+        self._future_registry.fail_step_startup(
+            invocation_id=invocation_id, exception=exception
+        )
+        nodes_ready = self._dependency_graph.mark_node_failed(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _on_step_finished(self, step_run: "StepRunResponse") -> None:
+        """Handle a terminal step run.
+
+        Args:
+            step_run: The terminal step run.
+        """
+        if not step_run.status.is_finished:
+            # When this is being called from an inline future, the step run
+            # might not be refreshed yet and therefore not have the correct
+            # status.
+            step_run = Client().get_run_step(step_run.id, hydrate=False)
+
+        logger.debug(
+            "Processing terminal step `%s` with status `%s`.",
+            step_run.name,
+            step_run.status,
+        )
+
+        if step_run.status.is_successful:
+            self._handle_step_execution_succeeded(invocation_id=step_run.name)
+        elif step_run.status.is_failed:
+            self._handle_step_execution_failed(invocation_id=step_run.name)
+        elif step_run.status == ExecutionStatus.STOPPED:
+            self._handle_step_execution_failed(invocation_id=step_run.name)
+
+    def _handle_step_execution_succeeded(self, invocation_id: str) -> None:
+        """Mark a step node as successfully finished.
+
+        Args:
+            invocation_id: The step invocation ID.
+        """
+        nodes_ready = self._dependency_graph.mark_node_succeeded(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_step_execution_failed(self, invocation_id: str) -> None:
+        """Mark a step node as failed.
+
+        Args:
+            invocation_id: The step invocation ID.
+        """
+        nodes_ready = self._dependency_graph.mark_node_failed(
+            node_id=invocation_id
+        )
+        self._handle_graph_update(nodes_ready)
+
+    # Concurrent map lifecycle
+
+    def _register_map_invocation(
+        self,
+        future: MapResultsFuture,
+        step: BaseStep,
+        inputs: Dict[str, Any],
+        product: bool,
+        after: Union[AnyStepFuture, Sequence[AnyStepFuture], None] = None,
+    ) -> None:
+        """Register a map invocation.
+
+        Args:
+            future: The map future.
+            step: The mapped step payload for startup.
+            inputs: The input payload for startup.
+            after: Optional upstream futures for startup.
+            product: The map expansion mode.
+        """
+        node_id = future.invocation_id
+        upstream_node_ids = _collect_upstream_node_ids(
+            inputs=inputs, after=after
+        )
+
+        self._future_registry.register_map_future(
+            map_id=node_id, future=future
+        )
+        nodes_ready = self._dependency_graph.register_map_node(
+            node_id=node_id,
+            step=step,
+            inputs=inputs,
+            product=product,
+            upstream_ids=upstream_node_ids,
+            after=after,
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_map_starting(self, map_id: str) -> None:
+        """Mark a map node as starting in the dependency graph.
+
+        Args:
+            map_id: The map node ID.
+        """
+        nodes_ready = self._dependency_graph.mark_node_starting(node_id=map_id)
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_map_ready(self, node: MapNode) -> None:
+        """Handle a ready map expansion node.
+
+        Args:
+            node: The ready map node to expand.
+        """
+        self._handle_map_starting(map_id=node.node_id)
+
+        kwargs = await_step_inputs(node.inputs)
+        step_inputs = expand_mapped_inputs(kwargs, product=node.product)
+
+        group_info = GroupInfo(
+            id=str(uuid4()),
+            name=node.step.name,
+            type=GroupType.MAP,
+        )
+
+        self._raise_if_startup_cancelled()
+
+        step_futures = [
+            self.launch_step(
+                node.step,
+                id=f"map:{node.node_id}:{index}",
+                args=(),
+                kwargs=inputs,
+                after=node.after,
+                group=group_info,
+                concurrent=True,
+            )
+            for index, inputs in enumerate(step_inputs)
+        ]
+
+        logger.debug(
+            "Populating futures for map %s",
+            node.node_id,
+        )
+        self._handle_map_expansion_succeeded(
+            map_id=node.node_id,
+            child_futures=step_futures,
+        )
+
+    def _handle_map_expansion_succeeded(
+        self, map_id: str, child_futures: List[StepFuture]
+    ) -> None:
+        """Store a successful map expansion in the registry and graph.
+
+        Args:
+            map_id: The map ID.
+            child_futures: The child step futures created for the map.
+        """
+        child_node_ids = [
+            child_future.invocation_id for child_future in child_futures
+        ]
+
+        self._future_registry.bind_map_child_futures(
+            map_id=map_id, child_futures=child_futures
+        )
+        nodes_ready = self._dependency_graph.attach_map_children(
+            map_node_id=map_id, child_node_ids=child_node_ids
+        )
+        self._handle_graph_update(nodes_ready)
+
+    def _handle_map_expansion_failed(
+        self, map_id: str, exception: BaseException
+    ) -> None:
+        """Store a failed map expansion in the registry and graph.
+
+        Args:
+            map_id: The map ID.
+            exception: The expansion exception.
+        """
+        self._future_registry.fail_map_startup(
+            map_id=map_id, exception=exception
+        )
+        nodes_ready = self._dependency_graph.mark_node_failed(node_id=map_id)
+        self._handle_graph_update(nodes_ready)
 
 
 def compile_dynamic_step_invocation(
@@ -1309,22 +1790,9 @@ def compile_dynamic_step_invocation(
     """
     upstream_steps = set()
 
-    if isinstance(after, BaseStepFuture):
-        after.result()
-        upstream_steps.add(after.invocation_id)
-    elif isinstance(after, MapResultsFuture):
-        for future in after:
-            future.result()
-            upstream_steps.add(future.invocation_id)
-    elif isinstance(after, Sequence):
-        for item in after:
-            if isinstance(item, BaseStepFuture):
-                item.result()
-                upstream_steps.add(item.invocation_id)
-            elif isinstance(item, MapResultsFuture):
-                for future in item:
-                    future.result()
-                    upstream_steps.add(future.invocation_id)
+    for future in collect_futures(after=after, expand_map_results=True):
+        future.wait()
+        upstream_steps.add(future.invocation_id)
 
     inputs = await_step_inputs(inputs)
 
@@ -1689,11 +2157,40 @@ def await_step_inputs(inputs: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
-def _get_running_upstream_steps(
+def _collect_upstream_node_ids(
     inputs: Dict[str, Any],
     after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None],
 ) -> List[str]:
-    """Get all running upstream steps for a step.
+    """Collect upstream node IDs from step inputs and `after` futures.
+
+    Args:
+        inputs: The step inputs.
+        after: Optional upstream futures for explicit ordering.
+
+    Raises:
+        TypeError: If an unexpected future type is passed.
+
+    Returns:
+        The upstream node IDs.
+    """
+    dependency_node_ids = []
+
+    for future in collect_futures(inputs=inputs, after=after):
+        if isinstance(future, MapResultsFuture):
+            dependency_node_ids.append(future.invocation_id)
+        elif isinstance(future, BaseStepFuture):
+            dependency_node_ids.append(future.invocation_id)
+        else:
+            raise TypeError(f"Unexpected future type: {type(future)}")
+
+    return dependency_node_ids
+
+
+def _get_running_upstream_dependencies(
+    inputs: Dict[str, Any],
+    after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None],
+) -> List[str]:
+    """Get all running upstream dependencies for a step.
 
     Args:
         inputs: The inputs of the step.
@@ -1703,37 +2200,27 @@ def _get_running_upstream_steps(
         TypeError: If an unexpected future type is passed.
 
     Returns:
-        The list of running upstream steps.
+        The list of running upstream dependencies.
     """
-    futures: List[BaseFuture] = []
+    futures = collect_futures(inputs=inputs, after=after)
 
-    for value in inputs.values():
-        if isinstance(value, BaseFuture):
-            futures.append(value)
-        elif isinstance(value, Sequence) and all(
-            isinstance(item, BaseFuture) for item in value
-        ):
-            futures.extend(value)
-
-    if isinstance(after, BaseFuture):
-        futures.append(after)
-    elif isinstance(after, Sequence):
-        futures.extend(after)
-
-    steps = []
+    dependencies = []
 
     for future in futures:
         if isinstance(future, MapResultsFuture):
-            for item in future.futures:
-                if item.running():
-                    steps.append(item.invocation_id)
+            if future.startup_succeeded:
+                for item in future.futures:
+                    if item.running():
+                        dependencies.append(item.invocation_id)
+            elif future.running():
+                dependencies.append(future.invocation_id)
         elif isinstance(future, BaseStepFuture):
             if future.running():
-                steps.append(future.invocation_id)
+                dependencies.append(future.invocation_id)
         else:
             raise TypeError(f"Unexpected future type: {type(future)}")
 
-    return steps
+    return dependencies
 
 
 def get_remaining_retries(step_run: "StepRunResponse") -> int:

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline runner."""
 
+import contextvars
 import copy
 import inspect
 import itertools
@@ -133,7 +134,6 @@ from zenml.steps.entrypoint_function_utils import StepArtifact
 from zenml.steps.step_invocation import StepInvocation
 from zenml.steps.utils import OutputSignature
 from zenml.utils import (
-    context_utils,
     env_utils,
     exception_utils,
     pydantic_utils,
@@ -234,7 +234,8 @@ class DynamicPipelineRunner:
 
         self._shutdown_requested = False
         self._failure_detected = False
-        self._failure_lock = threading.Lock()
+        self._exception: Optional[BaseException] = None
+        self._lifecycle_lock = threading.RLock()
         self._monitoring_event = threading.Event()
         self._startup_event = threading.Event()
         self._dependency_graph = InvocationDependencyGraph()
@@ -462,21 +463,26 @@ class DynamicPipelineRunner:
                             remaining_retries,
                         )
 
-                    if remaining_retries > 0 and not self._failure_detected:
-                        # If there was a failure already, we do not want to
-                        # start any new work no matter the execution mode.
-                        step = Step(
-                            spec=step_run.spec,
-                            config=step_run.config,
-                            step_config_overrides=step_run.config,
-                        )
-                        self._queue_concurrent_isolated_step(step=step)
+                    with self._lifecycle_lock:
+                        if (
+                            remaining_retries > 0
+                            and not self._failure_detected
+                        ):
+                            # If there was a failure already, we do not want to
+                            # start any new work no matter the execution mode.
+                            step = Step(
+                                spec=step_run.spec,
+                                config=step_run.config,
+                                step_config_overrides=step_run.config,
+                            )
+                            self._queue_concurrent_isolated_step(step=step)
 
                 time.sleep(monitoring_delay)
 
             duration = time.time() - start_time
             time_to_sleep = max(0, monitoring_interval - duration)
             self._monitoring_event.wait(timeout=time_to_sleep)
+            self._monitoring_event.clear()
 
     def _start_monitoring_loop(self) -> threading.Thread:
         """Start the monitoring loop.
@@ -484,11 +490,10 @@ class DynamicPipelineRunner:
         Returns:
             The monitoring thread.
         """
+        ctx = contextvars.copy_context()
         monitoring_thread = threading.Thread(
             name="DynamicPipelineRunner-Monitoring-Loop",
-            target=lambda: context_utils.run_in_current_context(
-                self._monitoring_loop
-            ),
+            target=lambda: ctx.run(self._monitoring_loop),
             daemon=True,
         )
         monitoring_thread.start()
@@ -544,11 +549,10 @@ class DynamicPipelineRunner:
         Returns:
             The startup thread.
         """
+        ctx = contextvars.copy_context()
         startup_thread = threading.Thread(
             name="DynamicPipelineRunner-Startup-Loop",
-            target=lambda: context_utils.run_in_current_context(
-                self._startup_loop
-            ),
+            target=lambda: ctx.run(self._startup_loop),
             daemon=True,
         )
         startup_thread.start()
@@ -563,9 +567,11 @@ class DynamicPipelineRunner:
             invocation_id: The step invocation ID.
             step_run: The step run response to monitor.
         """
-        self._steps_to_monitor[invocation_id] = step_run
+        with self._lifecycle_lock:
+            self._steps_to_monitor[invocation_id] = step_run
+            should_stop_step = self._failure_detected and self._fail_fast
 
-        if self._failure_detected and self._fail_fast:
+        if should_stop_step:
             try:
                 self._stop_isolated_step(step_run)
             except Exception:
@@ -661,20 +667,21 @@ class DynamicPipelineRunner:
                     # The pipeline function finished successfully, but some
                     # steps might still be running. We now wait for all of
                     # them and raise any exceptions that occurred.
-                    self.await_all_futures()
+                    self.wait_until_done_or_failure()
                 except _WaitConditionPollTimeout:
                     logger.info("Pausing pipeline run `%s`.", self._run.id)
                     return
-                except _WaitConditionAborted:
+                except _WaitConditionAborted as abort_exception:
                     logger.info(
                         "Stopping pipeline run `%s` because a wait condition "
                         "was aborted.",
                         self._run.id,
                     )
-                    self._abort_and_drain("Wait condition aborted.")
+                    self._abort_and_drain(exception=abort_exception)
                     return
                 except Exception as e:
-                    self._abort_and_drain("Pipeline function failed.")
+                    logger.debug("Exception in pipeline function: %s", e)
+                    self._abort_and_drain(exception=e)
                     exception_info = (
                         exception_utils.collect_exception_information(
                             exception=e,
@@ -849,6 +856,8 @@ class DynamicPipelineRunner:
                 self._existing_step_runs[invocation_id] = step_run
 
             if step_run.status.is_failed:
+                exception = self._get_step_exception(step_run=step_run)
+
                 # If the step is running concurrently, we only raise the
                 # exception once the future is awaited.
                 if concurrent:
@@ -866,17 +875,12 @@ class DynamicPipelineRunner:
                         initial_state=NodeState.FAILED,
                     )
                     self._handle_step_execution_failed(
-                        invocation_id=invocation_id
+                        invocation_id=invocation_id,
+                        exception=exception,
                     )
                     return future
                 else:
-                    raise exception_utils.reconstruct_exception(
-                        exception_info=step_run.exception_info,
-                        fallback_message=(
-                            f"Step `{invocation_id}` failed with status "
-                            f"`{step_run.status}`."
-                        ),
-                    )
+                    raise exception
 
             remaining_retries = get_remaining_retries(step_run=step_run)
 
@@ -1316,11 +1320,6 @@ class DynamicPipelineRunner:
             value=TypeAdapter(schema).validate_python(condition.result),
         )
 
-    def await_all_futures(self) -> None:
-        """Await all tracked futures."""
-        for future in self._future_registry.get_all_futures():
-            future.wait()
-
     def has_in_progress_work(self) -> bool:
         """Check if there is any in-progress tracked work.
 
@@ -1331,7 +1330,24 @@ class DynamicPipelineRunner:
 
     # Failure/Shutdown handling
 
-    def _on_failure_detected(self, failure_reason: str) -> None:
+    def wait_until_done_or_failure(self) -> None:
+        """Wait until all futures finished or a failure has been detected.
+
+        Raises:
+            BaseException: If a failure has been detected.
+        """  # noqa: DOC503
+        while True:
+            if self._exception:
+                raise self._exception
+
+            if not self.has_in_progress_work():
+                if self._exception:
+                    raise self._exception
+                return
+
+            time.sleep(1)
+
+    def _on_failure_detected(self, exception: BaseException) -> None:
         """Handle any failure that happens during pipeline execution.
 
         This method
@@ -1340,40 +1356,51 @@ class DynamicPipelineRunner:
         - stops all isolated steps in the FAIL_FAST execution mode
 
         Args:
-            failure_reason: The failure reason.
+            exception: The failure exception.
         """
-        with self._failure_lock:
+        steps_to_stop: List["StepRunResponse"] = []
+        nodes_to_cancel: List[Union["StepNode", "MapNode"]] = []
+
+        with self._lifecycle_lock:
             if self._failure_detected:
                 return
             self._failure_detected = True
+            self._exception = exception
 
-        exception: Optional[StartupCancelled] = None
-        if failure_reason:
-            exception = StartupCancelled(failure_reason)
+            nodes_to_cancel = self._dependency_graph.list_nodes(
+                states={NodeState.PENDING, NodeState.READY, NodeState.STARTING}
+            )
+            if self._fail_fast:
+                steps_to_stop = list(self._steps_to_monitor.values())
 
-        for node in self._dependency_graph.list_nodes(
-            states={NodeState.PENDING, NodeState.READY}
-        ):
+        logger.debug(
+            "Initial pipeline failure detected: %s",
+            str(exception),
+        )
+
+        startup_cancelled_exception = StartupCancelled(str(exception))
+        for node in nodes_to_cancel:
             if isinstance(node, StepNode):
                 self._future_registry.cancel_step_startup(
-                    invocation_id=node.node_id, exception=exception
+                    invocation_id=node.node_id,
+                    exception=startup_cancelled_exception,
                 )
             elif isinstance(node, MapNode):
                 self._future_registry.cancel_map_startup(
-                    map_id=node.node_id, exception=exception
+                    map_id=node.node_id,
+                    exception=startup_cancelled_exception,
                 )
 
+        logger.debug("Startup work cancelled.")
         self._startup_event.set()
 
-        if self._fail_fast:
-            for step_run in list(self._steps_to_monitor.values()):
-                try:
-                    self._stop_isolated_step(step_run)
-                except Exception:
-                    logger.exception(
-                        "Failed to stop step `%s`.", step_run.name
-                    )
+        for step_run in steps_to_stop:
+            try:
+                self._stop_isolated_step(step_run)
+            except Exception:
+                logger.exception("Failed to stop step `%s`.", step_run.name)
 
+        logger.debug("Requested stopping of isolated steps.")
         self._monitoring_event.set()
 
     def _stop_isolated_step(self, step_run: "StepRunResponse") -> None:
@@ -1399,14 +1426,33 @@ class DynamicPipelineRunner:
                 "Dynamic pipeline runner is not starting new work."
             )
 
-    def _abort_and_drain(self, failure_reason: str) -> None:
+    def _abort_and_drain(self, exception: BaseException) -> None:
         """Trigger the failure path and wait for in-flight work to finish.
 
         Args:
-            failure_reason: Human-readable description of why we are aborting.
+            exception: Exception that triggered the abort.
         """
-        self._on_failure_detected(failure_reason=failure_reason)
+        self._on_failure_detected(exception=exception)
         self._future_registry.await_all_no_raise()
+
+    def _get_step_exception(
+        self, step_run: "StepRunResponse"
+    ) -> BaseException:
+        """Get the failure exception for a step run.
+
+        Args:
+            step_run: The step run.
+
+        Returns:
+            The failure exception.
+        """
+        return exception_utils.reconstruct_exception(
+            exception_info=step_run.exception_info,
+            fallback_message=(
+                f"Step `{step_run.name}` failed with status "
+                f"`{step_run.status}`."
+            ),
+        )
 
     # Concurrent step lifecycle
 
@@ -1436,32 +1482,35 @@ class DynamicPipelineRunner:
         else:
             upstream_node_ids = None
 
-        if self._failure_detected and initial_state in {
-            None,
-            NodeState.PENDING,
-            NodeState.READY,
-        }:
-            # This is a future that requires startup but startup has already
-            # been cancelled.
-            future._cancel_startup(
-                StartupCancelled(
-                    f"Startup for step `{future.invocation_id}` was cancelled."
+        with self._lifecycle_lock:
+            if self._failure_detected and initial_state in {
+                None,
+                NodeState.PENDING,
+                NodeState.READY,
+                NodeState.STARTING,
+            }:
+                # This is a future that requires startup but startup has already
+                # been cancelled.
+                future._cancel_startup(
+                    StartupCancelled(
+                        f"Startup for step `{future.invocation_id}` was "
+                        "cancelled."
+                    )
                 )
-            )
-            return
+                return
 
-        self._future_registry.register_step_future(
-            invocation_id=future.invocation_id, future=future
-        )
-        nodes_ready = self._dependency_graph.register_step_node(
-            node_id=future.invocation_id,
-            upstream_ids=upstream_node_ids,
-            state=initial_state,
-            step=step,
-            inputs=inputs,
-            after=after,
-            config_overrides=config_overrides,
-        )
+            self._future_registry.register_step_future(
+                invocation_id=future.invocation_id, future=future
+            )
+            nodes_ready = self._dependency_graph.register_step_node(
+                node_id=future.invocation_id,
+                upstream_ids=upstream_node_ids,
+                state=initial_state,
+                step=step,
+                inputs=inputs,
+                after=after,
+                config_overrides=config_overrides,
+            )
         self._handle_graph_update(nodes_ready)
 
     def _handle_step_starting(self, invocation_id: str) -> None:
@@ -1505,29 +1554,31 @@ class DynamicPipelineRunner:
             orchestrator=self._orchestrator,
         )
 
-        # This error will be caught by the startup loop and set as a startup
-        # failure on the future.
-        self._raise_if_startup_cancelled()
+        with self._lifecycle_lock:
+            # This error will be caught by the startup loop and set as a
+            # startup failure on the future.
+            self._raise_if_startup_cancelled()
 
-        execution_future: StepExecutionFuture
+            execution_future: StepExecutionFuture
+            if runtime == StepRuntime.INLINE:
+                remaining_retries = None
+                if step_run := self._existing_step_runs.get(node.node_id):
+                    remaining_retries = get_remaining_retries(
+                        step_run=step_run
+                    )
 
-        if runtime == StepRuntime.INLINE:
-            remaining_retries = None
-            if step_run := self._existing_step_runs.get(node.node_id):
-                remaining_retries = get_remaining_retries(step_run=step_run)
+                execution_future = self._queue_concurrent_inline_step(
+                    step=compiled_step, remaining_retries=remaining_retries
+                )
+            else:
+                execution_future = self._queue_concurrent_isolated_step(
+                    step=compiled_step
+                )
 
-            execution_future = self._queue_concurrent_inline_step(
-                step=compiled_step, remaining_retries=remaining_retries
+            self._handle_step_startup_succeeded(
+                invocation_id=node.node_id,
+                execution_future=execution_future,
             )
-        else:
-            execution_future = self._queue_concurrent_isolated_step(
-                step=compiled_step
-            )
-
-        self._handle_step_startup_succeeded(
-            invocation_id=node.node_id,
-            execution_future=execution_future,
-        )
 
     def _queue_concurrent_isolated_step(
         self, step: "Step"
@@ -1554,7 +1605,7 @@ class DynamicPipelineRunner:
                 )
             except BaseException as e:
                 self._handle_step_execution_failed(
-                    invocation_id=step.spec.invocation_id
+                    invocation_id=step.spec.invocation_id, exception=e
                 )
                 raise e
 
@@ -1564,9 +1615,8 @@ class DynamicPipelineRunner:
             )
             return step_run
 
-        concurrent_future = self._executor.submit(
-            context_utils.run_in_current_context, _launch_no_wait
-        )
+        ctx = contextvars.copy_context()
+        concurrent_future = self._executor.submit(ctx.run, _launch_no_wait)
         return _IsolatedStepFuture(
             wrapped=concurrent_future,
             pipeline_run_id=self._run.id,
@@ -1593,16 +1643,15 @@ class DynamicPipelineRunner:
                 )
             except BaseException as e:
                 self._handle_step_execution_failed(
-                    invocation_id=step.spec.invocation_id
+                    invocation_id=step.spec.invocation_id, exception=e
                 )
                 raise e
 
             self._on_step_finished(step_run=step_run)
             return step_run
 
-        concurrent_future = self._executor.submit(
-            context_utils.run_in_current_context, _launch_and_wait
-        )
+        ctx = contextvars.copy_context()
+        concurrent_future = self._executor.submit(ctx.run, _launch_and_wait)
         return _InlineStepFuture(
             wrapped=concurrent_future,
             invocation_id=step.spec.invocation_id,
@@ -1652,9 +1701,7 @@ class DynamicPipelineRunner:
             node_id=invocation_id
         )
         self._handle_graph_update(nodes_ready)
-        self._on_failure_detected(
-            failure_reason=f"Step `{invocation_id}` startup failed."
-        )
+        self._on_failure_detected(exception=exception)
 
     def _on_step_finished(self, step_run: "StepRunResponse") -> None:
         """Handle a terminal step run.
@@ -1676,10 +1723,14 @@ class DynamicPipelineRunner:
 
         if step_run.status.is_successful:
             self._handle_step_execution_succeeded(invocation_id=step_run.name)
-        elif step_run.status.is_failed:
-            self._handle_step_execution_failed(invocation_id=step_run.name)
-        elif step_run.status == ExecutionStatus.STOPPED:
-            self._handle_step_execution_failed(invocation_id=step_run.name)
+        elif (
+            step_run.status.is_failed
+            or step_run.status == ExecutionStatus.STOPPED
+        ):
+            exception = self._get_step_exception(step_run=step_run)
+            self._handle_step_execution_failed(
+                invocation_id=step_run.name, exception=exception
+            )
 
     def _handle_step_execution_succeeded(self, invocation_id: str) -> None:
         """Mark a step node as successfully finished.
@@ -1692,19 +1743,22 @@ class DynamicPipelineRunner:
         )
         self._handle_graph_update(nodes_ready)
 
-    def _handle_step_execution_failed(self, invocation_id: str) -> None:
+    def _handle_step_execution_failed(
+        self,
+        invocation_id: str,
+        exception: BaseException,
+    ) -> None:
         """Mark a step node as failed.
 
         Args:
             invocation_id: The step invocation ID.
+            exception: Step execution exception.
         """
         nodes_ready = self._dependency_graph.mark_node_failed(
             node_id=invocation_id
         )
         self._handle_graph_update(nodes_ready)
-        self._on_failure_detected(
-            failure_reason=f"Step `{invocation_id}` failed."
-        )
+        self._on_failure_detected(exception=exception)
 
     # Concurrent map lifecycle
 
@@ -1730,25 +1784,26 @@ class DynamicPipelineRunner:
             inputs=inputs, after=after
         )
 
-        if self._failure_detected:
-            future._cancel_startup(
-                StartupCancelled(
-                    f"Startup for map expansion `{node_id}` was cancelled."
+        with self._lifecycle_lock:
+            if self._failure_detected:
+                future._cancel_startup(
+                    StartupCancelled(
+                        f"Startup for map expansion `{node_id}` was cancelled."
+                    )
                 )
-            )
-            return
+                return
 
-        self._future_registry.register_map_future(
-            map_id=node_id, future=future
-        )
-        nodes_ready = self._dependency_graph.register_map_node(
-            node_id=node_id,
-            step=step,
-            inputs=inputs,
-            product=product,
-            upstream_ids=upstream_node_ids,
-            after=after,
-        )
+            self._future_registry.register_map_future(
+                map_id=node_id, future=future
+            )
+            nodes_ready = self._dependency_graph.register_map_node(
+                node_id=node_id,
+                step=step,
+                inputs=inputs,
+                product=product,
+                upstream_ids=upstream_node_ids,
+                after=after,
+            )
         self._handle_graph_update(nodes_ready)
 
     def _handle_map_starting(self, map_id: str) -> None:
@@ -1777,9 +1832,10 @@ class DynamicPipelineRunner:
             type=GroupType.MAP,
         )
 
-        # This error will be caught by the startup loop and set as a startup
-        # failure on the future.
-        self._raise_if_startup_cancelled()
+        with self._lifecycle_lock:
+            # This error will be caught by the startup loop and set as a
+            # startup failure on the future.
+            self._raise_if_startup_cancelled()
 
         step_futures = [
             self.launch_step(
@@ -1838,9 +1894,7 @@ class DynamicPipelineRunner:
         )
         nodes_ready = self._dependency_graph.mark_node_failed(node_id=map_id)
         self._handle_graph_update(nodes_ready)
-        self._on_failure_detected(
-            failure_reason=f"Map expansion `{map_id}` failed."
-        )
+        self._on_failure_detected(exception=exception)
 
 
 def compile_dynamic_step_invocation(
@@ -2247,23 +2301,13 @@ def _collect_upstream_node_ids(
         inputs: The step inputs.
         after: Optional upstream futures for explicit ordering.
 
-    Raises:
-        TypeError: If an unexpected future type is passed.
-
     Returns:
         The upstream node IDs.
     """
-    dependency_node_ids = []
-
-    for future in collect_futures(inputs=inputs, after=after):
-        if isinstance(future, MapResultsFuture):
-            dependency_node_ids.append(future.invocation_id)
-        elif isinstance(future, BaseStepFuture):
-            dependency_node_ids.append(future.invocation_id)
-        else:
-            raise TypeError(f"Unexpected future type: {type(future)}")
-
-    return dependency_node_ids
+    return [
+        future.invocation_id
+        for future in collect_futures(inputs=inputs, after=after)
+    ]
 
 
 def _get_running_upstream_dependencies(

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -227,6 +227,7 @@ class DynamicPipelineRunner:
         self._steps_to_monitor: Dict[str, "StepRunResponse"] = {}
 
         self._shutdown_requested = False
+        self._prevent_new_startups = False
         self._monitoring_event = threading.Event()
         self._startup_event = threading.Event()
         self._dependency_graph = InvocationDependencyGraph()
@@ -490,7 +491,7 @@ class DynamicPipelineRunner:
             self._snapshot.pipeline_configuration.execution_mode
             == ExecutionMode.FAIL_FAST
         )
-        while not self._shutdown_requested:
+        while not self._prevent_new_startups:
             self._startup_event.clear()
 
             ready_step_node_ids = (
@@ -694,16 +695,15 @@ class DynamicPipelineRunner:
                         "was aborted.",
                         self._run.id,
                     )
+                    self._finalize_in_progress_work()
                 except Exception as e:
+                    self._finalize_in_progress_work()
                     exception_info = (
                         exception_utils.collect_exception_information(
                             exception=e,
                             user_func=self.pipeline.entrypoint,
                         )
                     )
-                    # TODO: this call already invalidates the token, so
-                    # the steps will keep running but won't be able to
-                    # report their status back to ZenML.
                     publish_failed_pipeline_run(
                         self._run.id, exception_info=exception_info
                     )
@@ -720,7 +720,6 @@ class DynamicPipelineRunner:
                         )
 
                     self._executor.shutdown(wait=True, cancel_futures=True)
-                    self._maybe_stop_isolated_steps()
                     monitoring_thread.join()
                     startup_thread.join()
 
@@ -1347,16 +1346,16 @@ class DynamicPipelineRunner:
         """
         return self._future_registry.has_in_progress_work()
 
-    def _shutdown(self) -> None:
-        """Shutdown the runner.
+    def _cancel_new_startup_work(self) -> None:
+        """Cancel pending startup work without stopping monitoring.
 
-        This wakes any background loops so they can observe the shutdown flag
-        and exit cleanly.
+        This keeps the monitoring loop alive while already-started isolated
+        steps finish and publish their terminal state.
         """
-        if self._shutdown_requested:
+        if self._prevent_new_startups:
             return
 
-        self._shutdown_requested = True
+        self._prevent_new_startups = True
 
         for node in self._dependency_graph.list_nodes(
             states={NodeState.PENDING, NodeState.READY}
@@ -1369,16 +1368,36 @@ class DynamicPipelineRunner:
                 self._future_registry.cancel_map_startup(map_id=node.node_id)
 
         self._startup_event.set()
-        self._monitoring_event.set()
 
     def _raise_if_startup_cancelled(self) -> None:
-        """Abort startup work once runner shutdown has started.
+        """Abort startup work once startup has been cancelled.
 
         Raises:
-            StartupCancelled: If the runner is shutting down.
+            StartupCancelled: If startup has been cancelled.
+        """
+        if self._prevent_new_startups:
+            raise StartupCancelled(
+                "Dynamic pipeline runner is not starting new work."
+            )
+
+    def _finalize_in_progress_work(self) -> None:
+        """Finalize in-progress work before runner shutdown."""
+        self._cancel_new_startup_work()
+        self._maybe_stop_isolated_steps()
+        self._future_registry.await_all_no_raise()
+
+    def _shutdown(self) -> None:
+        """Shutdown the runner.
+
+        This wakes any background loops so they can observe the shutdown flag
+        and exit cleanly.
         """
         if self._shutdown_requested:
-            raise StartupCancelled("Dynamic pipeline runner is shutting down.")
+            return
+
+        self._shutdown_requested = True
+        self._cancel_new_startup_work()
+        self._monitoring_event.set()
 
     # Concurrent step lifecycle
 

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -207,17 +207,23 @@ class DynamicPipelineRunner:
 
         self._snapshot = snapshot
         self._pipeline: Optional["DynamicPipeline"] = None
+        self._fail_fast = (
+            snapshot.pipeline_configuration.execution_mode
+            == ExecutionMode.FAIL_FAST
+        )
 
         worker_count = handle_int_env_var(
             ENV_ZENML_DYNAMIC_PIPELINE_WORKER_COUNT, default=10
         )
         self._executor = ThreadPoolExecutor(max_workers=worker_count)
+
+        stack = Stack.from_model(snapshot.stack)
         if orchestrator:
             self._orchestrator = orchestrator
         else:
-            self._orchestrator = Stack.from_model(snapshot.stack).orchestrator
+            self._orchestrator = stack.orchestrator
 
-        self._step_operator = Stack.from_model(snapshot.stack).step_operator
+        self._step_operator = stack.step_operator
         self._invocation_id_lock = threading.Lock()
         self._invocation_ids: Set[str] = set()
 
@@ -227,7 +233,8 @@ class DynamicPipelineRunner:
         self._steps_to_monitor: Dict[str, "StepRunResponse"] = {}
 
         self._shutdown_requested = False
-        self._prevent_new_startups = False
+        self._failure_detected = False
+        self._failure_lock = threading.Lock()
         self._monitoring_event = threading.Event()
         self._startup_event = threading.Event()
         self._dependency_graph = InvocationDependencyGraph()
@@ -353,8 +360,6 @@ class DynamicPipelineRunner:
                     continue
 
                 step_run = Client().get_run_step(step_run.id)
-                # Store the refreshed step run
-                self._steps_to_monitor[invocation_id] = step_run
 
                 db_status = step_run.status
 
@@ -365,7 +370,9 @@ class DynamicPipelineRunner:
                 ]:
                     # Step is running in the DB and we have no information on
                     # the infra side, so we wait for the next
-                    # monitoring interval to check again.
+                    # monitoring interval to check again. We store the
+                    # refreshed step run to have the most up to date status.
+                    self._steps_to_monitor[invocation_id] = step_run
                     continue
 
                 self._steps_to_monitor.pop(invocation_id, None)
@@ -455,7 +462,9 @@ class DynamicPipelineRunner:
                             remaining_retries,
                         )
 
-                    if remaining_retries > 0:
+                    if remaining_retries > 0 and not self._failure_detected:
+                        # If there was a failure already, we do not want to
+                        # start any new work no matter the execution mode.
                         step = Step(
                             spec=step_run.spec,
                             config=step_run.config,
@@ -487,66 +496,47 @@ class DynamicPipelineRunner:
 
     def _startup_loop(self) -> None:
         """Startup loop."""
-        fail_fast = (
-            self._snapshot.pipeline_configuration.execution_mode
-            == ExecutionMode.FAIL_FAST
-        )
-        while not self._prevent_new_startups:
-            self._startup_event.clear()
-
-            ready_step_node_ids = (
-                self._dependency_graph.list_ready_step_node_ids()
-            )
-            if ready_step_node_ids:
-                logger.debug(
-                    "Startup loop picked ready step nodes: %s",
-                    ready_step_node_ids,
-                )
-
-            for node_id in ready_step_node_ids:
-                step_node = self._dependency_graph.get_step_node(
-                    node_id=node_id
-                )
-                try:
-                    self._handle_step_ready(node=step_node)
-                except Exception as e:
-                    self._handle_step_startup_failed(
-                        invocation_id=node_id, exception=e
-                    )
-                    logger.exception(
-                        "Failed to start concurrent step `%s`.",
-                        node_id,
-                    )
-                    if fail_fast:
-                        self._shutdown()
-                        return
-
-            ready_map_node_ids = (
-                self._dependency_graph.list_ready_map_node_ids()
-            )
-            if ready_map_node_ids:
-                logger.debug(
-                    "Startup loop picked ready map nodes: %s",
-                    ready_map_node_ids,
-                )
-
-            for node_id in ready_map_node_ids:
-                map_node = self._dependency_graph.get_map_node(node_id=node_id)
-                try:
-                    self._handle_map_ready(node=map_node)
-                except Exception as e:
-                    self._handle_map_expansion_failed(
-                        map_id=node_id, exception=e
-                    )
-                    logger.exception(
-                        "Failed to start concurrent map `%s`.",
-                        node_id,
-                    )
-                    if fail_fast:
-                        self._shutdown()
-                        return
-
+        while not self._failure_detected and not self._shutdown_requested:
             self._startup_event.wait(timeout=None)
+
+            while not self._failure_detected and not self._shutdown_requested:
+                node = self._dependency_graph.get_ready_node()
+                if node is None:
+                    # Clear and immediately re-check to avoid missing work that
+                    # becomes ready concurrently with this transition to waiting.
+                    self._startup_event.clear()
+                    node = self._dependency_graph.get_ready_node()
+                    if node is None:
+                        break
+
+                node_id = node.node_id
+                try:
+                    if isinstance(node, StepNode):
+                        self._handle_step_ready(node=node)
+                    elif isinstance(node, MapNode):
+                        self._handle_map_ready(node=node)
+                except Exception as e:
+                    if isinstance(node, StepNode):
+                        self._handle_step_startup_failed(
+                            invocation_id=node_id, exception=e
+                        )
+                        logger.exception(
+                            "Failed to start concurrent step `%s`.",
+                            node_id,
+                        )
+                    elif isinstance(node, MapNode):
+                        self._handle_map_expansion_failed(
+                            map_id=node_id, exception=e
+                        )
+                        logger.exception(
+                            "Failed to start concurrent map `%s`.",
+                            node_id,
+                        )
+
+                    # ONLY FAIL_FAST and STOP_ON_FAILURE execution modes are
+                    # supported for dynamic pipelines. In both cases, we do not
+                    # allow starting any new steps after any failure.
+                    return
 
     def _start_startup_loop(self) -> threading.Thread:
         """Start the startup loop.
@@ -564,25 +554,22 @@ class DynamicPipelineRunner:
         startup_thread.start()
         return startup_thread
 
-    def _maybe_stop_isolated_steps(self) -> None:
-        """Maybe stop all isolated in progress steps.
+    def _register_isolated_step_for_monitoring(
+        self, invocation_id: str, step_run: "StepRunResponse"
+    ) -> None:
+        """Register an isolated step for monitoring.
 
-        This method will only stop concurrent isolated steps if the execution
-        mode is FAIL_FAST.
+        Args:
+            invocation_id: The step invocation ID.
+            step_run: The step run response to monitor.
         """
-        if (
-            self._snapshot.pipeline_configuration.execution_mode
-            != ExecutionMode.FAIL_FAST
-        ):
-            return
+        self._steps_to_monitor[invocation_id] = step_run
 
-        logger.info("Stopping isolated steps.")
-
-        for step_run in list(self._steps_to_monitor.values()):
+        if self._failure_detected and self._fail_fast:
             try:
                 self._stop_isolated_step(step_run)
             except Exception:
-                logger.exception("Failed to stop step `%s`.", step_run.name)
+                logger.exception("Failed to stop step `%s`.", invocation_id)
 
     def _get_isolated_step_infra_status(
         self, step_run: "StepRunResponse"
@@ -600,18 +587,6 @@ class DynamicPipelineRunner:
             return self._step_operator.get_status(step_run)
         else:
             return self._orchestrator.get_isolated_step_status(step_run)
-
-    def _stop_isolated_step(self, step_run: "StepRunResponse") -> None:
-        """Stop an isolated step.
-
-        Args:
-            step_run: The step run to stop.
-        """
-        if step_run.config.step_operator:
-            assert self._step_operator
-            self._step_operator.cancel(step_run)
-        else:
-            self._orchestrator.stop_isolated_step(step_run)
 
     def run_pipeline(self) -> None:
         """Run the pipeline.
@@ -689,15 +664,17 @@ class DynamicPipelineRunner:
                     self.await_all_futures()
                 except _WaitConditionPollTimeout:
                     logger.info("Pausing pipeline run `%s`.", self._run.id)
+                    return
                 except _WaitConditionAborted:
                     logger.info(
                         "Stopping pipeline run `%s` because a wait condition "
                         "was aborted.",
                         self._run.id,
                     )
-                    self._finalize_in_progress_work()
+                    self._abort_and_drain("Wait condition aborted.")
+                    return
                 except Exception as e:
-                    self._finalize_in_progress_work()
+                    self._abort_and_drain("Pipeline function failed.")
                     exception_info = (
                         exception_utils.collect_exception_information(
                             exception=e,
@@ -709,8 +686,6 @@ class DynamicPipelineRunner:
                     )
                     raise
                 finally:
-                    self._shutdown()
-
                     if not self._run.triggered_by_deployment:
                         # Only run the cleanup hook if the run is not
                         # triggered by a deployment, as the deployment
@@ -720,6 +695,10 @@ class DynamicPipelineRunner:
                         )
 
                     self._executor.shutdown(wait=True, cancel_futures=True)
+
+                    self._shutdown_requested = True
+                    self._startup_event.set()
+                    self._monitoring_event.set()
                     monitoring_thread.join()
                     startup_thread.join()
 
@@ -909,7 +888,6 @@ class DynamicPipelineRunner:
                     step_run.id,
                     remaining_retries,
                 )
-                self._steps_to_monitor[invocation_id] = step_run
                 execution_future = _IsolatedStepFuture(
                     pipeline_run_id=self._run.id,
                     invocation_id=invocation_id,
@@ -922,6 +900,10 @@ class DynamicPipelineRunner:
                 self._register_concurrent_step_invocation(
                     future=monitoring_future,
                     initial_state=NodeState.RUNNING,
+                )
+                self._register_isolated_step_for_monitoring(
+                    invocation_id=invocation_id,
+                    step_run=step_run,
                 )
                 self._handle_step_running(invocation_id=invocation_id)
                 if concurrent:
@@ -1336,7 +1318,8 @@ class DynamicPipelineRunner:
 
     def await_all_futures(self) -> None:
         """Await all tracked futures."""
-        self._future_registry.await_all()
+        for future in self._future_registry.get_all_futures():
+            future.wait()
 
     def has_in_progress_work(self) -> bool:
         """Check if there is any in-progress tracked work.
@@ -1346,58 +1329,84 @@ class DynamicPipelineRunner:
         """
         return self._future_registry.has_in_progress_work()
 
-    def _cancel_new_startup_work(self) -> None:
-        """Cancel pending startup work without stopping monitoring.
+    # Failure/Shutdown handling
 
-        This keeps the monitoring loop alive while already-started isolated
-        steps finish and publish their terminal state.
+    def _on_failure_detected(self, failure_reason: str) -> None:
+        """Handle any failure that happens during pipeline execution.
+
+        This method
+        - cancels all in-progress startup work
+        - sets a flag that prevents any new startup work from being started
+        - stops all isolated steps in the FAIL_FAST execution mode
+
+        Args:
+            failure_reason: The failure reason.
         """
-        if self._prevent_new_startups:
-            return
+        with self._failure_lock:
+            if self._failure_detected:
+                return
+            self._failure_detected = True
 
-        self._prevent_new_startups = True
+        exception: Optional[StartupCancelled] = None
+        if failure_reason:
+            exception = StartupCancelled(failure_reason)
 
         for node in self._dependency_graph.list_nodes(
             states={NodeState.PENDING, NodeState.READY}
         ):
             if isinstance(node, StepNode):
                 self._future_registry.cancel_step_startup(
-                    invocation_id=node.node_id
+                    invocation_id=node.node_id, exception=exception
                 )
             elif isinstance(node, MapNode):
-                self._future_registry.cancel_map_startup(map_id=node.node_id)
+                self._future_registry.cancel_map_startup(
+                    map_id=node.node_id, exception=exception
+                )
 
         self._startup_event.set()
 
+        if self._fail_fast:
+            for step_run in list(self._steps_to_monitor.values()):
+                try:
+                    self._stop_isolated_step(step_run)
+                except Exception:
+                    logger.exception(
+                        "Failed to stop step `%s`.", step_run.name
+                    )
+
+        self._monitoring_event.set()
+
+    def _stop_isolated_step(self, step_run: "StepRunResponse") -> None:
+        """Stop an isolated step.
+
+        Args:
+            step_run: The step run to stop.
+        """
+        if step_run.config.step_operator:
+            assert self._step_operator
+            self._step_operator.cancel(step_run)
+        else:
+            self._orchestrator.stop_isolated_step(step_run)
+
     def _raise_if_startup_cancelled(self) -> None:
-        """Abort startup work once startup has been cancelled.
+        """Abort startup work once a failure has been detected.
 
         Raises:
-            StartupCancelled: If startup has been cancelled.
+            StartupCancelled: If a failure has been detected.
         """
-        if self._prevent_new_startups:
+        if self._failure_detected:
             raise StartupCancelled(
                 "Dynamic pipeline runner is not starting new work."
             )
 
-    def _finalize_in_progress_work(self) -> None:
-        """Finalize in-progress work before runner shutdown."""
-        self._cancel_new_startup_work()
-        self._maybe_stop_isolated_steps()
-        self._future_registry.await_all_no_raise()
+    def _abort_and_drain(self, failure_reason: str) -> None:
+        """Trigger the failure path and wait for in-flight work to finish.
 
-    def _shutdown(self) -> None:
-        """Shutdown the runner.
-
-        This wakes any background loops so they can observe the shutdown flag
-        and exit cleanly.
+        Args:
+            failure_reason: Human-readable description of why we are aborting.
         """
-        if self._shutdown_requested:
-            return
-
-        self._shutdown_requested = True
-        self._cancel_new_startup_work()
-        self._monitoring_event.set()
+        self._on_failure_detected(failure_reason=failure_reason)
+        self._future_registry.await_all_no_raise()
 
     # Concurrent step lifecycle
 
@@ -1426,6 +1435,20 @@ class DynamicPipelineRunner:
             )
         else:
             upstream_node_ids = None
+
+        if self._failure_detected and initial_state in {
+            None,
+            NodeState.PENDING,
+            NodeState.READY,
+        }:
+            # This is a future that requires startup but startup has already
+            # been cancelled.
+            future._cancel_startup(
+                StartupCancelled(
+                    f"Startup for step `{future.invocation_id}` was cancelled."
+                )
+            )
+            return
 
         self._future_registry.register_step_future(
             invocation_id=future.invocation_id, future=future
@@ -1482,6 +1505,8 @@ class DynamicPipelineRunner:
             orchestrator=self._orchestrator,
         )
 
+        # This error will be caught by the startup loop and set as a startup
+        # failure on the future.
         self._raise_if_startup_cancelled()
 
         execution_future: StepExecutionFuture
@@ -1517,16 +1542,26 @@ class DynamicPipelineRunner:
         """
 
         def _launch_no_wait() -> StepRunResponse:
-            step_run = launch_step(
-                snapshot=self._snapshot,
-                step=step,
-                orchestrator_run_id=self._orchestrator_run_id,
-                # The monitoring loop is responsible for monitoring and retrying
-                # steps.
-                wait=False,
-                retry=False,
+            try:
+                step_run = launch_step(
+                    snapshot=self._snapshot,
+                    step=step,
+                    orchestrator_run_id=self._orchestrator_run_id,
+                    # The monitoring loop is responsible for monitoring and retrying
+                    # steps.
+                    wait=False,
+                    retry=False,
+                )
+            except BaseException as e:
+                self._handle_step_execution_failed(
+                    invocation_id=step.spec.invocation_id
+                )
+                raise e
+
+            self._register_isolated_step_for_monitoring(
+                invocation_id=step.spec.invocation_id,
+                step_run=step_run,
             )
-            self._steps_to_monitor[step.spec.invocation_id] = step_run
             return step_run
 
         concurrent_future = self._executor.submit(
@@ -1552,9 +1587,16 @@ class DynamicPipelineRunner:
         """
 
         def _launch_and_wait() -> StepRunResponse:
-            step_run = self._run_sync_step(
-                step=step, remaining_retries=remaining_retries
-            )
+            try:
+                step_run = self._run_sync_step(
+                    step=step, remaining_retries=remaining_retries
+                )
+            except BaseException as e:
+                self._handle_step_execution_failed(
+                    invocation_id=step.spec.invocation_id
+                )
+                raise e
+
             self._on_step_finished(step_run=step_run)
             return step_run
 
@@ -1610,6 +1652,9 @@ class DynamicPipelineRunner:
             node_id=invocation_id
         )
         self._handle_graph_update(nodes_ready)
+        self._on_failure_detected(
+            failure_reason=f"Step `{invocation_id}` startup failed."
+        )
 
     def _on_step_finished(self, step_run: "StepRunResponse") -> None:
         """Handle a terminal step run.
@@ -1657,6 +1702,9 @@ class DynamicPipelineRunner:
             node_id=invocation_id
         )
         self._handle_graph_update(nodes_ready)
+        self._on_failure_detected(
+            failure_reason=f"Step `{invocation_id}` failed."
+        )
 
     # Concurrent map lifecycle
 
@@ -1681,6 +1729,14 @@ class DynamicPipelineRunner:
         upstream_node_ids = _collect_upstream_node_ids(
             inputs=inputs, after=after
         )
+
+        if self._failure_detected:
+            future._cancel_startup(
+                StartupCancelled(
+                    f"Startup for map expansion `{node_id}` was cancelled."
+                )
+            )
+            return
 
         self._future_registry.register_map_future(
             map_id=node_id, future=future
@@ -1721,6 +1777,8 @@ class DynamicPipelineRunner:
             type=GroupType.MAP,
         )
 
+        # This error will be caught by the startup loop and set as a startup
+        # failure on the future.
         self._raise_if_startup_cancelled()
 
         step_futures = [
@@ -1780,6 +1838,9 @@ class DynamicPipelineRunner:
         )
         nodes_ready = self._dependency_graph.mark_node_failed(node_id=map_id)
         self._handle_graph_update(nodes_ready)
+        self._on_failure_detected(
+            failure_reason=f"Map expansion `{map_id}` failed."
+        )
 
 
 def compile_dynamic_step_invocation(

--- a/src/zenml/execution/pipeline/dynamic/utils.py
+++ b/src/zenml/execution/pipeline/dynamic/utils.py
@@ -306,7 +306,7 @@ def load_step_run_outputs(step_run_id: UUID) -> "StepRunOutputs":
 def collect_futures(
     inputs: Optional[Dict[str, Any]] = ...,
     after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = ...,
-    expand_map_results: Literal[True] = True,
+    expand_map_results: Literal[True] = ...,
 ) -> List["BaseStepFuture"]: ...
 
 
@@ -314,7 +314,7 @@ def collect_futures(
 def collect_futures(
     inputs: Optional[Dict[str, Any]] = ...,
     after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = ...,
-    expand_map_results: Literal[False] = False,
+    expand_map_results: Literal[False] = ...,
 ) -> List["AnyStepFuture"]: ...
 
 

--- a/src/zenml/execution/pipeline/dynamic/utils.py
+++ b/src/zenml/execution/pipeline/dynamic/utils.py
@@ -19,10 +19,13 @@ from typing import (
     Any,
     Dict,
     Generic,
+    List,
+    Literal,
     Optional,
     Sequence,
     Type,
     TypeVar,
+    Union,
     overload,
 )
 from uuid import UUID
@@ -39,6 +42,7 @@ from zenml.utils import string_utils
 if TYPE_CHECKING:
     from zenml.execution.pipeline.dynamic.outputs import (
         AnyStepFuture,
+        BaseStepFuture,
         OutputArtifact,
         StepRunOutputs,
     )
@@ -296,3 +300,88 @@ def load_step_run_outputs(step_run_id: UUID) -> "StepRunOutputs":
             )
 
         return tuple(outputs)
+
+
+@overload
+def collect_futures(
+    inputs: Optional[Dict[str, Any]] = ...,
+    after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = ...,
+    expand_map_results: Literal[True] = True,
+) -> List["BaseStepFuture"]: ...
+
+
+@overload
+def collect_futures(
+    inputs: Optional[Dict[str, Any]] = ...,
+    after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = ...,
+    expand_map_results: Literal[False] = False,
+) -> List["AnyStepFuture"]: ...
+
+
+def collect_futures(
+    inputs: Optional[Dict[str, Any]] = None,
+    after: Union["AnyStepFuture", Sequence["AnyStepFuture"], None] = None,
+    expand_map_results: bool = False,
+) -> Union[List["BaseStepFuture"], List["AnyStepFuture"]]:
+    """Collect futures referenced in step inputs and `after`.
+
+    Args:
+        inputs: Optional step inputs to inspect for futures.
+        after: Optional explicit upstream dependencies. Must be a future or a
+            sequence containing only futures.
+        expand_map_results: Whether map futures should be expanded into their
+            child step futures.
+
+    Raises:
+        TypeError: If `after` is not a future or a sequence containing only
+            futures.
+
+    Returns:
+        The collected futures.
+    """
+    from zenml.execution.pipeline.dynamic.outputs import (
+        ArtifactFuture,
+        MapResultsFuture,
+        StepFuture,
+    )
+
+    VALID_FUTURE_CLASSES = (ArtifactFuture, StepFuture, MapResultsFuture)
+
+    futures: List["AnyStepFuture"] = []
+
+    def _append_future(future: "AnyStepFuture") -> None:
+        if expand_map_results and isinstance(future, MapResultsFuture):
+            futures.extend(future.futures)
+        else:
+            futures.append(future)
+
+    def _collect_input_value(value: Any) -> None:
+        if isinstance(value, VALID_FUTURE_CLASSES):
+            _append_future(value)
+            return
+
+        if isinstance(value, Sequence) and all(
+            isinstance(item, VALID_FUTURE_CLASSES) for item in value
+        ):
+            for item in value:
+                _append_future(item)
+            return
+
+    if inputs:
+        for value in inputs.values():
+            _collect_input_value(value=value)
+
+    if after:
+        if isinstance(after, VALID_FUTURE_CLASSES):
+            _append_future(after)
+        elif isinstance(after, Sequence) and all(
+            isinstance(item, VALID_FUTURE_CLASSES) for item in after
+        ):
+            for item in after:
+                _append_future(item)
+        else:
+            raise TypeError(
+                "`after` must be a future or a sequence of futures."
+            )
+
+    return futures


### PR DESCRIPTION
## Describe changes
When running concurrent steps in a dynamic pipeline, waiting for the inputs is currently happening in the main thread and therefore blocking pipeline execution. This PR reworks this so that the waiting for inputs (and all subsequent steps, e.g. compiling and lauching the step) happens async.

**Example:**
```python
@pipeline(dynamic=True)
def my_pipeline():
  future = producer.submit()
  # Previously, the following line would block until the future finished, which
  # means the `sync_step` would be waiting as well. After this PR, the `consumer` step
  # will not block the main thread while waiting for its inputs and the `sync_step`
  # can start executing right away.
  consumer.submit(future)

  sync_step()
```

**Main Changes:**
- Introduces a new `FutureRegistry` class that is responsible for tracking and updating all step/map futures
- Introduces a new `InvocationDependencyGraph` class that keeps track of concurrent step/map invocations and their dependencies, and is used to compute when an invocation is ready to start
- Updates futures so that the user-facing interface stays consistent.
- Updates the `DynamicPipelineRunner` class:
  - use the new classes to track futures and compute startups
  - run a separate thread to launch steps that are ready


**Additional dynamic pipeline fixes/improvements:**
- stable map IDs across restarts
- better shutdown semantics
- fix race conditions when removing steps from monitoring while queueing next retry of the same step
- don't return future for sync running step when restarting
- improves the failure/shutdown handling when using the `FAIL_FAST` execution mode. In this case, we now try to always shut down isolated steps right away.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

