### PR TITLE
Improved keyboard interrupt handling in active wait conditions

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -1388,7 +1388,7 @@ class DynamicPipelineRunner:
 
         Returns:
             The resolved wait condition value.
-        """
+        """  # noqa: DOC503
         from zenml.execution.pipeline.dynamic.run_context import (
             DynamicPipelineRunContext,
         )
@@ -1504,7 +1504,7 @@ class DynamicPipelineRunner:
                             time.sleep(poll_interval)
             except _WaitConditionAborted:
                 raise
-            except KeyboardInterrupt:
+            except KeyboardInterrupt as keyboard_interrupt:
                 try:
                     Client().zen_store.resolve_run_wait_condition(
                         run_wait_condition_id=condition.id,
@@ -1519,7 +1519,19 @@ class DynamicPipelineRunner:
                         condition.id,
                         e,
                     )
-                raise
+                    # When resolving a wait condition with `ABORT` resolution,
+                    # the server will transition the run to a `STOPPED` status.
+                    # This failed, which means we re-raise the
+                    # KeyboardInterrupt, which causes downstream code to publish
+                    # a `FAILED` run status.
+                    raise keyboard_interrupt
+                else:
+                    # Raise _WaitConditionAborted to signal that the wait
+                    # condition was aborted. Downstream code will not publish
+                    # a `FAILED` run status in this case.
+                    raise _WaitConditionAborted(
+                        f"Wait condition `{condition.name}` was aborted."
+                    ) from keyboard_interrupt
             except BaseException:
                 try:
                     Client().zen_store.update_run_wait_condition_lease(


### PR DESCRIPTION
## Describe changes
Previously, when an active wait condition received a `KeyboardInterrupt`, it would abort the wait condition (which causes the server to transition to `STOPPED` status). Then the `KeyboardInterrupt` was re-raised, which caused client-side code to try to publish a `FAILED` run status, which got rejected by the server and caused an unclear error message for the user.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

