### PR TITLE
Fix typo in step creation error message

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -10912,9 +10912,9 @@ class SqlZenStore(BaseZenStore):
 
                 if execution_mode != ExecutionMode.CONTINUE_ON_FAILURE:
                     raise IllegalOperationError(
-                        f"Cannot creat step '{step_run.name}' for the run '{run.name}' "
-                        "because the run is in a FAILED state and the execution mode is"
-                        f"{execution_mode}."
+                        f"Cannot create step '{step_run.name}' for the run '{run.name}' "
+                        "because the run is in a FAILED state and the execution "
+                        f"mode is {execution_mode}."
                     )
 
             self._get_reference_schema_by_id(


### PR DESCRIPTION
## Describe changes

Corrects two small issues in the step-creation error path in `SqlZenStore._update_step_run_status_upgrading_if_necessary` (`src/zenml/zen_stores/sql_zen_store.py:10915`):

1. `Cannot creat step` → `Cannot create step` (typo).
2. A missing space before the execution-mode interpolation caused the rendered message to read `...execution mode is{mode}.` instead of `...execution mode is {mode}.`.

The neighbouring message at line 10904 already uses the correct spelling (`Cannot create step '{...}' for pipeline in ...`), so the existing working path stays aligned with this one.

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have based my new branch on `develop`.
- [ ] Documentation is not affected (message-level change only).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)