### PR TITLE
Add ty phase 1 migration for the login flow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ dev = [
     "coverage[toml]>=5.5,<6.0.0",
     "pytest>=7.4.0,<8.0.0",
     "mypy==1.18.1",
+    "ty==0.0.29",
     "pre-commit",
     "pyment>=0.3.3,<0.4.0",
     "tox>=3.24.3",
@@ -294,6 +295,17 @@ convention = "google"
 [tool.bandit]
 skips = ["B615"]
 
+[tool.ty.terminal]
+error-on-warning = true
+
+[tool.ty.environment]
+python-version = "3.10"
+python-platform = "all"
+
+[tool.ty.rules]
+unresolved-import = "ignore"
+possibly-missing-import = "ignore"
+
 [tool.mypy]
 
 plugins = ["pydantic.mypy"]
@@ -301,6 +313,10 @@ plugins = ["pydantic.mypy"]
 strict = true
 namespace_packages = true
 show_error_codes = true
+
+[[tool.mypy.overrides]]
+module = ["zenml.login.*", "zenml.cli.login"]
+follow_imports = "skip"
 
 # import all google, transformers and datasets files as `Any`
 [[tool.mypy.overrides]]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -58,4 +58,6 @@ ruff check $SRC --select F401,F841 --exclude "__init__.py" --exclude "*.ipynb" -
 ruff format $SRC  --check
 
 # check type annotations
-mypy $SRC_NO_TESTS
+PHASE_1_MYPY_EXCLUDE='src/zenml/login/|src/zenml/cli/login\.py'
+uv run ty check src/zenml/login src/zenml/cli/login.py
+uv run mypy --exclude "$PHASE_1_MYPY_EXCLUDE" $SRC_NO_TESTS

--- a/src/zenml/cli/login.py
+++ b/src/zenml/cli/login.py
@@ -511,6 +511,7 @@ def connect_to_pro_server(
                 f"running. Visit the ZenML Pro dashboard to manage the server "
                 f"status at: {server.dashboard_url}"
             )
+            return
     else:
         cli_utils.error(
             f"Your `{server.name}` ZenML Pro server is currently "
@@ -518,13 +519,23 @@ def connect_to_pro_server(
             "new server by visiting the ZenML Pro dashboard at "
             f"{server.dashboard_organization_url}."
         )
+        return
+
+    server_url_for_connection = server.url
+    if server_url_for_connection is None:
+        cli_utils.error(
+            f"The ZenML Pro server '{server.name}' does not currently expose "
+            "a usable server URL. Please manage the server state via the "
+            f"ZenML Pro dashboard at {server.dashboard_url}."
+        )
+        return
 
     cli_utils.declare(
         f"Connecting to ZenML Pro server: '{server.name}' [{str(server.id)}] "
     )
 
     connect_to_server(
-        server.url,
+        server_url_for_connection,
         api_key=api_key,
         pro_server=True,
         verify_ssl=verify_ssl,
@@ -533,7 +544,7 @@ def connect_to_pro_server(
 
     # Update the stored server info with more accurate data taken from the
     # ZenML Pro workspace object.
-    credentials_store.update_server_info(server.url, server)
+    credentials_store.update_server_info(server_url_for_connection, server)
 
     cli_utils.success(f"✔ Connected to ZenML Pro server: {server.name}.")
 

--- a/src/zenml/login/credentials_store.py
+++ b/src/zenml/login/credentials_store.py
@@ -15,7 +15,7 @@
 
 import os
 from datetime import timedelta
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Optional, Tuple, Union
 
 from zenml.config.global_config import GlobalConfiguration
 from zenml.constants import (
@@ -119,7 +119,7 @@ class CredentialsStore(metaclass=SingletonMetaClass):
             # instance is created and this call will have no effect
             current_store._delete_credentials_file()
 
-        cls._clear(store)  # type: ignore[arg-type]
+        cls._clear(store)
         if store:
             store._save_credentials()
 
@@ -130,7 +130,7 @@ class CredentialsStore(metaclass=SingletonMetaClass):
         Returns:
             The singleton instance of the CredentialsStore.
         """
-        return cast(CredentialsStore, cls._instance())
+        return cls._instance()
 
     @property
     def _credentials_file(self) -> str:
@@ -616,13 +616,14 @@ class CredentialsStore(metaclass=SingletonMetaClass):
 
         if server_url in self.credentials:
             credential = self.credentials[server_url]
-            if (
-                not credential.api_key
-                and not credential.username
-                and not credential.password is not None
-            ):
+            has_api_key = credential.api_key is not None
+            has_password_credentials = (
+                credential.username is not None
+                and credential.password is not None
+            )
+            if not has_api_key and not has_password_credentials:
                 # Only delete the credential entry if there is no API key or
-                # username/password to fall back on
+                # username/password to fall back on.
                 del self.credentials[server_url]
             else:
                 credential.api_token = None

--- a/src/zenml/login/pro/client.py
+++ b/src/zenml/login/pro/client.py
@@ -205,7 +205,14 @@ class ZenMLProClient(metaclass=SingletonMetaClass):
             exc: the exception converted from an error response, if one
                 is returned from the server.
         """
-        if 200 <= response.status_code < 300:
+        status_code = response.status_code
+        if status_code is None:
+            raise RuntimeError(
+                "Error retrieving from API. The response did not include an "
+                f"HTTP status code. Response body:\n{response.text}"
+            )
+
+        if 200 <= status_code < 300:
             try:
                 payload: Json = response.json()
                 return payload
@@ -214,19 +221,19 @@ class ZenMLProClient(metaclass=SingletonMetaClass):
                     "Bad response from API. Expected json, got\n"
                     f"{response.text}"
                 )
-        elif response.status_code >= 400:
+        elif status_code >= 400:
             exc = exception_from_response(response)
             if exc is not None:
                 raise exc
             else:
                 raise RuntimeError(
-                    f"{response.status_code} HTTP Error received from server: "
+                    f"{status_code} HTTP Error received from server: "
                     f"{response.text}"
                 )
         else:
             raise RuntimeError(
                 "Error retrieving from API. Got response "
-                f"{response.status_code} with body:\n{response.text}"
+                f"{status_code} with body:\n{response.text}"
             )
 
     def _request(

--- a/src/zenml/utils/singleton.py
+++ b/src/zenml/utils/singleton.py
@@ -14,7 +14,9 @@
 """Utility class to turn classes into singleton classes."""
 
 import contextvars
-from typing import Any, Optional, cast
+from typing import Any, Optional, TypeVar, cast
+
+SingletonInstance = TypeVar("SingletonInstance")
 
 
 class SingletonMetaClass(type):
@@ -38,6 +40,8 @@ class SingletonMetaClass(type):
     ```
     """
 
+    _singleton_instance: object | None = None
+
     def __init__(cls, *args: Any, **kwargs: Any) -> None:
         """Initialize a singleton class.
 
@@ -46,9 +50,11 @@ class SingletonMetaClass(type):
             **kwargs: Additional keyword arguments.
         """
         super().__init__(*args, **kwargs)
-        cls.__singleton_instance: Optional["SingletonMetaClass"] = None
+        cls._singleton_instance = None
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> "SingletonMetaClass":
+    def __call__(
+        cls: type[SingletonInstance], *args: Any, **kwargs: Any
+    ) -> SingletonInstance:
         """Create or return the singleton instance.
 
         Args:
@@ -58,28 +64,37 @@ class SingletonMetaClass(type):
         Returns:
             The singleton instance.
         """
-        if not cls.__singleton_instance:
-            cls.__singleton_instance = cast(
-                "SingletonMetaClass", super().__call__(*args, **kwargs)
+        meta_cls = cast("SingletonMetaClass", cls)
+        if meta_cls._singleton_instance is None:
+            meta_cls._singleton_instance = cast(
+                object, type.__call__(cls, *args, **kwargs)
             )
 
-        return cls.__singleton_instance
+        return cast(SingletonInstance, meta_cls._singleton_instance)
 
-    def _clear(cls, instance: Optional["SingletonMetaClass"] = None) -> None:
+    def _clear(
+        cls: type[SingletonInstance],
+        instance: Optional[SingletonInstance] = None,
+    ) -> None:
         """Clear or replace the singleton instance.
 
         Args:
             instance: The new singleton instance.
         """
-        cls.__singleton_instance = instance
+        cast("SingletonMetaClass", cls)._singleton_instance = instance
 
-    def _instance(cls) -> Optional["SingletonMetaClass"]:
+    def _instance(
+        cls: type[SingletonInstance],
+    ) -> Optional[SingletonInstance]:
         """Get the singleton instance.
 
         Returns:
             The singleton instance.
         """
-        return cls.__singleton_instance
+        return cast(
+            Optional[SingletonInstance],
+            cast("SingletonMetaClass", cls)._singleton_instance,
+        )
 
     def _exists(cls) -> bool:
         """Check if the singleton instance exists.
@@ -87,7 +102,7 @@ class SingletonMetaClass(type):
         Returns:
             `True` if the singleton instance exists, `False` otherwise.
         """
-        return cls.__singleton_instance is not None
+        return cls._singleton_instance is not None
 
 
 class ThreadLocalSingleton(type):


### PR DESCRIPTION
## Summary

This starts Phase 1 of the mypy-to-ty migration for the login/auth slice.

- add `ty` to the dev toolchain and configure the initial Phase 1 ty settings in `pyproject.toml`
- route `src/zenml/login/**` and `src/zenml/cli/login.py` through `ty` in `scripts/lint.sh` while keeping `mypy` on the rest of the repo
- apply the small login-slice type fixes needed for `ty` to pass without changing runtime behavior
- type `SingletonMetaClass` so singleton-backed constructors preserve their concrete instance types without noisy call-site casts

## Why this change

ZenML's type checking is currently mypy-centric. The migration plan in `design/ty_migration/gpt-5-4-plan.md` recommends proving the workflow on a small slice first before expanding coverage.

The login/auth path is a good first target because it has enough real typing complexity to exercise the migration pattern, but keeps the blast radius small.

## Implementation details

- pin `ty==0.0.29` in the dev dependencies and add conservative Phase 1 ty config
- make mypy skip the migrated modules via `follow_imports = "skip"` so the checker split remains non-overlapping
- update `scripts/lint.sh` to run `ty` on the migrated slice and `mypy` on the remaining tree
- fix ty diagnostics caused by response status code narrowing and Pro server URL handling
- type `SingletonMetaClass.__call__` / `_clear` / `_instance` generically so `ZenMLProClient(...)`, `LocalServerDeployer(...)`, and `CredentialsStore()` retain their concrete types under ty
- tighten `CredentialsStore.clear_token()` so it only preserves entries that have a real fallback credential path

## Impact

This is internal tooling work. It does not change the public CLI surface, but it establishes the first reusable ty migration boundary and keeps the login/auth slice clean under `ty`.

## Validation

- `uv run ty check src/zenml/utils/singleton.py src/zenml/login src/zenml/cli/login.py`
- `uv run --extra dev --extra local pytest tests/integration/functional/cli/test_cli.py::test_connect_to_server_sets_project_after_success tests/integration/functional/cli/test_cli.py::test_connect_to_server_does_not_set_project_on_failure`

## Notes

A full local `scripts/lint.sh` run still fails outside this slice in this environment because repo-wide mypy reaches unrelated FastAPI/SQLAlchemy/integration modules whose dependencies are not installed here.
