### PR TITLE
Moving `project_name` to settings for the `WandbExperiementTracker`

### DIFF
--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -90,7 +90,9 @@ class WandbExperimentTracker(BaseExperimentTracker):
         wandb_run_name = (
             settings.run_name or f"{info.run_name}_{info.pipeline_step_name}"
         )
-        self._initialize_wandb(run_name=wandb_run_name, tags=tags, info=info)
+        self._initialize_wandb(
+            run_name=wandb_run_name, tags=tags, settings=settings
+        )
 
     def get_step_run_metadata(
         self, info: "StepRunInfo"
@@ -112,18 +114,19 @@ class WandbExperimentTracker(BaseExperimentTracker):
             run_url = current_wandb_run.get_url()
             run_name = current_wandb_run.name
 
+        settings = cast(
+            WandbExperimentTrackerSettings, self.get_settings(info)
+        )
+
         # If the URL cannot be retrieved, use the default run URL
         default_run_url = (
             f"https://wandb.ai/{self.config.entity}/"
-            f"{self.config.project_name}/runs/"
+            f"{settings.project_name}/runs/"
         )
         run_url = run_url or default_run_url
 
         # If the run name cannot be retrieved, use the default run name
         default_run_name = f"{info.run_name}_{info.pipeline_step_name}"
-        settings = cast(
-            WandbExperimentTrackerSettings, self.get_settings(info)
-        )
         run_name = run_name or settings.run_name or default_run_name
 
         return {
@@ -143,27 +146,24 @@ class WandbExperimentTracker(BaseExperimentTracker):
 
     def _initialize_wandb(
         self,
-        info: "StepRunInfo",
         run_name: str,
         tags: List[str],
+        settings: WandbExperimentTrackerSettings,
     ) -> None:
         """Initializes a wandb run.
 
         Args:
-            info: Step run information.
             run_name: Name of the wandb run to create.
             tags: Tags to attach to the wandb run.
+            settings: Merged stack and runtime settings (including project name).
         """
         logger.info(
             f"Initializing wandb with entity {self.config.entity}, project "
-            f"name: {self.config.project_name}, run_name: {run_name}."
-        )
-        settings = cast(
-            WandbExperimentTrackerSettings, self.get_settings(info)
+            f"name: {settings.project_name}, run_name: {run_name}."
         )
         wandb.init(
             entity=self.config.entity,
-            project=self.config.project_name,
+            project=settings.project_name,
             name=run_name,
             tags=tags,
             settings=settings.settings,
@@ -172,9 +172,9 @@ class WandbExperimentTracker(BaseExperimentTracker):
         if settings.enable_weave:
             import weave
 
-            if self.config.project_name:
+            if settings.project_name:
                 logger.info("Initializing weave")
-                weave.init(project_name=self.config.project_name)
+                weave.init(project_name=settings.project_name)
             else:
                 logger.info(
                     "Weave enabled but no project_name specified. "

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -45,6 +45,11 @@ class WandbExperimentTrackerSettings(BaseSettings):
     run_name: Optional[str] = Field(
         None, description="The Wandb run name to use for tracking experiments."
     )
+    project_name: Optional[str] = Field(
+        None,
+        description="Name of an existing Wandb project to log experiments to. "
+        "If not specified, a default project will be used.",
+    )
     tags: List[str] = Field(
         default_factory=list,
         description="Tags to attach to the Wandb run for categorization and filtering.",
@@ -106,11 +111,6 @@ class WandbExperimentTrackerConfig(
         None,
         description="Name of an existing Wandb entity (team or user account) "
         "to log experiments to.",
-    )
-    project_name: Optional[str] = Field(
-        None,
-        description="Name of an existing Wandb project to log experiments to. "
-        "If not specified, a default project will be used.",
     )
 
 


### PR DESCRIPTION
## Describe changes
`project_name` has been moved from the config to the settings so people can set it differently for different steps.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

