### PR TITLE
Clarify that DynamicPipelineRunner.wait() timeout is a soft timeout

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -1026,10 +1026,24 @@ class DynamicPipelineRunner:
     ) -> Any:
         """Create and poll a run wait condition.
 
+        The ``timeout`` argument is a soft timeout: once the deadline
+        passes, the runner stops scheduling further *wait* polling cycles,
+        but it keeps polling as long as sibling steps in the same dynamic
+        pipeline are still in progress. This avoids hard-cancelling
+        concurrent work (e.g. a long-running training step running next to
+        a ``wait(timeout=30)`` for external input) just because the wait
+        condition's own budget ran out. Callers that want a hard upper
+        bound on ``wait`` should drain any concurrent step futures before
+        calling ``wait``.
+
         Args:
             schema: Optional expected output type for the resolved result.
             type: Wait condition type.
-            timeout: Maximum time in seconds to poll before pausing.
+            timeout: Soft timeout in seconds. After this many seconds the
+                runner stops accepting new poll cycles for this wait
+                condition, but polling continues until any in-progress
+                sibling steps have finished. See the method-level docstring
+                above for the full semantics.
             poll_interval: Poll interval in seconds.
             question: Optional question shown to external actors.
             metadata: Optional metadata attached to the condition.


### PR DESCRIPTION
## Describe changes

Per @schustmi's guidance on #4738, this PR updates the `DynamicPipelineRunner.wait()` docstring (`src/zenml/execution/pipeline/dynamic/runner.py:1027`) to match the actual (intentional) polling behaviour.

### Before

```
timeout: Maximum time in seconds to poll before pausing.
```

That reads as a hard ceiling. The polling loop, however, is:

```python
# src/zenml/execution/pipeline/dynamic/runner.py:1121-1123
# We keep polling until the deadline is reached and all ongoing
# steps have finished.
while time.time() < deadline or self.has_in_progress_steps():
    ...
```

So a `wait(timeout=30)` call in a dynamic pipeline will keep polling for as long as any sibling step (e.g. a concurrent training future) is still in progress - which can be minutes or hours. The behaviour is intentional: the timeout is meant to bound *this* wait condition's own budget, not to hard-cancel unrelated concurrent work that just happens to run on the same pipeline.

### After

The docstring now spells out that `timeout` is a soft timeout, describes the interaction with in-progress sibling steps, and points callers who need a strict upper bound at the workaround (drain sibling futures first). No behaviour change.

### Scope

- Docstring-only; no code paths, public APIs, or tests changed.
- Matches maintainer direction on #4738: https://github.com/zenml-io/zenml/issues/4738#issuecomment-4266519563

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have based my new branch on `develop`.
- [x] Docs-only change (no user-facing behaviour change, no test needed).

## Types of changes

- [x] Documentation Update

Closes #4738 (docs angle).