### PR TITLE
Fix nightly PyPI trusted publishing

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -14,18 +14,31 @@ jobs:
       git-ref: develop
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'
-  publish-python-package:
-    permissions:
-      id-token: write
-      contents: read
+  build-nightly-python-package:
     needs: setup-and-test
     uses: ./.github/workflows/publish_to_pypi_nightly.yml
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'
+  publish-nightly-python-package:
+    if: github.repository == 'zenml-io/zenml'
+    needs: build-nightly-python-package
+    runs-on: ubuntu-latest
+    environment: nightly
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download nightly Python distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: nightly-python-package-distributions
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
   wait-for-package-release:
     if: github.repository == 'zenml-io/zenml'
     runs-on: ubuntu-latest
-    needs: publish-python-package
+    needs: publish-nightly-python-package
     steps:
       - name: Sleep for 4 minutes
         run: sleep 240

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -9,8 +9,8 @@ on:
         default: false
         type: boolean
 jobs:
-  publish_to_pypi:
-    name: Publish Nightly Python 🐍 package 📦 to PyPI
+  build_nightly_python_package:
+    name: Build Nightly Python 🐍 package 📦
     runs-on: ubuntu-latest
     env:
       ZENML_DEBUG: 1
@@ -24,58 +24,47 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+          version: 0.8.14
+          enable-cache: false
       - name: Set nightly version
         run: |
           # Extract the current version
-          CURRENT_VERSION=$(poetry version -s)
+          CURRENT_VERSION=$(uv version --short)
 
-          # Get the current date in the format of YYYY-MM-DD
-          DATE=$(date +"%Y%m%d")
+          # Get the current date in UTC in the format YYYYMMDD
+          DATE=$(date -u +"%Y%m%d")
 
           # Combine the current version with the date to form
           # the new version string
           NIGHTLY_VERSION="${CURRENT_VERSION}.dev${DATE}"
 
           # Set the nightly version
-          echo "NIGHTLY_VERSION=$NIGHTLY_VERSION" >> $GITHUB_ENV
+          echo "NIGHTLY_VERSION=$NIGHTLY_VERSION" >> "$GITHUB_ENV"
       - name: Modify pyproject.toml for nightly release
         run: |
+          # Ensure expected package name exists before replacement
+          if ! grep -q 'name = "zenml"' pyproject.toml; then
+            echo "Expected name = \"zenml\" in pyproject.toml before nightly rename."
+            exit 1
+          fi
+
           # Change the package name to `zenml-nightly`
           sed -i 's/name = "zenml"/name = "zenml-nightly"/' pyproject.toml
 
           # Update the version to the nightly version
-          poetry version $NIGHTLY_VERSION
+          uv version "$NIGHTLY_VERSION"
 
           # Update the src/zenml/VERSION file with the nightly version
-          echo $NIGHTLY_VERSION > src/zenml/VERSION
+          echo "$NIGHTLY_VERSION" > src/zenml/VERSION
       - name: Include latest dashboard
         run: bash scripts/install-dashboard.sh
       - name: Build package
-        run: poetry build
-      - name: Mint token
-        id: mint
-        uses: tschm/token-mint-action@eef668ab210066f42abfe3f2af4e03ec24f30089  # v1.0.3
-      - name: Publish the package with poetry
-        run: |-
-          # Extract the tag from GITHUB_REF if it exists
-          TAG=$(echo ${GITHUB_REF} | sed 's|refs/tags/||g')
-
-          # Check if the current ref is a tag
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            # Check if the VERSION file matches the tag
-            if [ "$(cat src/zenml/VERSION)" = "$TAG" ]; then
-              poetry publish -u __token__ -p '${STEPS_MINT_OUTPUTS_API_TOKEN}' || ${{ inputs.test_env }}
-            else
-              echo "Version mismatch between src/zenml/VERSION and branch tag" && exit 1;
-            fi
-          else
-            # For branches, publish the nightly version without version check
-            poetry publish -u __token__ -p '${STEPS_MINT_OUTPUTS_API_TOKEN}' || ${{ inputs.test_env }}
-          fi
-        env:
-          STEPS_MINT_OUTPUTS_API_TOKEN: ${{ steps.mint.outputs.api-token }}
+        run: uv build
+      - name: Upload nightly Python distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: nightly-python-package-distributions
+          path: dist/*


### PR DESCRIPTION
## Description

Fixes the nightly `zenml-nightly` PyPI publication flow by moving it to PyPI Trusted Publishing without relying on the obsolete token-mint + `poetry publish` path.

The important detail: PyPI currently does **not** support reusable workflows as the trusted publisher workflow. To keep the nightly flow compatible with that limitation, this PR splits the process into two parts:

1. `.github/workflows/publish_to_pypi_nightly.yml` remains reusable, but now only builds the nightly distributions and uploads them as a GitHub artifact.
2. `.github/workflows/nightly_build.yml` downloads that artifact in a top-level job and publishes it with `pypa/gh-action-pypi-publish` using OIDC trusted publishing.

## Changes

- Replace Poetry setup/build in the nightly package workflow with the existing `uv` build pattern.
- Preserve nightly package behavior:
  - checkout `develop`
  - rename package to `zenml-nightly`
  - set version to `<base>.devYYYYMMDD` using UTC date
  - update `src/zenml/VERSION`
  - include the latest dashboard
  - build distributions into `dist/`
- Upload nightly distributions from the reusable workflow as `nightly-python-package-distributions`.
- Add a top-level trusted-publishing job in `nightly_build.yml` that downloads the artifact and publishes to PyPI.
- Remove the obsolete `tschm/token-mint-action` + `poetry publish` flow.

## Required PyPI/GitHub setup

For this to publish successfully, the `zenml-nightly` PyPI project should have a trusted publisher configured for:

- Owner: `zenml-io`
- Repository: `zenml`
- Workflow: `nightly_build.yml`
- Environment: `nightly`

The GitHub `nightly` environment should not require manual approval, otherwise the scheduled nightly build will pause every night.

## Validation

- `git diff --check`
- `actionlint .github/workflows/publish_to_pypi_nightly.yml .github/workflows/nightly_build.yml`

