### PR TITLE
Fix deployment invocation request fields

### DIFF
--- a/src/zenml/deployers/server/models.py
+++ b/src/zenml/deployers/server/models.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from zenml.logger import get_logger
 
@@ -57,14 +57,13 @@ class BaseDeploymentInvocationRequest(BaseModel):
     run_name: Optional[str] = Field(
         default=None, title="Custom name for the pipeline run."
     )
-    timeout: int = Field(
-        default=300, title="The timeout for the pipeline execution."
-    )
     skip_artifact_materialization: bool = Field(
         default=False,
         title="Whether to keep outputs in memory for fast access instead of "
         "storing them as artifacts.",
     )
+
+    model_config = ConfigDict(extra="ignore")
 
 
 class BaseDeploymentInvocationResponse(BaseModel):

--- a/src/zenml/deployers/server/service.py
+++ b/src/zenml/deployers/server/service.py
@@ -351,8 +351,6 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         Returns:
             A BaseDeploymentInvocationResponse describing the execution result.
         """
-        # Unused parameters for future implementation
-        _ = request.run_name, request.timeout
         parameters = request.parameters.model_dump()
         start_time = time.time()
         logger.info("Starting pipeline execution")
@@ -364,6 +362,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
             # pipeline execution fails.
             placeholder_run, deployment_snapshot = (
                 self._prepare_execute_with_orchestrator(
+                    run_name=request.run_name,
                     resolved_params=parameters,
                 )
             )
@@ -499,11 +498,13 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
 
     def _prepare_execute_with_orchestrator(
         self,
+        run_name: Optional[str],
         resolved_params: Dict[str, Any],
     ) -> Tuple[PipelineRunResponse, PipelineSnapshotResponse]:
         """Prepare the execution with the orchestrator.
 
         Args:
+            run_name: The name of the run.
             resolved_params: The resolved parameters.
 
         Returns:
@@ -512,6 +513,7 @@ class PipelineDeploymentService(BasePipelineDeploymentService):
         deployment_snapshot_request = (
             deployment_snapshot_request_from_source_snapshot(
                 source_snapshot=self.snapshot,
+                run_name=run_name,
                 deployment_parameters=resolved_params,
             )
         )

--- a/src/zenml/deployers/utils.py
+++ b/src/zenml/deployers/utils.py
@@ -296,6 +296,7 @@ def invoke_deployment(
 
 def deployment_snapshot_request_from_source_snapshot(
     source_snapshot: PipelineSnapshotResponse,
+    run_name: Optional[str],
     deployment_parameters: Dict[str, Any],
 ) -> PipelineSnapshotRequest:
     """Generate a snapshot request for deployment execution.
@@ -303,6 +304,7 @@ def deployment_snapshot_request_from_source_snapshot(
     Args:
         source_snapshot: The source snapshot from which to create the
             snapshot request.
+        run_name: The name of the run.
         deployment_parameters: Parameters to override for deployment execution.
 
     Raises:
@@ -395,7 +397,7 @@ def deployment_snapshot_request_from_source_snapshot(
 
     return PipelineSnapshotRequest(
         project=source_snapshot.project_id,
-        run_name_template=source_snapshot.run_name_template,
+        run_name_template=run_name or source_snapshot.run_name_template,
         pipeline_configuration=pipeline_configuration,
         step_configurations=steps,
         client_environment={},

--- a/tests/unit/deployers/server/test_service.py
+++ b/tests/unit/deployers/server/test_service.py
@@ -168,7 +168,8 @@ def test_execute_pipeline_calls_subroutines(mocker: MockerFixture) -> None:
 
     assert result == "response"
     service._prepare_execute_with_orchestrator.assert_called_once_with(
-        resolved_params={"city": "Berlin", "temperature": 20}
+        run_name=None,
+        resolved_params={"city": "Berlin", "temperature": 20},
     )
     service._execute_with_orchestrator.assert_called_once_with(
         placeholder_run=placeholder_run,

--- a/tests/unit/deployers/server/test_service_outputs.py
+++ b/tests/unit/deployers/server/test_service_outputs.py
@@ -199,7 +199,9 @@ def test_service_captures_in_memory_outputs(
     )
     monkeypatch.setattr(
         "zenml.deployers.server.service.deployment_snapshot_request_from_source_snapshot",
-        lambda source_snapshot, deployment_parameters: SimpleNamespace(),
+        lambda source_snapshot, run_name, deployment_parameters: (
+            SimpleNamespace()
+        ),
     )
 
     request = BaseDeploymentInvocationRequest(


### PR DESCRIPTION
## Describe changes
Removes the unused `timeout` field, and also uses `run_name` if passed instead of ignoring it.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

