### PR TITLE
Update docs for recent feature drift

### DIFF
--- a/docs/book/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/component-guide/orchestrators/kubernetes.md
@@ -119,6 +119,19 @@ E.g., you can use these labels to manually delete all pods related to a specific
 kubectl delete pod -n zenml -l pipeline=kubernetes_example_pipeline
 ```
 
+ZenML sanitizes these label values before sending them to Kubernetes. Invalid
+characters are replaced, leading/trailing punctuation is removed, and values are
+truncated to fit Kubernetes label limits. In practice, a pipeline called
+`My GPU Pipeline!!!` will not appear as that exact string in a label selector.
+If a selector using the raw name does not match anything, inspect one of the
+created pods first:
+
+```shell
+kubectl get pods -n zenml --show-labels
+```
+
+Then copy the sanitized label value from Kubernetes.
+
 ### Additional configuration
 
 Some configuration options for the Kubernetes orchestrator can only be set through the orchestrator config when you register it (and cannot be changed per-run or per-step through the settings):

--- a/docs/book/component-guide/step-operators/runai.md
+++ b/docs/book/component-guide/step-operators/runai.md
@@ -189,13 +189,33 @@ settings = RunAIStepOperatorSettings(
 | `gpu_portion_request` | float | 1.0 | Fractional GPU allocation (0.0-1.0) |
 | `gpu_request_type` | str | "portion" | GPU allocation method: "portion" or "memory" |
 | `gpu_memory_request` | str | None | GPU memory to request (e.g., "20Gi") when using memory type |
+| `gpu_portion_limit` | float | None | Maximum fractional GPU portion the workload can burst to when available |
+| `gpu_memory_limit` | str | None | Maximum GPU memory the workload can burst to when using memory requests |
 | `cpu_core_request` | float | 1.0 | Number of CPU cores to request |
+| `cpu_core_limit` | float | None | Maximum CPU cores the workload can burst to |
 | `cpu_memory_request` | str | "4G" | Memory to request (e.g., "4G", "8Gi") |
+| `cpu_memory_limit` | str | None | Maximum memory the workload can burst to |
 | `node_pools` | list | None | Ordered list of node pool names for scheduling |
 | `node_type` | str | None | Node type label for GPU selection |
 | `preemptibility` | str | None | "preemptible" or "non-preemptible" |
 | `priority_class` | str | None | Kubernetes PriorityClass name |
+| `tolerations` | list | None | Kubernetes tolerations for scheduling on tainted nodes |
+| `extended_resources` | dict | None | Extended Kubernetes resources such as InfiniBand or FPGAs |
 | `large_shm_request` | bool | False | Request large /dev/shm for PyTorch DataLoader |
+| `backoff_limit` | int | None | Number of retries before marking the workload as failed |
+| `termination_grace_period_seconds` | int | None | Seconds to wait for graceful termination before force killing |
+| `terminate_after_preemption` | bool | None | Terminate after preemption instead of requeuing |
+| `working_dir` | str | None | Working directory inside the container |
+| `labels` | dict | None | Extra Kubernetes labels to add to the workload pod |
+| `annotations` | dict | None | Extra Kubernetes annotations to add to the workload pod |
+| `workload_timeout` | int | None | Maximum time in seconds to wait for workload completion |
+| `pending_timeout` | int | None | Maximum time in seconds the workload may remain pending |
+
+A useful way to think about the timeout settings is: `pending_timeout` covers
+the queuing phase before Run:AI can start the workload, while
+`workload_timeout` covers the running phase after the workload has started. If a
+workload sits in `Pending` because no quota is available, `pending_timeout` is
+the timer that lets ZenML stop waiting instead of hanging indefinitely.
 
 Environment variables are configured through the standard ZenML `environment` settings on steps or pipelines; the Run:AI step operator does not introduce an additional environment-specific setting.
 

--- a/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
+++ b/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
@@ -629,8 +629,9 @@ You have the option of using [a custom implementation of the secrets store API](
      ZENML_SECRETS_STORE_SECRET_OPTION_4: value4
 
    # Extra environment variables to set in the ZenML server container that
-   # are injected from external secret references.
-    environmentSecretKeyRefs:
+   # are injected from external secret references. These references are also
+   # applied to the DB migration job and worker deployments.
+   environmentSecretKeyRefs:
       - name: ZENML_SECRETS_STORE_OPTION_5
         secretName: my-existing-secret
         secretKey: key_name_not_value5

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -70,7 +70,7 @@ zenml trigger schedule create daily-schedule-6-am --cron-expression "0 6 * * *"
 So far we have instructed our system with *when* to execute but not *what*. To do so,
 we need to *attach* a schedule to a snapshot.
 
-For the CLI, commands that take a trigger or snapshot accept itsname or ID
+For the CLI, commands that take a trigger or snapshot accept its name or ID
 (exact match, not a prefix). Positional order is always trigger first, then snapshot.
 
 Via the SDK:
@@ -198,13 +198,26 @@ Or its attached snapshots and executed pipeline runs:
 
 ![Image Showing Schedule Runs](../../.gitbook/assets/schedule_runs_dash.png)
 
-For each trigger–snapshot attachment, ZenML can persist the **dispatch state** (for
-example, last status, or error message and severity when a dispatch fails). The
-snapshot dispatch states on a trigger response reflect that information. After
-you fix the underlying problem, you can acknowledge the error and clear the
-stored details (see the next section). Use `get_schedule_trigger` with
-`trigger_name_id_or_prefix` to load a schedule by name, full ID, or ID prefix;
-set `allow_name_prefix_match=False` if you need an exact name match.
+For each trigger–snapshot attachment, ZenML can persist the **dispatch state**.
+This is the small status record that answers, "what happened the last time this
+trigger tried to launch this snapshot?" The status can be:
+
+- `SUCCESS`: a run was launched successfully.
+- `SKIPPED_CONCURRENCY`: a run was skipped because the trigger's concurrency
+  rule said not to start another one yet.
+- `SKIPPED_MAX_RUNS`: a run was skipped because the configured run limit for
+  this trigger-snapshot attachment has already been reached.
+- `ERROR`: ZenML tried to dispatch the run, but something failed.
+
+When the last status is `ERROR`, the dispatch state can also include the last
+error message, error type, severity, stack trace, first/last error timestamps,
+and an error count. After you fix the underlying problem, you can acknowledge
+the error and clear the stored dispatch state (see the next section). In the
+normal failure case, clearing errors removes the `ERROR` status record for that
+trigger-snapshot attachment, so the next dispatch can start from a clean state.
+Use `get_schedule_trigger` with `trigger_name_id_or_prefix` to load a schedule
+by name, full ID, or ID prefix; set `allow_name_prefix_match=False` if you need
+an exact name match.
 
 Via the SDK:
 
@@ -256,8 +269,14 @@ client.create_schedule_trigger(
 
 #### `max_runs`
 
-Limits how many times a schedule can trigger a pipeline. Once the limit is reached, no further runs are scheduled. 
-Note that this limit applies per attached snapshot, for example, with a limit of 2 and two attached snapshots, you will see a total of 4 runs.
+Limits how many times a schedule can trigger a pipeline. Once the limit is
+reached for a trigger-snapshot attachment, no further runs are scheduled for
+that attachment. Later dispatch attempts can show up as `SKIPPED_MAX_RUNS` in
+the dispatch state. This is not an error that needs to be cleared; it is ZenML
+saying, "the run limit you configured has been reached."
+
+Note that this limit applies per attached snapshot, for example, with a limit of
+2 and two attached snapshots, you will see a total of 4 runs.
 
 ~~~python
 from zenml.client import Client
@@ -400,14 +419,27 @@ trigger operates within your workflow.
 |---------------|-----------------------------------------------------------|------------------------------------|
 | name          | The name of the trigger                                   | Unique within project              |
 | source_type   | The type of ZenML entity to listen to (e.g., pipeline)    | Defines the event source category  |
-| source_id     | The unique identifier of the source entity                | e.g., a specific pipeline ID       |
-| target_events | List of events that will activate the trigger             | e.g., `completed`, `failed`        |
+| source_id     | The UUID of the source entity                             | e.g., a specific pipeline UUID     |
+| target_events | List of events that will activate the trigger             | Depends on the source type         |
 | active        | Status of the trigger (active/inactive)                   | -                                  |
 | concurrency   | Option to control how concurrent runs should be handled   | Skip is the default option         |
 
 You can manage platform event triggers using the same set of commands (create, update, attach, detach, list, delete, clear-errors)
 as for schedule triggers. While some parameters and responses differ slightly, additional utilities are 
 available to help you work more effectively with this trigger type.
+
+Supported target events depend on the source type:
+
+| Source type | Meaning | Target events |
+|-------------|---------|---------------|
+| `pipeline` | React to runs of a pipeline | `run_completed`, `run_failed` |
+| `pipeline_run` | React to one specific pipeline run | `completed`, `failed` |
+
+That distinction is easy to miss. If the source is a pipeline, the event name
+includes the word `run` because the pipeline itself is not what completes; one
+of its runs does. If the source is already a pipeline run, the event is simply
+`completed` or `failed`.
+
 
 ### Create Platform Event Trigger
 
@@ -443,7 +475,7 @@ zenml trigger platform-event list-supported-events pipeline
 Then we can create the trigger as follows:
 
 ```bash
-zenml trigger platform-event create "on-hello-pipeline-complete" pipeline <PIPELINE_NAME_OR_ID> --target_events=run_completed
+zenml trigger platform-event create "on-hello-pipeline-complete" pipeline <PIPELINE_UUID> --target_events=run_completed
 ```
 
 ### Update Platform Event Triggers
@@ -472,7 +504,7 @@ zenml trigger platform-event update "on-hello-pipeline-complete" \
 
 ### Remaining Platform Event Trigger operations
 
-The remaining operations (view, attach, detach, delete, and clear-errors) match schedule triggers. 
+The remaining operations (list, attach, detach, delete, and clear-errors) match schedule triggers.
 In the CLI, they are grouped under a different command namespace, but the syntax remains the same. 
 You can explore the available platform event trigger commands with:
 
@@ -508,7 +540,7 @@ c.attach_trigger_to_snapshot(
     pipeline_snapshot_id=UUID("<snapshot_uuid>"),
 )
 c.detach_trigger_from_snapshot(
-    trigger_id=UUID("<trigger_uuid>"),`
+    trigger_id=UUID("<trigger_uuid>"),
     pipeline_snapshot_id=UUID("<snapshot_uuid>"),
 )
 c.delete_trigger(trigger_id=UUID("<trigger_uuid>"), soft=True)

--- a/docs/book/how-to/artifacts/materializers.md
+++ b/docs/book/how-to/artifacts/materializers.md
@@ -29,6 +29,38 @@ ZenML includes built-in materializers for many common data types:
 
 ZenML also provides a CloudpickleMaterializer that can handle any object by saving it with [cloudpickle](https://github.com/cloudpipe/cloudpickle). However, this is not production-ready because the resulting artifacts cannot be loaded when running with a different Python version. For production use, you should implement a custom materializer for your specific data types.
 
+{% hint style="info" %}
+Pydantic artifacts created by current ZenML versions are stored in
+`data_v2.json`. ZenML can still load older Pydantic artifacts stored as
+`data.json` by ZenML `<= 0.94.2`, so existing runs remain readable after an
+upgrade.
+{% endhint %}
+
+### Dataclass artifacts
+
+The `DataclassMaterializer` handles JSON-serializable Python dataclasses
+without requiring you to write a custom materializer.
+
+```python
+from dataclasses import dataclass
+
+from zenml import step
+
+@dataclass
+class TrainingConfig:
+    learning_rate: float
+    epochs: int
+
+@step
+def make_config() -> TrainingConfig:
+    return TrainingConfig(learning_rate=0.01, epochs=10)
+```
+
+This works for dataclasses that Pydantic can serialize to JSON. If your
+dataclass contains objects such as open file handles, live model objects,
+database connections, or other arbitrary Python objects, use a custom
+materializer instead.
+
 ### Passing Files and Directories Between Steps
 
 The `PathMaterializer` lets you pass `pathlib.Path` objects between steps. This is especially useful when working with files or directories that need to be shared across steps — for example, dataset directories, exported model files, or any file-based artifacts.

--- a/docs/book/how-to/environment-variables/environment-variables.md
+++ b/docs/book/how-to/environment-variables/environment-variables.md
@@ -27,6 +27,26 @@ Environment variables and secrets can be configured at different levels with inc
 **Precedence order**: Step configuration overrides pipeline configuration, which overrides stack configuration, which overrides stack component configuration. Additionally, secrets always take precedence over direct environment variables when both are configured with the same key.
 {% endhint %}
 
+## ZenML repository directory name
+
+By default, `zenml init` creates a `.zen` directory that marks the root of a
+ZenML repository. ZenML uses that marker later when it resolves local code, for
+example custom stack component flavors that live in your repository.
+
+If your workspace cannot use `.zen` as the marker directory name, set
+`ZENML_REPOSITORY_DIRECTORY_NAME` before initializing or discovering the
+repository:
+
+```bash
+export ZENML_REPOSITORY_DIRECTORY_NAME=.my-zenml
+zenml init
+```
+
+After that, ZenML looks for `.my-zenml` instead of `.zen`. Keep this setting
+consistent for everyone and every process that works with the repository; if one
+shell uses `.zen` and another uses `.my-zenml`, they will not agree on where the
+ZenML repository root is.
+
 ## Automatic environment variable injection
 
 When executing a pipeline, ZenML automatically scans your local environment for any variables that start with the `__ZENML__` prefix and adds them to the pipeline environment. The prefix is removed during this process.

--- a/docs/book/how-to/stack-components/stack_components.md
+++ b/docs/book/how-to/stack-components/stack_components.md
@@ -33,6 +33,13 @@ Stacks may also include these optional components:
 * **Alerter**: Sends notifications about pipeline events
 * **Annotator**: Manages data labeling workflows
 
+Most component types appear at most once in a stack. Three component types are
+repeatable: **step operators**, **experiment trackers**, and **alerters**. If a
+stack has more than one component of one of these types, the first attached
+component is the default. You can still choose a non-default component by name
+in step or pipeline configuration, and you can change the default later with
+`zenml stack set-default`.
+
 ## Working with Stacks
 
 ### The Active Stack
@@ -60,11 +67,41 @@ zenml stack register my-stack -a local-store -o local-orchestrator
 
 # Register a stack with additional components
 zenml stack register production-stack \
-    -artifact-store s3-store \
+    --artifact-store s3-store \
     --orchestrator kubeflow \
     --container-registry ecr-registry \
     --experiment-tracker mlflow-tracker
+
+# Attach multiple repeatable components. The first one becomes the default.
+zenml stack register training-stack \
+    --artifact-store s3-store \
+    --orchestrator kubernetes \
+    --step_operator gpu-step-operator \
+    --step_operator cpu-step-operator \
+    --experiment_tracker mlflow \
+    --experiment_tracker wandb
+
+# Promote a different attached component to be the default.
+zenml stack set-default training-stack --step_operator cpu-step-operator
 ```
+
+### Discovering flavor-specific configuration
+
+Stack component flavors have different configuration fields. A local
+orchestrator needs very little information; a Kubernetes orchestrator needs
+cluster and namespace details; an S3 artifact store needs bucket information.
+Once you pass a flavor with `-f` / `--flavor`, the CLI can show the concrete
+configuration fields for that flavor:
+
+```bash
+zenml orchestrator register -f kubernetes --help
+zenml artifact-store register -f s3 --help
+zenml step-operator update my-runai-step-operator --help
+```
+
+The help output includes a **Flavor configuration** section. For register and
+update commands, pass those fields as `--name=value` arguments. This is often
+the fastest way to answer, "what exactly does this flavor need from me?"
 
 Or through the Python API:
 

--- a/docs/book/how-to/steps-pipelines/advanced_features.md
+++ b/docs/book/how-to/steps-pipelines/advanced_features.md
@@ -53,6 +53,47 @@ model, accuracy = train_classifier.entrypoint(X_train=X_train, y_train=y_train)
 
 You can make this the default behavior by setting the `ZENML_RUN_SINGLE_STEPS_WITHOUT_STACK` environment variable to `True`.
 
+### Step signatures, definitions, and semantic types
+
+A ZenML step is usually written as a normal Python function at module level:
+
+```python
+from zenml import step
+
+@step
+def train_model(dataset_path: str, *, epochs: int = 10) -> None:
+    ...
+```
+
+Keyword-only arguments, like `epochs` in the example above, are supported and
+are treated as normal step inputs. This is useful when you want a call site to be
+explicit about important values. Variadic signatures such as `*args` and
+`**kwargs` are not valid step inputs because ZenML needs to know the step
+interface before the pipeline runs.
+
+For production code, define the underlying Python functions for your steps and
+pipelines at module level. They are easier to import, package, test, and review
+that way. If you need a factory-style pattern, you can wrap those top-level
+functions with `@step` or `@pipeline(dynamic=True)` inside another function, but
+the decorated function itself should still be importable from a module.
+
+You can also add semantic metadata to a step with `step_type`:
+
+```python
+from zenml import step
+from zenml.enums import StepType
+
+@step(step_type=StepType.LLM_CALL)
+def summarize_prompt(prompt: str) -> str:
+    ...
+```
+
+The current step types are `StepType.TOOL_CALL`, `StepType.LLM_CALL`, and
+`StepType.MEMORY_CALL`. Think of this as a label on the step run: it does not
+change how your Python function executes, but it gives the dashboard, DAG
+metadata, and downstream consumers a clearer story about what kind of work the
+step represents.
+
 ### Asynchronous Pipeline Execution
 
 By default, pipelines run synchronously, with terminal logs displaying as the pipeline builds and runs. You can change this behavior to run pipelines asynchronously (in the background):
@@ -112,7 +153,7 @@ from zenml import pipeline
 from zenml.enums import ExecutionMode
 
 # Use the decorator
-@pipeline(execution_mode=ExecutionMode.CONTINUE_ON_ERROR)
+@pipeline(execution_mode=ExecutionMode.CONTINUE_ON_FAILURE)
 def my_pipeline():
     ...
 

--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -63,6 +63,36 @@ def dynamic_pipeline():
 
 This allows you to modify step behavior based on runtime conditions or data.
 
+### Artifact name substitutions in dynamic pipelines
+
+Dynamic pipelines support the same artifact name substitutions as regular
+pipelines. This matters when a dynamically generated step has outputs whose
+names include runtime-friendly placeholders. The substituted artifact name is
+still a real output that you can pass to downstream steps.
+
+```python
+from typing import Annotated
+
+from zenml import ArtifactConfig, pipeline, step
+
+@step(substitutions={"suffix": "validated"})
+def produce() -> Annotated[int, ArtifactConfig(name="score_{suffix}")]:
+    return 1
+
+@step
+def consume(score: int) -> None:
+    print(score)
+
+@pipeline(dynamic=True)
+def dynamic_pipeline() -> None:
+    score = produce()
+    consume(score)
+```
+
+One caveat: when you use `child_pipeline.embed(...)`, the child pipeline's own
+configuration is not applied. That includes child-level `substitutions`; the
+parent run's configuration controls the steps that execute inline.
+
 ### Step Runtime Configuration
 
 You can control where a step executes by specifying its runtime:
@@ -543,5 +573,10 @@ The [`examples/hierarchical_doc_search_agent`](https://github.com/zenml-io/zenml
 - Spawning steps dynamically based on AI agent decisions
 
 Each `traverse_node` call appears as a separate step in the DAG, created at runtime based on what the agent decides to explore.
+
+Two other examples are useful when you want to see dynamic pipelines in more specialized settings:
+
+- [`examples/rlm_document_analysis`](https://github.com/zenml-io/zenml/tree/main/examples/rlm_document_analysis) shows a Recursive Language Model style document-analysis workflow. ZenML decides how many chunk-processing steps to create at runtime, while the LLM loop inside each chunk decides which typed search tools to use.
+- [`examples/optuna_hyperparameter_tuning`](https://github.com/zenml-io/zenml/tree/main/examples/optuna_hyperparameter_tuning) combines Optuna's ask API with ZenML dynamic pipelines. Optuna decides which hyperparameters to try next; ZenML runs the trials, tracks their artifacts and metadata, and can fan the work out in parallel.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/how-to/steps-pipelines/scheduling.md
+++ b/docs/book/how-to/steps-pipelines/scheduling.md
@@ -109,7 +109,7 @@ Show archived schedules on the CLI:
 zenml pipeline schedule list --is_archived=true
 ```
 
-Sow archived schedules on the SDK:
+Show archived schedules on the SDK:
 
 ```python
 from zenml.client import Client

--- a/docs/book/how-to/steps-pipelines/wait_resume.md
+++ b/docs/book/how-to/steps-pipelines/wait_resume.md
@@ -134,4 +134,18 @@ In ZenML Pro, the run should start resuming automatically after the wait conditi
 zenml pipeline runs resume <RUN_ID_OR_NAME>
 ```
 
+If manual resume fails, check the error message before retrying. The common
+causes are concrete:
+
+- The run is a child run. Resume the parent run ID shown in the error instead;
+  the parent is the run that can safely continue the whole nested execution
+  tree.
+- The run is not currently `PAUSED`. A run that is still running, already
+  completed, failed, or stopped cannot be resumed with this command.
+- The run still has an active wait condition. Resolve the wait condition first,
+  then resume the run.
+- ZenML can no longer find the snapshot or stack that the paused run needs in
+  order to continue. In that case, the run cannot be resumed until the missing
+  reference is restored or recreated.
+
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/user-guide/tutorial/hyper-parameter-tuning.md
+++ b/docs/book/user-guide/tutorial/hyper-parameter-tuning.md
@@ -117,7 +117,7 @@ For a deeper exploration of how to query past pipeline runs, see the [Inspecting
 
 ## Next steps
 
-* Replace the simple grid‑search with a more sophisticated tuner (e.g. `sklearn.model_selection.GridSearchCV` or [Optuna](https://optuna.org/)).
+* Replace the simple grid‑search with a more sophisticated tuner (e.g. `sklearn.model_selection.GridSearchCV` or [Optuna](https://optuna.org/)). For a complete Optuna example that uses ZenML dynamic pipelines for parallel trial execution, see [`examples/optuna_hyperparameter_tuning`](https://github.com/zenml-io/zenml/tree/main/examples/optuna_hyperparameter_tuning).
 * Deploy the winning model as an HTTP service using [Pipeline Deployments](https://docs.zenml.io/concepts/deployment) (recommended) or via the legacy [Model Deployer](https://docs.zenml.io/stacks/stack-components/model-deployers).
 * Move the pipeline to a [remote
   orchestrator](https://docs.zenml.io/stacks/orchestrators) to scale out the


### PR DESCRIPTION
## What this changes

This PR updates docs that had drifted from recent code changes and examples. It covers:

- trigger dispatch states, `max_runs`, platform event source/event names, and CLI examples
- repeatable stack components and flavor-specific CLI help
- step signatures, `step_type`, dynamic pipeline artifact substitutions, and related examples
- Run:AI per-step settings that were missing from the docs
- Pydantic/dataclass materializer behavior
- Kubernetes label sanitization, Helm secret env refs, repository directory env var, and wait/resume troubleshooting
- small stale-doc fixes such as an archived schedule typo and an execution mode enum typo

## Why

This was a docs drift audit against recent user-facing code changes from the last few months. The goal was to catch places where the code now supports behavior that the docs either omitted, described with stale examples, or made harder to discover.

## Validation

- `git diff --check`
- targeted `typos` run on the edited docs files

## Release notes

No release notes needed; docs-only cleanup.
