### PR TITLE
Allow streaming intermediate events in deployed pipelines

### DIFF
--- a/src/zenml/__init__.py
+++ b/src/zenml/__init__.py
@@ -70,7 +70,6 @@ from zenml.steps.utils import log_step_metadata
 from zenml.utils.metadata_utils import log_metadata, bulk_log_metadata
 from zenml.utils.tag_utils import Tag, add_tags, remove_tags
 from zenml.execution.pipeline.dynamic.utils import unmapped, wait
-from zenml.deployers.streaming import stream
 
 __all__ = [
     "add_tags",
@@ -93,7 +92,6 @@ __all__ = [
     "register_artifact",
     "show",
     "step",
-    "stream",
     "unmapped",
     "wait",
 ]

--- a/src/zenml/__init__.py
+++ b/src/zenml/__init__.py
@@ -70,6 +70,7 @@ from zenml.steps.utils import log_step_metadata
 from zenml.utils.metadata_utils import log_metadata, bulk_log_metadata
 from zenml.utils.tag_utils import Tag, add_tags, remove_tags
 from zenml.execution.pipeline.dynamic.utils import unmapped, wait
+from zenml.deployers.streaming import stream
 
 __all__ = [
     "add_tags",
@@ -92,6 +93,7 @@ __all__ = [
     "register_artifact",
     "show",
     "step",
+    "stream",
     "unmapped",
     "wait",
 ]

--- a/src/zenml/config/deployment_settings.py
+++ b/src/zenml/config/deployment_settings.py
@@ -525,6 +525,7 @@ class DeploymentDefaultEndpoints(IntFlag):
         | METRICS
         | DASHBOARD
     )
+    DEFAULT_ENABLED = ALL ^ STREAM_INVOKE
 
 
 class DeploymentDefaultMiddleware(IntFlag):
@@ -673,7 +674,7 @@ class DeploymentSettings(BaseSettings):
     app_kwargs: Dict[str, Any] = {}
 
     include_default_endpoints: DeploymentDefaultEndpoints = (
-        DeploymentDefaultEndpoints.ALL
+        DeploymentDefaultEndpoints.DEFAULT_ENABLED
     )
     include_default_middleware: DeploymentDefaultMiddleware = (
         DeploymentDefaultMiddleware.ALL

--- a/src/zenml/config/deployment_settings.py
+++ b/src/zenml/config/deployment_settings.py
@@ -494,6 +494,7 @@ DEFAULT_DEPLOYMENT_APP_API_URL_PATH = ""
 DEFAULT_DEPLOYMENT_APP_DOCS_URL_PATH = "/docs"
 DEFAULT_DEPLOYMENT_APP_REDOC_URL_PATH = "/redoc"
 DEFAULT_DEPLOYMENT_APP_INVOKE_URL_PATH = "/invoke"
+DEFAULT_DEPLOYMENT_APP_STREAM_INVOKE_URL_PATH = "/invoke_stream"
 DEFAULT_DEPLOYMENT_APP_HEALTH_URL_PATH = "/health"
 DEFAULT_DEPLOYMENT_APP_INFO_URL_PATH = "/info"
 DEFAULT_DEPLOYMENT_APP_METRICS_URL_PATH = "/metrics"
@@ -506,14 +507,24 @@ class DeploymentDefaultEndpoints(IntFlag):
     DOCS = auto()
     REDOC = auto()
     INVOKE = auto()
+    STREAM_INVOKE = auto()
     HEALTH = auto()
     INFO = auto()
     METRICS = auto()
     DASHBOARD = auto()
 
     DOC = DOCS | REDOC
-    API = INVOKE | HEALTH | INFO | METRICS
-    ALL = DOCS | REDOC | INVOKE | HEALTH | INFO | METRICS | DASHBOARD
+    API = STREAM_INVOKE | INVOKE | HEALTH | INFO | METRICS
+    ALL = (
+        DOCS
+        | REDOC
+        | STREAM_INVOKE
+        | INVOKE
+        | HEALTH
+        | INFO
+        | METRICS
+        | DASHBOARD
+    )
 
 
 class DeploymentDefaultMiddleware(IntFlag):
@@ -542,6 +553,7 @@ class DeploymentSettings(BaseSettings):
     `app_version` and `app_kwargs`
     * the URL paths for the various built-in endpoints: `root_url_path`,
     `api_url_path`, `docs_url_path`, `redoc_url_path`, `invoke_url_path`,
+    `stream_invoke_url_path`,
     `health_url_path`, `info_url_path` and `metrics_url_path`
     * the location of dashboard static files can be provided to replace the
     default UI that is included with the deployment ASGI application:
@@ -602,6 +614,7 @@ class DeploymentSettings(BaseSettings):
         redoc_url_path: URL path for the Redoc documentation endpoint.
         api_url_path: URL path for the API endpoints.
         invoke_url_path: URL path for the API invoke endpoint.
+        stream_invoke_url_path: URL path for the streaming API invoke endpoint.
         health_url_path: URL path for the API health check endpoint.
         info_url_path: URL path for the API info endpoint.
         metrics_url_path: URL path for the API metrics endpoint.
@@ -671,6 +684,7 @@ class DeploymentSettings(BaseSettings):
     docs_url_path: str = DEFAULT_DEPLOYMENT_APP_DOCS_URL_PATH
     redoc_url_path: str = DEFAULT_DEPLOYMENT_APP_REDOC_URL_PATH
     invoke_url_path: str = DEFAULT_DEPLOYMENT_APP_INVOKE_URL_PATH
+    stream_invoke_url_path: str = DEFAULT_DEPLOYMENT_APP_STREAM_INVOKE_URL_PATH
     health_url_path: str = DEFAULT_DEPLOYMENT_APP_HEALTH_URL_PATH
     info_url_path: str = DEFAULT_DEPLOYMENT_APP_INFO_URL_PATH
     metrics_url_path: str = DEFAULT_DEPLOYMENT_APP_METRICS_URL_PATH

--- a/src/zenml/config/deployment_settings.py
+++ b/src/zenml/config/deployment_settings.py
@@ -507,11 +507,11 @@ class DeploymentDefaultEndpoints(IntFlag):
     DOCS = auto()
     REDOC = auto()
     INVOKE = auto()
-    STREAM_INVOKE = auto()
     HEALTH = auto()
     INFO = auto()
     METRICS = auto()
     DASHBOARD = auto()
+    STREAM_INVOKE = auto()
 
     DOC = DOCS | REDOC
     API = STREAM_INVOKE | INVOKE | HEALTH | INFO | METRICS

--- a/src/zenml/deployers/__init__.py
+++ b/src/zenml/deployers/__init__.py
@@ -51,6 +51,8 @@ from zenml.deployers.local.local_deployer import (
     LocalDeployerSettings,
 )
 
+from zenml.deployers.streaming import stream
+
 __all__ = [
     "BaseDeployer",
     "BaseDeployerFlavor",
@@ -64,4 +66,5 @@ __all__ = [
     "LocalDeployerConfig",
     "LocalDeployerFlavor",
     "LocalDeployerSettings",
+    "stream",
 ]

--- a/src/zenml/deployers/__init__.py
+++ b/src/zenml/deployers/__init__.py
@@ -51,7 +51,7 @@ from zenml.deployers.local.local_deployer import (
     LocalDeployerSettings,
 )
 
-from zenml.deployers.streaming import stream
+from zenml.deployers.streaming import emit_event
 
 __all__ = [
     "BaseDeployer",
@@ -66,5 +66,5 @@ __all__ = [
     "LocalDeployerConfig",
     "LocalDeployerFlavor",
     "LocalDeployerSettings",
-    "stream",
+    "emit_event",
 ]

--- a/src/zenml/deployers/server/app.py
+++ b/src/zenml/deployers/server/app.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Base deployment app runner."""
 
+import concurrent.futures
 import os
 import re
 from abc import ABC, abstractmethod
@@ -49,6 +50,7 @@ from zenml.config import (
     MiddlewareSpec,
 )
 from zenml.config.source import SourceOrObject
+from zenml.constants import handle_int_env_var
 from zenml.deployers.server.adapters import (
     EndpointAdapter,
     MiddlewareAdapter,
@@ -74,6 +76,8 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 ZENML_DEPLOYMENT_ID_ENV_VAR = "ZENML_DEPLOYMENT_ID"
+ZENML_STREAM_THREAD_POOL_SIZE_ENV_VAR = "ZENML_STREAM_THREAD_POOL_SIZE"
+DEFAULT_ZENML_STREAM_THREAD_POOL_SIZE = 4
 
 
 class BaseDeploymentAppRunner(ABC):
@@ -152,6 +156,14 @@ class BaseDeploymentAppRunner(ABC):
         self.endpoints: List[EndpointSpec] = []
         self.middlewares: List[MiddlewareSpec] = []
         self.extensions: List[AppExtensionSpec] = []
+
+        thread_pool_size = handle_int_env_var(
+            ZENML_STREAM_THREAD_POOL_SIZE_ENV_VAR,
+            DEFAULT_ZENML_STREAM_THREAD_POOL_SIZE,
+        )
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=thread_pool_size
+        )
 
     @property
     def asgi_app(self) -> ASGIApplication:
@@ -346,6 +358,22 @@ class BaseDeploymentAppRunner(ABC):
 
         return _invoke_endpoint
 
+    def _build_stream_invoke_endpoint(self) -> Callable[..., Any]:
+        """Create the endpoint used to invoke a streamed pipeline deployment.
+
+        Returns:
+            A callable endpoint that streams lifecycle events.
+        """
+
+        def _unsupported_stream_endpoint(*args: Any, **kwargs: Any) -> Any:
+            raise NotImplementedError(
+                f"Streaming invoke endpoint is not supported by "
+                f"{self.__class__.__name__}. Override "
+                "`_build_stream_invoke_endpoint` to enable it."
+            )
+
+        return _unsupported_stream_endpoint
+
     def dashboard_files_path(self) -> Optional[str]:
         """Get the absolute path of the dashboard files directory.
 
@@ -401,6 +429,18 @@ class BaseDeploymentAppRunner(ABC):
             List of endpoint specs for default endpoints.
         """
         specs = []
+
+        if self.settings.endpoint_enabled(
+            DeploymentDefaultEndpoints.STREAM_INVOKE
+        ):
+            specs.append(
+                EndpointSpec(
+                    path=f"{self.settings.api_url_path}{self.settings.stream_invoke_url_path}",
+                    method=EndpointMethod.POST,
+                    handler=self._build_stream_invoke_endpoint(),
+                    auth_required=True,
+                )
+            )
 
         if self.settings.endpoint_enabled(DeploymentDefaultEndpoints.INVOKE):
             specs.append(
@@ -754,6 +794,7 @@ class BaseDeploymentAppRunner(ABC):
             Exception: If the service cleanup fails.
         """
         self._run_shutdown_hook()
+        self._executor.shutdown(wait=True)
 
         logger.info("🛑 Cleaning up the pipeline deployment service...")
         try:

--- a/src/zenml/deployers/server/app.py
+++ b/src/zenml/deployers/server/app.py
@@ -349,6 +349,9 @@ class BaseDeploymentAppRunner(ABC):
     def _build_stream_invoke_endpoint(self) -> Callable[..., Any]:
         """Create the endpoint used to invoke a streamed pipeline deployment.
 
+        Returns:
+            A callable endpoint that streams lifecycle events.
+
         Raises:
             NotImplementedError: If the method is not implemented.
         """
@@ -417,14 +420,23 @@ class BaseDeploymentAppRunner(ABC):
         if self.settings.endpoint_enabled(
             DeploymentDefaultEndpoints.STREAM_INVOKE
         ):
-            specs.append(
-                EndpointSpec(
-                    path=f"{self.settings.api_url_path}{self.settings.stream_invoke_url_path}",
-                    method=EndpointMethod.POST,
-                    handler=self._build_stream_invoke_endpoint(),
-                    auth_required=True,
+            try:
+                stream_handler = self._build_stream_invoke_endpoint()
+            except NotImplementedError:
+                logger.warning(
+                    "Skipping stream invoke endpoint because %s does not "
+                    "implement `_build_stream_invoke_endpoint`.",
+                    self.__class__.__name__,
                 )
-            )
+            else:
+                specs.append(
+                    EndpointSpec(
+                        path=f"{self.settings.api_url_path}{self.settings.stream_invoke_url_path}",
+                        method=EndpointMethod.POST,
+                        handler=stream_handler,
+                        auth_required=True,
+                    )
+                )
 
         if self.settings.endpoint_enabled(DeploymentDefaultEndpoints.INVOKE):
             specs.append(

--- a/src/zenml/deployers/server/app.py
+++ b/src/zenml/deployers/server/app.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Base deployment app runner."""
 
-import concurrent.futures
 import os
 import re
 from abc import ABC, abstractmethod
@@ -50,7 +49,6 @@ from zenml.config import (
     MiddlewareSpec,
 )
 from zenml.config.source import SourceOrObject
-from zenml.constants import handle_int_env_var
 from zenml.deployers.server.adapters import (
     EndpointAdapter,
     MiddlewareAdapter,
@@ -76,8 +74,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 ZENML_DEPLOYMENT_ID_ENV_VAR = "ZENML_DEPLOYMENT_ID"
-ZENML_STREAM_THREAD_POOL_SIZE_ENV_VAR = "ZENML_STREAM_THREAD_POOL_SIZE"
-DEFAULT_ZENML_STREAM_THREAD_POOL_SIZE = 4
 
 
 class BaseDeploymentAppRunner(ABC):
@@ -156,14 +152,6 @@ class BaseDeploymentAppRunner(ABC):
         self.endpoints: List[EndpointSpec] = []
         self.middlewares: List[MiddlewareSpec] = []
         self.extensions: List[AppExtensionSpec] = []
-
-        thread_pool_size = handle_int_env_var(
-            ZENML_STREAM_THREAD_POOL_SIZE_ENV_VAR,
-            DEFAULT_ZENML_STREAM_THREAD_POOL_SIZE,
-        )
-        self._executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=thread_pool_size
-        )
 
     @property
     def asgi_app(self) -> ASGIApplication:
@@ -361,18 +349,14 @@ class BaseDeploymentAppRunner(ABC):
     def _build_stream_invoke_endpoint(self) -> Callable[..., Any]:
         """Create the endpoint used to invoke a streamed pipeline deployment.
 
-        Returns:
-            A callable endpoint that streams lifecycle events.
+        Raises:
+            NotImplementedError: If the method is not implemented.
         """
-
-        def _unsupported_stream_endpoint(*args: Any, **kwargs: Any) -> Any:
-            raise NotImplementedError(
-                f"Streaming invoke endpoint is not supported by "
-                f"{self.__class__.__name__}. Override "
-                "`_build_stream_invoke_endpoint` to enable it."
-            )
-
-        return _unsupported_stream_endpoint
+        raise NotImplementedError(
+            f"Streaming invoke endpoint is not supported by "
+            f"{self.__class__.__name__}. Override "
+            "`_build_stream_invoke_endpoint` to enable it."
+        )
 
     def dashboard_files_path(self) -> Optional[str]:
         """Get the absolute path of the dashboard files directory.
@@ -794,7 +778,6 @@ class BaseDeploymentAppRunner(ABC):
             Exception: If the service cleanup fails.
         """
         self._run_shutdown_hook()
-        self._executor.shutdown(wait=True)
 
         logger.info("🛑 Cleaning up the pipeline deployment service...")
         try:

--- a/src/zenml/deployers/server/fastapi/app.py
+++ b/src/zenml/deployers/server/fastapi/app.py
@@ -14,6 +14,7 @@
 """FastAPI application for running ZenML pipeline deployments."""
 
 import os
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from genericpath import isdir, isfile
 from typing import Any, AsyncGenerator, Dict, List, Optional, cast
@@ -28,7 +29,12 @@ from fastapi import (
     Request,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -53,7 +59,7 @@ from zenml.deployers.server.fastapi.adapters import (
     FastAPIEndpointAdapter,
     FastAPIMiddlewareAdapter,
 )
-from zenml.deployers.streaming import create_stream_queue, iter_sse_events
+from zenml.deployers.streaming import create_stream_state, iter_sse_events
 from zenml.logger import get_logger
 
 logger = get_logger(__name__)
@@ -61,6 +67,20 @@ logger = get_logger(__name__)
 
 class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
     """FastAPI deployment app runner."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the FastAPI deployment app runner.
+
+        Args:
+            *args: Positional arguments forwarded to the base app runner.
+            **kwargs: Keyword arguments forwarded to the base app runner.
+        """
+        super().__init__(*args, **kwargs)
+        # Limit concurrent executions to the thread pool size which configures
+        # the amount of concurrent requests that the deployment allows.
+        self._executor = ThreadPoolExecutor(
+            max_workers=self.settings.thread_pool_size
+        )
 
     @property
     def flavor(cls) -> "BaseDeploymentAppRunnerFlavor":
@@ -110,18 +130,16 @@ class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
         Returns:
             A callable endpoint that streams lifecycle events as SSE.
         """
-        from fastapi.responses import StreamingResponse
-
         PipelineInvokeRequest, _ = self.service.get_pipeline_invoke_models()
 
         def _stream_invoke_endpoint(
             request: PipelineInvokeRequest,  # type: ignore[valid-type]
         ) -> StreamingResponse:
-            event_queue = create_stream_queue()
+            stream_state = create_stream_state()
             execution_future = self._executor.submit(
                 self.service.execute_pipeline_streamed,
                 request,
-                event_queue,
+                stream_state,
             )
 
             # TODO: Once we upgrade to FastAPI 0.135.0, we should use the
@@ -129,7 +147,7 @@ class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
             # https://fastapi.tiangolo.com/tutorial/server-sent-events/
             return StreamingResponse(
                 iter_sse_events(
-                    event_queue=event_queue,
+                    stream_state=stream_state,
                     producer_future=execution_future,
                 ),
                 media_type="text/event-stream",
@@ -373,3 +391,8 @@ class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
         yield
 
         self.shutdown()
+
+    def shutdown(self) -> None:
+        """Shutdown the FastAPI deployment app."""
+        self._executor.shutdown(wait=True, cancel_futures=True)
+        super().shutdown()

--- a/src/zenml/deployers/server/fastapi/app.py
+++ b/src/zenml/deployers/server/fastapi/app.py
@@ -53,6 +53,7 @@ from zenml.deployers.server.fastapi.adapters import (
     FastAPIEndpointAdapter,
     FastAPIMiddlewareAdapter,
 )
+from zenml.deployers.streaming import create_stream_queue, iter_sse_events
 from zenml.logger import get_logger
 
 logger = get_logger(__name__)
@@ -102,6 +103,44 @@ class FastAPIDeploymentAppRunner(BaseDeploymentAppRunner):
             ),
             native=True,
         )
+
+    def _build_stream_invoke_endpoint(self) -> Any:
+        """Create the FastAPI endpoint used for streamed pipeline invocation.
+
+        Returns:
+            A callable endpoint that streams lifecycle events as SSE.
+        """
+        from fastapi.responses import StreamingResponse
+
+        PipelineInvokeRequest, _ = self.service.get_pipeline_invoke_models()
+
+        def _stream_invoke_endpoint(
+            request: PipelineInvokeRequest,  # type: ignore[valid-type]
+        ) -> StreamingResponse:
+            event_queue = create_stream_queue()
+            execution_future = self._executor.submit(
+                self.service.execute_pipeline_streamed,
+                request,
+                event_queue,
+            )
+
+            # TODO: Once we upgrade to FastAPI 0.135.0, we should use the
+            # builtin SSE functionality. See
+            # https://fastapi.tiangolo.com/tutorial/server-sent-events/
+            return StreamingResponse(
+                iter_sse_events(
+                    event_queue=event_queue,
+                    producer_future=execution_future,
+                ),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        return _stream_invoke_endpoint
 
     def _get_dashboard_endpoints(self) -> List[EndpointSpec]:
         """Get the dashboard endpoints specs.

--- a/src/zenml/deployers/server/models.py
+++ b/src/zenml/deployers/server/models.py
@@ -134,7 +134,7 @@ class AppInfo(BaseModel):
     docs_url_path: str
     redoc_url_path: str
     invoke_url_path: str
-    stream_invoke_url_path: str
+    stream_invoke_url_path: Optional[str] = None
     health_url_path: str
     info_url_path: str
     metrics_url_path: str

--- a/src/zenml/deployers/server/models.py
+++ b/src/zenml/deployers/server/models.py
@@ -131,6 +131,7 @@ class AppInfo(BaseModel):
     docs_url_path: str
     redoc_url_path: str
     invoke_url_path: str
+    stream_invoke_url_path: str
     health_url_path: str
     info_url_path: str
     metrics_url_path: str

--- a/src/zenml/deployers/server/models.py
+++ b/src/zenml/deployers/server/models.py
@@ -65,6 +65,9 @@ class BaseDeploymentInvocationRequest(BaseModel):
         title="Whether to keep outputs in memory for fast access instead of "
         "storing them as artifacts.",
     )
+    run_id: Optional[UUID] = Field(
+        default=None, title="The ID of the pipeline run to resume."
+    )
 
 
 class BaseDeploymentInvocationResponse(BaseModel):

--- a/src/zenml/deployers/server/service.py
+++ b/src/zenml/deployers/server/service.py
@@ -54,12 +54,13 @@ from zenml.deployers.streaming import (
 from zenml.deployers.utils import (
     deployment_snapshot_request_from_source_snapshot,
 )
-from zenml.enums import StackComponentType
+from zenml.enums import ExecutionStatus, StackComponentType
 from zenml.hooks.hook_validators import load_and_run_hook
 from zenml.logger import get_logger
 from zenml.models import (
     PipelineRunResponse,
     PipelineRunTriggerInfo,
+    PipelineRunUpdate,
     PipelineSnapshotResponse,
 )
 from zenml.orchestrators.base_orchestrator import BaseOrchestrator
@@ -420,42 +421,64 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         start_time = time.time()
         logger.info("Starting pipeline execution")
 
-        placeholder_run: Optional[PipelineRunResponse] = None
         response: Optional[BaseDeploymentInvocationResponse] = None
+        run: Optional[PipelineRunResponse] = None
+        resume = False
         try:
-            # Create a placeholder run separately from the actual execution,
-            # so that we have a run ID to include in the response even if the
-            # pipeline execution fails.
-            placeholder_run, deployment_snapshot = (
-                self._prepare_execute_with_orchestrator(
-                    resolved_params=parameters,
+            if request.run_id:
+                resume = True
+                run = self._client.zen_store.update_run(
+                    run_id=request.run_id,
+                    run_update=PipelineRunUpdate(
+                        status=ExecutionStatus.RESUMING,
+                        status_reason="Pipeline execution resumed by user.",
+                    ),
                 )
-            )
+                deployment_snapshot = run.snapshot
+                assert deployment_snapshot
+            else:
+                # Create a placeholder run separately from the actual execution,
+                # so that we have a run ID to include in the response even if the
+                # pipeline execution fails.
+                run, deployment_snapshot = (
+                    self._prepare_execute_with_orchestrator(
+                        resolved_params=parameters,
+                    )
+                )
 
             if stream_state and register_stream(
-                run_id=placeholder_run.id, stream_state=stream_state
+                run_id=run.id, stream_state=stream_state
             ):
                 publish_event(
                     stream_state=stream_state,
                     event_type=StreamEventType.RUN_STARTED,
                     payload={
-                        "run_id": str(placeholder_run.id),
-                        "run_name": placeholder_run.name,
-                        "run_index": placeholder_run.index,
+                        "run_id": str(run.id),
+                        "run_name": run.name,
+                        "run_index": run.index,
                     },
                 )
 
             captured_outputs = self._execute_with_orchestrator(
-                placeholder_run=placeholder_run,
+                placeholder_run=run,
                 deployment_snapshot=deployment_snapshot,
                 resolved_params=parameters,
                 skip_artifact_materialization=request.skip_artifact_materialization,
+                resume=resume,
             )
 
-            # Map outputs using fast (in-memory) or slow (artifact) path
-            mapped_outputs = self._map_outputs(captured_outputs)
+            run = Client().get_pipeline_run(
+                name_id_or_prefix=run.id,
+                hydrate=True,
+            )
+
+            mapped_outputs = None
+
+            if run.status.is_successful:
+                mapped_outputs = self._map_outputs(captured_outputs)
+
             response = self._build_response(
-                placeholder_run=placeholder_run,
+                placeholder_run=run,
                 mapped_outputs=mapped_outputs,
                 start_time=start_time,
                 resolved_params=parameters,
@@ -464,7 +487,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         except Exception as e:
             logger.exception("❌ Pipeline execution failed")
             response = self._build_response(
-                placeholder_run=placeholder_run,
+                placeholder_run=run,
                 mapped_outputs=None,
                 start_time=start_time,
                 resolved_params=parameters,
@@ -623,6 +646,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         deployment_snapshot: PipelineSnapshotResponse,
         resolved_params: Dict[str, Any],
         skip_artifact_materialization: bool,
+        resume: bool = False,
     ) -> Optional[Dict[str, Dict[str, Any]]]:
         """Run the snapshot via the orchestrator and return the concrete run.
 
@@ -633,6 +657,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
             resolved_params: Normalized pipeline parameters.
             skip_artifact_materialization: Whether runtime should skip artifact
                 materialization.
+            resume: Whether to resume the pipeline execution.
 
         Returns:
             The in-memory outputs of the execution.
@@ -672,12 +697,18 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
 
             captured_outputs: Optional[Dict[str, Dict[str, Any]]] = None
             try:
-                # Use the new deployment snapshot with pre-configured settings
-                orchestrator.run(
-                    snapshot=deployment_snapshot,
-                    stack=active_stack,
-                    placeholder_run=placeholder_run,
-                )
+                if resume:
+                    orchestrator.resume_run(
+                        snapshot=deployment_snapshot,
+                        stack=active_stack,
+                        run=placeholder_run,
+                    )
+                else:
+                    orchestrator.run(
+                        snapshot=deployment_snapshot,
+                        stack=active_stack,
+                        placeholder_run=placeholder_run,
+                    )
 
                 # Capture in-memory outputs before stopping the runtime context
                 if runtime.is_active():

--- a/src/zenml/deployers/server/service.py
+++ b/src/zenml/deployers/server/service.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Pipeline deployment service."""
 
+import queue
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -43,6 +44,12 @@ from zenml.deployers.server.models import (
     PipelineInfo,
     ServiceInfo,
     SnapshotInfo,
+)
+from zenml.deployers.streaming import (
+    StreamEvent,
+    StreamEventType,
+    register_stream,
+    unregister_stream,
 )
 from zenml.deployers.utils import (
     deployment_snapshot_request_from_source_snapshot,
@@ -155,6 +162,25 @@ class BasePipelineDeploymentService(ABC):
         Returns:
             A BaseDeploymentInvocationResponse describing the execution result.
         """
+
+    def execute_pipeline_streamed(
+        self,
+        request: BaseDeploymentInvocationRequest,
+        event_queue: queue.Queue[StreamEvent],
+    ) -> None:
+        """Execute the deployment and publish lifecycle events.
+
+        Args:
+            request: Runtime parameters supplied by the caller.
+            event_queue: Queue used to publish stream lifecycle and final events.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
+        """
+        raise NotImplementedError(
+            "Streamed pipeline execution is not implemented for "
+            f"{self.__class__.__name__}."
+        )
 
     @abstractmethod
     def get_service_info(self) -> ServiceInfo:
@@ -351,6 +377,37 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         Returns:
             A BaseDeploymentInvocationResponse describing the execution result.
         """
+        return self._execute_pipeline_internal(request=request)
+
+    def execute_pipeline_streamed(
+        self,
+        request: BaseDeploymentInvocationRequest,
+        event_queue: queue.Queue[StreamEvent],
+    ) -> None:
+        """Execute the deployment and publish stream events.
+
+        Args:
+            request: Runtime parameters supplied by the caller.
+            event_queue: Queue used to publish stream lifecycle and final events.
+        """
+        self._execute_pipeline_internal(
+            request=request, event_queue=event_queue
+        )
+
+    def _execute_pipeline_internal(
+        self,
+        request: BaseDeploymentInvocationRequest,
+        event_queue: Optional[queue.Queue[StreamEvent]] = None,
+    ) -> BaseDeploymentInvocationResponse:
+        """Execute the pipeline with optional lifecycle event emission.
+
+        Args:
+            request: Runtime parameters supplied by the caller.
+            event_queue: Optional queue used to emit lifecycle stream events.
+
+        Returns:
+            A BaseDeploymentInvocationResponse describing the execution result.
+        """
         # Unused parameters for future implementation
         _ = request.run_name, request.timeout
         parameters = request.parameters.model_dump()
@@ -368,6 +425,21 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 )
             )
 
+            if event_queue:
+                register_stream(
+                    run_id=placeholder_run.id, event_queue=event_queue
+                )
+                event_queue.put(
+                    StreamEvent(
+                        event_type=StreamEventType.RUN_STARTED,
+                        data={
+                            "run_id": str(placeholder_run.id),
+                            "run_name": placeholder_run.name,
+                            "run_index": placeholder_run.index,
+                        },
+                    )
+                )
+
             captured_outputs = self._execute_with_orchestrator(
                 placeholder_run=placeholder_run,
                 deployment_snapshot=deployment_snapshot,
@@ -377,23 +449,40 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
 
             # Map outputs using fast (in-memory) or slow (artifact) path
             mapped_outputs = self._map_outputs(captured_outputs)
-
-            return self._build_response(
+            response = self._build_response(
                 placeholder_run=placeholder_run,
                 mapped_outputs=mapped_outputs,
                 start_time=start_time,
                 resolved_params=parameters,
             )
-
+            if event_queue:
+                event_queue.put(
+                    StreamEvent(
+                        event_type=StreamEventType.RUN_FINISHED,
+                        data=response.model_dump(mode="json"),
+                    )
+                )
+            return response
         except Exception as e:
             logger.exception("❌ Pipeline execution failed")
-            return self._build_response(
+            response = self._build_response(
                 placeholder_run=placeholder_run,
                 mapped_outputs=None,
                 start_time=start_time,
                 resolved_params=parameters,
                 error=e,
             )
+            if event_queue:
+                event_queue.put(
+                    StreamEvent(
+                        event_type=StreamEventType.RUN_FINISHED,
+                        data=response.model_dump(mode="json"),
+                    )
+                )
+            return response
+        finally:
+            if event_queue and placeholder_run:
+                unregister_stream(run_id=placeholder_run.id)
 
     def get_service_info(self) -> ServiceInfo:
         """Get service information.
@@ -427,6 +516,8 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 docs_url_path=settings.docs_url_path,
                 redoc_url_path=settings.redoc_url_path,
                 invoke_url_path=api_urlpath + settings.invoke_url_path,
+                stream_invoke_url_path=api_urlpath
+                + settings.stream_invoke_url_path,
                 health_url_path=api_urlpath + settings.health_url_path,
                 info_url_path=api_urlpath + settings.info_url_path,
                 metrics_url_path=api_urlpath + settings.metrics_url_path,

--- a/src/zenml/deployers/server/service.py
+++ b/src/zenml/deployers/server/service.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Pipeline deployment service."""
 
-import queue
 import time
 import traceback
 from abc import ABC, abstractmethod
@@ -46,10 +45,11 @@ from zenml.deployers.server.models import (
     SnapshotInfo,
 )
 from zenml.deployers.streaming import (
-    StreamEvent,
     StreamEventType,
+    StreamState,
+    close_stream,
+    publish_event,
     register_stream,
-    unregister_stream,
 )
 from zenml.deployers.utils import (
     deployment_snapshot_request_from_source_snapshot,
@@ -166,13 +166,14 @@ class BasePipelineDeploymentService(ABC):
     def execute_pipeline_streamed(
         self,
         request: BaseDeploymentInvocationRequest,
-        event_queue: queue.Queue[StreamEvent],
-    ) -> None:
+        stream_state: StreamState,
+    ) -> BaseDeploymentInvocationResponse:
         """Execute the deployment and publish lifecycle events.
 
         Args:
             request: Runtime parameters supplied by the caller.
-            event_queue: Queue used to publish stream lifecycle and final events.
+            stream_state: Shared state used to coordinate stream lifecycle and
+                event delivery.
 
         Raises:
             NotImplementedError: If the method is not implemented.
@@ -382,28 +383,33 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
     def execute_pipeline_streamed(
         self,
         request: BaseDeploymentInvocationRequest,
-        event_queue: queue.Queue[StreamEvent],
-    ) -> None:
+        stream_state: StreamState,
+    ) -> BaseDeploymentInvocationResponse:
         """Execute the deployment and publish stream events.
 
         Args:
             request: Runtime parameters supplied by the caller.
-            event_queue: Queue used to publish stream lifecycle and final events.
+            stream_state: Shared state used to coordinate stream lifecycle and
+                event delivery.
+
+        Returns:
+            A BaseDeploymentInvocationResponse describing the execution result.
         """
-        self._execute_pipeline_internal(
-            request=request, event_queue=event_queue
+        return self._execute_pipeline_internal(
+            request=request, stream_state=stream_state
         )
 
     def _execute_pipeline_internal(
         self,
         request: BaseDeploymentInvocationRequest,
-        event_queue: Optional[queue.Queue[StreamEvent]] = None,
+        stream_state: Optional[StreamState] = None,
     ) -> BaseDeploymentInvocationResponse:
         """Execute the pipeline with optional lifecycle event emission.
 
         Args:
             request: Runtime parameters supplied by the caller.
-            event_queue: Optional queue used to emit lifecycle stream events.
+            stream_state: Optional shared state used to emit lifecycle stream
+                events.
 
         Returns:
             A BaseDeploymentInvocationResponse describing the execution result.
@@ -415,6 +421,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         logger.info("Starting pipeline execution")
 
         placeholder_run: Optional[PipelineRunResponse] = None
+        response: Optional[BaseDeploymentInvocationResponse] = None
         try:
             # Create a placeholder run separately from the actual execution,
             # so that we have a run ID to include in the response even if the
@@ -425,19 +432,17 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 )
             )
 
-            if event_queue:
-                register_stream(
-                    run_id=placeholder_run.id, event_queue=event_queue
-                )
-                event_queue.put(
-                    StreamEvent(
-                        event_type=StreamEventType.RUN_STARTED,
-                        data={
-                            "run_id": str(placeholder_run.id),
-                            "run_name": placeholder_run.name,
-                            "run_index": placeholder_run.index,
-                        },
-                    )
+            if stream_state and register_stream(
+                run_id=placeholder_run.id, stream_state=stream_state
+            ):
+                publish_event(
+                    stream_state=stream_state,
+                    event_type=StreamEventType.RUN_STARTED,
+                    payload={
+                        "run_id": str(placeholder_run.id),
+                        "run_name": placeholder_run.name,
+                        "run_index": placeholder_run.index,
+                    },
                 )
 
             captured_outputs = self._execute_with_orchestrator(
@@ -455,13 +460,6 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 start_time=start_time,
                 resolved_params=parameters,
             )
-            if event_queue:
-                event_queue.put(
-                    StreamEvent(
-                        event_type=StreamEventType.RUN_FINISHED,
-                        data=response.model_dump(mode="json"),
-                    )
-                )
             return response
         except Exception as e:
             logger.exception("❌ Pipeline execution failed")
@@ -472,17 +470,16 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 resolved_params=parameters,
                 error=e,
             )
-            if event_queue:
-                event_queue.put(
-                    StreamEvent(
-                        event_type=StreamEventType.RUN_FINISHED,
-                        data=response.model_dump(mode="json"),
-                    )
-                )
             return response
         finally:
-            if event_queue and placeholder_run:
-                unregister_stream(run_id=placeholder_run.id)
+            if stream_state:
+                if response is not None:
+                    publish_event(
+                        stream_state=stream_state,
+                        event_type=StreamEventType.RUN_FINISHED,
+                        payload=response.model_dump(mode="json"),
+                    )
+                close_stream(stream_state=stream_state)
 
     def get_service_info(self) -> ServiceInfo:
         """Get service information.

--- a/src/zenml/deployers/server/service.py
+++ b/src/zenml/deployers/server/service.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, WithJsonSchema
 
 import zenml.pipelines.run_utils as run_utils
 from zenml.client import Client
+from zenml.config import DeploymentDefaultEndpoints
 from zenml.deployers.server import runtime
 from zenml.deployers.server.models import (
     AppInfo,
@@ -47,7 +48,6 @@ from zenml.deployers.server.models import (
 from zenml.deployers.streaming import (
     StreamEventType,
     StreamState,
-    close_stream,
     publish_event,
     register_stream,
 )
@@ -175,6 +175,9 @@ class BasePipelineDeploymentService(ABC):
             request: Runtime parameters supplied by the caller.
             stream_state: Shared state used to coordinate stream lifecycle and
                 event delivery.
+
+        Returns:
+            A BaseDeploymentInvocationResponse describing the execution result.
 
         Raises:
             NotImplementedError: If the method is not implemented.
@@ -502,7 +505,6 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                         event_type=StreamEventType.RUN_FINISHED,
                         payload=response.model_dump(mode="json"),
                     )
-                close_stream(stream_state=stream_state)
 
     def get_service_info(self) -> ServiceInfo:
         """Get service information.
@@ -513,6 +515,11 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         uptime = time.time() - self.service_start_time
         settings = self.app_runner.settings
         api_urlpath = f"{self.app_runner.settings.root_url_path}{self.app_runner.settings.api_url_path}"
+        stream_invoke_url_path = None
+        if settings.endpoint_enabled(DeploymentDefaultEndpoints.STREAM_INVOKE):
+            stream_invoke_url_path = (
+                api_urlpath + settings.stream_invoke_url_path
+            )
         return ServiceInfo(
             deployment=DeploymentInfo(
                 id=self.deployment.id,
@@ -536,8 +543,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
                 docs_url_path=settings.docs_url_path,
                 redoc_url_path=settings.redoc_url_path,
                 invoke_url_path=api_urlpath + settings.invoke_url_path,
-                stream_invoke_url_path=api_urlpath
-                + settings.stream_invoke_url_path,
+                stream_invoke_url_path=stream_invoke_url_path,
                 health_url_path=api_urlpath + settings.health_url_path,
                 info_url_path=api_urlpath + settings.info_url_path,
                 metrics_url_path=api_urlpath + settings.metrics_url_path,

--- a/src/zenml/deployers/streaming.py
+++ b/src/zenml/deployers/streaming.py
@@ -1,0 +1,203 @@
+"""Streaming helpers."""
+
+import concurrent.futures
+import json
+import queue
+import threading
+from enum import Enum
+from typing import Any, Dict, Iterator, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from zenml.constants import handle_int_env_var
+from zenml.logger import get_logger
+
+logger = get_logger(__name__)
+
+_STREAM_QUEUE_MAX_SIZE_ENV_VAR = "ZENML_STREAM_QUEUE_MAX_SIZE"
+_DEFAULT_STREAM_QUEUE_MAX_SIZE = 256
+_DEFAULT_STREAM_POLL_INTERVAL_SECONDS = 1.0
+
+
+class StreamEventType(str, Enum):
+    """Known event types emitted by deployment streaming endpoints."""
+
+    RUN_STARTED = "run_started"
+    USER_MESSAGE = "user_message"
+    RUN_FINISHED = "run_finished"
+
+
+class StreamEvent(BaseModel):
+    """Transport-agnostic stream event representation."""
+
+    event_type: StreamEventType
+    data: Dict[str, Any]
+
+
+StreamQueue = queue.Queue[StreamEvent]
+
+
+_stream_registry: Dict[UUID, "StreamQueue"] = {}
+_stream_registry_lock = threading.Lock()
+
+
+def create_stream_queue() -> "StreamQueue":
+    """Create a stream queue honoring optional max-size configuration.
+
+    Returns:
+        A queue used to publish streaming events for a single invocation.
+    """
+    max_size = handle_int_env_var(
+        _STREAM_QUEUE_MAX_SIZE_ENV_VAR,
+        _DEFAULT_STREAM_QUEUE_MAX_SIZE,
+    )
+    return queue.Queue(maxsize=max_size)
+
+
+def register_stream(run_id: UUID, event_queue: "StreamQueue") -> None:
+    """Register a new stream queue for a pipeline run.
+
+    Args:
+        run_id: The run ID used as stream key.
+        event_queue: Queue carrying stream events for the run.
+    """
+    with _stream_registry_lock:
+        _stream_registry[run_id] = event_queue
+
+
+def publish_event(run_id: UUID, event: StreamEvent) -> bool:
+    """Publish an event to a run stream if still open.
+
+    Args:
+        run_id: Run ID used to locate the stream.
+        event: Event payload to publish.
+
+    Returns:
+        True if the event was queued, False if no open stream exists.
+    """
+    with _stream_registry_lock:
+        event_queue = _stream_registry.get(run_id)
+        if not event_queue:
+            return False
+
+    try:
+        event_queue.put_nowait(event)
+    except queue.Full:
+        logger.warning(
+            "Dropping stream event '%s' for run '%s' because queue is full.",
+            event.event_type.value,
+            run_id,
+        )
+        return False
+
+    return True
+
+
+def unregister_stream(run_id: UUID) -> None:
+    """Remove a run stream from the registry.
+
+    Args:
+        run_id: Run ID used to remove the stream.
+    """
+    with _stream_registry_lock:
+        _stream_registry.pop(run_id, None)
+
+
+def has_stream(run_id: UUID) -> bool:
+    """Check if a stream is currently registered for a run ID.
+
+    Args:
+        run_id: Run ID used to locate the stream.
+
+    Returns:
+        True if a stream is registered, False otherwise.
+    """
+    with _stream_registry_lock:
+        return run_id in _stream_registry
+
+
+def format_sse_event(event: StreamEvent) -> str:
+    """Serialize a stream event to SSE wire format.
+
+    Args:
+        event: Event to serialize.
+
+    Returns:
+        A string chunk formatted as an SSE event.
+    """
+    serialized_data = json.dumps(event.data)
+    return f"event: {event.event_type.value}\ndata: {serialized_data}\n\n"
+
+
+def iter_sse_events(
+    event_queue: "StreamQueue",
+    producer_future: Optional[concurrent.futures.Future[Any]] = None,
+    poll_interval_seconds: float = _DEFAULT_STREAM_POLL_INTERVAL_SECONDS,
+) -> Iterator[str]:
+    """Yield SSE-formatted events from a stream queue.
+
+    Args:
+        event_queue: Queue.
+        producer_future: Future used to detect background failures and avoid
+            hanging the response stream.
+        poll_interval_seconds: Queue poll interval in seconds when waiting for
+            new events.
+
+    Yields:
+        SSE formatted event strings.
+    """
+    run_id: Optional[UUID] = None
+    try:
+        while True:
+            try:
+                queue_item = event_queue.get(timeout=poll_interval_seconds)
+            except queue.Empty:
+                if producer_future and producer_future.done():
+                    queue_item = StreamEvent(
+                        event_type=StreamEventType.RUN_FINISHED,
+                        data={
+                            "success": False,
+                            "error": str(producer_future.exception()),
+                        },
+                    )
+                else:
+                    continue
+
+            if queue_item.event_type == StreamEventType.RUN_STARTED:
+                run_id = UUID(queue_item.data["run_id"])
+
+            yield format_sse_event(queue_item)
+            if queue_item.event_type == StreamEventType.RUN_FINISHED:
+                break
+    finally:
+        # Use this to unregister the stream e.g. when the client disconnects
+        # early.
+        if run_id:
+            unregister_stream(run_id=run_id)
+
+
+def stream(data: Any) -> None:
+    """Publish a user event for the active pipeline step run.
+
+    Args:
+        data: JSON-serializable payload to publish.
+    """
+    from zenml.steps import get_step_context
+
+    step_context = get_step_context()
+    run_id = step_context.pipeline_run.id
+    if not has_stream(run_id):
+        logger.debug(
+            "No stream registered for run '%s', skipping event publication.",
+            run_id,
+        )
+        return
+
+    event_payload = data if isinstance(data, dict) else {"value": data}
+    publish_event(
+        run_id=run_id,
+        event=StreamEvent(
+            event_type=StreamEventType.USER_MESSAGE, data=event_payload
+        ),
+    )

--- a/src/zenml/deployers/streaming.py
+++ b/src/zenml/deployers/streaming.py
@@ -1,27 +1,44 @@
-"""Streaming helpers."""
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Streaming utilities for ZenML deployments."""
 
 import concurrent.futures
 import json
 import queue
 import threading
-from enum import Enum
+import time
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from zenml.constants import handle_int_env_var
+from zenml.deployers.server.models import BaseDeploymentInvocationResponse
 from zenml.logger import get_logger
+from zenml.utils.enum_utils import StrEnum
+from zenml.utils.json_utils import pydantic_encoder
 
 logger = get_logger(__name__)
 
 _STREAM_QUEUE_MAX_SIZE_ENV_VAR = "ZENML_STREAM_QUEUE_MAX_SIZE"
-_DEFAULT_STREAM_QUEUE_MAX_SIZE = 256
 _DEFAULT_STREAM_POLL_INTERVAL_SECONDS = 1.0
+QUEUE_MAX_SIZE = handle_int_env_var(_STREAM_QUEUE_MAX_SIZE_ENV_VAR, 256)
 
 
-class StreamEventType(str, Enum):
-    """Known event types emitted by deployment streaming endpoints."""
+class StreamEventType(StrEnum):
+    """Stream event types."""
 
     RUN_STARTED = "run_started"
     USER_MESSAGE = "user_message"
@@ -29,92 +46,83 @@ class StreamEventType(str, Enum):
 
 
 class StreamEvent(BaseModel):
-    """Transport-agnostic stream event representation."""
+    """Stream event."""
 
     event_type: StreamEventType
-    data: Dict[str, Any]
+    payload: str
 
 
 StreamQueue = queue.Queue[StreamEvent]
 
 
-_stream_registry: Dict[UUID, "StreamQueue"] = {}
+@dataclass
+class StreamState:
+    """Mutable stream state shared by the producer and SSE iterator."""
+
+    event_queue: StreamQueue
+    run_id: Optional[UUID] = None
+    closed: bool = False
+    terminal_event: Optional[StreamEvent] = None
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+
+_stream_registry: Dict[UUID, "StreamState"] = {}
 _stream_registry_lock = threading.Lock()
 
 
-def create_stream_queue() -> "StreamQueue":
-    """Create a stream queue honoring optional max-size configuration.
+def create_stream_state() -> "StreamState":
+    """Create stream state honoring optional max-size configuration.
 
     Returns:
-        A queue used to publish streaming events for a single invocation.
+        Stream state used to coordinate a single invocation stream.
     """
-    max_size = handle_int_env_var(
-        _STREAM_QUEUE_MAX_SIZE_ENV_VAR,
-        _DEFAULT_STREAM_QUEUE_MAX_SIZE,
-    )
-    return queue.Queue(maxsize=max_size)
+    return StreamState(event_queue=queue.Queue(maxsize=QUEUE_MAX_SIZE))
 
 
-def register_stream(run_id: UUID, event_queue: "StreamQueue") -> None:
-    """Register a new stream queue for a pipeline run.
+def get_stream_state(run_id: UUID) -> Optional["StreamState"]:
+    """Get stream state for a pipeline run.
 
     Args:
         run_id: The run ID used as stream key.
-        event_queue: Queue carrying stream events for the run.
     """
     with _stream_registry_lock:
-        _stream_registry[run_id] = event_queue
+        return _stream_registry.get(run_id, None)
 
 
-def publish_event(run_id: UUID, event: StreamEvent) -> bool:
-    """Publish an event to a run stream if still open.
+def register_stream(run_id: UUID, stream_state: "StreamState") -> bool:
+    """Register stream state for a pipeline run if still open.
 
     Args:
-        run_id: Run ID used to locate the stream.
-        event: Event payload to publish.
+        run_id: The run ID used as stream key.
+        stream_state: State carrying stream events and lifecycle flags.
 
     Returns:
-        True if the event was queued, False if no open stream exists.
+        `True` if the stream was registered, `False` if it had already closed.
     """
-    with _stream_registry_lock:
-        event_queue = _stream_registry.get(run_id)
-        if not event_queue:
+    with stream_state.lock:
+        stream_state.run_id = run_id
+        if stream_state.closed:
             return False
 
-    try:
-        event_queue.put_nowait(event)
-    except queue.Full:
-        logger.warning(
-            "Dropping stream event '%s' for run '%s' because queue is full.",
-            event.event_type.value,
-            run_id,
-        )
-        return False
+        with _stream_registry_lock:
+            _stream_registry[run_id] = stream_state
 
     return True
 
 
-def unregister_stream(run_id: UUID) -> None:
-    """Remove a run stream from the registry.
+def close_stream(stream_state: "StreamState") -> None:
+    """Mark stream state closed and unregister it if possible.
 
     Args:
-        run_id: Run ID used to remove the stream.
+        stream_state: State for the stream to close.
     """
-    with _stream_registry_lock:
-        _stream_registry.pop(run_id, None)
+    with stream_state.lock:
+        stream_state.closed = True
+        run_id = stream_state.run_id
 
-
-def has_stream(run_id: UUID) -> bool:
-    """Check if a stream is currently registered for a run ID.
-
-    Args:
-        run_id: Run ID used to locate the stream.
-
-    Returns:
-        True if a stream is registered, False otherwise.
-    """
-    with _stream_registry_lock:
-        return run_id in _stream_registry
+    if run_id:
+        with _stream_registry_lock:
+            _stream_registry.pop(run_id, None)
 
 
 def format_sse_event(event: StreamEvent) -> str:
@@ -126,78 +134,194 @@ def format_sse_event(event: StreamEvent) -> str:
     Returns:
         A string chunk formatted as an SSE event.
     """
-    serialized_data = json.dumps(event.data)
-    return f"event: {event.event_type.value}\ndata: {serialized_data}\n\n"
+    return f"event: {event.event_type.value}\ndata: {event.payload}\n\n"
+
+
+def _set_terminal_event(
+    stream_state: "StreamState", terminal_event: StreamEvent
+) -> bool:
+    """Set a terminal stream event if no terminal event exists yet.
+
+    Args:
+        stream_state: Shared stream state for this invocation.
+        terminal_event: Terminal event to set.
+
+    Returns:
+        True if the event was set, False if a terminal event already existed.
+    """
+    with stream_state.lock:
+        if stream_state.terminal_event is not None:
+            return False
+        stream_state.terminal_event = terminal_event
+    return True
+
+
+def _build_fallback_run_finished_event(
+    producer_future: concurrent.futures.Future[
+        "BaseDeploymentInvocationResponse"
+    ],
+) -> StreamEvent:
+    """Build a fallback terminal event from producer future state.
+
+    Args:
+        producer_future: Future associated with the stream producer.
+
+    Returns:
+        A synthetic `RUN_FINISHED` event.
+    """
+    try:
+        result = producer_future.result()
+        payload = result.model_dump(mode="json")
+    except Exception as e:
+        logger.exception(
+            "Stream producer raised an exception.",
+            exc_info=e,
+        )
+        payload = {"success": False, "error": str(e)}
+
+    return StreamEvent(
+        event_type=StreamEventType.RUN_FINISHED,
+        payload=json.dumps(payload, default=pydantic_encoder),
+    )
 
 
 def iter_sse_events(
-    event_queue: "StreamQueue",
-    producer_future: Optional[concurrent.futures.Future[Any]] = None,
+    stream_state: "StreamState",
+    producer_future: concurrent.futures.Future[
+        "BaseDeploymentInvocationResponse"
+    ],
     poll_interval_seconds: float = _DEFAULT_STREAM_POLL_INTERVAL_SECONDS,
+    keep_alive_interval_seconds: float = 15.0,
 ) -> Iterator[str]:
     """Yield SSE-formatted events from a stream queue.
 
     Args:
-        event_queue: Queue.
+        stream_state: Shared stream state for this invocation.
         producer_future: Future used to detect background failures and avoid
             hanging the response stream.
         poll_interval_seconds: Queue poll interval in seconds when waiting for
             new events.
+        keep_alive_interval_seconds: Maximum idle time before emitting an SSE
+            keep-alive comment.
 
     Yields:
         SSE formatted event strings.
     """
-    run_id: Optional[UUID] = None
+    event_queue = stream_state.event_queue
+    last_sent_at = time.monotonic()
     try:
         while True:
+            queue_item: Optional[StreamEvent] = None
+
+            if producer_future.done():
+                _set_terminal_event(
+                    stream_state=stream_state,
+                    terminal_event=_build_fallback_run_finished_event(
+                        producer_future=producer_future
+                    ),
+                )
+
             try:
-                queue_item = event_queue.get(timeout=poll_interval_seconds)
+                queue_item = event_queue.get_nowait()
             except queue.Empty:
-                if producer_future and producer_future.done():
-                    queue_item = StreamEvent(
-                        event_type=StreamEventType.RUN_FINISHED,
-                        data={
-                            "success": False,
-                            "error": str(producer_future.exception()),
-                        },
-                    )
+                with stream_state.lock:
+                    terminal_event = stream_state.terminal_event
+                if terminal_event is not None:
+                    queue_item = terminal_event
                 else:
-                    continue
+                    try:
+                        queue_item = event_queue.get(
+                            timeout=poll_interval_seconds
+                        )
+                    except queue.Empty:
+                        pass
 
-            if queue_item.event_type == StreamEventType.RUN_STARTED:
-                run_id = UUID(queue_item.data["run_id"])
-
-            yield format_sse_event(queue_item)
-            if queue_item.event_type == StreamEventType.RUN_FINISHED:
-                break
+            now = time.monotonic()
+            if queue_item:
+                yield format_sse_event(queue_item)
+                last_sent_at = now
+                if queue_item.event_type == StreamEventType.RUN_FINISHED:
+                    return
+            else:
+                if now - last_sent_at >= keep_alive_interval_seconds:
+                    yield ": keep-alive\n\n"
+                    last_sent_at = now
     finally:
-        # Use this to unregister the stream e.g. when the client disconnects
-        # early.
-        if run_id:
-            unregister_stream(run_id=run_id)
+        close_stream(stream_state=stream_state)
 
 
-def stream(data: Any) -> None:
-    """Publish a user event for the active pipeline step run.
+def publish_event(
+    stream_state: "StreamState",
+    event_type: StreamEventType,
+    payload: Dict[str, Any],
+) -> bool:
+    """Publish an event to a stream queue if still open.
+
+    Args:
+        stream_state: Shared stream state for this invocation.
+        event_type: Event type to publish.
+        payload: Event payload to publish.
+
+    Returns:
+        True if the event was queued, False otherwise.
+    """
+    try:
+        serialized_payload = json.dumps(payload, default=pydantic_encoder)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"Failed to serialize event payload: {e}") from e
+
+    event = StreamEvent(
+        event_type=event_type,
+        payload=serialized_payload,
+    )
+
+    if event_type == StreamEventType.RUN_FINISHED:
+        return _set_terminal_event(
+            stream_state=stream_state, terminal_event=event
+        )
+
+    with stream_state.lock:
+        if stream_state.closed:
+            return False
+
+        try:
+            stream_state.event_queue.put_nowait(event)
+        except queue.Full:
+            logger.warning(
+                "Dropping stream event '%s' because queue is full.",
+                event.event_type.value,
+            )
+            return False
+
+    return True
+
+
+def stream(data: Any) -> bool:
+    """Publish an event for the active step run.
 
     Args:
         data: JSON-serializable payload to publish.
+
+    Returns:
+        True if the event was published, False if there was no open stream to
+        publish to.
     """
     from zenml.steps import get_step_context
 
     step_context = get_step_context()
     run_id = step_context.pipeline_run.id
-    if not has_stream(run_id):
+
+    if stream_state := get_stream_state(run_id):
+        payload = {"value": data, "invocation_id": step_context.step_run.name}
+
+        return publish_event(
+            stream_state=stream_state,
+            event_type=StreamEventType.USER_MESSAGE,
+            payload=payload,
+        )
+    else:
         logger.debug(
-            "No stream registered for run '%s', skipping event publication.",
+            "No stream registered for run '%s', skipping event publishing.",
             run_id,
         )
-        return
-
-    event_payload = data if isinstance(data, dict) else {"value": data}
-    publish_event(
-        run_id=run_id,
-        event=StreamEvent(
-            event_type=StreamEventType.USER_MESSAGE, data=event_payload
-        ),
-    )
+        return False

--- a/src/zenml/deployers/streaming.py
+++ b/src/zenml/deployers/streaming.py
@@ -84,6 +84,9 @@ def get_stream_state(run_id: UUID) -> Optional["StreamState"]:
 
     Args:
         run_id: The run ID used as stream key.
+
+    Returns:
+        The stream state registered for the run ID if it exists, otherwise None.
     """
     with _stream_registry_lock:
         return _stream_registry.get(run_id, None)
@@ -122,7 +125,10 @@ def close_stream(stream_state: "StreamState") -> None:
 
     if run_id:
         with _stream_registry_lock:
-            _stream_registry.pop(run_id, None)
+            # Avoid unregistering a newer stream accidentally if another
+            # invocation reused the same run ID in the meantime.
+            if _stream_registry.get(run_id) is stream_state:
+                _stream_registry.pop(run_id, None)
 
 
 def format_sse_event(event: StreamEvent) -> str:
@@ -134,7 +140,10 @@ def format_sse_event(event: StreamEvent) -> str:
     Returns:
         A string chunk formatted as an SSE event.
     """
-    return f"event: {event.event_type.value}\ndata: {event.payload}\n\n"
+    payload = event.payload.replace("\r\n", "\n").replace("\r", "\n")
+    data_lines = payload.splitlines() or [""]
+    serialized_data = "\n".join(f"data: {line}" for line in data_lines)
+    return f"event: {event.event_type.value}\n{serialized_data}\n\n"
 
 
 def _set_terminal_event(
@@ -154,6 +163,19 @@ def _set_terminal_event(
             return False
         stream_state.terminal_event = terminal_event
     return True
+
+
+def _has_terminal_event(stream_state: "StreamState") -> bool:
+    """Check if a terminal event exists for a stream state.
+
+    Args:
+        stream_state: Shared stream state for this invocation.
+
+    Returns:
+        True if a terminal event exists, False otherwise.
+    """
+    with stream_state.lock:
+        return stream_state.terminal_event is not None
 
 
 def _build_fallback_run_finished_event(
@@ -213,7 +235,9 @@ def iter_sse_events(
         while True:
             queue_item: Optional[StreamEvent] = None
 
-            if producer_future.done():
+            if producer_future.done() and not _has_terminal_event(
+                stream_state
+            ):
                 _set_terminal_event(
                     stream_state=stream_state,
                     terminal_event=_build_fallback_run_finished_event(
@@ -264,6 +288,9 @@ def publish_event(
 
     Returns:
         True if the event was queued, False otherwise.
+
+    Raises:
+        ValueError: If the payload cannot be serialized as JSON.
     """
     try:
         serialized_payload = json.dumps(payload, default=pydantic_encoder)

--- a/src/zenml/deployers/streaming.py
+++ b/src/zenml/deployers/streaming.py
@@ -296,15 +296,15 @@ def publish_event(
     return True
 
 
-def stream(data: Any) -> bool:
-    """Publish an event for the active step run.
+def emit_event(data: Any) -> bool:
+    """Emit an event for the active step run.
 
     Args:
-        data: JSON-serializable payload to publish.
+        data: JSON-serializable payload to emit.
 
     Returns:
-        True if the event was published, False if there was no open stream to
-        publish to.
+        True if the event was emitted, False if there was no open stream to
+        emit to.
     """
     from zenml.steps import get_step_context
 


### PR DESCRIPTION
## Describe changes
This PR adds a new endpoint for deployments that enables invoking the deployment and streaming events to a client while the pipeline run is ongoing.

**Limitations:**
- Once a client disconnects, they have no way to reconnect to the stream again.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

