### PR TITLE
Fix MLflow deployment healthcheck method

### DIFF
--- a/src/zenml/integrations/mlflow/services/mlflow_deployment.py
+++ b/src/zenml/integrations/mlflow/services/mlflow_deployment.py
@@ -197,11 +197,9 @@ class MLFlowDeploymentService(LocalDaemonService, BaseDeploymentService):
             if config.mlserver:
                 prediction_url_path = MLSERVER_PREDICTION_URL_PATH
                 healthcheck_uri_path = MLSERVER_HEALTHCHECK_URL_PATH
-                use_head_request = False
             else:
                 prediction_url_path = MLFLOW_PREDICTION_URL_PATH
                 healthcheck_uri_path = MLFLOW_HEALTHCHECK_URL_PATH
-                use_head_request = True
 
             endpoint = MLFlowDeploymentEndpoint(
                 config=MLFlowDeploymentEndpointConfig(
@@ -211,7 +209,7 @@ class MLFlowDeploymentService(LocalDaemonService, BaseDeploymentService):
                 monitor=HTTPEndpointHealthMonitor(
                     config=HTTPEndpointHealthMonitorConfig(
                         healthcheck_uri_path=healthcheck_uri_path,
-                        use_head_request=use_head_request,
+                        use_head_request=False,
                     )
                 ),
             )

--- a/tests/integration/integrations/mlflow/test_mlflow_deployment_service.py
+++ b/tests/integration/integrations/mlflow/test_mlflow_deployment_service.py
@@ -1,0 +1,77 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for MLflow deployment service endpoint configuration."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("mlflow")
+
+from zenml.integrations.mlflow.services.mlflow_deployment import (
+    MLFLOW_HEALTHCHECK_URL_PATH,
+    MLFLOW_PREDICTION_URL_PATH,
+    MLSERVER_HEALTHCHECK_URL_PATH,
+    MLSERVER_PREDICTION_URL_PATH,
+    MLFlowDeploymentConfig,
+    MLFlowDeploymentService,
+)
+
+
+def _deployment_service(*, mlserver: bool) -> MLFlowDeploymentService:
+    """Create an MLflow deployment service without starting its daemon."""
+    config = MLFlowDeploymentConfig(
+        model_uri="runs:/test-run-id/model",
+        model_name="model",
+        mlserver=mlserver,
+    )
+    return MLFlowDeploymentService(uuid=uuid4(), config=config)
+
+
+def test_standard_mlflow_deployment_healthcheck_uses_get() -> None:
+    """Check that standard MLflow serving uses GET /ping health checks."""
+    service = _deployment_service(mlserver=False)
+
+    assert service.endpoint.config.prediction_url_path == MLFLOW_PREDICTION_URL_PATH
+    assert (
+        service.endpoint.monitor.config.healthcheck_uri_path
+        == MLFLOW_HEALTHCHECK_URL_PATH
+    )
+    assert service.endpoint.monitor.config.use_head_request is False
+
+
+def test_mlserver_deployment_healthcheck_uses_get(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Check that the MLServer endpoint keeps its existing GET readiness probe."""
+
+    def import_module(name: str) -> MagicMock:
+        if name in {"mlserver", "mlserver_mlflow"}:
+            return MagicMock()
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(
+        "zenml.integrations.mlflow.services.mlflow_deployment.importlib.import_module",
+        import_module,
+    )
+
+    service = _deployment_service(mlserver=True)
+
+    assert service.endpoint.config.prediction_url_path == MLSERVER_PREDICTION_URL_PATH
+    assert (
+        service.endpoint.monitor.config.healthcheck_uri_path
+        == MLSERVER_HEALTHCHECK_URL_PATH
+    )
+    assert service.endpoint.monitor.config.use_head_request is False

--- a/tests/integration/integrations/mlflow/test_mlflow_deployment_service.py
+++ b/tests/integration/integrations/mlflow/test_mlflow_deployment_service.py
@@ -44,7 +44,10 @@ def test_standard_mlflow_deployment_healthcheck_uses_get() -> None:
     """Check that standard MLflow serving uses GET /ping health checks."""
     service = _deployment_service(mlserver=False)
 
-    assert service.endpoint.config.prediction_url_path == MLFLOW_PREDICTION_URL_PATH
+    assert (
+        service.endpoint.config.prediction_url_path
+        == MLFLOW_PREDICTION_URL_PATH
+    )
     assert (
         service.endpoint.monitor.config.healthcheck_uri_path
         == MLFLOW_HEALTHCHECK_URL_PATH
@@ -69,7 +72,10 @@ def test_mlserver_deployment_healthcheck_uses_get(
 
     service = _deployment_service(mlserver=True)
 
-    assert service.endpoint.config.prediction_url_path == MLSERVER_PREDICTION_URL_PATH
+    assert (
+        service.endpoint.config.prediction_url_path
+        == MLSERVER_PREDICTION_URL_PATH
+    )
     assert (
         service.endpoint.monitor.config.healthcheck_uri_path
         == MLSERVER_HEALTHCHECK_URL_PATH


### PR DESCRIPTION
## Description

Fixes MLflow deployment service health checks for the standard MLflow serving path.

MLflow 3 uses a FastAPI-based local scoring server whose `/ping` endpoint is documented and validated via `GET`. ZenML was still probing standard MLflow deployments with `HEAD /ping`, which can return `405 Method Not Allowed` even when the service itself is alive.

The concrete failure chain looks like this:

1. The MLflow deployment service starts.
2. ZenML checks `/ping` with `HEAD`.
3. MLflow/FastAPI may reject that method.
4. ZenML marks the endpoint as not running.
5. `MLFlowDeploymentService.predict()` refuses to call `/invocations` because `is_running` is false.
6. Generated template tests can then fail with “MLflow prediction service is not running.”

This switches the standard MLflow deployment health monitor to `GET`, matching the existing MLServer behavior and MLflow 3 serving expectations.

## Testing

- `uv run --extra dev ruff check src/zenml/integrations/mlflow/services/mlflow_deployment.py tests/integration/integrations/mlflow/test_mlflow_deployment_service.py`
- `uv run --extra dev --extra local --with 'mlflow>=2.1.1,<4' --with 'python-rapidjson<1.15' pytest tests/integration/integrations/mlflow/test_mlflow_deployment_service.py`
