### PR TITLE
Fix multiple RBAC calls during dehydration

### DIFF
--- a/src/zenml/integrations/comet/experiment_trackers/comet_experiment_tracker.py
+++ b/src/zenml/integrations/comet/experiment_trackers/comet_experiment_tracker.py
@@ -16,7 +16,7 @@
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
-from comet_ml import Experiment  # type: ignore
+from comet_ml import Experiment
 
 from zenml.constants import METADATA_EXPERIMENT_TRACKER_URL
 from zenml.experiment_trackers.base_experiment_tracker import (

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -156,10 +156,21 @@ def _dehydrate_value(
         if not resource:
             return dehydrate_response_model(value, permissions=permissions)
 
-        has_permissions = (permissions or {}).get(resource, False)
-        if has_permissions or has_permissions_for_model(
-            model=permission_model, action=Action.READ
+        has_permissions = (permissions or {}).get(resource)
+
+        if has_permissions or is_owned_by_authenticated_user(
+            model=permission_model
         ):
+            return dehydrate_response_model(value, permissions=permissions)
+
+        if has_permissions is None:
+            # Permission wasn't prefetched, so we send a separate request to
+            # check.
+            has_permissions = has_permissions_for_model(
+                model=permission_model, action=Action.READ
+            )
+
+        if has_permissions:
             return dehydrate_response_model(value, permissions=permissions)
         else:
             return get_permission_denied_model(value)


### PR DESCRIPTION
## Describe changes
During dehydration, the following happened:
- We first gather all subresources, and then send 1 RBAC request that checks all permissions.
- We then recursively dehydrate all response models, passing in the pre-fetched permissions.
- During the hydration, if the prefetched permissions contained `False` (= not allowed to read), we would send another RBAC request for each sub-model.

This PR fixes this by making sure to not check permissions again if they were already prefetched.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

