### PR TITLE
Fix empty PR number in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -80,11 +80,11 @@ jobs:
             CODE REVIEW GUIDELINES (use when reviewing PRs):
             Focus on ensuring the changes are sound, clean, intentional, and void of regressions.
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
             Context:
             - You can fetch additional PR context via:
-              - gh pr view ${{ github.event.pull_request.number }} --json title,body,author,headRefName,baseRefName,commits
-              - gh pr diff ${{ github.event.pull_request.number }} --name-only
+              - gh pr view ${{ github.event.issue.number || github.event.pull_request.number }} --json title,body,author,headRefName,baseRefName,commits
+              - gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --name-only
             - Use the repository's CLAUDE.md (if present) and existing code patterns for conventions.
             Primary Review Goals:
             1) Verify Change Correctness
@@ -115,7 +115,7 @@ jobs:
                - Documentation gaps for complex logic
             Documentation & Release Notes Review:
             - Determine if user-facing behavior, APIs, CLI commands/flags, configuration options, or defaults have changed.
-            - Heuristics (run): gh pr diff ${{ github.event.pull_request.number }} --name-only
+            - Heuristics (run): gh pr diff ${{ github.event.issue.number || github.event.pull_request.number }} --name-only
               - If code changes are present under src/ or cli/ or other user-facing modules but docs/ are not updated, flag as "docs update needed".
               - If docs/ changes exist, check if they match the code changes and are placed in the correct sections (e.g., docs/book/, docs/how-to/, docs/reference/).
               - If CLI or config flags changed, ensure corresponding docs and examples are updated (including any README or quickstart sections if applicable).


### PR DESCRIPTION
## Summary

The `@claude /full-review` command on PR #4692 silently failed to post its review — only the initial "job link" placeholder comment appeared, and the GitHub Actions run (`24500218816`) reported a green checkmark even though no review was generated.

### Root cause

The prompt template in `.github/workflows/claude.yml` referenced `${{ github.event.pull_request.number }}` in four places. When the workflow is triggered by an `issue_comment` event (which is what a user typing `@claude /full-review` on a PR fires), `github.event.pull_request` is **not populated** — PR comments come through as issue comments, and the PR number lives at `github.event.issue.number`.

That caused the template to expand with empty strings, producing this garbled prompt (visible in the CI logs):

```
PR NUMBER:                               ← empty
gh pr view  --json title,body,...        ← double space
gh pr diff  --name-only                  ← double space
```

The Claude Code CLI then exited with `duration_ms: 21`, `num_turns: 1`, `total_cost_usd: 0` — no meaningful LLM work, no review body, but a clean exit code. The action's success masked the silent failure.

### Fix

Replace all four occurrences with the same fallback pattern already used for the concurrency group (line 53):

```yaml
${{ github.event.issue.number || github.event.pull_request.number }}
```

`issue.number` is listed first because `issue_comment` is the most common trigger for this workflow.

## Test plan

- [ ] Trigger `@claude /full-review` on a test PR via an `issue_comment`; verify the expanded prompt contains the correct PR number and that Claude produces a review comment
- [ ] Confirm the other supported trigger types (`pull_request_review`, `pull_request_review_comment`, `issues`) still resolve to a sensible value via the fallback chain