### PR TITLE
Fix PydanticAI agent example dependencies

### DIFF
--- a/examples/agent_framework_integrations/pydanticai/requirements.txt
+++ b/examples/agent_framework_integrations/pydanticai/requirements.txt
@@ -1,4 +1,4 @@
-pydantic-ai>=0.0.13
+pydantic-ai-slim[openai]>=0.0.13
 zenml[local]
 jinja2>=3.1.0
 secure>=0.3.0


### PR DESCRIPTION
## Description

Fixes the weekly agent examples failure for the PydanticAI example by depending on the OpenAI-only slim PydanticAI package instead of the full provider bundle.

The full `pydantic-ai` package now pulls in provider/logfire dependencies that conflict with ZenML's pinned `opentelemetry-sdk==1.38.0`. This example only uses OpenAI, so `pydantic-ai-slim[openai]` is sufficient and avoids the conflicting extras.

## Testing

- `uv venv --python 3.11 /tmp/zenml-pydanticai-verify/.venv`
- `VIRTUAL_ENV=/tmp/zenml-pydanticai-verify/.venv uv pip install -e /Users/strickvl/coding/zenml/repos/zenml -r examples/agent_framework_integrations/pydanticai/requirements.txt`
- Verified `from pydanticai_agent import agent` succeeds with a dummy `OPENAI_API_KEY`.

## Review notes

This intentionally only updates `examples/agent_framework_integrations/pydanticai/requirements.txt`; it does not touch the hierarchical doc search agent example.
