### PR TITLE
Allow non module-level definitions of steps and dynamic pipelines

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -137,7 +137,6 @@ from zenml.utils import (
     env_utils,
     exception_utils,
     pydantic_utils,
-    source_utils,
     string_utils,
 )
 from zenml.utils.logging_utils import (
@@ -299,12 +298,9 @@ class DynamicPipelineRunner:
             ):
                 raise RuntimeError("Missing pipeline source for snapshot.")
 
-            pipeline = source_utils.load(self._snapshot.pipeline_spec.source)
-            if not isinstance(pipeline, DynamicPipeline):
-                raise RuntimeError(
-                    "Invalid pipeline source: "
-                    f"{self._snapshot.pipeline_spec.source.import_path}"
-                )
+            pipeline = DynamicPipeline.load_from_source(
+                self._snapshot.pipeline_spec.source
+            )
             pipeline = copy.deepcopy(pipeline)
             pipeline._configuration = self._snapshot.pipeline_configuration
             self._pipeline = pipeline

--- a/src/zenml/pipelines/dynamic/pipeline_definition.py
+++ b/src/zenml/pipelines/dynamic/pipeline_definition.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline definition."""
 
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,6 +21,7 @@ from typing import (
     List,
     Optional,
     Type,
+    Union,
 )
 
 from pydantic import BaseModel, ConfigDict, create_model
@@ -59,8 +61,8 @@ class DynamicPipeline(Pipeline):
             depends_on: The steps that the pipeline depends on.
             **kwargs: Pipeline constructor keyword arguments.
         """
-        # This is the only execution mode that is currently supported for
-        # dynamic pipelines, so we default to it.
+        # The default execution mode (CONTINUE_ON_FAILURE) is not supported
+        # for dynamic pipelines, so we default to STOP_ON_FAILURE.
         if kwargs.get("execution_mode", None) is None:
             kwargs["execution_mode"] = ExecutionMode.STOP_ON_FAILURE
         super().__init__(**kwargs)
@@ -131,6 +133,37 @@ class DynamicPipeline(Pipeline):
             ) from e
 
         return source
+
+    @classmethod
+    def load_from_source(cls, source: Union[Source, str]) -> "DynamicPipeline":
+        """Loads a dynamic pipeline from source.
+
+        Args:
+            source: The path to the dynamic pipeline source.
+
+        Returns:
+            The loaded dynamic pipeline.
+
+        Raises:
+            ValueError: If the source is not a valid dynamic pipeline source.
+        """
+        obj = source_utils.load(source)
+
+        if isinstance(obj, DynamicPipeline):
+            return obj
+        elif isinstance(obj, type) and issubclass(obj, DynamicPipeline):
+            return obj()
+        elif inspect.isfunction(obj):
+            return DynamicPipeline(name=obj.__name__, entrypoint=obj)
+        else:
+            import_path = (
+                source.import_path if isinstance(source, Source) else source
+            )
+            raise ValueError(
+                f"Invalid dynamic pipeline source `{import_path}`: expected "
+                f"it to resolve to a `DynamicPipeline` instance/subclass or "
+                f"a function, got `{type(obj).__name__}`."
+            )
 
     def _prepare_invocations(self, **kwargs: Any) -> None:
         """Prepares the invocations of the pipeline.

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -290,8 +290,19 @@ class BaseStep:
             return obj
         elif isinstance(obj, type) and issubclass(obj, BaseStep):
             return obj()
+        elif inspect.isfunction(obj):
+            from zenml.steps.step_decorator import step
+
+            return step(obj)
         else:
-            raise ValueError("Invalid step source.")
+            import_path = (
+                source.import_path if isinstance(source, Source) else source
+            )
+            raise ValueError(
+                f"Invalid step source `{import_path}`: expected it to "
+                f"resolve to a `BaseStep` instance/subclass or a function, "
+                f"got `{type(obj).__name__}`."
+            )
 
     def resolve(self) -> Source:
         """Resolves the step.

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -132,3 +132,17 @@ def test_replay_skips_first_step_and_overrides_second_step_input():
         skip={"producer"},
         step_input_overrides={"consumer": {"input_": 42}},
     )
+
+
+def pipeline_function_definition() -> None:
+    producer()
+
+
+def test_pipeline_run_with_nested_pipeline_definition() -> None:
+    """Tests that a dynamic pipeline run succeeds when the pipeline is defined "
+    "inside a function rather than at module top level."""
+    nested_pipeline = pipeline(dynamic=True, enable_cache=False)(
+        pipeline_function_definition
+    )
+    with does_not_raise():
+        nested_pipeline()

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -139,8 +139,8 @@ def pipeline_function_definition() -> None:
 
 
 def test_pipeline_run_with_nested_pipeline_definition() -> None:
-    """Tests that a dynamic pipeline run succeeds when the pipeline is defined "
-    "inside a function rather than at module top level."""
+    """Tests that a dynamic pipeline run succeeds when the pipeline is defined 
+    inside a function rather than at module top level."""
     nested_pipeline = pipeline(dynamic=True, enable_cache=False)(
         pipeline_function_definition
     )

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -139,7 +139,7 @@ def pipeline_function_definition() -> None:
 
 
 def test_pipeline_run_with_nested_pipeline_definition() -> None:
-    """Tests that a dynamic pipeline run succeeds when the pipeline is defined 
+    """Tests that a dynamic pipeline run succeeds when the pipeline is defined
     inside a function rather than at module top level."""
     nested_pipeline = pipeline(dynamic=True, enable_cache=False)(
         pipeline_function_definition

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -1121,3 +1121,19 @@ def test_step_source_code_cache_value():
 
     assert source_code_1 == source_code_2 == source_code_3
     assert source_code_4 == source_code_5
+
+
+def step_function_definition() -> int:
+    return 1
+
+
+def test_pipeline_run_with_nested_step_definition():
+    """Tests that a step can be defined inside a function rather than at
+    module top level."""
+
+    @pipeline
+    def p() -> None:
+        step(step_function_definition)()
+
+    with does_not_raise():
+        p()


### PR DESCRIPTION
## Describe changes

Allow `@step` and `@pipeline(dynamic=True)` wrapping to live inside another function or class instead of only at module top level.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

