### PR TITLE
Fix zizmor SHA/version mismatch and add zizmor to `lint.sh`

### DIFF
--- a/.github/workflows/publish_helm_chart.yml
+++ b/.github/workflows/publish_helm_chart.yml
@@ -31,7 +31,7 @@ jobs:
           aws-region: us-east-1
       - name: Login to Amazon ECR Public
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896  # v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896  # v2.1.1
         with:
           mask-password: 'true'
           registry-type: public

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -14,23 +14,42 @@ ruff check $SRC_NO_TESTS
 # TODO: Fix docstrings in tests and examples and remove the `--extend-ignore D` flag
 ruff check $TESTS_EXAMPLES --extend-ignore D --extend-exclude "*.ipynb"
 
-# Flag check for skipping yamlfix
+# Flag checks for skipping optional linters
+SKIP_YAMLFIX=false
+SKIP_ZIZMOR=false
+
 if [ "$OS" = "windows-latest" ]; then
     SKIP_YAMLFIX=true
-else
-    SKIP_YAMLFIX=false
-    for arg in "$@"
-    do
-        if [ "$arg" = "--no-yamlfix" ]; then
-            SKIP_YAMLFIX=true
-            break
-        fi
-    done
 fi
+
+for arg in "$@"
+do
+    if [ "$arg" = "--no-yamlfix" ]; then
+        SKIP_YAMLFIX=true
+    elif [ "$arg" = "--no-zizmor" ]; then
+        SKIP_ZIZMOR=true
+    fi
+done
 
 # checks for yaml formatting errors
 if [ "$SKIP_YAMLFIX" = false ]; then
     yamlfix --check .github tests -e "dependabot.yml" -e "workflows/release_prepare.yml" -e "workflows/release_finalize.yml" -e "workflows/integration-test-fast-services.yml" -e "workflows/integration-test-slow-services.yml"
+fi
+
+# checks for GitHub Actions security issues (SHA pinning, version mismatches, etc.)
+if [ "$SKIP_ZIZMOR" = false ] && [ -d ".github/workflows" ]; then
+    # Resolve GH_TOKEN: use existing env var, or try gh CLI
+    if [ -z "$GH_TOKEN" ] && command -v gh &> /dev/null; then
+        GH_TOKEN=$(gh auth token 2>/dev/null) || true
+    fi
+
+    if [ -n "$GH_TOKEN" ]; then
+        export GH_TOKEN
+        uvx zizmor --config=.github/zizmor.yml .github/workflows/
+    else
+        echo "⚠️  Skipping zizmor check: no GH_TOKEN and gh CLI not authenticated."
+        echo "   Run: GH_TOKEN=\$(gh auth token) bash scripts/lint.sh"
+    fi
 fi
 
 # autoflake replacement: checks for unused imports and variables


### PR DESCRIPTION
## Summary
- Fixes the zizmor CI failure caused by a SHA/version comment mismatch in `publish_helm_chart.yml` — the `aws-actions/amazon-ecr-login` SHA corresponds to `v2.1.1` but the comment said `v2`
- Adds zizmor as a check in `scripts/lint.sh` so these issues are caught locally before pushing, rather than only in CI after the fact
- The zizmor check is token-aware (auto-resolves `GH_TOKEN` from env or `gh auth token`) and gracefully skips with a message when no token is available
- Skippable via `--no-zizmor` flag, consistent with the existing `--no-yamlfix` pattern

## Test plan
- [x] Verified `zizmor` passes locally on all workflows after the comment fix
- [ ] CI zizmor check passes on this PR
- [ ] Verify `bash scripts/lint.sh` runs zizmor when `GH_TOKEN` is available
- [ ] Verify `bash scripts/lint.sh --no-zizmor` skips the check