### PR TITLE
Fail a pipeline run if failing to import the user pipeline function

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -757,8 +757,8 @@ class DynamicPipelineRunner:
         """Run the pipeline.
 
         Raises:
-            Exception: If the pipeline run failed.
-        """  # noqa: DOC502
+            Exception: If loading the pipeline fails.
+        """
         self._state.id = threading.get_ident()
         logs_context: ContextManager[Any] = nullcontext()
         if is_pipeline_logging_enabled(self._snapshot.pipeline_configuration):
@@ -803,13 +803,19 @@ class DynamicPipelineRunner:
 
             assert self._snapshot.stack
 
+            try:
+                pipeline = self.pipeline
+            except Exception as e:
+                self._publish_run_status(exception=e)
+                raise
+
             with (
                 InMemoryArtifactCache(),
                 env_utils.temporary_runtime_environment(
                     self._snapshot.pipeline_configuration, self._snapshot.stack
                 ),
                 DynamicPipelineRunContext(
-                    pipeline=self.pipeline,
+                    pipeline=pipeline,
                     run=self._run,
                     snapshot=self._snapshot,
                     runner=self,
@@ -1735,9 +1741,12 @@ class DynamicPipelineRunner:
             exception: Exception that caused the run to fail.
         """
         if exception is not None:
+            pipeline_func = (
+                self._pipeline.entrypoint if self._pipeline else None
+            )
             exception_info = exception_utils.collect_exception_information(
                 exception=exception,
-                user_func=self.pipeline.entrypoint,
+                user_func=pipeline_func,
             )
             self._run = publish_failed_pipeline_run(
                 self._run.id, exception_info=exception_info


### PR DESCRIPTION
## Describe changes
If the importing of the user pipeline function failed (e.g. due to some packages being not installed), we would not catch it and the run would stay in `running` state. We now catch that, and fail the run instead.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

