### PR TITLE
Fix notify projects backend zizmor scan

### DIFF
--- a/.github/workflows/notify-projects-backend.yml
+++ b/.github/workflows/notify-projects-backend.yml
@@ -19,11 +19,13 @@ jobs:
       - name: Get release info
         id: release_info
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         with:
           script: |
             let release;
             if (context.eventName === 'workflow_dispatch') {
-              const tag = '${{ inputs.release_tag }}';
+              const tag = process.env.RELEASE_TAG;
               release = await github.rest.repos.getReleaseByTag({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- Avoid direct template expansion of the manual release tag inside github-script JavaScript.
- Read the release tag from an environment variable instead so zizmor treats it as data, not executable code.

## Testing
- `GH_TOKEN=$(gh auth token) uvx zizmor --format=github --config=.github/zizmor.yml .github/workflows/notify-projects-backend.yml`
- `uv run --extra dev yamlfix .github/workflows/notify-projects-backend.yml`
- `GH_TOKEN=$(gh auth token) uv run --extra dev zizmor --format=github --config=.github/zizmor.yml .github/workflows/`
- `git diff --check`