### PR TITLE
Support for max-runs stop criteria

### DIFF
--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -231,6 +231,50 @@ Via the CLI:
 zenml trigger schedule list --active=true
 ~~~
 
+### Stopping Criteria
+
+You can control when a schedule stops by limiting it in time or by number of runs. This helps avoid unintended 
+long-running schedules and gives you tighter control over resource usage.
+
+#### `end_time`
+
+Defines the point in time after which the schedule will no longer trigger runs. 
+The schedule remains visible but inactive for future executions.
+
+~~~python
+from datetime import datetime, timedelta
+from zenml.client import Client
+
+client = Client()
+
+client.create_schedule_trigger(
+    name="limited-schedule",
+    cron_expression="0 0 * * *",
+    end_time=datetime.now() + timedelta(days=2),
+)
+~~~
+
+#### `max_runs`
+
+Limits how many times a schedule can trigger a pipeline. Once the limit is reached, no further runs are scheduled. 
+Note that this limit applies per attached snapshot, for example, with a limit of 2 and two attached snapshots, you will see a total of 4 runs.
+
+~~~python
+from zenml.client import Client
+
+client = Client()
+
+client.create_schedule_trigger(
+    name="limited-schedule",
+    cron_expression="0 0 * * *",
+    max_runs=24,
+)
+~~~
+
+#### Combined usage
+
+If both are set, the schedule stops when the first condition is reached (time or run limit).
+
 #### Clear dispatch errors
 
 To clear stored dispatch error details after the issue is resolved, use the SDK

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -27,16 +27,17 @@ one-off executions, interval-based schedules, or cron expressions for fine-grain
 Additional options, such as time boundaries, concurrency limits, and activation settings, let you 
 tailor the trigger to your workflow requirements.
 
-| Attribute           | Description                                                  | Notes                        |
-|---------------------|--------------------------------------------------------------|------------------------------|
-| name                | The name of the schedule                                     | Unique within project        |
-| cron_expression     | A cron expression describing your schedule's frequency       | Standard 5-field cron format |
-| interval            | An interval (in seconds) describing the schedule's frequency | Combined with start_time     |
-| run_once_start_time | One-off execution at a specific time in the future           | UTC                          |
-| start_time          | The beginning of the schedule                                | UTC                          |
-| end_time            | The end time of the schedule                                 | UTC                          |
-| active              | Status of the schedule (active/inactive)                     | -                            |
-| concurrency         | Option to control how concurrent runs should be handled      | Skip is the default option   |
+| Attribute           | Description                                                             | Notes                        |
+|---------------------|-------------------------------------------------------------------------|------------------------------|
+| name                | The name of the schedule                                                | Unique within project        |
+| cron_expression     | A cron expression describing your schedule's frequency                  | Standard 5-field cron format |
+| interval            | An interval (in seconds) describing the schedule's frequency            | Combined with start_time     |
+| run_once_start_time | One-off execution at a specific time in the future                      | UTC                          |
+| start_time          | The beginning of the schedule                                           | UTC                          |
+| end_time            | The end time of the schedule                                            | UTC                          |
+| active              | Status of the schedule (active/inactive)                                | -                            |
+| concurrency         | Option to control how concurrent runs should be handled                 | Skip is the default option   |
+| max_runs            | Option to control maximum runs (per attached snapshot) for the schedule | -                            |
 
 ### Create a schedule
 

--- a/src/zenml/cli/trigger.py
+++ b/src/zenml/cli/trigger.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 import click
 
+from zenml import PlatformEventTriggerResponse, ScheduleTriggerResponse
 from zenml.cli import utils as cli_utils
 from zenml.cli.cli import TagGroup, cli
 from zenml.client import Client
@@ -27,6 +28,7 @@ from zenml.enums import (
     CliCategories,
     SourceType,
     TriggerRunConcurrency,
+    TriggerType,
 )
 from zenml.logger import get_logger
 from zenml.models import TriggerFilter
@@ -275,8 +277,51 @@ def list_schedules(
 # COMMON COMMANDS
 
 
-def make_delete_command() -> click.Command:
+def get_trigger_by_type(
+    trigger_type: TriggerType,
+    trigger_name_id_or_prefix: str,
+    hydrate: bool,
+    allow_name_prefix_match: bool,
+    is_archived: bool = False,
+) -> ScheduleTriggerResponse | PlatformEventTriggerResponse:
+    """Getter helper. Resolves trigger type getter by id.
+
+    Args:
+        trigger_type: The trigger type.
+        trigger_name_id_or_prefix: The name or ID of the trigger.
+        hydrate: Whether to hydrate response object.
+        allow_name_prefix_match: Whether to allow name prefix matching.
+        is_archived: Whether to search for archived triggers.
+
+    Returns:
+        The trigger by ID.
+
+    Raises:
+        RuntimeError: If trigger type is not supported.
+    """
+    if trigger_type == TriggerType.SCHEDULE:
+        return Client().get_schedule_trigger(
+            trigger_name_id_or_prefix=trigger_name_id_or_prefix,
+            hydrate=hydrate,
+            is_archived=is_archived,
+            allow_name_prefix_match=allow_name_prefix_match,
+        )
+    elif trigger_type == TriggerType.PLATFORM_EVENT:
+        return Client().get_platform_event_trigger(
+            trigger_name_id_or_prefix=trigger_name_id_or_prefix,
+            hydrate=hydrate,
+            is_archived=is_archived,
+            allow_name_prefix_match=allow_name_prefix_match,
+        )
+    else:
+        raise RuntimeError(f"Unknown trigger type: {trigger_type}")
+
+
+def make_delete_command(trigger_type: TriggerType) -> click.Command:
     """Delete command factory function.
+
+    Args:
+        trigger_type: The trigger type.
 
     Returns:
         A Click.command for the delete method
@@ -293,16 +338,14 @@ def make_delete_command() -> click.Command:
             archived: Whether to delete an archived trigger.
         """
         try:
-            trigger_id = (
-                Client()
-                .get_schedule_trigger(
-                    trigger_name_id_or_prefix=trigger_name_or_id,
-                    allow_name_prefix_match=False,
-                    is_archived=archived,
-                    hydrate=False,
-                )
-                .id
-            )
+            trigger_id = get_trigger_by_type(
+                trigger_type=trigger_type,
+                trigger_name_id_or_prefix=trigger_name_or_id,
+                allow_name_prefix_match=False,
+                is_archived=archived,
+                hydrate=False,
+            ).id
+
             Client().delete_trigger(
                 trigger_id=trigger_id, soft=not hard and not archived
             )
@@ -333,8 +376,11 @@ def make_delete_command() -> click.Command:
     return click.command(name="delete", help="Delete a trigger.")(f)
 
 
-def make_attach_command() -> click.Command:
+def make_attach_command(trigger_type: TriggerType) -> click.Command:
     """Attach command factory function.
+
+    Args:
+        trigger_type: The trigger type.
 
     Returns:
         A Click.command for the attach method
@@ -355,15 +401,12 @@ def make_attach_command() -> click.Command:
             allow_replace: Allow replacement if attachment already exists.
         """
         try:
-            trigger_id = (
-                Client()
-                .get_schedule_trigger(
-                    trigger_name_id_or_prefix=trigger_name_or_id,
-                    allow_name_prefix_match=False,
-                    hydrate=False,
-                )
-                .id
-            )
+            trigger_id = get_trigger_by_type(
+                trigger_type=trigger_type,
+                trigger_name_id_or_prefix=trigger_name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=False,
+            ).id
             snapshot_id = (
                 Client()
                 .get_snapshot(
@@ -414,8 +457,11 @@ def make_attach_command() -> click.Command:
     return click.command("attach", help="Attach trigger to snapshot")(f)
 
 
-def make_detach_command() -> click.Command:
+def make_detach_command(trigger_type: TriggerType) -> click.Command:
     """Detach command factory function.
+
+    Args:
+        trigger_type: The trigger type.
 
     Returns:
         A Click.command for the detach method
@@ -431,15 +477,12 @@ def make_detach_command() -> click.Command:
             snapshot_name_or_id: The name or ID of the snapshot.
         """
         try:
-            trigger_id = (
-                Client()
-                .get_schedule_trigger(
-                    trigger_name_id_or_prefix=trigger_name_or_id,
-                    allow_name_prefix_match=False,
-                    hydrate=False,
-                )
-                .id
-            )
+            trigger_id = get_trigger_by_type(
+                trigger_type=trigger_type,
+                trigger_name_id_or_prefix=trigger_name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=False,
+            ).id
             snapshot_id = (
                 Client()
                 .get_snapshot(
@@ -469,8 +512,11 @@ def make_detach_command() -> click.Command:
     return click.command("detach", help="Detach trigger from snapshot")(f)
 
 
-def make_clear_errors_command() -> click.Command:
+def make_clear_errors_command(trigger_type: TriggerType) -> click.Command:
     """Create a command for clearing trigger dispatch error details.
+
+    Args:
+        trigger_type: The trigger type.
 
     Returns:
         A Click command for dispatch error acknowledgement.
@@ -487,15 +533,12 @@ def make_clear_errors_command() -> click.Command:
             snapshot_name_or_id: Optional name or ID of a specific snapshot.
         """
         try:
-            trigger_id = (
-                Client()
-                .get_schedule_trigger(
-                    trigger_name_id_or_prefix=trigger_name_or_id,
-                    allow_name_prefix_match=False,
-                    hydrate=False,
-                )
-                .id
-            )
+            trigger_id = get_trigger_by_type(
+                trigger_type=trigger_type,
+                trigger_name_id_or_prefix=trigger_name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=False,
+            ).id
             snapshot_id = None
             if snapshot_name_or_id is not None:
                 snapshot_id = (
@@ -713,8 +756,11 @@ def list_platform_events(
     )
 
 
-for group in [schedule, platform_event]:
-    group.add_command(make_delete_command())
-    group.add_command(make_attach_command())
-    group.add_command(make_detach_command())
-    group.add_command(make_clear_errors_command())
+for group, tr_type in [
+    (schedule, TriggerType.SCHEDULE),
+    (platform_event, TriggerType.PLATFORM_EVENT),
+]:
+    group.add_command(make_delete_command(tr_type))
+    group.add_command(make_attach_command(tr_type))
+    group.add_command(make_detach_command(tr_type))
+    group.add_command(make_clear_errors_command(tr_type))

--- a/src/zenml/cli/trigger.py
+++ b/src/zenml/cli/trigger.py
@@ -82,6 +82,11 @@ def platform_event() -> None:
     type=str,
     help="The end time of the schedule (ISO 8601 format).",
 )
+@click.option(
+    "--max-runs",
+    type=int,
+    help="The maximum number of runs to execute with this schedule",
+)
 def create_schedule(
     name: str,
     active: bool,
@@ -91,6 +96,7 @@ def create_schedule(
     run_once_start_time: str | None = None,
     start_time: str | None = None,
     end_time: str | None = None,
+    max_runs: int | None = None,
 ) -> None:
     """Create a schedule trigger.
 
@@ -103,6 +109,7 @@ def create_schedule(
         start_time: The start time of the trigger.
         end_time: The end time of the trigger.
         run_once_start_time: The run_once_start_time of the trigger.
+        max_runs: The maximum number of runs to execute with this schedule.
     """
     options = [cron_expression, interval, run_once_start_time]
 
@@ -124,6 +131,7 @@ def create_schedule(
             if start_time
             else None,
             end_time=iso8601_to_utc_naive(end_time) if end_time else None,
+            max_runs=max_runs,
         )
     except Exception as e:
         cli_utils.exception(e)
@@ -157,6 +165,11 @@ def create_schedule(
     type=click.Choice(TriggerRunConcurrency.values()),
     help="Option to control the concurrency of the trigger.",
 )
+@click.option(
+    "--max-runs",
+    type=int,
+    help="The maximum number of runs to execute with this schedule",
+)
 def update_schedule_trigger(
     schedule_name_or_id: str,
     name: str | None = None,
@@ -167,6 +180,7 @@ def update_schedule_trigger(
     start_time: str | None = None,
     end_time: str | None = None,
     concurrency: str | None = None,
+    max_runs: int | None = None,
 ) -> None:
     """Update a schedule trigger.
 
@@ -180,6 +194,7 @@ def update_schedule_trigger(
         end_time: The new end time of the trigger.
         run_once_start_time: The new run_once_start_time of the trigger.
         concurrency: The new concurrency of the trigger.
+        max_runs: The new maximum number of runs to execute with this schedule.
     """
     options = [
         name,
@@ -190,6 +205,7 @@ def update_schedule_trigger(
         end_time,
         run_once_start_time,
         concurrency,
+        max_runs,
     ]
 
     if not any(option is not None for option in options):
@@ -213,6 +229,7 @@ def update_schedule_trigger(
             concurrency=TriggerRunConcurrency(concurrency)
             if concurrency
             else None,
+            max_runs=max_runs,
         )
     except Exception as e:
         cli_utils.exception(e)

--- a/src/zenml/cli/trigger.py
+++ b/src/zenml/cli/trigger.py
@@ -651,6 +651,9 @@ def update_platform_event_trigger(
         name,
         active,
         concurrency,
+        source_id,
+        source_type,
+        target_events,
     ]
 
     if not any(option is not None for option in options):

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -4177,6 +4177,7 @@ class Client(metaclass=ClientMetaClass):
         run_once_start_time: datetime | None = None,
         end_time: datetime | None = None,
         start_time: datetime | None = None,
+        max_runs: int | None = None,
     ) -> ScheduleTriggerResponse:
         """Create a native schedule trigger.
 
@@ -4190,6 +4191,7 @@ class Client(metaclass=ClientMetaClass):
             run_once_start_time: Schedule one-off execution
             end_time: The end time of the trigger.
             start_time: The start time of the trigger.
+            max_runs: Maximum number of runs to execute with this schedule.
 
         Returns:
             The created trigger.
@@ -4207,6 +4209,7 @@ class Client(metaclass=ClientMetaClass):
                 run_once_start_time=run_once_start_time,
                 end_time=end_time,
                 start_time=start_time,
+                max_runs=max_runs,
             )
         )
 
@@ -4225,6 +4228,7 @@ class Client(metaclass=ClientMetaClass):
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         concurrency: TriggerRunConcurrency | None = None,
+        max_runs: int | None = None,
     ) -> ScheduleTriggerResponse:
         """Update a native schedule trigger.
 
@@ -4239,6 +4243,7 @@ class Client(metaclass=ClientMetaClass):
             end_time: The new end time of the trigger.
             run_once_start_time: The new run_once_start_time of the trigger.
             concurrency: The new trigger run concurrency.
+            max_runs: Maximum number of runs to execute with this schedule.
 
         Returns:
             The updated trigger.
@@ -4248,15 +4253,25 @@ class Client(metaclass=ClientMetaClass):
             allow_name_prefix_match=False,
         )
 
+        sets_scheduling_option = any(
+            option is not None
+            for option in [cron_expression, interval, run_once_start_time]
+        )
+
         response = self.zen_store.update_trigger(
             trigger_id=trigger.id,
             trigger_update=ScheduleTriggerUpdate(
                 name=name or trigger.name,
                 active=active if active is not None else trigger.active,
-                cron_expression=cron_expression or trigger.cron_expression,
-                interval=interval or trigger.interval,
+                cron_expression=cron_expression
+                if sets_scheduling_option
+                else trigger.cron_expression,
+                interval=interval
+                if sets_scheduling_option
+                else trigger.interval,
                 run_once_start_time=run_once_start_time
-                or trigger.run_once_start_time,
+                if sets_scheduling_option
+                else trigger.run_once_start_time,
                 start_time=start_time
                 if start_time is not None
                 else trigger.start_time,
@@ -4266,6 +4281,7 @@ class Client(metaclass=ClientMetaClass):
                 concurrency=concurrency
                 if concurrency is not None
                 else trigger.concurrency,
+                max_runs=max_runs or trigger.max_runs,
             ),
         )
 

--- a/src/zenml/models/v2/core/pipeline_run.py
+++ b/src/zenml/models/v2/core/pipeline_run.py
@@ -243,6 +243,10 @@ class PipelineRunResponseBody(ProjectScopedResponseBody):
     index: int = Field(
         title="The unique index of the run within the pipeline."
     )
+    pipeline_id: UUID | None = Field(
+        default=None,
+        title="The ID of the pipeline this run is associated with.",
+    )
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -318,10 +322,6 @@ class PipelineRunResponseMetadata(ProjectScopedResponseMetadata):
     trigger_execution_info: Optional["TriggerExecutionInfo"] = Field(
         default=None,
         title="Extra information for trigger execution like upstream_run_id etc.",
-    )
-    pipeline_id: UUID | None = Field(
-        default=None,
-        title="The ID of the pipeline this run is associated with.",
     )
 
 
@@ -739,7 +739,7 @@ class PipelineRunResponse(
         Returns:
             The ID of the pipeline this run is associated with.
         """
-        return self.get_metadata().pipeline_id
+        return self.get_body().pipeline_id
 
 
 # ------------------ Filter Model ------------------

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -61,6 +61,7 @@ class TriggerDispatchStatusCode(StrEnum):
 
     SUCCESS = "SUCCESS"
     SKIPPED_CONCURRENCY = "SKIPPED_CONCURRENCY"
+    SKIPPED_MAX_RUNS = "SKIPPED_MAX_RUNS"
     ERROR = "ERROR"
 
 

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -510,6 +510,11 @@ class ScheduleTrigger(BaseModel):
         default=None,
         description="Scheduling option: Execute once on selected start time.",
     )
+    max_runs: int | None = Field(
+        default=None,
+        description="Maximum number of runs to execute with this schedule.",
+        ge=1,
+    )
 
     @field_validator(
         "start_time", "end_time", "run_once_start_time", mode="after"
@@ -858,6 +863,15 @@ class ScheduleTriggerResponse(TriggerResponse[ScheduleTriggerResponseBody,]):
             The schedule's run once start time.
         """
         return self.get_body().run_once_start_time
+
+    @property
+    def max_runs(self) -> int | None:
+        """Implements the 'max_runs' property.
+
+        Returns:
+            The scheduler's max runs.
+        """
+        return self.get_body().max_runs
 
 
 # ----------- EVENT CLASSES ------------------- #

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -454,6 +454,8 @@ def get_resource_type_for_model(
         PipelineRunResponse,
         PipelineSnapshotRequest,
         PipelineSnapshotResponse,
+        PlatformEventTriggerRequest,
+        PlatformEventTriggerResponse,
         ProjectRequest,
         ProjectResponse,
         ResourcePoolRequest,
@@ -534,6 +536,8 @@ def get_resource_type_for_model(
         ResourcePoolSubjectPolicyRequest: ResourceType.RESOURCE_POOL_SUBJECT_POLICY,
         ResourcePoolSubjectPolicyResponse: ResourceType.RESOURCE_POOL_SUBJECT_POLICY,
         # UserResponse: ResourceType.USER,
+        PlatformEventTriggerRequest: ResourceType.TRIGGER,
+        PlatformEventTriggerResponse: ResourceType.TRIGGER,
         ScheduleTriggerRequest: ResourceType.TRIGGER,
         ScheduleTriggerResponse: ResourceType.TRIGGER,
         TriggerRequest: ResourceType.TRIGGER,
@@ -751,6 +755,9 @@ def delete_model_resources(models: List[AnyModel]) -> None:
         if resource := get_resource_for_model(model):
             resources.add(resource)
 
+    if not resources:
+        return
+
     delete_resources(resources=list(resources))
 
 
@@ -762,6 +769,9 @@ def delete_resources(resources: List[Resource]) -> None:
             information.
     """
     if not server_config().rbac_enabled:
+        return
+
+    if not resources:
         return
 
     rbac().delete_resources(resources=resources)

--- a/src/zenml/zen_server/rbac/zenml_cloud_rbac.py
+++ b/src/zenml/zen_server/rbac/zenml_cloud_rbac.py
@@ -156,6 +156,8 @@ class ZenMLCloudRBAC(RBACInterface):
             resources: The resources for which to delete the resource membership
                 information.
         """
+        if not resources:
+            return
         params = {
             "resources": [str(resource) for resource in resources],
         }

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -277,6 +277,11 @@ def attach_trigger_to_snapshot(
             "Trigger and snapshot must be in the same project"
         )
 
+    if not snapshot.name:
+        raise IllegalOperationError(
+            "Can not attach a snapshot without name to a trigger."
+        )
+
     snapshot_replaced_id = None
 
     for s in trigger.snapshots:

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -636,6 +636,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             updated=self.updated,
             in_progress=self.in_progress,
             index=self.index,
+            pipeline_id=self.pipeline_id,
         )
         metadata = None
         if include_metadata:
@@ -698,7 +699,6 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 trigger_execution_info=json.loads(self.trigger_execution.info)
                 if self.trigger_execution and self.trigger_execution.info
                 else None,
-                pipeline_id=self.pipeline_id,
             )
 
         resources = None

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5069,7 +5069,6 @@ class SqlZenStore(BaseZenStore):
                 col(TriggerSnapshotSchema.snapshot_id).in_(linked_snapshot_ids)
             )
         )
-        session.commit()
 
     def _remove_name_from_snapshot(
         self, session: Session, pipeline_id: UUID, name: str
@@ -5375,6 +5374,7 @@ class SqlZenStore(BaseZenStore):
                     snapshot_id=snapshot.id,
                     session=session,
                 )
+                session.commit()
 
             session.refresh(snapshot)
             return snapshot.to_model(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5042,6 +5042,35 @@ class SqlZenStore(BaseZenStore):
         with Session(self.engine) as session:
             return session.exec(query).first() is not None
 
+    def _drop_snapshot_trigger_assoc(
+        self,
+        snapshot_id: UUID,
+        session: Session,
+    ) -> None:
+        """Drops any trigger associations linked to a snapshot.
+
+        Args:
+            snapshot_id: The ID of the snapshot (to be deleted or un-named).
+            session: SQLAlchemy session
+        """
+        linked_snapshot_ids = session.exec(
+            select(PipelineSnapshotSchema.id).where(
+                PipelineSnapshotSchema.source_snapshot_id == snapshot_id
+            )
+        ).all()
+
+        # Remove the attached trigger snapshots
+
+        if not linked_snapshot_ids:
+            return
+
+        session.execute(
+            delete(TriggerSnapshotSchema).where(
+                col(TriggerSnapshotSchema.snapshot_id).in_(linked_snapshot_ids)
+            )
+        )
+        session.commit()
+
     def _remove_name_from_snapshot(
         self, session: Session, pipeline_id: UUID, name: str
     ) -> None:
@@ -5052,15 +5081,24 @@ class SqlZenStore(BaseZenStore):
             pipeline_id: The pipeline ID of the snapshot.
             name: The name of the snapshot.
         """
-        query = (
-            update(PipelineSnapshotSchema)
-            .where(
+        existing = session.exec(
+            select(PipelineSnapshotSchema).where(
                 col(PipelineSnapshotSchema.pipeline_id) == pipeline_id,
                 col(PipelineSnapshotSchema.name) == name,
             )
-            .values(name=None)
+        ).first()
+
+        if not existing:
+            return
+
+        existing.name = None
+
+        session.add(existing)
+
+        self._drop_snapshot_trigger_assoc(
+            snapshot_id=existing.id,
+            session=session,
         )
-        session.execute(query)
 
     def create_snapshot(
         self,
@@ -5332,6 +5370,12 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
 
+            if snapshot.name is None:
+                self._drop_snapshot_trigger_assoc(
+                    snapshot_id=snapshot.id,
+                    session=session,
+                )
+
             session.refresh(snapshot)
             return snapshot.to_model(
                 include_metadata=True, include_resources=True
@@ -5363,6 +5407,16 @@ class SqlZenStore(BaseZenStore):
             for snapshot in snapshots:
                 snapshot.source_snapshot_id = None
                 session.add(snapshot)
+
+            # Remove the attached trigger snapshots
+
+            session.execute(
+                delete(TriggerSnapshotSchema).where(
+                    col(TriggerSnapshotSchema.snapshot_id).in_(
+                        [s.id for s in snapshots]
+                    )
+                )
+            )
 
             session.commit()
 

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -8283,6 +8283,61 @@ class SqlZenStore(BaseZenStore):
                 for row in session.exec(stmt).all()
             ]
 
+    def get_run_count_by_trigger_snapshot(
+        self, trigger_id: UUID, snapshot_id: UUID | None = None
+    ) -> dict[UUID, int]:
+        """Calculates the number of runs for trigger/snapshot pair.
+
+        Note: This should take into account multiple attachments of the
+        same source snapshot.
+
+        Args:
+            trigger_id: The ID of the trigger.
+            snapshot_id: The ID of the snapshot. If not specified will return counts for all trigger snapshots.
+
+        Returns:
+            A dictionary where keys are {trigger_id}_{snapshot_id} pairs and values their run counts.
+        """
+        with Session(self.engine) as session:
+            stmt = (
+                select(
+                    TriggerExecutionSchema.trigger_id,
+                    PipelineSnapshotSchema.source_snapshot_id,
+                    func.count().label("run_count"),
+                )
+                .select_from(TriggerExecutionSchema)
+                .join(
+                    PipelineRunSchema,
+                    col(PipelineRunSchema.id)
+                    == TriggerExecutionSchema.pipeline_run_id,
+                )
+                .join(
+                    PipelineSnapshotSchema,
+                    col(PipelineSnapshotSchema.id)
+                    == PipelineRunSchema.snapshot_id,
+                )
+                .where(
+                    TriggerExecutionSchema.trigger_id == trigger_id,
+                    col(PipelineSnapshotSchema.source_snapshot_id).isnot(None),
+                )
+            )
+
+            if snapshot_id:
+                stmt = stmt.where(
+                    PipelineSnapshotSchema.source_snapshot_id == snapshot_id,
+                )
+
+            stmt = stmt.group_by(
+                col(TriggerExecutionSchema.trigger_id),
+                col(PipelineSnapshotSchema.source_snapshot_id),
+            )
+
+            return {
+                row[1]: row[2]
+                for row in session.exec(stmt).all()
+                if row[1] is not None
+            }
+
     # ----------------------------- Schedules -----------------------------
 
     def create_schedule(self, schedule: ScheduleRequest) -> ScheduleResponse:


### PR DESCRIPTION
## Describe changes

Implements support for additional stopping criteria for schedules:

1. max-run: Limit the maximum number of runs per snapshot triggered by  a schedule.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

