### PR TITLE
Fix CLI page info formatting

### DIFF
--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -2754,8 +2754,8 @@ def print_page_info(page: "Page[Any]") -> None:
         page: The page object containing pagination information.
     """
     declare(
-        f"Page `({page.index}/{page.total_pages})`, "
-        f"`{page.total}` items found for the applied filters."
+        f"Page [cyan]({page.index}/{page.total_pages})[/cyan], "
+        f"[cyan]{page.total}[/cyan] items found for the applied filters."
     )
 
 

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,0 +1,31 @@
+import io
+
+import pytest
+from rich.console import Console
+
+from zenml.cli import utils as cli_utils
+from zenml.console import zenml_custom_theme
+from zenml.models import Page
+
+
+def test_print_page_info_does_not_render_backticks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = io.StringIO()
+    test_console = Console(
+        file=output,
+        force_terminal=False,
+        theme=zenml_custom_theme,
+        width=100,
+    )
+    monkeypatch.setattr(cli_utils, "console", test_console)
+
+    page = Page(index=1, max_size=10, total_pages=1, total=1, items=[])
+    cli_utils.print_page_info(page)
+
+    rendered_output = output.getvalue()
+    assert rendered_output == (
+        "Page (1/1), 1 items found for the applied filters.\n"
+    )
+    assert "`" not in rendered_output
+    assert "[cyan]" not in rendered_output


### PR DESCRIPTION
## Summary
- Replace literal Markdown-style backticks in the CLI pagination summary with Rich cyan markup.
- Preserve visual emphasis for the page/count values while ensuring no backticks are rendered in terminal output.
- Add a unit regression test for `print_page_info()` that captures rendered Rich console output.

## Root cause
`print_page_info()` used Markdown-style backticks around the page and item count, but `declare()` prints plain strings through Rich `console.print()`. Rich does not treat Markdown backticks as inline-code markup in this path, so the backticks were shown literally in commands like `zenml stack list`.

## Testing
- `uv run --extra local --with pytest --with pytest-mock pytest tests/unit/cli/test_utils.py -q`
- `uv run --with ruff bash scripts/format.sh --no-yamlfix src/zenml/cli/utils.py tests/unit/cli/test_utils.py`