### PR TITLE
Refresh agent guidance docs

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -8,18 +8,18 @@ This document provides guidance for AI assistants working with ZenML's GitHub Ac
 
 | Category | Workflows | Purpose |
 |----------|-----------|---------|
-| **CI/Testing** | ci-fast.yml, ci-slow.yml | Primary PR testing (two-tier approach) |
-| **Reusable Tests** | unit-test.yml, linting.yml, integration-test-*.yml | Called by CI and release workflows |
-| **Release** | release.yml, publish_*.yml | PyPI, Docker, Helm publishing |
-| **Security** | codeql.yml, trivy-*.yml | Vulnerability scanning |
-| **Maintenance** | stale-prs.yml, pr_labeler.yml, require-release-label.yml | Repo automation |
-| **Special** | templates-test.yml, update-templates-to-examples.yml | Template syncing |
+| **CI/Testing** | ci-fast.yml, ci-slow.yml, unit-test.yml, integration-test-*.yml, base-package-functionality.yml | Primary PR testing and reusable test jobs |
+| **Linting/Quality** | linting.yml, spellcheck.yml, zizmor.yml, check-links.yml, check-markdown-links.yml, gitbook-redirect-check.yml, validate-changelog.yml | Code quality, docs links, changelog, and workflow security checks |
+| **Release/Nightly** | release.yml, release_prepare.yml, release_finalize.yml, publish_*.yml, nightly_build.yml | PyPI, Docker, Helm, stack template, and nightly publishing |
+| **Security** | codeql.yml, trivy-*.yml, zizmor.yml | Static analysis and vulnerability/supply-chain scanning |
+| **Maintenance** | stale-prs.yml, pr_labeler.yml, require-release-label.yml, snack-it.yml, notify-*.yml, dependabot.yml | Repo automation and project notifications |
+| **Special/Examples** | templates-test.yml, update-templates-to-examples.yml, vscode-tutorial-pipelines-test.yml, weekly-agent-pipelines-test.yml, performance-profiling.yml | Template syncing, tutorial/example regression tests, and profiling |
 
 ### Entry Points vs Reusable Workflows
 
-**Entry points** (triggered externally): ci-fast.yml, ci-slow.yml, release.yml, nightly_build.yml
+**Entry points** (triggered externally): ci-fast.yml, ci-slow.yml, release.yml, nightly_build.yml, check-links.yml, check-markdown-links.yml, gitbook-redirect-check.yml, validate-changelog.yml, zizmor.yml
 
-**Reusable workflows** (called via `workflow_call`): unit-test.yml, linting.yml, integration-test-*.yml, publish_*.yml
+**Reusable workflows** (called via `workflow_call`): unit-test.yml, linting.yml, integration-test-*.yml, base-package-functionality.yml, publish_*.yml
 
 All reusable workflows use `secrets: inherit` for centralized secret management.
 
@@ -68,14 +68,11 @@ Triggered by tag push. Sequence:
 ### Running zizmor locally
 
 ```bash
-# Install (requires Python environment with dev deps)
-uv pip install zizmor
+# Run analysis using the repo config; uvx installs/runs zizmor in one step
+GH_TOKEN=$(gh auth token) uvx zizmor --config=.github/zizmor.yml .github/workflows/
 
-# Run analysis
-zizmor .github/workflows/
-
-# Auto-fix SHA pinning (IMPORTANT: requires GH_TOKEN)
-GH_TOKEN=$(gh auth token) zizmor --fix=all .github/workflows/
+# Auto-fix SHA pinning (IMPORTANT: requires GH_TOKEN and manual review)
+GH_TOKEN=$(gh auth token) uvx zizmor --fix=all --config=.github/zizmor.yml .github/workflows/
 ```
 
 **Critical**: zizmor requires `GH_TOKEN` (not `GITHUB_TOKEN`) environment variable for SHA lookups when auto-fixing.
@@ -156,11 +153,12 @@ Cache invalidates when integrations change.
 | File | Purpose |
 |------|---------|
 | `actions/setup_environment/action.yml` | Composite action for Python + ZenML dev setup |
-| `zizmor.yml` | Security linter configuration |
+| `zizmor.yml` | Security linter configuration used by `scripts/lint.sh` and `.github/workflows/zizmor.yml` |
 | `codecov.yml` | Coverage reporting (lenient thresholds) |
-| `dependabot.yml` | Weekly GitHub Actions updates (Tuesdays 07:00 CET) |
+| `dependabot.yml` | Weekly GitHub Actions updates on Tuesdays 07:00 Europe/Amsterdam, grouped by minor/patch updates with cooldowns |
 | `teams.yml` | Internal team members for privileged workflows |
 | `branch-labels.yml` | Auto-labeling rules based on branch patterns |
+| `markdown_check_config.json` | Markdown link checker configuration |
 
 ## Template Workflows
 
@@ -187,6 +185,18 @@ AI code review integration. Triggered by `@claude` mentions in issues/PRs. Gated
 ### snack-it.yml
 
 Creates tracking issues from PRs when `snack-it` label is applied. Adds to GitHub Projects roadmap.
+
+### zizmor.yml
+
+Runs GitHub Actions security analysis on workflow/config changes, pushes to `main`/`develop`, a weekly schedule, and manual dispatch. Use the same config locally with `GH_TOKEN=$(gh auth token) uvx zizmor --config=.github/zizmor.yml .github/workflows/`.
+
+### check-links.yml / check-markdown-links.yml / gitbook-redirect-check.yml
+
+Documentation link safety net. Use these as the source of truth when changing docs URL structure, generated API docs, or GitBook redirects.
+
+### weekly-agent-pipelines-test.yml / vscode-tutorial-pipelines-test.yml
+
+Regression tests for example/tutorial/agent pipelines. If a code change affects pipeline authoring, dynamic pipelines, or example behavior, mention these workflows in the PR so maintainers know whether to rerun them.
 
 ## Important Gotchas
 
@@ -221,7 +231,7 @@ This runs yamlfix on YAML files to ensure consistent formatting.
 
 ## Adding New Workflows
 
-1. Use SHA-pinned actions: `actions/checkout@<full-sha>  # v4.2.2`
+1. Use SHA-pinned actions with a version comment: `actions/checkout@<full-sha>  # v6.0.2`
 2. Add appropriate concurrency settings
 3. Include standard environment variables
 4. Consider if it should be reusable (`workflow_call`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Use filesystem navigation tools to explore the codebase structure as needed.
   - Automatically fixes and formats code using ruff and yamlfix
 - Check code quality with: `bash scripts/lint.sh`
   - Unlike format.sh, this doesn't auto-fix issues
-  - Runs mypy type checking on the codebase
+  - Runs Ruff, pydoclint (on `src/zenml tests/harness`), yamlfix, zizmor, unused import/variable checks, Ruff formatting checks, and mypy
   - Note: Full mypy check is slow on the entire codebase
   - For faster checks, run mypy directly on specific files: `mypy src/zenml/path/to/file.py`
 - The primary code style is enforced by ruff, configured in `pyproject.toml`
@@ -285,7 +285,7 @@ ZenML documentation is available via a built-in GitBook MCP server: https://docs
 - Database schema changes require Alembic migrations
 - ZenML uses **SQLModel** (SQLAlchemy-based) — no raw SQL unless absolutely necessary
 - Create migrations with descriptive names: `alembic revision -m "Add X to Y table"`
-- Test migrations both up and down: `alembic upgrade head` and `alembic downgrade -1`
+- Test the upgrade path with `alembic upgrade head`; downgrade testing is optional because ZenML does not generally support downgrades
 - Never modify existing migrations that are already on main/develop branches
 - Always consider backward compatibility for rolling deployments
 - Include both schema changes and data migrations when needed
@@ -381,12 +381,18 @@ This ensures migrations handle existing data correctly. CI does basic migration 
 - `BaseOrchestrator` - Pipeline execution
 - `BaseStepOperator` - Remote step execution (submit/status/wait/cancel lifecycle)
 
+### Recently Active Architecture Areas
+- `src/zenml/execution/pipeline/dynamic/` and `src/zenml/pipelines/dynamic/` contain dynamic pipeline execution, including nested child pipelines. Changes here often need matching updates in orchestrators, pipeline run models/schemas, migrations, tests, and docs.
+- `src/zenml/triggers/` and `src/zenml/models/v2/core/triggers.py` contain the trigger architecture, including schedule triggers and platform event triggers. Keep CLI, client, server, model, schema, and docs layers aligned when touching triggers.
+- `src/zenml/models/v2/core/resource_pool*.py`, `resource_request.py`, and `src/zenml/zen_stores/resource_pools/` contain resource pool and resource request functionality. These features coordinate API models, store behavior, CLI commands, and Pro/backend integrations.
+- `src/zenml/container_engines/` contains the client-side container engine abstraction for Docker and Podman. Prefer this abstraction over calling Docker-specific helpers directly when local OCI tooling is involved.
+
 ## Common Tasks
 
 ### Adding New Integrations
 1. Create integration package in `/src/zenml/integrations/`
 2. Implement required abstractions and register flavors
-3. Add tests in `/tests/integrations/`
+3. Add tests in `/tests/integration/` (usually `/tests/integration/integrations/` for integration-specific tests)
 4. Add documentation in `/docs/book/component-guide/`
 
 ### Modifying Core Functionality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,7 +381,9 @@ This ensures migrations handle existing data correctly. CI does basic migration 
 - `BaseOrchestrator` - Pipeline execution
 - `BaseStepOperator` - Remote step execution (submit/status/wait/cancel lifecycle)
 
-### Recently Active Architecture Areas
+### Cross-Cutting Architecture Areas
+Some ZenML features span many layers. When working in these areas, follow the full chain instead of editing only the file where the immediate change appears:
+
 - `src/zenml/execution/pipeline/dynamic/` and `src/zenml/pipelines/dynamic/` contain dynamic pipeline execution, including nested child pipelines. Changes here often need matching updates in orchestrators, pipeline run models/schemas, migrations, tests, and docs.
 - `src/zenml/triggers/` and `src/zenml/models/v2/core/triggers.py` contain the trigger architecture, including schedule triggers and platform event triggers. Keep CLI, client, server, model, schema, and docs layers aligned when touching triggers.
 - `src/zenml/models/v2/core/resource_pool*.py`, `resource_request.py`, and `src/zenml/zen_stores/resource_pools/` contain resource pool and resource request functionality. These features coordinate API models, store behavior, CLI commands, and Pro/backend integrations.

--- a/src/zenml/cli/AGENTS.md
+++ b/src/zenml/cli/AGENTS.md
@@ -7,7 +7,10 @@ Guidance for agents working with ZenML CLI code.
 | File | Purpose |
 |------|---------|
 | `utils.py` | CLI utilities including `list_options` decorator |
-| `pipeline.py` | Pipeline and run management commands |
+| `pipeline.py` | Pipeline, run, legacy schedule, and replay/resume management commands |
+| `trigger.py` | Native trigger commands, including schedule triggers and platform event triggers |
+| `resource_pool.py` | Resource pool commands and resource pool subject policies |
+| `resource_request.py` | Resource request / queue inspection commands |
 | `stack.py` | Stack management commands |
 | `base.py` | Core CLI setup and common decorators |
 
@@ -47,12 +50,17 @@ class EntityFilter(...):
 
 ## Scheduling Command Families
 
-There are now two separate scheduling command families in the CLI:
+There are now separate scheduling/trigger command families in the CLI:
 
 - `zenml pipeline schedule ...` — Legacy schedule records (CRUD on `ScheduleResponse`)
-- `zenml trigger schedule ...` — Native schedule triggers (new trigger-based architecture)
+- `zenml trigger schedule ...` — Native schedule triggers in the trigger architecture
+- `zenml trigger platform-event ...` — Platform event triggers and their supported events
 
-When modifying scheduling CLI code, be explicit about which stack you are changing. The trigger CLI lives in `cli/trigger.py`, while legacy schedule commands live in `cli/pipeline.py`.
+When modifying scheduling or trigger CLI code, be explicit about which stack you are changing. The trigger CLI lives in `cli/trigger.py`, while legacy schedule commands live in `cli/pipeline.py`. Trigger changes usually span CLI, client, server endpoints, models, schemas, and docs.
+
+## Resource Pool Command Family
+
+Resource pools have their own CLI surfaces in `cli/resource_pool.py` and `cli/resource_request.py`. When changing resource pool behavior, check both the management commands (create/update/list/delete, policy attach/detach/list) and request/queue inspection commands. These commands are coupled to `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and `ResourceRequest*` models.
 
 ## Import Considerations
 

--- a/src/zenml/models/AGENTS.md
+++ b/src/zenml/models/AGENTS.md
@@ -43,14 +43,14 @@ Response generics:
 - Metadata extends BaseResponseMetadata
 - Resources extends BaseResponseResources
 
-## Recently Added / High-Touch Entity Families
+## Cross-Layer Entity Families
 
-Several newer features span models, schemas, client methods, CLI commands, server endpoints, migrations, and docs. When touching these, trace the whole path instead of changing only the model file:
+Some model families are coordination points between API models, ORM schemas, store methods, client methods, CLI commands, server endpoints, migrations, and docs. When touching these, trace the whole path instead of changing only the model file:
 
 - **Triggers:** `Trigger*`, `ScheduleTrigger*`, `PlatformEventTrigger*`, dispatch status/error models, and supported-event helpers. These back `zenml trigger ...` commands and trigger endpoints.
 - **Resource pools:** `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and `ResourceRequest*` models. These back resource pool commands, queue/request inspection, store interfaces, and Pro/backend scheduling behavior.
 - **Run wait conditions:** `RunWaitCondition*` models coordinate pause/resume and wait-condition behavior for pipeline runs.
-- **Nested child pipelines:** `PipelineRun*` now includes parent/child/root run fields such as `parent_run_id`, `child_key`, and `root_run_id`. Keep these aligned with ORM schemas, migrations, filters, client list methods, and dynamic pipeline tests.
+- **Nested child pipelines:** `PipelineRun*` includes parent/child/root run fields such as `parent_run_id`, `child_key`, and `root_run_id`. Keep these aligned with ORM schemas, migrations, filters, client list methods, and dynamic pipeline tests.
 
 ## Domain Model Types
 

--- a/src/zenml/models/AGENTS.md
+++ b/src/zenml/models/AGENTS.md
@@ -43,6 +43,15 @@ Response generics:
 - Metadata extends BaseResponseMetadata
 - Resources extends BaseResponseResources
 
+## Recently Added / High-Touch Entity Families
+
+Several newer features span models, schemas, client methods, CLI commands, server endpoints, migrations, and docs. When touching these, trace the whole path instead of changing only the model file:
+
+- **Triggers:** `Trigger*`, `ScheduleTrigger*`, `PlatformEventTrigger*`, dispatch status/error models, and supported-event helpers. These back `zenml trigger ...` commands and trigger endpoints.
+- **Resource pools:** `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and `ResourceRequest*` models. These back resource pool commands, queue/request inspection, store interfaces, and Pro/backend scheduling behavior.
+- **Run wait conditions:** `RunWaitCondition*` models coordinate pause/resume and wait-condition behavior for pipeline runs.
+- **Nested child pipelines:** `PipelineRun*` now includes parent/child/root run fields such as `parent_run_id`, `child_key`, and `root_run_id`. Keep these aligned with ORM schemas, migrations, filters, client list methods, and dynamic pipeline tests.
+
 ## Domain Model Types
 
 1) Request ({Entity}Request)

--- a/src/zenml/orchestrators/AGENTS.md
+++ b/src/zenml/orchestrators/AGENTS.md
@@ -9,12 +9,15 @@ Guidance for agents implementing or modifying ZenML orchestrators.
 | `base_orchestrator.py` | Base class with abstract methods to implement |
 | `containerized_orchestrator.py` | Base for orchestrators that run steps in containers |
 | `utils.py` | Shared orchestrator utilities |
+| `step_launcher.py` | Step execution launcher, including step-operator and isolated-step paths |
+| `step_runner.py` | Runtime step execution logic |
+| `cache_utils.py`, `input_utils.py`, `publish_utils.py` | Shared cache/input/status and metadata helpers |
 
 ## Methods to Implement
 
 When implementing a custom orchestrator, there are two main submission methods:
 
-### 1. `submit_pipeline` (line ~179)
+### 1. `submit_pipeline` (line ~188)
 
 For **static pipelines** where the DAG is known at submission time.
 
@@ -30,7 +33,7 @@ def submit_pipeline(
     """Submit the pipeline to your orchestration backend."""
 ```
 
-### 2. `submit_dynamic_pipeline` (line ~209)
+### 2. `submit_dynamic_pipeline` (line ~218)
 
 For **dynamic pipelines** where the DAG can change during execution.
 
@@ -64,9 +67,25 @@ These are used by the `StepLauncher` when running steps via step operators or in
 
 ---
 
+### Nested Child Pipelines
+
+Dynamic pipelines can now call other dynamic pipelines as child pipelines. A child pipeline may create its own pipeline run with `parent_run_id`, `child_key`, and `root_run_id` links back to the parent run. Inline child pipelines execute their steps inside the parent run instead.
+
+When changing dynamic pipeline or orchestrator behavior, check the full chain:
+- Dynamic execution: `src/zenml/execution/pipeline/dynamic/`
+- Dynamic pipeline public API: `src/zenml/pipelines/dynamic/`
+- Parent/child run models and schemas: `PipelineRun*` models, `pipeline_run_schemas.py`, and migrations
+- Step launching: `src/zenml/orchestrators/step_launcher.py`
+- Tests: `tests/unit/execution/pipeline/dynamic/test_child_pipelines.py`
+- Docs: `docs/book/how-to/steps-pipelines/dynamic_pipelines.md`
+
+Concrete failure story: the parent dynamic run launches a child pipeline, then resumes or retries. If the child key or orchestration run ID changes unexpectedly, ZenML can fail to find the existing child run and may start duplicate work. Keep child identifiers stable across replay/resume/retry paths.
+
+---
+
 ## ⚠️ The Tricky Method: `get_orchestrator_run_id`
 
-**Location:** `base_orchestrator.py:169`
+**Location:** `base_orchestrator.py:173`
 
 This is where most implementers get confused, despite the docstring documentation.
 
@@ -104,19 +123,19 @@ def get_orchestrator_run_id(self) -> str:
 **Key differences:**
 - There's always one initial container that gets spun up first: the "orchestration container"
 - This container creates the pipeline run
-- The ID only needs to be unique when running **inside the orchestration container**
-- Does NOT need to be unique across all step containers that get spun up later
+- The ID needs to be unique for the orchestration environment and stable for retries of that same orchestration environment
+- It does NOT need to be unique across all step containers that get spun up later
 
 **What to use:**
-- **Kubernetes:** The pod name (`socket.gethostname()`) — it's unique per container
+- **Kubernetes:** Prefer the parent Kubernetes job name for the orchestration pod; fall back to the pod name only if the job lookup fails
 - **SageMaker:** The job ID of the orchestration container
 
 ### Orchestration Exception: Kubernetes
 
 Kubernetes is special because it **does** spin up an orchestration container first, even for static pipelines. This means:
-- The Kubernetes orchestrator can use the pod name as the run ID
-- It first checks for `ENV_ZENML_KUBERNETES_RUN_ID` (set for static pipelines)
-- Falls back to `socket.gethostname()` for dynamic pipelines
+- The Kubernetes orchestrator first checks for `ENV_ZENML_KUBERNETES_RUN_ID` (set for static pipelines)
+- For dynamic pipelines, it tries to use the parent Kubernetes job name so retries of the orchestration pod resolve to the same run ID
+- It falls back to `socket.gethostname()` only if the job-name lookup fails
 
 ---
 
@@ -125,19 +144,21 @@ Kubernetes is special because it **does** spin up an orchestration container fir
 Study these implementations when building your own orchestrator:
 
 ### Kubernetes (recommended starting point)
-**File:** `src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py:961`
+**File:** `src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py:1080`
 
 ```python
 def get_orchestrator_run_id(self) -> str:
     try:
         return os.environ[ENV_ZENML_KUBERNETES_RUN_ID]
     except KeyError:
-        # Dynamic pipeline: use pod name
-        return socket.gethostname()
+        # Dynamic pipeline: use parent job name for retry stability,
+        # falling back to pod name if the lookup fails.
+        pod_name = socket.gethostname()
+        return get_parent_job_name(...) or pod_name
 ```
 
 ### SageMaker (complex example)
-**File:** `src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py:258`
+**File:** `src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py:270`
 
 ```python
 def get_orchestrator_run_id(self) -> str:
@@ -154,7 +175,7 @@ def get_orchestrator_run_id(self) -> str:
 ```
 
 ### Vertex AI
-**File:** `src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py:785`
+**File:** `src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py:1004`
 
 ```python
 def get_orchestrator_run_id(self) -> str:

--- a/src/zenml/zen_stores/schemas/AGENTS.md
+++ b/src/zenml/zen_stores/schemas/AGENTS.md
@@ -258,5 +258,5 @@ Practical Checklist for New/Updated Schemas
 - Implement to_model(...), from_request/from_model(...), and update/update_from_model(...).
 - Update src/zenml/zen_stores/schemas/__init__.py to export new schema(s).
 - Ensure updated is refreshed on mutations; avoid including heavy related resources unless requested via flags.
-- Plan and apply DB migrations for schema changes; update src/zenml/zen_stores/migrations and test upgrade/downgrade paths.
+- Plan and apply DB migrations for schema changes; update src/zenml/zen_stores/migrations and test the upgrade path. Downgrade testing is optional because ZenML does not generally support downgrades.
 - Consult domain models in src/zenml/models/v2 to keep names and types aligned.


### PR DESCRIPTION
## What this changes

Refreshes the agent guidance docs after repository architecture and workflow changes.

Updated guidance for:

- root `AGENTS.md` linting/migration/test-path guidance and cross-cutting architecture areas
- `.github/CLAUDE.md` workflow categories, current zizmor commands, link-checking workflows, and action pinning examples
- CLI guidance for triggers, platform-event triggers, resource pools, and resource requests
- orchestrator guidance for nested child pipelines and retry-stable dynamic pipeline run IDs
- model guidance for cross-layer entity families: triggers, resource pools, run wait conditions, and child pipeline run fields
- schema guidance to make migration downgrade wording consistent

## Why

These instruction files were out of sync with changes such as nested child pipelines, resource pools, event triggers, container engine abstraction/Podman support, and the current GitHub Actions/zizmor setup. This keeps future agent work pointed at the right files and avoids stale advice.

## Notes for review

@schustmi tagging you as requested for a sanity check, especially around the dynamic pipeline / orchestrator guidance.

## Validation

- `git diff --check`
- Oracle review pass found no blocking concerns

Docs-only change; no tests run.
