### PR TITLE
Fix run status update condition

### DIFF
--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -885,11 +885,16 @@ def main() -> None:
 
             # If any steps failed and the pipeline run is still in a transient
             # state, we need to mark it as failed.
-            if pipeline_failed and pipeline_run.status in {
-                ExecutionStatus.INITIALIZING,
-                ExecutionStatus.RUNNING,
-            }:
-                publish_utils.publish_failed_pipeline_run(pipeline_run.id)
+            if pipeline_failed:
+                # refresh the run
+                pipeline_run = client.get_pipeline_run(pipeline_run.id)
+
+                if pipeline_run.status in {
+                    ExecutionStatus.INITIALIZING,
+                    ExecutionStatus.PROVISIONING,
+                    ExecutionStatus.RUNNING,
+                }:
+                    publish_utils.publish_failed_pipeline_run(pipeline_run.id)
         except AuthorizationException:
             # If a step of the pipeline failed or all of them completed
             # successfully, the pipeline run will be finished and the API token

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -387,13 +387,24 @@ def main() -> None:
 
             return False
 
-        def _maybe_publish_failed_step_run(step_name: str) -> None:
+        def _handle_failed_job(step_name: str) -> NodeStatus:
             steps = Client().list_run_steps(
                 name=step_name, pipeline_run_id=pipeline_run.id
             )
             if steps.total > 0:
-                # Step run already exists, we don't need to publish a new one
-                return
+                step_run = steps[0]
+
+                if step_run.status.is_successful:
+                    # If the step run is successful in the DB, we override the
+                    # failed job status.
+                    logger.info(
+                        "Found successful step run in the DB for failed job "
+                        "of step `%s`, overriding failed job status.",
+                        step_name,
+                    )
+                    return NodeStatus.COMPLETED
+                else:
+                    return NodeStatus.FAILED
 
             step_run_request = step_run_request_factory.create_request(
                 step_name
@@ -408,7 +419,7 @@ def main() -> None:
                     step_name,
                     e,
                 )
-                return
+                return NodeStatus.FAILED
 
             step_run_request.status = ExecutionStatus.FAILED
             step_run_request.end_time = utc_now()
@@ -419,6 +430,8 @@ def main() -> None:
                 logger.error(
                     "Failed to publish failed step run `%s`: %s", step_name, e
                 )
+
+            return NodeStatus.FAILED
 
         startup_lock = threading.Lock()
         last_startup_time: float = 0.0
@@ -744,8 +757,7 @@ def main() -> None:
                     step_name,
                     error_message,
                 )
-                _maybe_publish_failed_step_run(step_name)
-                return NodeStatus.FAILED
+                return _handle_failed_job(step_name)
             elif (
                 snapshot.pipeline_configuration.enable_heartbeat
                 and is_node_heartbeat_unhealthy(node)


### PR DESCRIPTION
## Describe changes
This PR fixes the following bug:
- A step of a static pipeline running on Kubernetes finishes successful
- Something causes the step pod to fail after reporting a successful step to ZenML
- The orchestrator pod picks up this failure, and skips downstream step.
- After executing all steps, the orchestrator pod should report the run as failed. In some cases, the run was not refreshed and therefore in a status that caused us to skip this reporting of the failed status.
 
## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

