### PR TITLE
Avoid KeyError in template config schema when step has parameter_spec without config parameters

### DIFF
--- a/src/zenml/zen_stores/template_utils.py
+++ b/src/zenml/zen_stores/template_utils.py
@@ -405,7 +405,11 @@ def _replace_step_parameter_definitions(
         step_schema.setdefault("properties", {})["parameters"] = (
             parameter_schema
         )
-        # Remove the original parameter schema #def that we just replaced
-        root_definitions.pop(f"{step_name}_parameters")
+        # The `{step_name}_parameters` entry is only added to `$defs` when
+        # the step has configured parameters (see the `create_model` call
+        # above). Steps that carry a `parameter_spec` without matching
+        # `config.parameters` - for example templates regenerated from a
+        # stored spec - never produced that entry, so pop defensively.
+        root_definitions.pop(f"{step_name}_parameters", None)
 
     return schema

--- a/tests/unit/zen_stores/test_template_utils.py
+++ b/tests/unit/zen_stores/test_template_utils.py
@@ -134,3 +134,45 @@ def test_generate_config_schema_reuses_and_renames_step_defs():
         ]["config"]["$ref"]
         == "#/$defs/conflicting_step__NestedConfig"
     )
+
+
+def test_generate_config_schema_with_parameter_spec_and_no_config_parameters():
+    """Schema generation must not crash when a step carries a
+    `parameter_spec` without matching `config.parameters`.
+
+    The step-level `{step_name}_parameters` `$def` is only created when
+    `step.config.parameters` is truthy. A step whose spec was loaded from
+    a stored snapshot (for example when regenerating a config schema from
+    an existing template) may expose a `parameter_spec` while having an
+    empty `config.parameters`; the schema substitution path must handle
+    that case gracefully instead of raising `KeyError`.
+    """
+    step = Step(
+        spec=StepSpec(
+            source="module.step",
+            upstream_steps=[],
+            invocation_id="my_step",
+            parameter_spec={
+                "type": "object",
+                "properties": {"a": {"type": "integer"}},
+                "required": ["a"],
+            },
+        ),
+        config=StepConfiguration(name="my_step", parameters={}),
+        step_config_overrides=StepConfiguration(
+            name="my_step", parameters={}
+        ),
+    )
+    snapshot = SimpleNamespace(
+        is_dynamic=False,
+        build=SimpleNamespace(stack=SimpleNamespace(components=[])),
+    )
+
+    # Must not raise `KeyError('my_step_parameters')`.
+    schema = generate_config_schema(
+        snapshot=snapshot,
+        pipeline_configuration=PipelineConfiguration(name="pipeline"),
+        step_configurations={"my_step": step},
+    )
+
+    assert "$defs" in schema

--- a/tests/unit/zen_stores/test_template_utils.py
+++ b/tests/unit/zen_stores/test_template_utils.py
@@ -137,8 +137,7 @@ def test_generate_config_schema_reuses_and_renames_step_defs():
 
 
 def test_generate_config_schema_with_parameter_spec_and_no_config_parameters():
-    """Schema generation must not crash when a step carries a
-    `parameter_spec` without matching `config.parameters`.
+    """Schema generation handles a parameter_spec with empty config.parameters.
 
     The step-level `{step_name}_parameters` `$def` is only created when
     `step.config.parameters` is truthy. A step whose spec was loaded from
@@ -159,9 +158,7 @@ def test_generate_config_schema_with_parameter_spec_and_no_config_parameters():
             },
         ),
         config=StepConfiguration(name="my_step", parameters={}),
-        step_config_overrides=StepConfiguration(
-            name="my_step", parameters={}
-        ),
+        step_config_overrides=StepConfiguration(name="my_step", parameters={}),
     )
     snapshot = SimpleNamespace(
         is_dynamic=False,


### PR DESCRIPTION
## Describe changes

`generate_config_schema` in `src/zenml/zen_stores/template_utils.py` crashes with `KeyError('{step_name}_parameters')` when a step carries a `parameter_spec` but has no matching entries in `config.parameters`.

### Where it breaks

The substitution loop unconditionally pops the step's parameter schema `$def`:

```python
# src/zenml/zen_stores/template_utils.py:408-409
# Remove the original parameter schema #def that we just replaced
root_definitions.pop(f"{step_name}_parameters")
```

That entry is only added a few hundred lines above, inside a guarded block that only runs when `step.config.parameters` is truthy:

```python
# src/zenml/zen_stores/template_utils.py:242-260
if step.config.parameters:
    ...
    parameters_class = create_model(
        f"{step_name}_parameters", **parameter_fields
    )
```

The outer loop, however, only checks `step.spec.parameter_spec`:

```python
# src/zenml/zen_stores/template_utils.py:368-370
for step_name, step in step_configurations.items():
    if not step.spec.parameter_spec:
        continue
```

So any step that reaches the substitution block with an empty `config.parameters` (for example when regenerating a config schema from a previously stored spec, where `parameter_spec` is persisted but the resolved `config.parameters` dict may not be) hits the `pop` on a key that was never inserted, aborting the whole schema generation.

### Fix

Use `pop(..., None)` so the substitution path is safe regardless of whether the step's `config.parameters` produced the intermediate definition. A regression test in `tests/unit/zen_stores/test_template_utils.py::test_generate_config_schema_with_parameter_spec_and_no_config_parameters` exercises the previously failing scenario and fails on `develop` without this fix.

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added a regression test that reproduces the crash on `develop`.
- [x] I have based my new branch on `develop`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)