### PR TITLE
Fix pydantic materializer double encoding

### DIFF
--- a/src/zenml/materializers/pydantic_materializer.py
+++ b/src/zenml/materializers/pydantic_materializer.py
@@ -27,7 +27,8 @@ from zenml.utils import yaml_utils
 if TYPE_CHECKING:
     from zenml.metadata.metadata_types import MetadataType
 
-DEFAULT_FILENAME = "data.json"
+DEFAULT_FILENAME = "data_v2.json"
+LEGACY_FILENAME = "data.json"
 
 
 class PydanticMaterializer(BaseMaterializer):
@@ -42,12 +43,25 @@ class PydanticMaterializer(BaseMaterializer):
         Args:
             data_type: The type of the data to read.
 
+        Raises:
+            FileNotFoundError: If the data is not found.
+
         Returns:
-            The data read.
+            The loaded data.
         """
         data_path = os.path.join(self.uri, DEFAULT_FILENAME)
-        contents = yaml_utils.read_json(data_path)
-        return data_type.model_validate_json(contents)
+        if self.artifact_store.exists(data_path):
+            contents = yaml_utils.read_json(data_path)
+            return data_type.model_validate(contents)
+        else:
+            legacy_data_path = os.path.join(self.uri, LEGACY_FILENAME)
+            if self.artifact_store.exists(legacy_data_path):
+                contents = yaml_utils.read_json(legacy_data_path)
+                return data_type.model_validate_json(contents)
+            else:
+                raise FileNotFoundError(
+                    f"No data found at {data_path} or {legacy_data_path}."
+                )
 
     def save(self, data: BaseModel) -> None:
         """Serialize a BaseModel to JSON.
@@ -56,7 +70,7 @@ class PydanticMaterializer(BaseMaterializer):
             data: The data to store.
         """
         data_path = os.path.join(self.uri, DEFAULT_FILENAME)
-        yaml_utils.write_json(data_path, data.model_dump_json())
+        yaml_utils.write_json(data_path, data.model_dump(mode="json"))
 
     def extract_metadata(self, data: BaseModel) -> Dict[str, "MetadataType"]:
         """Extract metadata from the given BaseModel object.

--- a/src/zenml/materializers/pydantic_materializer.py
+++ b/src/zenml/materializers/pydantic_materializer.py
@@ -57,6 +57,10 @@ class PydanticMaterializer(BaseMaterializer):
             legacy_data_path = os.path.join(self.uri, LEGACY_FILENAME)
             if self.artifact_store.exists(legacy_data_path):
                 contents = yaml_utils.read_json(legacy_data_path)
+                # In ZenML versions <= 0.94.2, the pydantic materializer double
+                # encoded the data before writing it to a file. The first round
+                # of decoding happens in the `read_json` function, we now call
+                # `model_validate_json` to decode the data again.
                 return data_type.model_validate_json(contents)
             else:
                 raise FileNotFoundError(

--- a/tests/unit/artifacts/test_utils.py
+++ b/tests/unit/artifacts/test_utils.py
@@ -137,7 +137,7 @@ def builtin_type_file_uri(clean_client: "Client"):
     # Save the integer to the temporary file
     from zenml.utils.yaml_utils import write_json
 
-    write_json(filepath, TempClass().model_dump_json())
+    write_json(filepath, TempClass().model_dump(mode="json"))
 
     # Yield the temporary directory
     yield temp_dir

--- a/tests/unit/materializers/test_pydantic_materializer.py
+++ b/tests/unit/materializers/test_pydantic_materializer.py
@@ -12,10 +12,17 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
+import os
+from tempfile import TemporaryDirectory
+
 from pydantic import BaseModel
 
 from tests.unit.test_general import _test_materializer
-from zenml.materializers.pydantic_materializer import PydanticMaterializer
+from zenml.materializers.pydantic_materializer import (
+    LEGACY_FILENAME,
+    PydanticMaterializer,
+)
+from zenml.utils import yaml_utils
 
 
 def test_pydantic_materializer():
@@ -35,3 +42,25 @@ def test_pydantic_materializer():
     )
     assert result.a == 2
     assert result.b == 3
+
+
+def test_pydantic_materializer_loads_legacy_double_encoded_json(clean_client):
+    """Tests legacy double encoded json compatibility in `load`."""
+
+    class MyModel(BaseModel):
+        a: int
+        b: str
+
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        artifact_path = os.path.join(artifact_uri, LEGACY_FILENAME)
+        yaml_utils.write_json(
+            artifact_path,
+            MyModel(a=7, b="hello").model_dump_json(),
+        )
+
+        materializer = PydanticMaterializer(uri=artifact_uri)
+        result = materializer.load(MyModel)
+        assert result.a == 7
+        assert result.b == "hello"


### PR DESCRIPTION
## Describe changes
The pydantic materializer double encoded values. This doesn't affect it at runtime, because it also double-decodes. But it leads to "wrong" visualizations in the UI.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

