### PR TITLE
Fix python package fetching

### DIFF
--- a/src/zenml/environment.py
+++ b/src/zenml/environment.py
@@ -17,6 +17,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 from typing import Any, Dict, List
 
 import distro
@@ -381,10 +382,12 @@ class Environment(metaclass=SingletonMetaClass):
             List of installed packages in pip freeze format.
         """
         try:
-            output = subprocess.check_output(["pip", "freeze"]).decode()
+            output = subprocess.check_output(
+                [sys.executable, "-m", "pip", "freeze"]
+            ).decode()
             return output.strip().split("\n")
-        except FileNotFoundError:
-            # pip not found in PATH, try uv as a fallback
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            # pip not found in current python environment, try uv as a fallback
             if shutil.which("uv"):
                 try:
                     output = subprocess.check_output(


### PR DESCRIPTION
## Describe changes
In some setups, our `get_python_packages` returned wrong values.
- Setup a virtualenv in which `pip` is not installed
- (For example) Have `pyenv` setup, which sets a global shim pointing to some pip installation

Our code would simply list packages from whichever environment `pyenv` points to. This is fixed now by making sure to use pip from the current active python environment, and fallback to `uv` if that's not possible.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

