### PR TITLE
Add option to mount build cache during python package installation

### DIFF
--- a/docs/book/how-to/containerization/containerization.md
+++ b/docs/book/how-to/containerization/containerization.md
@@ -425,6 +425,21 @@ If you're using `uv` and specify a custom parent image or Dockerfile that does n
 `uv` installs the packages for the Python system installation. Depending on the parent image, you might also need to include `"break-system-packages": None` in the installer args as well to make it work.
 {% endhint %}
 
+To speed up repeated image builds, set `python_package_installer_cache_mount` to a BuildKit `--mount` spec. ZenML emits `RUN --mount=<value> ...` on the install steps and drops the default `--no-cache-dir` flag so the mount is actually used. The value is passed through verbatim, so any valid `--mount` spec works (e.g. `type=cache` or `type=bind`). Requires BuildKit to be enabled on the builder.
+
+```python
+# uv (default installer)
+docker_settings = DockerSettings(
+    python_package_installer_cache_mount="type=cache,target=/root/.cache/uv",
+)
+
+# pip
+docker_settings = DockerSettings(
+    python_package_installer="pip",
+    python_package_installer_cache_mount="type=cache,target=/root/.cache/pip",
+)
+```
+
 ### Using custom python executable
 
 To use a custom python executable, instead of a standard `python` you can use the `ZENML_CONTAINER_PYTHON_EXECUTABLE` environment 

--- a/src/zenml/config/docker_settings.py
+++ b/src/zenml/config/docker_settings.py
@@ -264,6 +264,15 @@ class DockerSettings(BaseSettings):
             stack component settings will be used.
         python_package_installer: The package installer to use for python
             packages.
+        python_package_installer_cache_mount: If set, this is rendered as the
+            value of a BuildKit `RUN --mount=<value>` instruction on the
+            package install steps, so the installer's cache is preserved
+            across builds. Requires BuildKit. The value is passed through
+            verbatim, so any valid `--mount` spec works (e.g. `type=cache` or
+            `type=bind`). When set, the default `--no-cache-dir` install
+            argument is dropped so the mount is actually used. Examples:
+            `type=cache,target=/root/.cache/uv` for the `uv` installer,
+            `type=cache,target=/root/.cache/pip` for the `pip` installer.
         python_package_installer_args: Arguments to pass to the python package
             installer.
         disable_automatic_requirements_detection: If set to True, ZenML will
@@ -336,6 +345,7 @@ class DockerSettings(BaseSettings):
     python_package_installer: PythonPackageInstaller = (
         PythonPackageInstaller.UV
     )
+    python_package_installer_cache_mount: Optional[str] = None
     python_package_installer_args: Dict[str, Any] = {}
     disable_automatic_requirements_detection: bool = True
     replicate_local_python_environment: Optional[

--- a/src/zenml/utils/pipeline_docker_image_builder.py
+++ b/src/zenml/utils/pipeline_docker_image_builder.py
@@ -770,6 +770,16 @@ class PipelineDockerImageBuilder:
             **default_installer_args,
             **docker_settings.python_package_installer_args,
         }
+
+        cache_mount = docker_settings.python_package_installer_cache_mount
+        if cache_mount:
+            # Drop the default --no-cache-dir argument if a cache mount is
+            # configured
+            installer_args.pop("no-cache-dir", None)
+            run_directive = f"RUN --mount={cache_mount}"
+        else:
+            run_directive = "RUN"
+
         installer_args_string = " ".join(
             f"--{key}" if value is None else f"--{key}={value}"
             for key, value in installer_args.items()
@@ -779,7 +789,7 @@ class PipelineDockerImageBuilder:
             option_string = " ".join(options)
 
             lines.append(
-                f"RUN {install_command} {installer_args_string}"
+                f"{run_directive} {install_command} {installer_args_string}"
                 f"{option_string} -r {file}"
             )
 
@@ -793,7 +803,7 @@ class PipelineDockerImageBuilder:
 
         if docker_settings.local_project_install_command:
             lines.append(
-                f"RUN {docker_settings.local_project_install_command}"
+                f"{run_directive} {docker_settings.local_project_install_command}"
             )
 
         if docker_settings.user:

--- a/tests/unit/utils/test_pipeline_docker_image_builder.py
+++ b/tests/unit/utils/test_pipeline_docker_image_builder.py
@@ -215,6 +215,62 @@ def test_python_package_installer_args():
     )
 
 
+def test_python_package_installer_cache_mount():
+    """Tests that the installer cache mount is rendered into the RUN line."""
+    requirements_files = [("requirements.txt", "numpy", [])]
+
+    # uv installer with cache mount: --mount is added and --no-cache-dir is
+    # dropped so the cache is actually used.
+    docker_settings = DockerSettings(
+        python_package_installer_cache_mount="type=cache,target=/root/.cache/uv",
+    )
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag",
+            docker_settings,
+            requirements_files=requirements_files,
+        )
+    )
+    assert (
+        "RUN --mount=type=cache,target=/root/.cache/uv uv pip install"
+        in generated_dockerfile
+    )
+    assert "-r requirements.txt" in generated_dockerfile
+    assert "--no-cache-dir" not in generated_dockerfile
+
+    # pip installer with cache mount.
+    docker_settings = DockerSettings(
+        python_package_installer="pip",
+        python_package_installer_cache_mount="type=cache,target=/root/.cache/pip",
+    )
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag",
+            docker_settings,
+            requirements_files=requirements_files,
+        )
+    )
+    assert (
+        "RUN --mount=type=cache,target=/root/.cache/pip pip install"
+        in generated_dockerfile
+    )
+    assert "--default-timeout=60" in generated_dockerfile
+    assert "--no-cache-dir" not in generated_dockerfile
+
+    # Without the cache mount, the default --no-cache-dir is kept and no
+    # --mount flag is rendered.
+    docker_settings = DockerSettings()
+    generated_dockerfile = (
+        PipelineDockerImageBuilder._generate_zenml_pipeline_dockerfile(
+            "image:tag",
+            docker_settings,
+            requirements_files=requirements_files,
+        )
+    )
+    assert "--mount=" not in generated_dockerfile
+    assert "--no-cache-dir" in generated_dockerfile
+
+
 def test_dockerfile_needs_to_exist():
     """Tests that an error gets raised if the Dockerfile specified in the
     DockerSettings does not exist."""


### PR DESCRIPTION
## Describe changes
This PR adds an option to mount a build cache when installing python packages in our automated Docker image building.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

