### PR TITLE
Allow keyword only args in step function

### DIFF
--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -185,7 +185,7 @@ class StepRunner:
 
             with step_context:
                 function_params = self._parse_inputs(
-                    args=spec.args,
+                    args=spec.args + spec.kwonlyargs,
                     annotations=spec.annotations,
                     input_artifacts=input_artifacts,
                 )

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -1121,3 +1121,17 @@ def test_step_source_code_cache_value():
 
     assert source_code_1 == source_code_2 == source_code_3
     assert source_code_4 == source_code_5
+
+
+@step
+def step_with_keyword_only_arguments(a: int, *, b: int) -> None:
+    pass
+
+
+def test_step_with_keyword_only_arguments_works():
+    @pipeline
+    def test_pipeline():
+        step_with_keyword_only_arguments(a=1, b=2)
+
+    with does_not_raise():
+        test_pipeline()


### PR DESCRIPTION
## Describe changes
Previously, keyword only arguments in the step function would cause steps to fail because our parsing failed to pass them.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

