### PR TITLE
Fix `Check Links` workflow failures (`runai.md` + dangling preemption refs + Slack 403)

### DIFF
--- a/docs/book/component-guide/step-operators/runai.md
+++ b/docs/book/component-guide/step-operators/runai.md
@@ -4,7 +4,7 @@ description: Executing individual steps on Run:AI clusters with fractional GPU s
 
 # Run:AI Step Operator
 
-ZenML's Run:AI step operator allows you to submit individual steps to be run on [Run:AI](https://www.run.ai/) clusters as training workloads with support for fractional GPU allocation.
+ZenML's Run:AI step operator allows you to submit individual steps to be run on [Run:AI](https://www.nvidia.com/en-us/software/run-ai/) clusters as training workloads with support for fractional GPU allocation.
 
 ### When to use it
 

--- a/docs/book/getting-started/zenml-pro/resource-pools-core-concepts.md
+++ b/docs/book/getting-started/zenml-pro/resource-pools-core-concepts.md
@@ -223,5 +223,5 @@ zenml resource-pool requests training-gpus --view all
 
 * [Resource pools](resource-pools.md) — overview and UX story
 * [Examples](resource-pools-examples.md) — scenarios and outcomes
-* [How preemption works](resource-pools-preemption.md) — behavior and ordering
+* [How preemption works](resource-pools-reconciliation.md#how-preemption-works) — behavior and ordering
 * [Resource pool reconciliation](resource-pools-reconciliation.md) — runtime flow

--- a/docs/book/getting-started/zenml-pro/resource-pools-examples.md
+++ b/docs/book/getting-started/zenml-pro/resource-pools-examples.md
@@ -24,7 +24,7 @@ orchestrator or step operator may use that pool), and the step
 
 For definitions of reserved, limit, and priority, see
 [Core concepts](resource-pools-core-concepts.md). For preemption ordering, see
-[How preemption works](resource-pools-preemption.md).
+[How preemption works](resource-pools-reconciliation.md#how-preemption-works).
 
 ## Primer: from `ResourceSettings` to the resource request
 
@@ -932,7 +932,7 @@ def prod_train() -> None:
 
 **Outcome:** If four GPUs cannot be granted without reclaiming space, the
 reconciler may preempt Sandbox’s preemptible runs (lower policy priority) so Prod
-can proceed. See [How preemption works](resource-pools-preemption.md) for victim
+can proceed. See [How preemption works](resource-pools-reconciliation.md#how-preemption-works) for victim
 ordering.
 
 ---
@@ -1229,7 +1229,7 @@ heavy CPU/RAM asks.
 
 * [Resource pools](resource-pools.md) — overview
 * [Core concepts](resource-pools-core-concepts.md) — pools, policies, requests
-* [How preemption works](resource-pools-preemption.md) — preemption
+* [How preemption works](resource-pools-reconciliation.md#how-preemption-works) — preemption
   ordering
 * [Step configuration](https://docs.zenml.io/how-to/steps-pipelines/configuration)
   — full `ResourceSettings` reference

--- a/docs/link_checker.py
+++ b/docs/link_checker.py
@@ -95,6 +95,12 @@ except ImportError:
 EXEMPT_URL_STATUS: Dict[str, set] = {
     # Requires authentication; often returns 403 to unauthenticated HEAD/GET.
     "https://huggingface.co/settings/tokens": {403},
+    # zenml.io/slack and /slack-invite redirect to a zenml.slack.com invite URL.
+    # Slack returns 403 to any unauthenticated request to those invite URLs by
+    # design, regardless of User-Agent or HEAD/GET. A real takedown would
+    # surface as 404/410/5xx, which is not exempted here and would still fail.
+    "https://zenml.io/slack": {403},
+    "https://zenml.io/slack-invite": {403},
 }
 
 EXEMPT_DOMAIN_STATUS: Dict[str, set] = {


### PR DESCRIPTION
## Summary

This PR started as an autofixer change for one broken external link, but the
Check Links workflow surfaced two additional pre-existing problems on
`develop`. All three are addressed here so the workflow goes green.

### 1. Original autofixer fix (`runai.md`)
File: `docs/book/component-guide/step-operators/runai.md`
Replaced `https://www.run.ai/` → `https://www.nvidia.com/en-us/software/run-ai/`
(Run:AI was acquired by NVIDIA and the old URL no longer resolves cleanly.)

### 2. Fix dangling `resource-pools-preemption.md` references
Commit `f22ac7a5d Docs update` renamed
`docs/book/getting-started/zenml-pro/resource-pools-preemption.md` →
`resource-pools-reconciliation.md` but left four references behind. All four
now point at `resource-pools-reconciliation.md#how-preemption-works`,
preserving the original intent of linking to the preemption *section*
specifically rather than just the top of the renamed doc.

Files updated:
- `docs/book/getting-started/zenml-pro/resource-pools-core-concepts.md:226`
- `docs/book/getting-started/zenml-pro/resource-pools-examples.md:27`, `:935`, `:1232`

The `## How preemption works` section anchor exists at line 39 of the renamed
doc, and `scripts/check_relative_links.py` correctly handles `#fragment`
suffixes.

### 3. Exempt Slack invite URLs from 403 in `docs/link_checker.py`
`https://zenml.io/slack` and `https://zenml.io/slack-invite` both redirect to
`https://zenml.slack.com/join/shared_invite/...`. Slack returns **403 to any
unauthenticated request** to those invite URLs regardless of User-Agent or
HEAD/GET (verified locally with all four UA/method combinations). This isn't
fixable at the request shape — it's Slack's intentional behaviour for invite
links.

Added both URLs to `EXEMPT_URL_STATUS` at status `403` specifically. The
exemption is scoped per-URL and per-status, so a real takedown (404/410/5xx)
would still fail and surface in CI:

```python
"https://zenml.io/slack": {403},
"https://zenml.io/slack-invite": {403},
```

This follows the pattern already used for `huggingface.co/settings/tokens:
{403}` and the `is_exception_status` normalization (`rstrip("/")`) means a
single key handles both `/slack` and `/slack/`.

## Verification

Run locally on the branch tip:

- `scripts/check_relative_links.py --dir docs/book` → **1178 valid, 0 broken**
- Unit-checked `is_exception_status`:
  - `True` for `403` on `/slack`, `/slack/`, `/slack-invite`
  - `False` for `404`/`500` on the same URLs (real takedown still fails)
  - `False` for `403` on other zenml.io paths (no blanket domain exemption)

## Notes

The original CI log under-counted the dangling references (reported 2, actual
4). The two extra references in `resource-pools-examples.md` (lines 935 and
1232) landed via the most recent `develop` merge into this branch, so they
weren't visible at the time the workflow ran on the autofixer's initial push.

## Test plan

- [ ] `Check Links` workflow passes on this PR (both `check-relative-links`
      and `check-absolute-links` jobs green)
- [ ] No unrelated regressions in the link checker for non-Slack zenml.io URLs