### PR TITLE
Only run DB backup/restore tests on local code version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ build-backend = "uv_build"
 # NOTE: when a version is filtered out, uv does NOT mention it — resolution
 # just fails with "no compatible version found". Keep this in mind when debugging.
 exclude-newer = "3 days"
+# Don't exclude our own package which is installed in some CI jobs.
+exclude-newer-package = { zenml = false }
 
 [tool.uv.build-backend]
 module-name = ["zenml", "zenml_cli"]

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -152,10 +152,8 @@ function run_tests_for_version() {
     # Confirm DB works and is accessible
     ZENML_LOGGING_VERBOSITY=INFO zenml pipeline runs list
 
-    # The database backup and restore feature is available since 0.55.1.
-    # However, it has been broken for various reasons up to and including
-    # 0.57.0, so we skip this test for those versions.
-    if [ "$VERSION" == "current" ] || [ "$(version_compare "$VERSION" "0.57.0")" == ">" ]; then
+    # Only test backup/restore on the current local code
+    if [ "$VERSION" == "current" ]; then
         echo "===== Testing database backup and restore (file dump) ====="
 
         pipelines_before_restore=$(ZENML_LOGGING_VERBOSITY=INFO zenml pipeline runs list --size 5000)


### PR DESCRIPTION
## Describe changes
Don't run the DB backup/restore for historic releases anymore, but only for the current local code checkout.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

