### PR TITLE
Don't resolve zenml pypi version on flavor model generation

### DIFF
--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -26,7 +26,6 @@ from zenml.models import (
 )
 from zenml.stack.stack_component import StackComponent, StackComponentConfig
 from zenml.utils import source_utils
-from zenml.utils.package_utils import is_latest_zenml_version
 
 
 class Flavor:
@@ -226,21 +225,10 @@ class Flavor:
         Returns:
             The complete url to the zenml documentation
         """
-        from zenml import __version__
-
         component_type = self.type.plural.replace("_", "-")
         name = self.name.replace("_", "-")
 
-        try:
-            is_latest = is_latest_zenml_version()
-        except RuntimeError:
-            # We assume in error cases that we are on the latest version
-            is_latest = True
-
-        if is_latest:
-            base = "https://docs.zenml.io"
-        else:
-            base = f"https://zenml-io.gitbook.io/zenml-legacy-documentation/v/{__version__}"
+        base = "https://docs.zenml.io"
         return f"{base}/stack-components/{component_type}/{name}"
 
     def generate_default_sdk_docs_url(self) -> str:

--- a/src/zenml/utils/package_utils.py
+++ b/src/zenml/utils/package_utils.py
@@ -20,43 +20,8 @@ from importlib.metadata import (
 )
 from typing import Dict, List, Optional, Union, cast
 
-import requests
-from packaging import version
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
-
-
-def is_latest_zenml_version() -> bool:
-    """Checks if the currently running ZenML package is on the latest version.
-
-    Returns:
-        True in case the current running zenml code is the latest available version on PYPI, otherwise False.
-
-    Raises:
-        RuntimeError: In case something goes wrong
-    """
-    from zenml import __version__
-
-    # Get the current version of the package
-    current_local_version = __version__
-
-    # Get the latest version from PyPI
-    try:
-        response = requests.get("https://pypi.org/pypi/zenml/json", timeout=60)
-        response.raise_for_status()
-        latest_published_version = response.json()["info"]["version"]
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to fetch the latest version from PyPI: {e}"
-        )
-
-    # Compare versions
-    if version.parse(latest_published_version) > version.parse(
-        current_local_version
-    ):
-        return False
-    else:
-        return True
 
 
 def clean_requirements(requirements: List[str]) -> List[str]:


### PR DESCRIPTION
## Describe changes
Calling pypi to resolve the latest zenml version for flavor API URLs is inefficient and results in long execution times when running zenml servers in air-gapped environments.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

