### PR TITLE
Fix StrEnum import breaking 3.10

### DIFF
--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -15,7 +15,6 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from enum import StrEnum
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -51,6 +50,7 @@ from zenml.models.v2.base.scoped import (
     ProjectScopedResponseMetadata,
     ProjectScopedResponseResources,
 )
+from zenml.utils.enum_utils import StrEnum
 from zenml.utils.time_utils import utc_now
 
 # ----------- DISPATCH STATE MODELS ------------------ #


### PR DESCRIPTION
## Describe changes

Fix breaking python3.10 Zenml initialization logic 

Culprit: An import using enum.StrEnum instead of our own StrEnum utility causes this (enum.StrEnum is 3.11+ compatible)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

