### PR TITLE
Add isnull/isnotnull filter operators

### DIFF
--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -366,6 +366,8 @@ class GenericFilterOps(StrEnum):
     LTE = "lte"
     LT = "lt"
     IN = "in"
+    ISNULL = "isnull"
+    ISNOTNULL = "isnotnull"
 
 
 class SorterOps(StrEnum):

--- a/src/zenml/models/v2/base/filter.py
+++ b/src/zenml/models/v2/base/filter.py
@@ -144,6 +144,35 @@ class Filter(BaseModel, ABC):
         """
 
 
+class NullFilter(Filter):
+    """Filter that emits `IS NULL` / `IS NOT NULL` for any nullable column.
+
+    Routed by `FilterGenerator.define_filter` whenever the user supplies the
+    `isnull:` or `isnotnull:` operator, regardless of the column's datatype.
+    These operators are unary, so the filter carries no value.
+    """
+
+    ALLOWED_OPS: ClassVar[List[str]] = [
+        GenericFilterOps.ISNULL,
+        GenericFilterOps.ISNOTNULL,
+    ]
+
+    value: None = None
+
+    def generate_query_conditions_from_column(self, column: Any) -> Any:
+        """Generate query conditions for a null check on any column.
+
+        Args:
+            column: The column of an SQLModel table on which to filter.
+
+        Returns:
+            The query condition.
+        """
+        if self.operation == GenericFilterOps.ISNOTNULL:
+            return column.is_not(None)
+        return column.is_(None)
+
+
 class BoolFilter(Filter):
     """Filter for all Boolean fields."""
 
@@ -1056,6 +1085,11 @@ class FilterGenerator:
         Returns:
             A Filter object.
         """
+        # Null checks are datatype-agnostic; route them before the type-
+        # specific factories below cast `value` and crash on the empty input.
+        if operator in (GenericFilterOps.ISNULL, GenericFilterOps.ISNOTNULL):
+            return NullFilter(operation=operator, column=column)
+
         # Create datetime filters
         if self.is_datetime_field(column):
             return self._define_datetime_filter(

--- a/tests/unit/models/test_filter_models.py
+++ b/tests/unit/models/test_filter_models.py
@@ -26,6 +26,7 @@ from zenml.models.v2.base.filter import (
     BaseFilter,
     DatetimeFilter,
     Filter,
+    NullFilter,
     NumericFilter,
     StrFilter,
     UUIDFilter,
@@ -68,8 +69,12 @@ def _test_filter_model(
     if expected_value is None:
         expected_value = filter_value
 
+    # Null operators are datatype-agnostic and intentionally bypass each
+    # filter's `ALLOWED_OPS`, so this datatype-focused helper skips them.
+    null_operators = {GenericFilterOps.ISNULL, GenericFilterOps.ISNOTNULL}
+
     for filter_op in GenericFilterOps.values():
-        if filter_op in ignore_operators:
+        if filter_op in ignore_operators or filter_op in null_operators:
             continue
 
         filter_str = f"{filter_op}:{filter_value}"
@@ -208,6 +213,9 @@ def test_datetime_filter_model_fails_for_wrong_formats(
     with pytest.raises(ValueError):
         SomeFilterModel(datetime_field=false_format_datetime)
     for filter_op in GenericFilterOps.values():
+        # Null operators ignore the value, so a malformed datetime is fine.
+        if filter_op in (GenericFilterOps.ISNULL, GenericFilterOps.ISNOTNULL):
+            continue
         with pytest.raises(ValueError):
             SomeFilterModel(
                 datetime_field=f"{filter_op}:{false_format_datetime}"
@@ -260,3 +268,42 @@ def test_string_filter_model():
         filter_value="a_random_string",
         ignore_operators=[GenericFilterOps.ONEOF],
     )
+
+
+@pytest.mark.parametrize(
+    "filter_field",
+    ["uuid_field", "datetime_field", "int_field", "str_field"],
+)
+@pytest.mark.parametrize("operator", ["isnull", "isnotnull"])
+def test_null_filter_model_for_all_field_types(
+    filter_field: str, operator: str
+) -> None:
+    """Null operators produce a NullFilter regardless of column datatype."""
+    model_instance = SomeFilterModel(**{filter_field: f"{operator}:"})
+
+    assert len(model_instance.list_of_filters) == 1
+    model_filter = model_instance.list_of_filters[0]
+    assert isinstance(model_filter, NullFilter)
+    assert model_filter.operation == operator
+    assert model_filter.column == filter_field
+
+
+@pytest.mark.parametrize(
+    "operation,expected_sql",
+    [
+        (GenericFilterOps.ISNULL, "IS NULL"),
+        (GenericFilterOps.ISNOTNULL, "IS NOT NULL"),
+    ],
+)
+def test_null_filter_emits_expected_sql(
+    operation: GenericFilterOps, expected_sql: str
+) -> None:
+    """NullFilter compiles to a SQL `IS [NOT] NULL` predicate."""
+    from sqlalchemy import Column, MetaData, String, Table
+
+    nullable = Table("t", MetaData(), Column("c", String))
+    condition = NullFilter(
+        operation=operation, column="c"
+    ).generate_query_conditions_from_column(nullable.c.c)
+    rendered = str(condition.compile(compile_kwargs={"literal_binds": True}))
+    assert expected_sql in rendered.upper()


### PR DESCRIPTION
## Summary

Resolves #4761.

The base filter framework treats `None` as "no filter" (skipped at `BaseFilter._generate_filter_list`), so there is currently no way to express "this column is NULL" through the public API. This PR adds two unary operators — `isnull:` and `isnotnull:` — and a `NullFilter` that emits `column.is_(None)` / `column.is_not(None)` regardless of the column's datatype.

End-to-end, this means:

```python
PipelineRunFilter(orchestrator_run_id="isnull:")
# -> WHERE pipeline_run.orchestrator_run_id IS NULL

PipelineRunFilter(orchestrator_run_id="isnotnull:")
# -> WHERE pipeline_run.orchestrator_run_id IS NOT NULL
```

## Why a separate Filter class

Each datatype-specific factory in `FilterGenerator.define_filter` (datetime, UUID, int, bool, str) casts the user-supplied value (`int(value)`, `datetime.strptime(value)`, …). Those casts would crash on the empty value that follows `isnull:`. Routing null operators to a dedicated `NullFilter` short-circuits before any casting and keeps the rest of the type-specific factories untouched.

## Scope notes

- Works on every filter field that is *not* in `FILTER_EXCLUDE_FIELDS` and accepts the standard `op:value` string protocol (i.e., the field type is `Optional[str]` or `Optional[Union[X, str]]`).
- Fields handled by `get_custom_filters` (e.g., `source_snapshot_id`, `templatable`, the various JOIN-based filters in `PipelineRunFilter`) keep their bespoke logic and would need per-field follow-ups to honor `isnull:`. The `source_snapshot_id` example from the issue belongs to that bucket — it can be migrated separately, now that the framework primitive exists.
- Pure `Optional[bool]` / `Optional[UUID]` fields without a `str` fallback in their `Union` won't accept the operator string at the pydantic layer; a future PR can widen those types if there's demand.

## Backwards compatibility

Pure addition: two new enum members and one new Filter subclass. No existing filter inputs change behavior.

## Test plan
- [x] `pytest tests/unit/models/test_filter_models.py` (41 tests, all green)
- [x] `pytest tests/unit/utils/` (162 tests pass)
- [x] Manual SQL render check via `BaseFilter.generate_filters` confirms `IS [NOT] NULL` for `orchestrator_run_id` on `PipelineRunSchema`
- [x] `ruff check`, `ruff format`, `mypy`, `pydoclint` clean on changed files