### PR TITLE
Add experimental ZenBabel portable JSON steps

### DIFF
--- a/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
+++ b/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
@@ -1,0 +1,94 @@
+---
+description: >-
+  Experimental TypeScript step bodies through ZenBabel portable JSON execution.
+---
+
+# Experimental TypeScript steps with ZenBabel
+
+ZenBabel is an experimental execution path for running a non-Python step body inside an otherwise normal ZenML pipeline. The current proof point is deliberately small: a Python-controlled static pipeline can route one TypeScript step body through a portable JSON subprocess protocol.
+
+The short version is:
+
+- ZenML's control plane is still Python.
+- The orchestrator path is still the existing ZenML stack path.
+- The TypeScript step exchanges inputs, outputs, and parameters as JSON-compatible values only.
+- This is not yet a public TypeScript SDK.
+
+## What actually happens
+
+Think of the TypeScript process as a guest worker inside a normal ZenML step container. The house is still Python: ZenML creates the run, resolves upstream artifacts, starts the step, records status, and stores outputs. The guest worker only receives JSON files, does its work, writes JSON files back, and exits.
+
+```mermaid
+graph LR
+    A[Python control plane] --> B[ZenML orchestrator]
+    B --> C[Python step entrypoint]
+    C --> D[PortableStepRunner]
+    D --> E[TypeScript command]
+    E --> D
+    D --> F[ZenML artifact store]
+```
+
+For a mixed pipeline, the shape looks like this:
+
+```mermaid
+graph LR
+    A[Python load step] --> B[TypeScript portable step]
+    B --> C[Python summarize step]
+```
+
+The handoff between Python and TypeScript is the `zenml-portable-json-v1` contract:
+
+1. ZenML materializes upstream artifacts in Python.
+2. `PortableStepRunner` validates that those values are strict portable JSON.
+3. It writes input JSON files and a manifest file.
+4. It sets `ZENML_PORTABLE_STEP_MANIFEST` for the child process.
+5. The TypeScript command reads the manifest, reads inputs, writes outputs, and exits.
+6. ZenML reads the output JSON and stores it through existing Python materializers.
+
+## Current v1 scope
+
+Supported in the experimental path:
+
+- static pipeline snapshots,
+- TypeScript step bodies launched as subprocess commands,
+- JSON-compatible values: objects with string keys, arrays, strings, booleans, null, finite numbers, and JavaScript-safe integers,
+- existing ZenML artifact tracking after the TypeScript process returns JSON.
+
+Not supported yet:
+
+- Python-free pipeline definition or submission,
+- dynamic pipelines with portable steps,
+- non-JSON artifacts such as pandas DataFrames, NumPy arrays, model objects, images, files, pickle/cloudpickle payloads, custom materializers, metadata extraction, or visualizations across the language boundary,
+- a stable TypeScript SDK surface,
+- broad orchestrator-specific guarantees beyond the existing container entrypoint path.
+
+## Why the example has a small compiler bridge
+
+The runtime support and the importer are in place, but the public SDK does not yet expose a first-class way to write `typescript_step(...)` inside a Python `@pipeline`. The example therefore uses a narrow local bridge:
+
+1. Python compiles a normal static pipeline with a placeholder step.
+2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec.
+3. The bridge patches the compiled placeholder step with the portable `source` and `execution_spec`.
+4. The normal ZenML run path then sees `zenml-portable-json-v1` and routes the step to `PortableStepRunner`.
+
+That bridge is explanatory scaffolding, not the final SDK shape.
+
+## Try it
+
+See the repository example at:
+
+```text
+examples/zenbabel_mixed_static/
+```
+
+It contains:
+
+- a Python-controlled pipeline,
+- a TypeScript helper that reads `ZENML_PORTABLE_STEP_MANIFEST`,
+- a TypeScript scoring step,
+- a Dockerfile for a Python + ZenML + Node step image,
+- smoke-test instructions and Local Docker run instructions.
+
+Use this page and the example as a snapshot of the experimental v1 story. Future TypeScript SDK work may make the authoring experience cleaner, but it should preserve the same honest boundary: the current stable ZenML control plane is Python, and this portable path only moves a JSON-shaped step body across the language line.
+
+<figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
+++ b/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
@@ -90,6 +90,13 @@ It contains:
 - a Dockerfile for a Python + ZenML + Node step image,
 - smoke-test instructions and Local Docker run instructions.
 
+The full demo requires both pieces to be true:
+
+1. The active stack must be Docker-capable for this path, such as Local Docker with an image builder. The plain local orchestrator is not enough because it runs Python steps directly and does not use the TypeScript step's Docker settings.
+2. The active ZenML server/store must include this experimental branch schema. Older Cloud or staging servers can strip the new `StepSpec.execution_spec` field when the snapshot is saved and returned. If that happens, the TypeScript step reaches the normal Python runner as `PortableStepAdapter`, and the adapter correctly fails because it should only run through `PortableStepRunner`.
+
+For quick local validation without Docker or a compatible server, use the example's `--compile-only` mode. It checks that the compiler bridge creates the `zenml-portable-json-v1` execution spec before any server/store round trip.
+
 Use this page and the example as a snapshot of the experimental v1 story. Future TypeScript SDK work may make the authoring experience cleaner, but it should preserve the same honest boundary: the current stable ZenML control plane is Python, and this portable path only moves a JSON-shaped step body across the language line.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
+++ b/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
@@ -62,17 +62,17 @@ Not supported yet:
 - a stable TypeScript SDK surface,
 - broad orchestrator-specific guarantees beyond the existing container entrypoint path.
 
-## Why the example has a small compiler bridge
+## Why the example has an experimental authoring helper
 
-The runtime support and the importer are in place, but the public SDK does not yet expose a first-class way to write `typescript_step(...)` inside a Python `@pipeline`. The example therefore uses a narrow local bridge:
+The runtime support and the importer are in place, but the public SDK does not yet expose a first-class way to write `typescript_step(...)` inside a Python `@pipeline`. The example therefore uses a narrow experimental helper under `zenml.zenbabel`:
 
 1. Python compiles a normal static pipeline with a placeholder step.
-2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec.
-   In this example, the external TypeScript step spec is still authored as a small Python dictionary; a real TypeScript emitter or SDK is out of scope for v1.
-3. The bridge patches the compiled placeholder step with the portable `source` and `execution_spec`.
-4. The normal ZenML run path then sees `zenml-portable-json-v1` and routes the step to `PortableStepRunner`.
+2. `experimental_portable_json_step(...)` declares the TypeScript command, source identity, and JSON parameters for that placeholder invocation.
+3. `experimental_compile_snapshot(...)` or `experimental_submit_pipeline(...)` activates the compiler bridge while ZenML compiles or submits the pipeline.
+4. The bridge patches the compiled placeholder step with the portable `source` and `execution_spec`.
+5. The normal ZenML run path then sees `zenml-portable-json-v1` and routes the step to `PortableStepRunner`.
 
-That bridge is explanatory scaffolding, not the final SDK shape.
+That helper is cleanup scaffolding for the proof, not the final SDK shape. The `experimental_...` prefix is intentional: future TypeScript SDK work should replace this with a more deliberate API.
 
 ## Try it
 
@@ -103,7 +103,7 @@ If your local daemon was started before you switched to this worktree, restart i
 uv run zenml login --local --restart
 ```
 
-For quick local validation without Docker or a compatible server, use the example's `--compile-only` mode. It checks that the compiler bridge creates the `zenml-portable-json-v1` execution spec before any server/store round trip.
+For quick local validation without Docker or a compatible server, use the example's `--compile-only` mode. It checks that the experimental helper creates the `zenml-portable-json-v1` execution spec before any server/store round trip.
 
 Use this page and the example as a snapshot of the experimental v1 story. Future TypeScript SDK work may make the authoring experience cleaner, but it should preserve the same honest boundary: the current stable ZenML control plane is Python, and this portable path only moves a JSON-shaped step body across the language line.
 

--- a/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
+++ b/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
@@ -68,6 +68,7 @@ The runtime support and the importer are in place, but the public SDK does not y
 
 1. Python compiles a normal static pipeline with a placeholder step.
 2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec.
+   In this example, the external TypeScript step spec is still authored as a small Python dictionary; a real TypeScript emitter or SDK is out of scope for v1.
 3. The bridge patches the compiled placeholder step with the portable `source` and `execution_spec`.
 4. The normal ZenML run path then sees `zenml-portable-json-v1` and routes the step to `PortableStepRunner`.
 

--- a/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
+++ b/docs/book/how-to/steps-pipelines/zenbabel-typescript.md
@@ -92,8 +92,16 @@ It contains:
 
 The full demo requires both pieces to be true:
 
-1. The active stack must be Docker-capable for this path, such as Local Docker with an image builder. The plain local orchestrator is not enough because it runs Python steps directly and does not use the TypeScript step's Docker settings.
-2. The active ZenML server/store must include this experimental branch schema. Older Cloud or staging servers can strip the new `StepSpec.execution_spec` field when the snapshot is saved and returned. If that happens, the TypeScript step reaches the normal Python runner as `PortableStepAdapter`, and the adapter correctly fails because it should only run through `PortableStepRunner`.
+1. The active stack must be Docker-capable for this path, such as Local Docker with an image builder. The plain local orchestrator is not enough because it runs Python steps directly and does not use the demo pipeline's Docker settings. The demo image must contain the branch ZenML code for all steps, not only the TypeScript step, because the Python step module imports the experimental ZenBabel symbols.
+2. The active ZenML server/store must include this experimental branch schema. Older Cloud or staging servers can strip the new `StepSpec.execution_spec` field when the snapshot is saved and returned. The same thing can happen with a local daemon if it was started earlier from another virtual environment. If that happens, the TypeScript step reaches the normal Python runner as `PortableStepAdapter`, and the adapter correctly fails because it should only run through `PortableStepRunner`.
+
+For Local Docker, the example also rewrites a local store URL from `127.0.0.1` or `localhost` to `host.docker.internal` inside the step environment. Without that rewrite, the container phones its own loopback address instead of the host ZenML server. The demo also disables step heartbeat because portable JSON v1 does not support heartbeat yet.
+
+If your local daemon was started before you switched to this worktree, restart it from the ZenBabel branch environment:
+
+```bash
+uv run zenml login --local --restart
+```
 
 For quick local validation without Docker or a compatible server, use the example's `--compile-only` mode. It checks that the compiler bridge creates the `zenml-portable-json-v1` execution spec before any server/store round trip.
 

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -42,6 +42,7 @@
   * [YAML Configuration](how-to/steps-pipelines/yaml_configuration.md)
   * [Source Code and Imports](how-to/steps-pipelines/sources.md)
   * [Execution](how-to/steps-pipelines/execution.md)
+  * [Experimental TypeScript steps with ZenBabel](how-to/steps-pipelines/zenbabel-typescript.md)
   * [Wait for External Input](how-to/steps-pipelines/wait_resume.md)
   * [Advanced Features](how-to/steps-pipelines/advanced_features.md)
   * [Dynamic Pipelines](how-to/steps-pipelines/dynamic_pipelines.md)

--- a/examples/zenbabel_mixed_static/.gitignore
+++ b/examples/zenbabel_mixed_static/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/examples/zenbabel_mixed_static/Dockerfile
+++ b/examples/zenbabel_mixed_static/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:20-bookworm-slim AS node
-FROM python:3.12-slim-bookworm
+ARG ZENBABEL_IMAGE_PLATFORM=linux/amd64
+FROM --platform=${ZENBABEL_IMAGE_PLATFORM} node:20-bookworm-slim AS node
+FROM --platform=${ZENBABEL_IMAGE_PLATFORM} python:3.12-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -17,7 +18,7 @@ WORKDIR /work/zenml
 COPY pyproject.toml README.md ./
 COPY src ./src
 RUN python -m pip install --no-cache-dir uv \
-    && uv pip install --system -e ".[local]"
+    && uv pip install --system -e ".[local,s3fs,connectors-aws]"
 
 WORKDIR /app
 RUN mkdir -p /app/.config /app/.zenconfig && chmod -R a+rw /app

--- a/examples/zenbabel_mixed_static/Dockerfile
+++ b/examples/zenbabel_mixed_static/Dockerfile
@@ -1,25 +1,26 @@
-FROM python:3.12-slim
+FROM node:20-bookworm-slim AS node
+FROM python:3.12-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    UV_SYSTEM_PYTHON=1
+    UV_SYSTEM_PYTHON=1 \
+    HOME=/app \
+    XDG_CONFIG_HOME=/app/.config \
+    ZENML_CONFIG_PATH=/app/.zenconfig
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-        git \
-        nodejs \
-        npm \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 WORKDIR /work/zenml
 COPY pyproject.toml README.md ./
 COPY src ./src
 RUN python -m pip install --no-cache-dir uv \
-    && uv pip install --system -e .
+    && uv pip install --system -e ".[local]"
 
 WORKDIR /app
+RUN mkdir -p /app/.config /app/.zenconfig && chmod -R a+rw /app
 COPY examples/zenbabel_mixed_static/package.json ./package.json
 COPY examples/zenbabel_mixed_static/package-lock.json ./package-lock.json
 COPY examples/zenbabel_mixed_static/tsconfig.json ./tsconfig.json

--- a/examples/zenbabel_mixed_static/Dockerfile
+++ b/examples/zenbabel_mixed_static/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_SYSTEM_PYTHON=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        nodejs \
+        npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work/zenml
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN python -m pip install --no-cache-dir uv \
+    && uv pip install --system -e .
+
+WORKDIR /app
+COPY examples/zenbabel_mixed_static/package.json ./package.json
+COPY examples/zenbabel_mixed_static/package-lock.json ./package-lock.json
+COPY examples/zenbabel_mixed_static/tsconfig.json ./tsconfig.json
+COPY examples/zenbabel_mixed_static/ts ./ts
+RUN npm ci && npm run build

--- a/examples/zenbabel_mixed_static/Dockerfile.dockerignore
+++ b/examples/zenbabel_mixed_static/Dockerfile.dockerignore
@@ -1,0 +1,14 @@
+*
+!/README.md
+!/pyproject.toml
+!/src/
+!/src/**
+/src/zenml/zen_server/dashboard/
+/src/zenml/zen_server/dashboard/**
+!/examples/
+!/examples/zenbabel_mixed_static/
+!/examples/zenbabel_mixed_static/package.json
+!/examples/zenbabel_mixed_static/package-lock.json
+!/examples/zenbabel_mixed_static/tsconfig.json
+!/examples/zenbabel_mixed_static/ts/
+!/examples/zenbabel_mixed_static/ts/**

--- a/examples/zenbabel_mixed_static/README.md
+++ b/examples/zenbabel_mixed_static/README.md
@@ -77,23 +77,23 @@ ZenBabel portable JSON v1 does **not** support:
 
 ## Why there is a Python placeholder step
 
-ZenML does not yet expose a public API where a Python pipeline can directly call a TypeScript step. This example therefore uses a small demo-only compiler bridge:
+ZenML does not yet expose a public API where a Python pipeline can directly call a TypeScript step. This example therefore uses a tiny experimental authoring helper from `zenml.zenbabel`:
 
 1. The Python pipeline is compiled normally with a placeholder Python step named `score_or_transform`.
-2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec and creates a portable ZenML step description.
-   In this example, the external TypeScript step spec is still authored as a small Python dictionary; a real TypeScript emitter or SDK is out of scope for v1.
-3. During compilation, the bridge patches only two fields on the compiled placeholder step:
+2. `experimental_portable_json_step(...)` declares the TypeScript command, source identity, and JSON parameters for that placeholder invocation.
+3. `experimental_compile_snapshot(...)` and `experimental_submit_pipeline(...)` activate a compiler bridge while ZenML compiles the pipeline.
+4. During compilation, the bridge patches only two fields on the compiled placeholder step:
    - `spec.source`, so the step points at `PortableStepAdapter` instead of the placeholder Python function.
    - `spec.execution_spec`, so `StepLauncher` routes the step to `PortableStepRunner`.
-4. The bridge keeps the normal compiled inputs, upstreams, output shape, parameters, and Docker settings.
+5. The bridge keeps the normal compiled inputs, upstreams, output shape, parameters, and Docker settings.
 
-In other words: the normal Python compiler builds the train tracks, and ZenBabel swaps the engine for one step.
+In other words: the normal Python compiler builds the train tracks, and ZenBabel swaps the engine for one step. The helper is intentionally marked `experimental_...`; it is cleanup scaffolding for this proof, not a stable TypeScript SDK.
 
 ## Files
 
 ```text
 zenbabel_mixed_static/
-├── run.py                         # Python pipeline and demo compiler bridge
+├── run.py                         # Python pipeline and experimental helper usage
 ├── Dockerfile                     # Python + ZenML + Node image for the TS step
 ├── package.json                   # TypeScript build/smoke scripts
 ├── package-lock.json              # Reproducible TypeScript tool install
@@ -124,7 +124,7 @@ From the repository root, with the feature branch installed in your environment:
 uv run python examples/zenbabel_mixed_static/run.py --compile-only
 ```
 
-This compiles the Python pipeline with the demo bridge active and checks that `score_or_transform` was routed to `zenml-portable-json-v1` while preserving the Python `load_data` upstream wiring.
+This compiles the Python pipeline with the experimental ZenBabel authoring helper active and checks that `score_or_transform` was routed to `zenml-portable-json-v1` while preserving the Python `load_data` upstream wiring.
 
 ## Run with Local Docker
 

--- a/examples/zenbabel_mixed_static/README.md
+++ b/examples/zenbabel_mixed_static/README.md
@@ -1,0 +1,174 @@
+# ZenBabel mixed static pipeline
+
+This example demonstrates the experimental ZenBabel portable JSON path with a small mixed-language static pipeline:
+
+```text
+Python load_data → TypeScript score_or_transform → Python summarize
+```
+
+The important claim is deliberately narrow: **the TypeScript step body runs, but the ZenML control plane is still Python**. Python still defines and submits the pipeline, the active ZenML stack still schedules the step containers, and ZenML still loads and stores artifacts through the existing Python materializer path.
+
+## Why this matters
+
+The useful v1 story is: a team can keep ZenML's existing Python orchestration model, but move one simple step body into another language when that language is a better fit. Imagine a frontend/platform team already owns a small TypeScript scoring rule. ZenBabel lets ZenML run that rule as a step without asking the team to rewrite it in Python first.
+
+For now, the bridge is intentionally small. The step boundary is JSON files, not arbitrary Python objects.
+
+## What this example proves
+
+The pipeline has three steps:
+
+```mermaid
+graph LR
+    A[Python step<br/>load_data] --> B[TypeScript step body<br/>score_or_transform]
+    B --> C[Python step<br/>summarize]
+```
+
+The data crossing the language boundary is JSON-compatible only:
+
+1. `load_data` returns a `list[dict[str, Any]]`.
+2. `PortableStepRunner` materializes that Python artifact, validates that it is strict portable JSON, and writes it to an input JSON file.
+3. The TypeScript process reads `ZENML_PORTABLE_STEP_MANIFEST`, reads the input JSON file, writes the output JSON file, and exits.
+4. `PortableStepRunner` reads the output JSON back into Python and stores it through ZenML's normal built-in materializers.
+5. `summarize` consumes the TypeScript output as an ordinary ZenML artifact.
+
+## Runtime path
+
+With the Local Docker orchestrator, the outer container path is unchanged. The step container still starts the normal ZenML Python entrypoint. The switch happens inside the step launcher:
+
+```mermaid
+sequenceDiagram
+    participant O as Local Docker orchestrator
+    participant E as python -m zenml.entrypoints.entrypoint
+    participant L as StepLauncher
+    participant P as PortableStepRunner
+    participant T as node /app/dist/steps/score_or_transform.js
+
+    O->>E: start step container
+    E->>L: run score_or_transform step
+    L->>P: execution_spec.protocol = zenml-portable-json-v1
+    P->>P: materialize inputs and write manifest JSON
+    P->>T: set ZENML_PORTABLE_STEP_MANIFEST and run command
+    T->>T: read input JSON, score records, write output JSON
+    T-->>P: exit 0
+    P->>P: read output JSON and store ZenML artifact
+```
+
+## What v1 supports
+
+This example is honest about the current scope:
+
+- Static pipelines only.
+- TypeScript step body only, not a full TypeScript SDK.
+- Python-backed ZenML control plane.
+- JSON-compatible inputs, outputs, and parameters only.
+- Existing Python materializers store the artifacts after the TypeScript process returns JSON.
+- Local Docker is the intended end-to-end demo path.
+
+## What v1 does not support
+
+ZenBabel portable JSON v1 does **not** support:
+
+- Python-free pipeline submission.
+- Dynamic pipelines with portable steps.
+- pandas, NumPy, model objects, images, files, pickle/cloudpickle, or custom materializers across the TypeScript boundary.
+- A stable public TypeScript SDK.
+- Broad orchestrator-specific behavior beyond the existing container entrypoint path.
+
+## Why there is a Python placeholder step
+
+ZenML does not yet expose a public API where a Python pipeline can directly call a TypeScript step. This example therefore uses a small demo-only compiler bridge:
+
+1. The Python pipeline is compiled normally with a placeholder Python step named `score_or_transform`.
+2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec and creates a portable ZenML step description.
+3. During compilation, the bridge patches only two fields on the compiled placeholder step:
+   - `spec.source`, so the step points at `PortableStepAdapter` instead of the placeholder Python function.
+   - `spec.execution_spec`, so `StepLauncher` routes the step to `PortableStepRunner`.
+4. The bridge keeps the normal compiled inputs, upstreams, output shape, parameters, and Docker settings.
+
+In other words: the normal Python compiler builds the train tracks, and ZenBabel swaps the engine for one step.
+
+## Files
+
+```text
+zenbabel_mixed_static/
+├── run.py                         # Python pipeline and demo compiler bridge
+├── Dockerfile                     # Python + ZenML + Node image for the TS step
+├── package.json                   # TypeScript build/smoke scripts
+├── package-lock.json              # Reproducible TypeScript tool install
+├── tsconfig.json
+└── ts/src/
+    ├── portable.ts                # Manifest/input/output helper
+    ├── smoke.ts                   # Local TypeScript smoke test
+    └── steps/score_or_transform.ts
+```
+
+## Run the TypeScript smoke test
+
+From this directory:
+
+```bash
+npm ci
+npm run build
+npm run smoke
+```
+
+This does not start ZenML. It proves that the TypeScript helper can read a portable manifest, read input JSON, execute the step body, and write output JSON.
+
+## Compile the ZenML snapshot without Docker
+
+From the repository root, with the feature branch installed in your environment:
+
+```bash
+uv run python examples/zenbabel_mixed_static/run.py --compile-only
+```
+
+This compiles the Python pipeline with the demo bridge active and checks that `score_or_transform` was routed to `zenml-portable-json-v1` while preserving the Python `load_data` upstream wiring.
+
+## Run with Local Docker
+
+The intended end-to-end path uses a stack with the Local Docker orchestrator and a local artifact store. The TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`.
+
+```bash
+# From the repository root
+# Use an existing stack whose orchestrator flavor is `local_docker`, or create one.
+zenml orchestrator register zenbabel_local_docker --flavor=local_docker
+zenml stack register zenbabel_local_docker_stack \
+  -o zenbabel_local_docker \
+  -a <your-local-artifact-store> \
+  --set
+
+uv run python examples/zenbabel_mixed_static/run.py
+```
+
+The Dockerfile builds an image that contains:
+
+- Python 3.12,
+- the current ZenML worktree installed from `src/`, including the ZenBabel feature branch code,
+- Node/npm,
+- the compiled TypeScript step under `/app/dist/steps/score_or_transform.js`.
+
+If Docker is too heavy for your local machine or the stack is not configured, run the TypeScript smoke test and the `--compile-only` check instead. Those checks prove the portable contract and the Python snapshot routing, but they do not prove container execution.
+
+## The portable manifest contract
+
+`PortableStepRunner` writes a temporary manifest and sets:
+
+```text
+ZENML_PORTABLE_STEP_MANIFEST=/tmp/.../manifest.json
+```
+
+The manifest shape used by the TypeScript helper is:
+
+```json
+{
+  "protocol": "zenml-portable-json-v1",
+  "step_name": "score_or_transform",
+  "source_identity": "examples/zenbabel_mixed_static/ts/src/steps/score_or_transform.ts#scoreOrTransform",
+  "parameters": {"threshold": 0.64},
+  "inputs": {"records": "/tmp/.../inputs/input_0.json"},
+  "outputs": {"output": "/tmp/.../outputs/output_0.json"}
+}
+```
+
+The TypeScript process must exit with code `0` after writing every expected output. If it exits non-zero, writes invalid JSON, or misses an output file, the ZenML step fails through normal step failure handling.

--- a/examples/zenbabel_mixed_static/README.md
+++ b/examples/zenbabel_mixed_static/README.md
@@ -128,7 +128,10 @@ This compiles the Python pipeline with the demo bridge active and checks that `s
 
 ## Run with Local Docker
 
-The intended end-to-end path uses a stack with the Local Docker orchestrator, a local artifact store, and a local image builder. The image builder is required because the TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`, so ZenML must be able to build that step image before Local Docker runs it.
+The intended end-to-end path has two requirements:
+
+1. A Docker-capable stack for this demo, specifically a stack with the Local Docker orchestrator, a local artifact store, and a local image builder. The image builder is required because the TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`, so ZenML must be able to build that step image before Local Docker runs it. The plain local orchestrator is not enough: it runs Python steps directly and ignores these Docker settings.
+2. A ZenML server/store that includes this branch's experimental portable execution schema. If you are connected to an older Cloud or staging server, the server/store can accept the snapshot but strip the new `StepSpec.execution_spec` field on the way back. The next thing that happens is concrete but confusing: the step reaches the normal Python `StepRunner` as `PortableStepAdapter`, and the adapter raises that it must not be executed as a normal Python step. Run the full demo against a local ZenML server/store or a backend deployed from this branch.
 
 ```bash
 # From the repository root

--- a/examples/zenbabel_mixed_static/README.md
+++ b/examples/zenbabel_mixed_static/README.md
@@ -81,6 +81,7 @@ ZenML does not yet expose a public API where a Python pipeline can directly call
 
 1. The Python pipeline is compiled normally with a placeholder Python step named `score_or_transform`.
 2. `zenml.zenbabel.build_steps(...)` imports the external TypeScript step spec and creates a portable ZenML step description.
+   In this example, the external TypeScript step spec is still authored as a small Python dictionary; a real TypeScript emitter or SDK is out of scope for v1.
 3. During compilation, the bridge patches only two fields on the compiled placeholder step:
    - `spec.source`, so the step points at `PortableStepAdapter` instead of the placeholder Python function.
    - `spec.execution_spec`, so `StepLauncher` routes the step to `PortableStepRunner`.
@@ -127,15 +128,19 @@ This compiles the Python pipeline with the demo bridge active and checks that `s
 
 ## Run with Local Docker
 
-The intended end-to-end path uses a stack with the Local Docker orchestrator and a local artifact store. The TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`.
+The intended end-to-end path uses a stack with the Local Docker orchestrator, a local artifact store, and a local image builder. The image builder is required because the TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`, so ZenML must be able to build that step image before Local Docker runs it.
 
 ```bash
 # From the repository root
-# Use an existing stack whose orchestrator flavor is `local_docker`, or create one.
+# Use an existing stack with local_docker, local artifact store, and local image builder,
+# or create/register the missing pieces.
 zenml orchestrator register zenbabel_local_docker --flavor=local_docker
+zenml artifact-store register zenbabel_local_artifact_store --flavor=local
+zenml image-builder register zenbabel_local_image_builder --flavor=local
 zenml stack register zenbabel_local_docker_stack \
   -o zenbabel_local_docker \
-  -a <your-local-artifact-store> \
+  -a zenbabel_local_artifact_store \
+  -i zenbabel_local_image_builder \
   --set
 
 uv run python examples/zenbabel_mixed_static/run.py

--- a/examples/zenbabel_mixed_static/README.md
+++ b/examples/zenbabel_mixed_static/README.md
@@ -130,8 +130,13 @@ This compiles the Python pipeline with the demo bridge active and checks that `s
 
 The intended end-to-end path has two requirements:
 
-1. A Docker-capable stack for this demo, specifically a stack with the Local Docker orchestrator, a local artifact store, and a local image builder. The image builder is required because the TypeScript step has step-level `DockerSettings` pointing at the example `Dockerfile`, so ZenML must be able to build that step image before Local Docker runs it. The plain local orchestrator is not enough: it runs Python steps directly and ignores these Docker settings.
-2. A ZenML server/store that includes this branch's experimental portable execution schema. If you are connected to an older Cloud or staging server, the server/store can accept the snapshot but strip the new `StepSpec.execution_spec` field on the way back. The next thing that happens is concrete but confusing: the step reaches the normal Python `StepRunner` as `PortableStepAdapter`, and the adapter raises that it must not be executed as a normal Python step. Run the full demo against a local ZenML server/store or a backend deployed from this branch.
+1. A Docker-capable stack for this demo, specifically a stack with the Local Docker orchestrator, a local artifact store, and a local image builder. The image builder is required because the pipeline has `DockerSettings` pointing at the example `Dockerfile`, so ZenML must be able to build an image that contains the branch ZenML code and the compiled TypeScript step. The plain local orchestrator is not enough: it runs Python steps directly and ignores these Docker settings.
+2. A ZenML server/store that includes this branch's experimental portable execution schema. If you are connected to an older Cloud or staging server, the server/store can accept the snapshot but strip the new `StepSpec.execution_spec` field on the way back. The same thing can happen with a local daemon if it was started earlier from another virtual environment. The next thing that happens is concrete but confusing: the step reaches the normal Python `StepRunner` as `PortableStepAdapter`, and the adapter raises that it must not be executed as a normal Python step. Run the full demo against a local ZenML server/store started from this worktree, or a backend deployed from this branch.
+
+The example also applies two Local Docker-specific settings in `run.py`:
+
+- Step containers cannot reach the host server through `127.0.0.1`, because inside Docker that address means "this container". When the active store URL is local, the example passes `ZENML_STORE_URL=http://host.docker.internal:<port>` to the step environment instead.
+- Portable JSON v1 does not support step heartbeat yet, so the demo disables heartbeat at the pipeline level. This keeps the example focused on the JSON subprocess contract.
 
 ```bash
 # From the repository root
@@ -146,14 +151,19 @@ zenml stack register zenbabel_local_docker_stack \
   -i zenbabel_local_image_builder \
   --set
 
+# Restart the local daemon from this worktree's environment so the server
+# understands the experimental StepSpec.execution_spec field.
+uv run zenml login --local --restart
+
 uv run python examples/zenbabel_mixed_static/run.py
 ```
 
-The Dockerfile builds an image that contains:
+The Dockerfile builds one demo image used by all steps. It contains:
 
 - Python 3.12,
-- the current ZenML worktree installed from `src/`, including the ZenBabel feature branch code,
-- Node/npm,
+- the current ZenML worktree installed from `src/`, including the ZenBabel feature branch code and local stack dependencies,
+- Node/npm copied from the official Node image, avoiding `apt-get` during the demo image build,
+- writable config directories under `/app`, so the container user does not try to write ZenML config under `/.config`,
 - the compiled TypeScript step under `/app/dist/steps/score_or_transform.js`.
 
 If Docker is too heavy for your local machine or the stack is not configured, run the TypeScript smoke test and the `--compile-only` check instead. Those checks prove the portable contract and the Python snapshot routing, but they do not prove container execution.

--- a/examples/zenbabel_mixed_static/package-lock.json
+++ b/examples/zenbabel_mixed_static/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "zenbabel-mixed-static",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zenbabel-mixed-static",
+      "devDependencies": {
+        "@types/node": "^20.12.12",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/zenbabel_mixed_static/package.json
+++ b/examples/zenbabel_mixed_static/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "zenbabel-mixed-static",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "smoke": "node dist/smoke.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "typescript": "^5.4.5"
+  }
+}

--- a/examples/zenbabel_mixed_static/run.py
+++ b/examples/zenbabel_mixed_static/run.py
@@ -30,10 +30,14 @@ from typing import Any, Iterator, Mapping
 
 import zenml.pipelines.pipeline_definition as pipeline_definition_module
 from zenml import pipeline, step
+from zenml.client import Client
 from zenml.config import DockerSettings
 from zenml.config.compiler import Compiler as BaseCompiler
 from zenml.config.step_configurations import Step
 from zenml.config.step_execution_spec import StepExecutionProtocol
+from zenml.execution.pipeline.utils import submit_pipeline
+from zenml.models import PipelineSnapshotResponse
+from zenml.pipelines.run_utils import create_placeholder_run
 from zenml.zenbabel import build_pipeline_spec, build_steps
 
 EXAMPLE_DIR = Path(__file__).resolve().parent
@@ -169,19 +173,67 @@ def zenbabel_compiler_bridge() -> Iterator[None]:
         pipeline_definition_module.Compiler = original_compiler
 
 
+def _validate_portable_execution_spec(
+    snapshot: PipelineSnapshotResponse,
+) -> None:
+    """Check that the portable step survived snapshot persistence."""
+    portable_step = snapshot.step_configurations[PORTABLE_STEP_NAME]
+    execution_spec = portable_step.spec.execution_spec
+    if (
+        execution_spec is None
+        or execution_spec.protocol
+        != StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+    ):
+        raise RuntimeError(
+            "The ZenBabel demo compiled `score_or_transform` as a portable "
+            "TypeScript step, but the created snapshot returned by the "
+            "active ZenML server/store no longer contains "
+            "`spec.execution_spec = zenml-portable-json-v1`. This usually "
+            "means you are connected to an older ZenML server, for example "
+            "Cloud/staging, that does not include this experimental branch "
+            "schema and stripped the field during the server/store round "
+            "trip. Run this branch against a local ZenML server/store, or a "
+            "backend deployed from this branch, before running the full demo."
+        )
+
+
+def _validate_local_docker_stack() -> None:
+    """Check that the active stack can run the TypeScript Docker step."""
+    stack = Client().active_stack
+    orchestrator = stack.orchestrator
+    if orchestrator.flavor != "local_docker":
+        raise RuntimeError(
+            "The ZenBabel mixed static demo needs the Local Docker "
+            "orchestrator because the TypeScript step uses step-level "
+            "Docker settings to build and run a Node-enabled image. The "
+            f"active stack `{stack.name}` uses orchestrator "
+            f"`{orchestrator.name}` with flavor `{orchestrator.flavor}`. "
+            "Set a stack with a `local_docker` orchestrator and a local image "
+            "builder, or run `uv run python "
+            "examples/zenbabel_mixed_static/run.py --compile-only` instead."
+        )
+    if stack.image_builder is None:
+        raise RuntimeError(
+            "The ZenBabel mixed static demo needs an image builder on the "
+            "active stack. The TypeScript step has Docker settings pointing "
+            "at `examples/zenbabel_mixed_static/Dockerfile`, so ZenML must "
+            "build that step image before Local Docker can run it. Register "
+            "and set a stack with a local image builder, or run "
+            "`uv run python examples/zenbabel_mixed_static/run.py "
+            "--compile-only` instead."
+        )
+
+
 def compile_demo_snapshot() -> None:
     """Compile the demo and print the patched TypeScript step contract."""
     with zenbabel_compiler_bridge():
         zenbabel_mixed_static.prepare()
         snapshot, _, _ = zenbabel_mixed_static._compile()
 
+    _validate_portable_execution_spec(snapshot)
     portable_step = snapshot.step_configurations[PORTABLE_STEP_NAME]
     execution_spec = portable_step.spec.execution_spec
     assert execution_spec is not None
-    assert (
-        execution_spec.protocol
-        == StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
-    )
     assert portable_step.spec.inputs["records"].step_name == "load_data"
     assert portable_step.spec.upstream_steps == ["load_data"]
     assert "docker" in portable_step.config.settings
@@ -196,8 +248,14 @@ def compile_demo_snapshot() -> None:
 
 def run_pipeline() -> None:
     """Run the mixed-language pipeline on the active ZenML stack."""
+    _validate_local_docker_stack()
     with zenbabel_compiler_bridge():
-        zenbabel_mixed_static()
+        zenbabel_mixed_static.prepare()
+        snapshot = zenbabel_mixed_static._create_snapshot()
+
+    _validate_portable_execution_spec(snapshot)
+    run = create_placeholder_run(snapshot=snapshot)
+    submit_pipeline(snapshot=snapshot, stack=Client().active_stack, placeholder_run=run)
 
 
 def main() -> None:

--- a/examples/zenbabel_mixed_static/run.py
+++ b/examples/zenbabel_mixed_static/run.py
@@ -1,0 +1,222 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Mixed Python + TypeScript ZenBabel static pipeline example.
+
+This file intentionally keeps the bridge small and local to the example. ZenML
+can already execute portable JSON steps once a compiled step contains a
+``StepExecutionSpec``. What ZenML does not have yet is a public TypeScript step
+SDK that lets users call a TypeScript step directly from a Python ``@pipeline``.
+
+The example therefore uses a normal Python placeholder step for graph building,
+then swaps only that placeholder's compiled source/execution metadata for the
+portable metadata produced by ``zenml.zenbabel.build_steps``.
+"""
+
+import argparse
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+import zenml.pipelines.pipeline_definition as pipeline_definition_module
+from zenml import pipeline, step
+from zenml.config import DockerSettings
+from zenml.config.compiler import Compiler as BaseCompiler
+from zenml.config.step_configurations import Step
+from zenml.config.step_execution_spec import StepExecutionProtocol
+from zenml.zenbabel import build_pipeline_spec, build_steps
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EXAMPLE_DIR.parents[1]
+PORTABLE_STEP_NAME = "score_or_transform"
+DEFAULT_THRESHOLD = 0.64
+
+
+def _typescript_docker_settings() -> DockerSettings:
+    """Return the Docker settings for the TypeScript step image."""
+    return DockerSettings(
+        dockerfile=str(EXAMPLE_DIR / "Dockerfile"),
+        build_context_root=str(REPO_ROOT),
+        disable_automatic_requirements_detection=True,
+        prevent_build_reuse=True,
+    )
+
+
+@step
+def load_data() -> list[dict[str, Any]]:
+    """Load a tiny JSON-shaped dataset in Python."""
+    return [
+        {"id": "order-001", "feature": 0.12, "segment": "small"},
+        {"id": "order-002", "feature": 0.71, "segment": "enterprise"},
+        {"id": "order-003", "feature": 0.49, "segment": "small"},
+    ]
+
+
+@step(settings={"docker": _typescript_docker_settings()})
+def score_or_transform(
+    records: list[dict[str, Any]], threshold: float = DEFAULT_THRESHOLD
+) -> dict[str, Any]:
+    """Placeholder compiled as a normal step, then routed to TypeScript."""
+    raise RuntimeError(
+        "The Python placeholder step `score_or_transform` should have been "
+        "replaced by the ZenBabel demo compiler bridge. If you see this, run "
+        "the pipeline through `zenbabel_compiler_bridge()`."
+    )
+
+
+@step
+def summarize(scored_bundle: dict[str, Any]) -> dict[str, Any]:
+    """Summarize the TypeScript step output back in Python."""
+    records = scored_bundle["records"]
+    accepted = [record for record in records if record["label"] == "accept"]
+    summary = {
+        "total_records": len(records),
+        "accepted_records": len(accepted),
+        "threshold": scored_bundle["metadata"]["threshold"],
+        "accepted_ids": [record["id"] for record in accepted],
+    }
+    print(f"Python summary received TypeScript output: {summary}")
+    return summary
+
+
+@pipeline(enable_cache=False)
+def zenbabel_mixed_static() -> None:
+    """Python control-plane pipeline with one TypeScript step body."""
+    records = load_data()
+    scored_bundle = score_or_transform(records, threshold=DEFAULT_THRESHOLD)
+    summarize(scored_bundle)
+
+
+def _zenbabel_external_spec() -> dict[str, Any]:
+    """Return the external TypeScript step spec used by the demo bridge."""
+    return {
+        "name": "zenbabel_mixed_static",
+        "steps": [
+            {
+                "name": PORTABLE_STEP_NAME,
+                "command": [
+                    "node",
+                    "/app/dist/steps/score_or_transform.js",
+                ],
+                "source_identity": (
+                    "examples/zenbabel_mixed_static/ts/src/steps/"
+                    "score_or_transform.ts#scoreOrTransform"
+                ),
+                "parameters": {"threshold": DEFAULT_THRESHOLD},
+                "outputs": ["output"],
+            }
+        ],
+        "outputs": [{"step": PORTABLE_STEP_NAME, "output": "output"}],
+    }
+
+
+class ZenBabelDemoCompiler(BaseCompiler):
+    """Example-local compiler that donates portable metadata to one step."""
+
+    def __init__(self, portable_steps: Mapping[str, Step]) -> None:
+        """Initialize the compiler bridge.
+
+        Args:
+            portable_steps: Portable metadata donor steps keyed by invocation id.
+        """
+        super().__init__()
+        self._portable_steps = portable_steps
+
+    def _compile_step_invocation(self, *args: Any, **kwargs: Any) -> Step:
+        """Compile normally, then route selected invocations to ZenBabel."""
+        compiled_step = super()._compile_step_invocation(*args, **kwargs)
+        portable_step = self._portable_steps.get(compiled_step.spec.invocation_id)
+        if portable_step is None:
+            return compiled_step
+
+        patched_spec = compiled_step.spec.model_copy(
+            update={
+                "source": portable_step.spec.source,
+                "execution_spec": portable_step.spec.execution_spec,
+            }
+        )
+        return compiled_step.model_copy(update={"spec": patched_spec})
+
+
+@contextmanager
+def zenbabel_compiler_bridge() -> Iterator[None]:
+    """Temporarily route the demo placeholder step through ZenBabel.
+
+    This is not a product API. It is deliberately scoped to this example so the
+    already implemented portable runner can be exercised without broadening the
+    public SDK surface.
+    """
+    original_compiler = pipeline_definition_module.Compiler
+    portable_steps = build_steps(_zenbabel_external_spec())
+
+    def compiler_factory() -> ZenBabelDemoCompiler:
+        return ZenBabelDemoCompiler(portable_steps=portable_steps)
+
+    pipeline_definition_module.Compiler = compiler_factory  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        pipeline_definition_module.Compiler = original_compiler
+
+
+def compile_demo_snapshot() -> None:
+    """Compile the demo and print the patched TypeScript step contract."""
+    with zenbabel_compiler_bridge():
+        zenbabel_mixed_static.prepare()
+        snapshot, _, _ = zenbabel_mixed_static._compile()
+
+    portable_step = snapshot.step_configurations[PORTABLE_STEP_NAME]
+    execution_spec = portable_step.spec.execution_spec
+    assert execution_spec is not None
+    assert (
+        execution_spec.protocol
+        == StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+    )
+    assert portable_step.spec.inputs["records"].step_name == "load_data"
+    assert portable_step.spec.upstream_steps == ["load_data"]
+    assert "docker" in portable_step.config.settings
+
+    importer_spec = build_pipeline_spec(_zenbabel_external_spec())
+    print("Compiled ZenBabel demo snapshot successfully.")
+    print(f"Pipeline spec version: {snapshot.pipeline_spec.version}")
+    print(f"Importer-only portable spec version: {importer_spec.version}")
+    print(f"Portable command: {execution_spec.command}")
+    print(f"Portable source: {execution_spec.source_identity}")
+
+
+def run_pipeline() -> None:
+    """Run the mixed-language pipeline on the active ZenML stack."""
+    with zenbabel_compiler_bridge():
+        zenbabel_mixed_static()
+
+
+def main() -> None:
+    """CLI entrypoint for the example."""
+    parser = argparse.ArgumentParser(
+        description="Run or compile the ZenBabel mixed static example."
+    )
+    parser.add_argument(
+        "--compile-only",
+        action="store_true",
+        help="Compile the patched snapshot without submitting a pipeline run.",
+    )
+    args = parser.parse_args()
+
+    if args.compile_only:
+        compile_demo_snapshot()
+    else:
+        run_pipeline()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/zenbabel_mixed_static/run.py
+++ b/examples/zenbabel_mixed_static/run.py
@@ -27,14 +27,18 @@ import argparse
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Mapping
+from urllib.parse import urlparse, urlunparse
 
 import zenml.pipelines.pipeline_definition as pipeline_definition_module
 from zenml import pipeline, step
 from zenml.client import Client
 from zenml.config import DockerSettings
 from zenml.config.compiler import Compiler as BaseCompiler
+from zenml.config.docker_settings import DockerBuildConfig
+from zenml.config.global_config import GlobalConfiguration
 from zenml.config.step_configurations import Step
 from zenml.config.step_execution_spec import StepExecutionProtocol
+from zenml.enums import StoreType
 from zenml.execution.pipeline.utils import submit_pipeline
 from zenml.models import PipelineSnapshotResponse
 from zenml.pipelines.run_utils import create_placeholder_run
@@ -44,14 +48,20 @@ EXAMPLE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = EXAMPLE_DIR.parents[1]
 PORTABLE_STEP_NAME = "score_or_transform"
 DEFAULT_THRESHOLD = 0.64
+LOCAL_DOCKER_HOSTNAME = "host.docker.internal"
+LOCAL_DOCKER_LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
 
 
-def _typescript_docker_settings() -> DockerSettings:
-    """Return the Docker settings for the TypeScript step image."""
+def _zenbabel_docker_settings() -> DockerSettings:
+    """Return the Docker settings for the mixed-language demo image."""
     return DockerSettings(
         dockerfile=str(EXAMPLE_DIR / "Dockerfile"),
         build_context_root=str(REPO_ROOT),
+        parent_image_build_config=DockerBuildConfig(
+            dockerignore=str(EXAMPLE_DIR / "Dockerfile.dockerignore"),
+        ),
         disable_automatic_requirements_detection=True,
+        install_stack_requirements=False,
         prevent_build_reuse=True,
     )
 
@@ -66,7 +76,7 @@ def load_data() -> list[dict[str, Any]]:
     ]
 
 
-@step(settings={"docker": _typescript_docker_settings()})
+@step
 def score_or_transform(
     records: list[dict[str, Any]], threshold: float = DEFAULT_THRESHOLD
 ) -> dict[str, Any]:
@@ -93,12 +103,42 @@ def summarize(scored_bundle: dict[str, Any]) -> dict[str, Any]:
     return summary
 
 
-@pipeline(enable_cache=False)
+@pipeline(
+    enable_cache=False,
+    enable_heartbeat=False,
+    settings={"docker": _zenbabel_docker_settings()},
+)
 def zenbabel_mixed_static() -> None:
     """Python control-plane pipeline with one TypeScript step body."""
     records = load_data()
     scored_bundle = score_or_transform(records, threshold=DEFAULT_THRESHOLD)
     summarize(scored_bundle)
+
+
+def _container_store_environment() -> dict[str, str]:
+    """Return store env vars that work from inside Local Docker steps."""
+    store_config = GlobalConfiguration().store_configuration
+    if store_config.type != StoreType.REST:
+        raise RuntimeError(
+            "The ZenBabel mixed static demo needs a REST ZenML store when "
+            "running with Local Docker. Start a local ZenML server from this "
+            "worktree with `uv run zenml login --local --restart`, then run "
+            "the demo again."
+        )
+
+    store_url = store_config.url
+    parsed_url = urlparse(store_url)
+    if parsed_url.hostname in LOCAL_DOCKER_LOOPBACK_HOSTS:
+        if parsed_url.port is None:
+            netloc = LOCAL_DOCKER_HOSTNAME
+        else:
+            netloc = f"{LOCAL_DOCKER_HOSTNAME}:{parsed_url.port}"
+        store_url = urlunparse(parsed_url._replace(netloc=netloc))
+
+    return {
+        "ZENML_STORE_TYPE": StoreType.REST.value,
+        "ZENML_STORE_URL": store_url,
+    }
 
 
 def _zenbabel_external_spec() -> dict[str, Any]:
@@ -139,7 +179,9 @@ class ZenBabelDemoCompiler(BaseCompiler):
     def _compile_step_invocation(self, *args: Any, **kwargs: Any) -> Step:
         """Compile normally, then route selected invocations to ZenBabel."""
         compiled_step = super()._compile_step_invocation(*args, **kwargs)
-        portable_step = self._portable_steps.get(compiled_step.spec.invocation_id)
+        portable_step = self._portable_steps.get(
+            compiled_step.spec.invocation_id
+        )
         if portable_step is None:
             return compiled_step
 
@@ -189,11 +231,13 @@ def _validate_portable_execution_spec(
             "TypeScript step, but the created snapshot returned by the "
             "active ZenML server/store no longer contains "
             "`spec.execution_spec = zenml-portable-json-v1`. This usually "
-            "means you are connected to an older ZenML server, for example "
-            "Cloud/staging, that does not include this experimental branch "
-            "schema and stripped the field during the server/store round "
-            "trip. Run this branch against a local ZenML server/store, or a "
-            "backend deployed from this branch, before running the full demo."
+            "means the active ZenML server/store does not include this "
+            "experimental branch schema and stripped the field during the "
+            "server/store round trip. If you are connected to a local daemon, "
+            "make sure that daemon was started from this worktree's virtual "
+            "environment, for example with `uv run zenml login --local "
+            "--restart`. If you are connected to Cloud/staging, deploy a "
+            "backend from this branch before running the full demo."
         )
 
 
@@ -204,8 +248,9 @@ def _validate_local_docker_stack() -> None:
     if orchestrator.flavor != "local_docker":
         raise RuntimeError(
             "The ZenBabel mixed static demo needs the Local Docker "
-            "orchestrator because the TypeScript step uses step-level "
-            "Docker settings to build and run a Node-enabled image. The "
+            "orchestrator because the pipeline uses Docker settings to "
+            "build and run a Node-enabled image containing this branch's "
+            "ZenML code. The "
             f"active stack `{stack.name}` uses orchestrator "
             f"`{orchestrator.name}` with flavor `{orchestrator.flavor}`. "
             "Set a stack with a `local_docker` orchestrator and a local image "
@@ -215,9 +260,9 @@ def _validate_local_docker_stack() -> None:
     if stack.image_builder is None:
         raise RuntimeError(
             "The ZenBabel mixed static demo needs an image builder on the "
-            "active stack. The TypeScript step has Docker settings pointing "
-            "at `examples/zenbabel_mixed_static/Dockerfile`, so ZenML must "
-            "build that step image before Local Docker can run it. Register "
+            "active stack. The pipeline has Docker settings pointing at "
+            "`examples/zenbabel_mixed_static/Dockerfile`, so ZenML must "
+            "build the demo image before Local Docker can run it. Register "
             "and set a stack with a local image builder, or run "
             "`uv run python examples/zenbabel_mixed_static/run.py "
             "--compile-only` instead."
@@ -249,13 +294,18 @@ def compile_demo_snapshot() -> None:
 def run_pipeline() -> None:
     """Run the mixed-language pipeline on the active ZenML stack."""
     _validate_local_docker_stack()
+    runtime_pipeline = zenbabel_mixed_static.with_options(
+        environment=_container_store_environment()
+    )
     with zenbabel_compiler_bridge():
-        zenbabel_mixed_static.prepare()
-        snapshot = zenbabel_mixed_static._create_snapshot()
+        runtime_pipeline.prepare()
+        snapshot = runtime_pipeline._create_snapshot()
 
     _validate_portable_execution_spec(snapshot)
     run = create_placeholder_run(snapshot=snapshot)
-    submit_pipeline(snapshot=snapshot, stack=Client().active_stack, placeholder_run=run)
+    submit_pipeline(
+        snapshot=snapshot, stack=Client().active_stack, placeholder_run=run
+    )
 
 
 def main() -> None:

--- a/examples/zenbabel_mixed_static/run.py
+++ b/examples/zenbabel_mixed_static/run.py
@@ -20,6 +20,7 @@ which placeholder invocation should be routed through ``zenml-portable-json-v1``
 """
 
 import argparse
+import os
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -27,7 +28,7 @@ from urllib.parse import urlparse, urlunparse
 from zenml import pipeline, step
 from zenml.client import Client
 from zenml.config import DockerSettings
-from zenml.config.docker_settings import DockerBuildConfig
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
 from zenml.config.global_config import GlobalConfiguration
 from zenml.config.step_execution_spec import StepExecutionProtocol
 from zenml.enums import StoreType
@@ -45,6 +46,7 @@ PORTABLE_STEP_NAME = "score_or_transform"
 DEFAULT_THRESHOLD = 0.64
 LOCAL_DOCKER_HOSTNAME = "host.docker.internal"
 LOCAL_DOCKER_LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
+IMAGE_PLATFORM = os.environ.get("ZENBABEL_IMAGE_PLATFORM", "linux/amd64")
 
 ZENBABEL_PORTABLE_SPEC = experimental_portable_json_pipeline_spec(
     name="zenbabel_mixed_static",
@@ -65,12 +67,18 @@ ZENBABEL_PORTABLE_SPEC = experimental_portable_json_pipeline_spec(
 
 def _zenbabel_docker_settings() -> DockerSettings:
     """Return the Docker settings for the mixed-language demo image."""
+    build_options = DockerBuildOptions(
+        build_args={"ZENBABEL_IMAGE_PLATFORM": IMAGE_PLATFORM},
+        platform=IMAGE_PLATFORM,
+    )
     return DockerSettings(
         dockerfile=str(EXAMPLE_DIR / "Dockerfile"),
         build_context_root=str(REPO_ROOT),
         parent_image_build_config=DockerBuildConfig(
+            build_options=build_options,
             dockerignore=str(EXAMPLE_DIR / "Dockerfile.dockerignore"),
         ),
+        build_config=DockerBuildConfig(build_options=build_options),
         disable_automatic_requirements_detection=True,
         install_stack_requirements=False,
         prevent_build_reuse=True,
@@ -129,13 +137,14 @@ def zenbabel_mixed_static() -> None:
 
 
 def _container_store_environment() -> dict[str, str]:
-    """Return store env vars that work from inside Local Docker steps."""
+    """Return REST store env vars that work from inside containerized steps."""
     store_config = GlobalConfiguration().store_configuration
     if store_config.type != StoreType.REST:
         raise RuntimeError(
             "The ZenBabel mixed static demo needs a REST ZenML store when "
-            "running with Local Docker. Start a local ZenML server from this "
-            "worktree with `uv run zenml login --local --restart`, then run "
+            "running with a containerized stack. Start a local ZenML server "
+            "from this worktree with `uv run zenml login --local --restart`, "
+            "or connect to a branch-compatible remote ZenML server, then run "
             "the demo again."
         )
 
@@ -178,20 +187,21 @@ def _validate_portable_execution_spec(snapshot: Any) -> None:
         )
 
 
-def _validate_local_docker_stack() -> None:
+def _validate_containerized_stack() -> None:
     """Check that the active stack can run the TypeScript Docker step."""
     stack = Client().active_stack
     orchestrator = stack.orchestrator
-    if orchestrator.flavor != "local_docker":
+    supported_orchestrators = {"kubernetes", "local_docker"}
+    if orchestrator.flavor not in supported_orchestrators:
+        supported = "`, `".join(sorted(supported_orchestrators))
         raise RuntimeError(
-            "The ZenBabel mixed static demo needs the Local Docker "
+            "The ZenBabel mixed static demo needs a containerized "
             "orchestrator because the pipeline uses Docker settings to "
             "build and run a Node-enabled image containing this branch's "
             "ZenML code. The "
             f"active stack `{stack.name}` uses orchestrator "
             f"`{orchestrator.name}` with flavor `{orchestrator.flavor}`. "
-            "Set a stack with a `local_docker` orchestrator and a local image "
-            "builder, or run `uv run python "
+            f"Set a stack with one of: `{supported}`, or run `uv run python "
             "examples/zenbabel_mixed_static/run.py --compile-only` instead."
         )
     if stack.image_builder is None:
@@ -199,8 +209,8 @@ def _validate_local_docker_stack() -> None:
             "The ZenBabel mixed static demo needs an image builder on the "
             "active stack. The pipeline has Docker settings pointing at "
             "`examples/zenbabel_mixed_static/Dockerfile`, so ZenML must "
-            "build the demo image before Local Docker can run it. Register "
-            "and set a stack with a local image builder, or run "
+            "build the demo image before the containerized orchestrator can "
+            "run it. Register and set a stack with an image builder, or run "
             "`uv run python examples/zenbabel_mixed_static/run.py "
             "--compile-only` instead."
         )
@@ -231,7 +241,7 @@ def compile_demo_snapshot() -> None:
 
 def run_pipeline() -> None:
     """Run the mixed-language pipeline on the active ZenML stack."""
-    _validate_local_docker_stack()
+    _validate_containerized_stack()
     runtime_pipeline = zenbabel_mixed_static.with_options(
         environment=_container_store_environment()
     )

--- a/examples/zenbabel_mixed_static/run.py
+++ b/examples/zenbabel_mixed_static/run.py
@@ -13,36 +13,31 @@
 #  permissions and limitations under the License.
 """Mixed Python + TypeScript ZenBabel static pipeline example.
 
-This file intentionally keeps the bridge small and local to the example. ZenML
-can already execute portable JSON steps once a compiled step contains a
-``StepExecutionSpec``. What ZenML does not have yet is a public TypeScript step
-SDK that lets users call a TypeScript step directly from a Python ``@pipeline``.
-
-The example therefore uses a normal Python placeholder step for graph building,
-then swaps only that placeholder's compiled source/execution metadata for the
-portable metadata produced by ``zenml.zenbabel.build_steps``.
+The pipeline below is intentionally ordinary ZenML Python code: a Python step,
+a placeholder where the TypeScript step body should run, and another Python
+step. The small experimental ZenBabel authoring helper then tells the compiler
+which placeholder invocation should be routed through ``zenml-portable-json-v1``.
 """
 
 import argparse
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, Mapping
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
-import zenml.pipelines.pipeline_definition as pipeline_definition_module
 from zenml import pipeline, step
 from zenml.client import Client
 from zenml.config import DockerSettings
-from zenml.config.compiler import Compiler as BaseCompiler
 from zenml.config.docker_settings import DockerBuildConfig
 from zenml.config.global_config import GlobalConfiguration
-from zenml.config.step_configurations import Step
 from zenml.config.step_execution_spec import StepExecutionProtocol
 from zenml.enums import StoreType
-from zenml.execution.pipeline.utils import submit_pipeline
-from zenml.models import PipelineSnapshotResponse
-from zenml.pipelines.run_utils import create_placeholder_run
-from zenml.zenbabel import build_pipeline_spec, build_steps
+from zenml.zenbabel import (
+    build_pipeline_spec,
+    experimental_compile_snapshot,
+    experimental_portable_json_pipeline_spec,
+    experimental_portable_json_step,
+    experimental_submit_pipeline,
+)
 
 EXAMPLE_DIR = Path(__file__).resolve().parent
 REPO_ROOT = EXAMPLE_DIR.parents[1]
@@ -50,6 +45,22 @@ PORTABLE_STEP_NAME = "score_or_transform"
 DEFAULT_THRESHOLD = 0.64
 LOCAL_DOCKER_HOSTNAME = "host.docker.internal"
 LOCAL_DOCKER_LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
+
+ZENBABEL_PORTABLE_SPEC = experimental_portable_json_pipeline_spec(
+    name="zenbabel_mixed_static",
+    steps=[
+        experimental_portable_json_step(
+            name=PORTABLE_STEP_NAME,
+            command=["node", "/app/dist/steps/score_or_transform.js"],
+            source_identity=(
+                "examples/zenbabel_mixed_static/ts/src/steps/"
+                "score_or_transform.ts#scoreOrTransform"
+            ),
+            parameters={"threshold": DEFAULT_THRESHOLD},
+        )
+    ],
+    outputs=[(PORTABLE_STEP_NAME, "output")],
+)
 
 
 def _zenbabel_docker_settings() -> DockerSettings:
@@ -80,11 +91,13 @@ def load_data() -> list[dict[str, Any]]:
 def score_or_transform(
     records: list[dict[str, Any]], threshold: float = DEFAULT_THRESHOLD
 ) -> dict[str, Any]:
-    """Placeholder compiled as a normal step, then routed to TypeScript."""
+    """Placeholder compiled normally, then routed to TypeScript."""
     raise RuntimeError(
         "The Python placeholder step `score_or_transform` should have been "
-        "replaced by the ZenBabel demo compiler bridge. If you see this, run "
-        "the pipeline through `zenbabel_compiler_bridge()`."
+        "routed through ZenBabel's experimental portable JSON helper. If you "
+        "see this, compile or submit the pipeline with "
+        "`experimental_compile_snapshot(...)` or "
+        "`experimental_submit_pipeline(...)`."
     )
 
 
@@ -141,83 +154,7 @@ def _container_store_environment() -> dict[str, str]:
     }
 
 
-def _zenbabel_external_spec() -> dict[str, Any]:
-    """Return the external TypeScript step spec used by the demo bridge."""
-    return {
-        "name": "zenbabel_mixed_static",
-        "steps": [
-            {
-                "name": PORTABLE_STEP_NAME,
-                "command": [
-                    "node",
-                    "/app/dist/steps/score_or_transform.js",
-                ],
-                "source_identity": (
-                    "examples/zenbabel_mixed_static/ts/src/steps/"
-                    "score_or_transform.ts#scoreOrTransform"
-                ),
-                "parameters": {"threshold": DEFAULT_THRESHOLD},
-                "outputs": ["output"],
-            }
-        ],
-        "outputs": [{"step": PORTABLE_STEP_NAME, "output": "output"}],
-    }
-
-
-class ZenBabelDemoCompiler(BaseCompiler):
-    """Example-local compiler that donates portable metadata to one step."""
-
-    def __init__(self, portable_steps: Mapping[str, Step]) -> None:
-        """Initialize the compiler bridge.
-
-        Args:
-            portable_steps: Portable metadata donor steps keyed by invocation id.
-        """
-        super().__init__()
-        self._portable_steps = portable_steps
-
-    def _compile_step_invocation(self, *args: Any, **kwargs: Any) -> Step:
-        """Compile normally, then route selected invocations to ZenBabel."""
-        compiled_step = super()._compile_step_invocation(*args, **kwargs)
-        portable_step = self._portable_steps.get(
-            compiled_step.spec.invocation_id
-        )
-        if portable_step is None:
-            return compiled_step
-
-        patched_spec = compiled_step.spec.model_copy(
-            update={
-                "source": portable_step.spec.source,
-                "execution_spec": portable_step.spec.execution_spec,
-            }
-        )
-        return compiled_step.model_copy(update={"spec": patched_spec})
-
-
-@contextmanager
-def zenbabel_compiler_bridge() -> Iterator[None]:
-    """Temporarily route the demo placeholder step through ZenBabel.
-
-    This is not a product API. It is deliberately scoped to this example so the
-    already implemented portable runner can be exercised without broadening the
-    public SDK surface.
-    """
-    original_compiler = pipeline_definition_module.Compiler
-    portable_steps = build_steps(_zenbabel_external_spec())
-
-    def compiler_factory() -> ZenBabelDemoCompiler:
-        return ZenBabelDemoCompiler(portable_steps=portable_steps)
-
-    pipeline_definition_module.Compiler = compiler_factory  # type: ignore[assignment]
-    try:
-        yield
-    finally:
-        pipeline_definition_module.Compiler = original_compiler
-
-
-def _validate_portable_execution_spec(
-    snapshot: PipelineSnapshotResponse,
-) -> None:
+def _validate_portable_execution_spec(snapshot: Any) -> None:
     """Check that the portable step survived snapshot persistence."""
     portable_step = snapshot.step_configurations[PORTABLE_STEP_NAME]
     execution_spec = portable_step.spec.execution_spec
@@ -271,9 +208,10 @@ def _validate_local_docker_stack() -> None:
 
 def compile_demo_snapshot() -> None:
     """Compile the demo and print the patched TypeScript step contract."""
-    with zenbabel_compiler_bridge():
-        zenbabel_mixed_static.prepare()
-        snapshot, _, _ = zenbabel_mixed_static._compile()
+    snapshot = experimental_compile_snapshot(
+        pipeline=zenbabel_mixed_static,
+        external_spec=ZENBABEL_PORTABLE_SPEC,
+    )
 
     _validate_portable_execution_spec(snapshot)
     portable_step = snapshot.step_configurations[PORTABLE_STEP_NAME]
@@ -283,7 +221,7 @@ def compile_demo_snapshot() -> None:
     assert portable_step.spec.upstream_steps == ["load_data"]
     assert "docker" in portable_step.config.settings
 
-    importer_spec = build_pipeline_spec(_zenbabel_external_spec())
+    importer_spec = build_pipeline_spec(ZENBABEL_PORTABLE_SPEC)
     print("Compiled ZenBabel demo snapshot successfully.")
     print(f"Pipeline spec version: {snapshot.pipeline_spec.version}")
     print(f"Importer-only portable spec version: {importer_spec.version}")
@@ -297,14 +235,10 @@ def run_pipeline() -> None:
     runtime_pipeline = zenbabel_mixed_static.with_options(
         environment=_container_store_environment()
     )
-    with zenbabel_compiler_bridge():
-        runtime_pipeline.prepare()
-        snapshot = runtime_pipeline._create_snapshot()
-
-    _validate_portable_execution_spec(snapshot)
-    run = create_placeholder_run(snapshot=snapshot)
-    submit_pipeline(
-        snapshot=snapshot, stack=Client().active_stack, placeholder_run=run
+    experimental_submit_pipeline(
+        pipeline=runtime_pipeline,
+        external_spec=ZENBABEL_PORTABLE_SPEC,
+        snapshot_validator=_validate_portable_execution_spec,
     )
 
 

--- a/examples/zenbabel_mixed_static/ts/src/portable.ts
+++ b/examples/zenbabel_mixed_static/ts/src/portable.ts
@@ -1,0 +1,63 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const MANIFEST_ENV_VAR = "ZENML_PORTABLE_STEP_MANIFEST";
+
+export type PortableManifest = {
+  protocol: "zenml-portable-json-v1";
+  step_name: string;
+  source_identity?: string;
+  parameters: Record<string, unknown>;
+  inputs: Record<string, string>;
+  outputs: Record<string, string>;
+};
+
+export function readManifestFromEnvironment(): PortableManifest {
+  const manifestPath = process.env[MANIFEST_ENV_VAR];
+  if (!manifestPath) {
+    throw new Error(`Missing ${MANIFEST_ENV_VAR} environment variable.`);
+  }
+
+  const manifest = readJsonFile<PortableManifest>(manifestPath);
+  if (manifest.protocol !== "zenml-portable-json-v1") {
+    throw new Error(
+      `Unsupported portable protocol ${JSON.stringify(manifest.protocol)}.`
+    );
+  }
+
+  return manifest;
+}
+
+export function readInput<T>(manifest: PortableManifest, name: string): T {
+  const inputPath = manifest.inputs[name];
+  if (!inputPath) {
+    throw new Error(
+      `Portable manifest for step ${manifest.step_name} has no input ${name}.`
+    );
+  }
+
+  return readJsonFile<T>(inputPath);
+}
+
+export function writeOutput(
+  manifest: PortableManifest,
+  name: string,
+  value: unknown
+): void {
+  const outputPath = manifest.outputs[name];
+  if (!outputPath) {
+    throw new Error(
+      `Portable manifest for step ${manifest.step_name} has no output ${name}.`
+    );
+  }
+
+  writeFileSync(outputPath, JSON.stringify(value, null, 2), "utf8");
+}
+
+function readJsonFile<T>(path: string): T {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read JSON file ${path}: ${message}`);
+  }
+}

--- a/examples/zenbabel_mixed_static/ts/src/smoke.ts
+++ b/examples/zenbabel_mixed_static/ts/src/smoke.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const workDir = mkdtempSync(join(tmpdir(), "zenbabel-smoke-"));
+const inputPath = join(workDir, "records.json");
+const outputPath = join(workDir, "output.json");
+const manifestPath = join(workDir, "manifest.json");
+
+writeFileSync(
+  inputPath,
+  JSON.stringify([
+    { id: "order-001", feature: 0.12, segment: "small" },
+    { id: "order-002", feature: 0.71, segment: "enterprise" }
+  ]),
+  "utf8"
+);
+
+writeFileSync(
+  manifestPath,
+  JSON.stringify({
+    protocol: "zenml-portable-json-v1",
+    step_name: "score_or_transform",
+    source_identity:
+      "examples/zenbabel_mixed_static/ts/src/steps/score_or_transform.ts#scoreOrTransform",
+    parameters: { threshold: 0.64 },
+    inputs: { records: inputPath },
+    outputs: { output: outputPath }
+  }),
+  "utf8"
+);
+
+process.env.ZENML_PORTABLE_STEP_MANIFEST = manifestPath;
+await import("./steps/score_or_transform.js");
+
+const output = JSON.parse(readFileSync(outputPath, "utf8"));
+if (output.metadata.accepted_count !== 1) {
+  throw new Error(
+    `Expected one accepted record, got ${output.metadata.accepted_count}.`
+  );
+}
+
+console.log(`Smoke test wrote portable output to ${outputPath}`);

--- a/examples/zenbabel_mixed_static/ts/src/steps/score_or_transform.ts
+++ b/examples/zenbabel_mixed_static/ts/src/steps/score_or_transform.ts
@@ -1,0 +1,87 @@
+import {
+  readInput,
+  readManifestFromEnvironment,
+  writeOutput,
+} from "../portable.js";
+
+type InputRecord = {
+  id: string;
+  feature: number;
+  segment: string;
+};
+
+type ScoredRecord = InputRecord & {
+  score: number;
+  label: "accept" | "review";
+};
+
+type ScoredBundle = {
+  records: ScoredRecord[];
+  metadata: {
+    threshold: number;
+    accepted_count: number;
+    total_count: number;
+  };
+};
+
+export function scoreOrTransform(
+  records: InputRecord[],
+  parameters: Record<string, unknown>
+): ScoredBundle {
+  const threshold = readNumberParameter(parameters, "threshold", 0.64);
+  const scoredRecords: ScoredRecord[] = records.map((record) => {
+    const segmentBoost = record.segment === "enterprise" ? 0.18 : 0.04;
+    const score = clamp(round(record.feature + segmentBoost));
+    const label: ScoredRecord["label"] =
+      score >= threshold ? "accept" : "review";
+    return {
+      ...record,
+      score,
+      label,
+    };
+  });
+  const acceptedCount = scoredRecords.filter(
+    (record) => record.label === "accept"
+  ).length;
+
+  return {
+    records: scoredRecords,
+    metadata: {
+      threshold,
+      accepted_count: acceptedCount,
+      total_count: scoredRecords.length,
+    },
+  };
+}
+
+function readNumberParameter(
+  parameters: Record<string, unknown>,
+  name: string,
+  fallback: number
+): number {
+  const value = parameters[name];
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Parameter ${name} must be a finite number.`);
+  }
+  return value;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function clamp(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function main(): void {
+  const manifest = readManifestFromEnvironment();
+  const records = readInput<InputRecord[]>(manifest, "records");
+  const output = scoreOrTransform(records, manifest.parameters);
+  writeOutput(manifest, "output", output);
+}
+
+main();

--- a/examples/zenbabel_mixed_static/tsconfig.json
+++ b/examples/zenbabel_mixed_static/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "rootDir": "ts/src",
+    "outDir": "dist"
+  },
+  "include": ["ts/src/**/*.ts"]
+}

--- a/src/zenml/config/__init__.py
+++ b/src/zenml/config/__init__.py
@@ -12,27 +12,33 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 """Config classes."""
+
+from zenml.config.cache_policy import CachePolicy
 from zenml.config.deployment_settings import (
-    DeploymentSettings,
+    AppExtensionSpec,
+    CORSConfig,
     DeploymentDefaultEndpoints,
     DeploymentDefaultMiddleware,
-    EndpointSpec,
+    DeploymentSettings,
     EndpointMethod,
+    EndpointSpec,
     MiddlewareSpec,
-    AppExtensionSpec,
     SecureHeadersConfig,
-    CORSConfig,
 )
 from zenml.config.docker_settings import (
     DockerSettings,
-    PythonPackageInstaller,
     PythonEnvironmentExportMethod,
+    PythonPackageInstaller,
 )
-from zenml.config.resource_settings import ResourceSettings, ByteUnit
+from zenml.config.resource_settings import ByteUnit, ResourceSettings
 from zenml.config.retry_config import StepRetryConfig
 from zenml.config.schedule import Schedule
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+    StepExecutionSpec,
+)
 from zenml.config.store_config import StoreConfiguration
-from zenml.config.cache_policy import CachePolicy
 
 __all__ = [
     "DeploymentSettings",
@@ -51,6 +57,9 @@ __all__ = [
     "ByteUnit",
     "StepRetryConfig",
     "Schedule",
+    "StepExecutionLanguage",
+    "StepExecutionProtocol",
+    "StepExecutionSpec",
     "StoreConfiguration",
     "CachePolicy",
 ]

--- a/src/zenml/config/pipeline_spec.py
+++ b/src/zenml/config/pipeline_spec.py
@@ -16,7 +16,7 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from zenml.config.frozen_base_model import FrozenBaseModel
 from zenml.config.source import Source, SourceWithValidator
@@ -43,6 +43,7 @@ class PipelineSpec(FrozenBaseModel):
     # - 0.4: New Pipeline class, the upstream steps and
     #   inputs in the step specs refer to the pipeline parameter names
     # - 0.5: Adds input schema, outputs and output schema
+    # - 0.6: Adds optional step execution specs for portable step bodies
     version: str = "0.5"
     source: Optional[SourceWithValidator] = None
     parameters: Dict[str, Any] = {}
@@ -64,6 +65,22 @@ class PipelineSpec(FrozenBaseModel):
         "schema generation failed, which is most likely because some of the "
         "pipeline outputs are not JSON serializable.",
     )
+
+    @model_validator(mode="after")
+    def _set_version_for_portable_steps(self) -> "PipelineSpec":
+        """Set the portable pipeline spec version only when needed.
+
+        Returns:
+            The validated pipeline spec.
+        """
+        from packaging import version
+
+        if any(step.execution_spec for step in self.steps) and version.parse(
+            self.version
+        ) < version.parse("0.6"):
+            object.__setattr__(self, "version", "0.6")
+
+        return self
 
     def __eq__(self, other: Any) -> bool:
         """Returns whether the other object is referring to the same pipeline.

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -31,6 +31,7 @@ from pydantic import (
     Field,
     SerializeAsAny,
     field_validator,
+    model_serializer,
     model_validator,
 )
 
@@ -45,6 +46,7 @@ from zenml.config.constants import DOCKER_SETTINGS_KEY, RESOURCE_SETTINGS_KEY
 from zenml.config.frozen_base_model import FrozenBaseModel
 from zenml.config.retry_config import StepRetryConfig
 from zenml.config.source import Source, SourceWithValidator
+from zenml.config.step_execution_spec import StepExecutionSpec
 from zenml.enums import GroupType, StepRuntime, StepType
 from zenml.logger import get_logger
 from zenml.model.lazy_load import ModelVersionDataLazyLoader
@@ -418,6 +420,10 @@ class StepSpec(FrozenBaseModel):
     invocation_id: str
     enable_heartbeat: bool = False
     parameter_spec: Optional[Dict[str, Any]] = None
+    execution_spec: Optional[StepExecutionSpec] = Field(
+        default=None,
+        description="Optional execution contract for portable step bodies.",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -425,6 +431,22 @@ class StepSpec(FrozenBaseModel):
     def _migrate_legacy_fields(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         if "invocation_id" not in data:
             data["invocation_id"] = data.pop("pipeline_parameter_name", "")
+
+        return data
+
+    @model_serializer(mode="wrap")
+    def _serialize_without_empty_execution_spec(self, handler: Any) -> Any:
+        """Serialize while preserving old Python-only spec shape.
+
+        Args:
+            handler: The wrapped Pydantic serializer.
+
+        Returns:
+            The serialized step spec.
+        """
+        data = handler(self)
+        if self.execution_spec is None:
+            data.pop("execution_spec", None)
 
         return data
 
@@ -474,6 +496,9 @@ class StepSpec(FrozenBaseModel):
                 return False
 
             if self.parameter_spec != other.parameter_spec:
+                return False
+
+            if self.execution_spec != other.execution_spec:
                 return False
 
             if self.invocation_id != other.invocation_id:

--- a/src/zenml/config/step_execution_spec.py
+++ b/src/zenml/config/step_execution_spec.py
@@ -1,0 +1,108 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Step execution specifications."""
+
+import json
+from typing import List
+
+from pydantic import Field, field_validator
+
+from zenml.config.frozen_base_model import FrozenBaseModel
+from zenml.utils.enum_utils import StrEnum
+
+
+class StepExecutionLanguage(StrEnum):
+    """Supported languages for step body execution."""
+
+    PYTHON = "python"
+    TYPESCRIPT = "typescript"
+
+
+class StepExecutionProtocol(StrEnum):
+    """Supported protocols for step body execution."""
+
+    ZENML_PYTHON_STEP_V1 = "zenml-python-step-v1"
+    ZENML_PORTABLE_JSON_V1 = "zenml-portable-json-v1"
+
+
+class StepExecutionSpec(FrozenBaseModel):
+    """Specification for executing a step body.
+
+    A missing execution spec means the step follows the existing Python
+    ``BaseStep`` path. A non-null execution spec gives ZenML enough stable
+    identity to route and cache a deliberately portable step body.
+    """
+
+    language: StepExecutionLanguage
+    protocol: StepExecutionProtocol
+    command: List[str] = Field(
+        description="Exact argv to execute inside the step container."
+    )
+    source_identity: str = Field(
+        description="Stable display, debug and cache identity for the step body."
+    )
+
+    @field_validator("command")
+    @classmethod
+    def _validate_command(cls, command: List[str]) -> List[str]:
+        """Validate the portable step command.
+
+        Args:
+            command: The argv list to validate.
+
+        Raises:
+            ValueError: If the command is empty or contains empty arguments.
+
+        Returns:
+            The validated command.
+        """
+        if not command:
+            raise ValueError("Step execution command must not be empty.")
+
+        if any(not argument for argument in command):
+            raise ValueError(
+                "Step execution command arguments must not be empty."
+            )
+
+        return command
+
+    @field_validator("source_identity")
+    @classmethod
+    def _validate_source_identity(cls, source_identity: str) -> str:
+        """Validate the source identity.
+
+        Args:
+            source_identity: The source identity to validate.
+
+        Raises:
+            ValueError: If the source identity is empty.
+
+        Returns:
+            The validated source identity.
+        """
+        if not source_identity:
+            raise ValueError(
+                "Step execution source identity must not be empty."
+            )
+
+        return source_identity
+
+    @property
+    def cache_key_fragment(self) -> str:
+        """Stable JSON fragment for cache key computation.
+
+        Returns:
+            A deterministic JSON string representing the execution identity.
+        """
+        return json.dumps(self.model_dump(mode="json"), sort_keys=True)

--- a/src/zenml/orchestrators/cache_utils.py
+++ b/src/zenml/orchestrators/cache_utils.py
@@ -99,6 +99,9 @@ def generate_cache_key(
     # when committing some unrelated files
     hash_.update(step.spec.source.import_path.encode())
 
+    if execution_spec := step.spec.execution_spec:
+        hash_.update(execution_spec.cache_key_fragment.encode())
+
     if cache_policy.include_step_parameters:
         for key, value in sorted(step.config.parameters.items()):
             hash_.update(key.encode())

--- a/src/zenml/orchestrators/portable_step_runner.py
+++ b/src/zenml/orchestrators/portable_step_runner.py
@@ -31,6 +31,10 @@ from zenml.config.step_run_info import StepRunInfo
 from zenml.deployers.server import runtime
 from zenml.hooks.hook_validators import load_and_run_hook
 from zenml.logger import get_logger
+from zenml.materializers.built_in_materializer import (
+    BuiltInContainerMaterializer,
+    BuiltInMaterializer,
+)
 from zenml.models.v2.core.step_run import StepRunInputResponse
 from zenml.orchestrators.publish_utils import (
     publish_failed_step_run,
@@ -42,7 +46,7 @@ from zenml.orchestrators.step_runner import StepRunner
 from zenml.orchestrators.utils import is_setting_enabled
 from zenml.steps.step_context import StepContext
 from zenml.steps.utils import OutputSignature
-from zenml.utils import env_utils, exception_utils
+from zenml.utils import env_utils, exception_utils, source_utils
 from zenml.utils.logging_utils import (
     is_step_logging_enabled,
     setup_logging_context,
@@ -60,6 +64,10 @@ ZENML_PORTABLE_STEP_MANIFEST = "ZENML_PORTABLE_STEP_MANIFEST"
 PORTABLE_JSON_PROTOCOL_VERSION = "zenml-portable-json-v1"
 _SUBPROCESS_OUTPUT_LIMIT = 4000
 _JAVASCRIPT_MAX_SAFE_INTEGER = 2**53 - 1
+_ALLOWED_OUTPUT_MATERIALIZER_SOURCES = {
+    source_utils.resolve(BuiltInMaterializer).import_path,
+    source_utils.resolve(BuiltInContainerMaterializer).import_path,
+}
 
 
 class PortableJSONValueError(TypeError):
@@ -370,6 +378,18 @@ class PortableStepRunner:
             raise RuntimeError(
                 "Portable JSON v1 steps do not support step heartbeat yet."
             )
+
+        for output_name, output in self.configuration.outputs.items():
+            configured_materializers = {
+                source.import_path for source in output.materializer_source
+            }
+            if configured_materializers - _ALLOWED_OUTPUT_MATERIALIZER_SOURCES:
+                raise RuntimeError(
+                    "Portable JSON v1 steps do not support custom output "
+                    "materializers. Outputs must use the default built-in "
+                    "JSON-compatible materializer path. Custom materializers "
+                    f"were configured for output `{output_name}`."
+                )
 
     def _output_annotations(self) -> Dict[str, OutputSignature]:
         """Build output signatures from the portable step configuration.

--- a/src/zenml/orchestrators/portable_step_runner.py
+++ b/src/zenml/orchestrators/portable_step_runner.py
@@ -1,0 +1,601 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Runner for ZenBabel portable JSON steps."""
+
+import json
+import math
+import os
+import subprocess
+import tempfile
+from contextlib import nullcontext
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ContextManager, Dict, List
+
+from zenml.config.step_configurations import StepConfiguration
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+)
+from zenml.config.step_run_info import StepRunInfo
+from zenml.deployers.server import runtime
+from zenml.hooks.hook_validators import load_and_run_hook
+from zenml.logger import get_logger
+from zenml.models.v2.core.step_run import StepRunInputResponse
+from zenml.orchestrators.publish_utils import (
+    publish_failed_step_run,
+    publish_step_run_metadata,
+    publish_successful_step_run,
+    step_exception_info,
+)
+from zenml.orchestrators.step_runner import StepRunner
+from zenml.orchestrators.utils import is_setting_enabled
+from zenml.steps.step_context import StepContext
+from zenml.steps.utils import OutputSignature
+from zenml.utils import env_utils, exception_utils
+from zenml.utils.logging_utils import (
+    is_step_logging_enabled,
+    setup_logging_context,
+)
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
+
+if TYPE_CHECKING:
+    from zenml.config.step_configurations import Step
+    from zenml.models import PipelineRunResponse, StepRunResponse
+    from zenml.stack import Stack
+
+logger = get_logger(__name__)
+
+ZENML_PORTABLE_STEP_MANIFEST = "ZENML_PORTABLE_STEP_MANIFEST"
+PORTABLE_JSON_PROTOCOL_VERSION = "zenml-portable-json-v1"
+_SUBPROCESS_OUTPUT_LIMIT = 4000
+_JAVASCRIPT_MAX_SAFE_INTEGER = 2**53 - 1
+
+
+class PortableJSONValueError(TypeError):
+    """Raised when a value is not shaped like strict portable JSON."""
+
+
+def validate_portable_json_value(value: Any, path: str = "value") -> None:
+    """Validate that a value is strict JSON, not merely Python-json-dumpable.
+
+    Args:
+        value: The value to validate.
+        path: Human-readable path used in error messages.
+
+    Raises:
+        PortableJSONValueError: If the value cannot cross the portable JSON
+            boundary without changing shape or losing JSON compatibility.
+    """
+    if value is None or isinstance(value, (str, bool)):
+        return
+
+    if isinstance(value, int) and not isinstance(value, bool):
+        if abs(value) > _JAVASCRIPT_MAX_SAFE_INTEGER:
+            raise PortableJSONValueError(
+                f"Portable JSON value at `{path}` contains integer "
+                f"{value!r}, which is outside the JavaScript safe integer "
+                "range."
+            )
+        return
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise PortableJSONValueError(
+                f"Portable JSON value at `{path}` contains non-finite float "
+                f"{value!r}."
+            )
+        return
+
+    if isinstance(value, tuple):
+        raise PortableJSONValueError(
+            f"Portable JSON value at `{path}` is a tuple. Use a list instead."
+        )
+
+    if isinstance(value, set):
+        raise PortableJSONValueError(
+            f"Portable JSON value at `{path}` is a set. Use a list instead."
+        )
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            validate_portable_json_value(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise PortableJSONValueError(
+                    f"Portable JSON object at `{path}` has non-string key "
+                    f"{key!r}."
+                )
+            validate_portable_json_value(item, f"{path}.{key}")
+        return
+
+    raise PortableJSONValueError(
+        f"Portable JSON value at `{path}` has unsupported type "
+        f"{type(value).__name__}."
+    )
+
+
+class PortableStepRunner:
+    """Runs a step body through the portable JSON subprocess protocol."""
+
+    def __init__(self, step: "Step", stack: "Stack") -> None:
+        """Initialize the portable step runner.
+
+        Args:
+            step: The step to run.
+            stack: The stack on which the step should run.
+        """
+        self._step = step
+        self._stack = stack
+        self._python_artifact_runner = StepRunner(step=step, stack=stack)
+
+    @property
+    def configuration(self) -> StepConfiguration:
+        """Configuration of the step to run.
+
+        Returns:
+            The step configuration.
+        """
+        return self._step.config
+
+    def run(
+        self,
+        pipeline_run: "PipelineRunResponse",
+        step_run: "StepRunResponse",
+        input_artifacts: Dict[str, List[StepRunInputResponse]],
+        output_artifact_uris: Dict[str, str],
+        step_run_info: StepRunInfo,
+    ) -> None:
+        """Run a portable JSON step.
+
+        Args:
+            pipeline_run: The model of the current pipeline run.
+            step_run: The model of the current step run.
+            input_artifacts: The input artifact versions of the step.
+            output_artifact_uris: The URIs of the output artifacts of the step.
+            step_run_info: The step run info.
+        """
+        logs_context: ContextManager[Any] = nullcontext()
+        if is_step_logging_enabled(
+            step_configuration=step_run.config,
+            pipeline_configuration=pipeline_run.config,
+        ):
+            logs_context = setup_logging_context(
+                source="step", step_run=step_run, pipeline_run=pipeline_run
+            )
+
+        with logs_context:
+            self._validate_step_contract()
+            output_materializers = (
+                self._python_artifact_runner._load_output_materializers()
+            )
+            output_annotations = self._output_annotations()
+            self._python_artifact_runner._evaluate_artifact_names_in_collections(
+                step_run,
+                output_annotations,
+                [output_artifact_uris, output_materializers],
+            )
+
+            self._stack.prepare_step_run(info=step_run_info)
+
+            step_context = StepContext(
+                pipeline_run=pipeline_run,
+                step_run=step_run,
+                output_materializers=output_materializers,
+                output_artifact_uris=output_artifact_uris,
+                output_artifact_configs={
+                    name: signature.artifact_config
+                    for name, signature in output_annotations.items()
+                },
+            )
+
+            step_environment = env_utils.get_runtime_environment(
+                config=step_run.config, stack=self._stack
+            )
+            secret_environment = env_utils.get_runtime_secret_environment(
+                config=step_run.config, stack=self._stack
+            )
+            step_environment.update(secret_environment)
+
+            step_failed = False
+            output_artifacts = {}
+
+            with step_context:
+                try:
+                    if (
+                        pipeline_run.snapshot
+                        and self._stack.orchestrator.run_init_cleanup_at_step_level
+                    ):
+                        self._stack.orchestrator.run_init_hook(
+                            snapshot=pipeline_run.snapshot
+                        )
+
+                    output_data = self._execute_portable_step(
+                        input_artifacts=input_artifacts,
+                        expected_outputs=list(output_annotations),
+                        step_environment=step_environment,
+                    )
+
+                    if runtime.is_active():
+                        runtime.record_step_outputs(step_run.name, output_data)
+
+                    artifact_metadata_enabled = is_setting_enabled(
+                        is_enabled_on_step=step_run_info.config.enable_artifact_metadata,
+                        is_enabled_on_pipeline=step_run_info.pipeline.enable_artifact_metadata,
+                    )
+                    artifact_visualization_enabled = is_setting_enabled(
+                        is_enabled_on_step=step_run_info.config.enable_artifact_visualization,
+                        is_enabled_on_pipeline=step_run_info.pipeline.enable_artifact_visualization,
+                    )
+                    output_artifacts = self._python_artifact_runner._store_output_artifacts(
+                        output_data=output_data,
+                        output_artifact_uris=output_artifact_uris,
+                        output_materializers=output_materializers,
+                        output_annotations=output_annotations,
+                        artifact_metadata_enabled=artifact_metadata_enabled,
+                        artifact_visualization_enabled=artifact_visualization_enabled,
+                    )
+
+                    if (
+                        model_version := step_run.model_version
+                        or pipeline_run.model_version
+                    ):
+                        from zenml.orchestrators import step_run_utils
+
+                        step_run_utils.link_output_artifacts_to_model_version(
+                            artifacts={
+                                name: [artifact]
+                                for name, artifact in output_artifacts.items()
+                            },
+                            model_version=model_version,
+                        )
+
+                except BaseException as step_exception:  # noqa: E722
+                    step_failed = True
+                    exception_info = (
+                        exception_utils.collect_exception_information(
+                            step_exception
+                        )
+                    )
+                    step_exception_info.set(exception_info)
+                    step_run = publish_failed_step_run(
+                        step_run_id=step_run_info.step_run_id
+                    )
+
+                    if not step_run.is_retriable:
+                        if (
+                            failure_hook_source
+                            := self.configuration.failure_hook_source
+                        ):
+                            logger.info("Detected failure hook. Running...")
+                            with env_utils.temporary_environment(
+                                step_environment
+                            ):
+                                load_and_run_hook(
+                                    failure_hook_source,
+                                    step_exception=step_exception,
+                                )
+                    raise
+                finally:
+                    step_run_metadata = self._stack.get_step_run_metadata(
+                        info=step_run_info,
+                    )
+                    publish_step_run_metadata(
+                        step_run_id=step_run_info.step_run_id,
+                        step_run_metadata=step_run_metadata,
+                    )
+                    self._stack.cleanup_step_run(
+                        info=step_run_info, step_failed=step_failed
+                    )
+
+                    if not step_failed:
+                        if (
+                            success_hook_source
+                            := self.configuration.success_hook_source
+                        ):
+                            logger.info("Detected success hook. Running...")
+                            with env_utils.temporary_environment(
+                                step_environment
+                            ):
+                                load_and_run_hook(
+                                    success_hook_source,
+                                    step_exception=None,
+                                )
+
+                    if (
+                        pipeline_run.snapshot
+                        and self._stack.orchestrator.run_init_cleanup_at_step_level
+                    ):
+                        self._stack.orchestrator.run_cleanup_hook(
+                            snapshot=pipeline_run.snapshot
+                        )
+
+            output_artifact_ids = {
+                output_name: [artifact.id]
+                for output_name, artifact in output_artifacts.items()
+            }
+            publish_successful_step_run(
+                step_run_id=step_run_info.step_run_id,
+                output_artifact_ids=output_artifact_ids,
+            )
+
+    def _validate_step_contract(self) -> None:
+        """Validate the portable step execution contract.
+
+        Raises:
+            RuntimeError: If the step cannot be executed by this runner.
+        """
+        execution_spec = self._step.spec.execution_spec
+        if execution_spec is None:
+            raise RuntimeError(
+                "PortableStepRunner requires a step execution spec."
+            )
+
+        if (
+            execution_spec.protocol
+            != StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+        ):
+            raise RuntimeError(
+                "PortableStepRunner only supports protocol "
+                f"`{StepExecutionProtocol.ZENML_PORTABLE_JSON_V1}` but got "
+                f"`{execution_spec.protocol}`."
+            )
+
+        if execution_spec.language != StepExecutionLanguage.TYPESCRIPT:
+            raise RuntimeError(
+                "Portable JSON v1 steps currently support only TypeScript "
+                f"step bodies, but got `{execution_spec.language}`."
+            )
+
+        if self._step.spec.source.import_path != PORTABLE_STEP_ADAPTER_SOURCE:
+            raise RuntimeError(
+                "Portable JSON v1 steps must use the PortableStepAdapter "
+                f"source `{PORTABLE_STEP_ADAPTER_SOURCE}`."
+            )
+
+        if self._step.spec.enable_heartbeat:
+            raise RuntimeError(
+                "Portable JSON v1 steps do not support step heartbeat yet."
+            )
+
+    def _output_annotations(self) -> Dict[str, OutputSignature]:
+        """Build output signatures from the portable step configuration.
+
+        Returns:
+            Output signatures keyed by output name.
+        """
+        return {
+            name: OutputSignature(
+                resolved_annotation=Any,
+                artifact_config=output.artifact_config,
+            )
+            for name, output in self.configuration.outputs.items()
+        }
+
+    def _execute_portable_step(
+        self,
+        input_artifacts: Dict[str, List[StepRunInputResponse]],
+        expected_outputs: List[str],
+        step_environment: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Execute the child process and collect output JSON values.
+
+        Args:
+            input_artifacts: Input artifacts resolved by StepLauncher.
+            expected_outputs: Output names expected from the child process.
+            step_environment: Environment variables for the child process.
+
+        Returns:
+            Output values keyed by output name.
+        """
+        execution_spec = self._step.spec.execution_spec
+        assert execution_spec is not None
+
+        with tempfile.TemporaryDirectory(prefix="zenml-portable-step-") as tmp:
+            work_dir = Path(tmp)
+            input_paths = self._stage_inputs(
+                input_artifacts=input_artifacts, work_dir=work_dir
+            )
+            output_paths = {
+                output_name: str(work_dir / "outputs" / f"output_{index}.json")
+                for index, output_name in enumerate(expected_outputs)
+            }
+            Path(work_dir / "outputs").mkdir(parents=True, exist_ok=True)
+
+            manifest_path = work_dir / "manifest.json"
+            manifest = {
+                "protocol": PORTABLE_JSON_PROTOCOL_VERSION,
+                "step_name": self._step.config.name,
+                "source_identity": execution_spec.source_identity,
+                "parameters": self._validated_parameters(),
+                "inputs": input_paths,
+                "outputs": output_paths,
+            }
+            _write_json_file(manifest_path, manifest)
+
+            env = os.environ.copy()
+            env.update(step_environment)
+            env[ZENML_PORTABLE_STEP_MANIFEST] = str(manifest_path)
+
+            completed_process = subprocess.run(
+                execution_spec.command,
+                cwd=str(work_dir),
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if completed_process.stdout:
+                logger.info(completed_process.stdout.rstrip())
+            if completed_process.stderr:
+                logger.warning(completed_process.stderr.rstrip())
+
+            if completed_process.returncode != 0:
+                raise RuntimeError(
+                    "Portable step subprocess failed with exit code "
+                    f"{completed_process.returncode}.\n"
+                    f"stdout:\n{_limit_output(completed_process.stdout)}\n"
+                    f"stderr:\n{_limit_output(completed_process.stderr)}"
+                )
+
+            return self._read_outputs(output_paths)
+
+    def _stage_inputs(
+        self,
+        input_artifacts: Dict[str, List[StepRunInputResponse]],
+        work_dir: Path,
+    ) -> Dict[str, str]:
+        """Load input artifacts and write portable JSON input files.
+
+        Args:
+            input_artifacts: Input artifacts resolved by StepLauncher.
+            work_dir: Temporary portable work directory.
+
+        Returns:
+            Input JSON file paths keyed by input name.
+        """
+        input_dir = work_dir / "inputs"
+        input_dir.mkdir(parents=True, exist_ok=True)
+        input_paths = {}
+
+        for index, (input_name, artifact_list) in enumerate(
+            input_artifacts.items()
+        ):
+            value = self._load_input_value(input_name, artifact_list)
+            validate_portable_json_value(value, path=f"input `{input_name}`")
+            input_path = input_dir / f"input_{index}.json"
+            _write_json_file(input_path, value)
+            input_paths[input_name] = str(input_path)
+
+        return input_paths
+
+    def _load_input_value(
+        self,
+        input_name: str,
+        artifact_list: List[StepRunInputResponse],
+    ) -> Any:
+        """Load a scalar or collection input value.
+
+        Args:
+            input_name: The step input name.
+            artifact_list: The artifacts connected to the input.
+
+        Returns:
+            The materialized input value.
+        """
+        is_scalar = (
+            input_name not in self._step.spec.inputs
+            or self._step.spec.is_scalar_input(input_name)
+        )
+        if is_scalar:
+            if len(artifact_list) != 1:
+                raise RuntimeError(
+                    f"Expected a single artifact for portable input "
+                    f"`{input_name}`."
+                )
+            return self._python_artifact_runner._load_input_artifact(
+                artifact_list[0], data_type=Any
+            )
+
+        return [
+            self._python_artifact_runner._load_input_artifact(
+                artifact, data_type=Any
+            )
+            for artifact in artifact_list
+        ]
+
+    def _validated_parameters(self) -> Dict[str, Any]:
+        """Validate and return portable step parameters.
+
+        Returns:
+            The JSON-compatible parameter mapping.
+        """
+        parameters = dict(self.configuration.parameters)
+        validate_portable_json_value(parameters, path="parameters")
+        return parameters
+
+    def _read_outputs(self, output_paths: Dict[str, str]) -> Dict[str, Any]:
+        """Read and validate child-process output JSON files.
+
+        Args:
+            output_paths: Expected output file paths keyed by output name.
+
+        Returns:
+            Output values keyed by output name.
+        """
+        output_data = {}
+        for output_name, output_path in output_paths.items():
+            path = Path(output_path)
+            if not path.exists():
+                raise RuntimeError(
+                    f"Portable step did not write expected output "
+                    f"`{output_name}` to `{output_path}`."
+                )
+
+            try:
+                with path.open("r", encoding="utf-8") as file:
+                    value = json.load(
+                        file, parse_constant=_reject_json_constant
+                    )
+            except (json.JSONDecodeError, ValueError) as e:
+                raise RuntimeError(
+                    f"Portable step wrote invalid JSON for output "
+                    f"`{output_name}` at `{output_path}`: {e}"
+                ) from e
+
+            validate_portable_json_value(value, path=f"output `{output_name}`")
+            output_data[output_name] = value
+
+        return output_data
+
+
+def _write_json_file(path: Path, value: Any) -> None:
+    """Write strict JSON to a file.
+
+    Args:
+        path: The file to write.
+        value: The JSON-compatible value to write.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(value, file, allow_nan=False, sort_keys=True)
+
+
+def _reject_json_constant(value: str) -> None:
+    """Reject JSON constants accepted by Python but invalid in strict JSON.
+
+    Args:
+        value: The invalid constant.
+
+    Raises:
+        ValueError: Always, because the value is not strict JSON.
+    """
+    raise ValueError(f"Invalid JSON constant `{value}`.")
+
+
+def _limit_output(output: str) -> str:
+    """Limit subprocess output included in exceptions.
+
+    Args:
+        output: The subprocess output.
+
+    Returns:
+        The output, truncated from the front if necessary.
+    """
+    if len(output) <= _SUBPROCESS_OUTPUT_LIMIT:
+        return output
+
+    return "..." + output[-_SUBPROCESS_OUTPUT_LIMIT:]

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -28,6 +28,7 @@ from typing import (
 
 from zenml.client import Client
 from zenml.config.step_configurations import Step
+from zenml.config.step_execution_spec import StepExecutionProtocol
 from zenml.config.step_run_info import StepRunInfo
 from zenml.constants import (
     ENV_ZENML_STEP_OPERATOR,
@@ -49,6 +50,7 @@ from zenml.models import (
 from zenml.models.v2.core.step_run import StepRunInputResponse
 from zenml.orchestrators import output_utils, publish_utils, step_run_utils
 from zenml.orchestrators import utils as orchestrator_utils
+from zenml.orchestrators.portable_step_runner import PortableStepRunner
 from zenml.orchestrators.signal_handler import SignalHandler
 from zenml.orchestrators.step_runner import StepRunner
 from zenml.stack import Stack
@@ -395,6 +397,17 @@ class StepLauncher:
             self._wait_until_resources_acquired(step_run_info)
 
         try:
+            if (
+                self._snapshot.is_dynamic
+                and self._step.spec.execution_spec
+                and self._step.spec.execution_spec.protocol
+                == StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+            ):
+                raise RuntimeError(
+                    "ZenBabel portable steps are only supported for static "
+                    "pipelines in v1."
+                )
+
             if self._step.config.step_operator:
                 step_operator_name = None
                 if isinstance(self._step.config.step_operator, str):
@@ -620,7 +633,26 @@ class StepLauncher:
             input_artifacts: The input artifact versions of the current step.
             output_artifact_uris: The output artifact URIs of the current step.
         """
-        runner = StepRunner(step=self._step, stack=self._stack)
+        execution_spec = self._step.spec.execution_spec
+        if execution_spec is None:
+            runner = StepRunner(step=self._step, stack=self._stack)
+        elif (
+            execution_spec.protocol
+            == StepExecutionProtocol.ZENML_PYTHON_STEP_V1
+        ):
+            runner = StepRunner(step=self._step, stack=self._stack)
+        elif (
+            execution_spec.protocol
+            == StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+        ):
+            runner = PortableStepRunner(step=self._step, stack=self._stack)
+        else:
+            raise RuntimeError(
+                f"Unsupported step execution protocol "
+                f"`{execution_spec.protocol}` for step "
+                f"`{self._invocation_id}`."
+            )
+
         runner.run(
             pipeline_run=pipeline_run,
             step_run=step_run,

--- a/src/zenml/zenbabel/__init__.py
+++ b/src/zenml/zenbabel/__init__.py
@@ -1,0 +1,24 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Experimental ZenBabel namespace."""
+
+from zenml.zenbabel.adapters import (
+    PORTABLE_STEP_ADAPTER_SOURCE,
+    PortableStepAdapter,
+)
+
+__all__ = [
+    "PORTABLE_STEP_ADAPTER_SOURCE",
+    "PortableStepAdapter",
+]

--- a/src/zenml/zenbabel/__init__.py
+++ b/src/zenml/zenbabel/__init__.py
@@ -17,6 +17,15 @@ from zenml.zenbabel.adapters import (
     PORTABLE_STEP_ADAPTER_SOURCE,
     PortableStepAdapter,
 )
+from zenml.zenbabel.authoring import (
+    ExperimentalPortableStepCompiler,
+    experimental_compile_snapshot,
+    experimental_create_snapshot,
+    experimental_portable_json_compiler_bridge,
+    experimental_portable_json_pipeline_spec,
+    experimental_portable_json_step,
+    experimental_submit_pipeline,
+)
 from zenml.zenbabel.external_spec import (
     ExternalInputReference,
     ExternalPipelineOutput,
@@ -34,9 +43,16 @@ __all__ = [
     "ExternalPipelineOutput",
     "ExternalPipelineSpec",
     "ExternalPortableStep",
+    "ExperimentalPortableStepCompiler",
     "PORTABLE_STEP_ADAPTER_SOURCE",
     "PortableStepAdapter",
     "build_pipeline_snapshot",
     "build_pipeline_spec",
     "build_steps",
+    "experimental_compile_snapshot",
+    "experimental_create_snapshot",
+    "experimental_portable_json_compiler_bridge",
+    "experimental_portable_json_pipeline_spec",
+    "experimental_portable_json_step",
+    "experimental_submit_pipeline",
 ]

--- a/src/zenml/zenbabel/__init__.py
+++ b/src/zenml/zenbabel/__init__.py
@@ -17,8 +17,26 @@ from zenml.zenbabel.adapters import (
     PORTABLE_STEP_ADAPTER_SOURCE,
     PortableStepAdapter,
 )
+from zenml.zenbabel.external_spec import (
+    ExternalInputReference,
+    ExternalPipelineOutput,
+    ExternalPipelineSpec,
+    ExternalPortableStep,
+)
+from zenml.zenbabel.importer import (
+    build_pipeline_snapshot,
+    build_pipeline_spec,
+    build_steps,
+)
 
 __all__ = [
+    "ExternalInputReference",
+    "ExternalPipelineOutput",
+    "ExternalPipelineSpec",
+    "ExternalPortableStep",
     "PORTABLE_STEP_ADAPTER_SOURCE",
     "PortableStepAdapter",
+    "build_pipeline_snapshot",
+    "build_pipeline_spec",
+    "build_steps",
 ]

--- a/src/zenml/zenbabel/adapters.py
+++ b/src/zenml/zenbabel/adapters.py
@@ -1,0 +1,57 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Adapters for experimental ZenBabel step specifications."""
+
+from typing import Any
+
+from zenml.steps.base_step import BaseStep
+
+PORTABLE_STEP_ADAPTER_SOURCE = "zenml.zenbabel.adapters.PortableStepAdapter"
+
+
+class PortableStepAdapter(BaseStep):
+    """Importable marker step for portable ZenBabel step bodies.
+
+    Portable steps still need a Python ``Source`` so existing snapshot and
+    pre-execution code can load a ``BaseStep`` and extract source/docstring
+    information. This adapter provides that shape, but it is not a runnable
+    step body. Portable execution must be routed through the dedicated portable
+    runner once that runner exists.
+    """
+
+    def __init__(self) -> None:
+        """Initialize without normal step interface validation.
+
+        The adapter intentionally accepts arbitrary accidental execution
+        arguments below, but normal ZenML step validation rejects catch-all
+        entrypoints. This marker only needs the minimal ``BaseStep`` shape used
+        for source/docstring/source-code extraction.
+        """
+
+    def entrypoint(self, *args: Any, **kwargs: Any) -> Any:
+        """Reject accidental execution through the normal Python step path.
+
+        Args:
+            *args: Accidental positional arguments.
+            **kwargs: Accidental keyword arguments.
+
+        Raises:
+            RuntimeError: Always, because this adapter is never the real step
+                body.
+        """
+        raise RuntimeError(
+            "PortableStepAdapter is a marker for ZenBabel portable steps and "
+            "must not be executed as a normal Python step. Route this step "
+            "through the portable step runner instead."
+        )

--- a/src/zenml/zenbabel/authoring.py
+++ b/src/zenml/zenbabel/authoring.py
@@ -1,0 +1,268 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Experimental authoring helpers for ZenBabel portable JSON steps.
+
+This module is deliberately small scaffolding, not a stable TypeScript SDK. It
+lets a Python-authored static pipeline keep a normal placeholder step in the
+pipeline graph while compilation swaps that placeholder's execution metadata for
+a portable JSON step description.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Mapping, Sequence, Union
+
+import zenml.pipelines.pipeline_definition as pipeline_definition_module
+from zenml.client import Client
+from zenml.config.compiler import Compiler
+from zenml.config.step_configurations import Step
+from zenml.execution.pipeline.utils import submit_pipeline
+from zenml.models import PipelineSnapshotResponse
+from zenml.pipelines.run_utils import create_placeholder_run
+from zenml.zenbabel.external_spec import (
+    ExternalPipelineOutput,
+    ExternalPipelineSpec,
+    ExternalPortableStep,
+)
+from zenml.zenbabel.importer import ExternalSpecLike, build_steps
+
+PipelineOutputLike = Union[
+    ExternalPipelineOutput, Mapping[str, str], tuple[str, str]
+]
+SnapshotValidator = Callable[[PipelineSnapshotResponse], None]
+
+
+class ExperimentalPortableStepCompiler(Compiler):
+    """Compiler bridge that donates portable metadata to placeholders."""
+
+    def __init__(self, portable_steps: Mapping[str, Step]) -> None:
+        """Initialize the compiler bridge.
+
+        Args:
+            portable_steps: Portable metadata donor steps keyed by invocation id.
+        """
+        super().__init__()
+        self._portable_steps = portable_steps
+
+    def _compile_step_invocation(self, *args: Any, **kwargs: Any) -> Step:
+        """Compile normally, then route selected invocations to ZenBabel."""
+        compiled_step = super()._compile_step_invocation(*args, **kwargs)
+        portable_step = self._portable_steps.get(
+            compiled_step.spec.invocation_id
+        )
+        if portable_step is None:
+            return compiled_step
+
+        return _replace_with_portable_execution(
+            compiled_step=compiled_step,
+            portable_step=portable_step,
+        )
+
+
+@contextmanager
+def experimental_portable_json_compiler_bridge(
+    external_spec: ExternalSpecLike,
+) -> Iterator[None]:
+    """Temporarily route placeholder steps through ZenBabel portable JSON.
+
+    Args:
+        external_spec: External ZenBabel spec containing portable step metadata.
+    """
+    original_compiler = pipeline_definition_module.Compiler
+    portable_steps = build_steps(external_spec)
+
+    def compiler_factory() -> ExperimentalPortableStepCompiler:
+        return ExperimentalPortableStepCompiler(portable_steps=portable_steps)
+
+    pipeline_definition_module.Compiler = compiler_factory  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        pipeline_definition_module.Compiler = original_compiler
+
+
+def experimental_portable_json_step(
+    *,
+    name: str,
+    command: Sequence[str],
+    source_identity: str,
+    inputs: Mapping[str, Any] | None = None,
+    depends_on: Sequence[str] | None = None,
+    parameters: Mapping[str, Any] | None = None,
+    parameter_schema: Mapping[str, Any] | None = None,
+    outputs: Sequence[str] = ("output",),
+) -> ExternalPortableStep:
+    """Create a minimal experimental TypeScript portable JSON step spec.
+
+    Args:
+        name: Placeholder invocation id in the Python pipeline.
+        command: Command to run inside the step container.
+        source_identity: Stable TypeScript source identity for hashes/debugging.
+        inputs: Optional portable input references.
+        depends_on: Optional explicit upstream dependencies.
+        parameters: Optional portable JSON parameters.
+        parameter_schema: Optional JSON-schema-like parameter schema.
+        outputs: Declared output names. Defaults to the normal ZenML ``output``.
+
+    Returns:
+        A validated external portable step model.
+    """
+    return ExternalPortableStep(
+        name=name,
+        command=list(command),
+        source_identity=source_identity,
+        inputs=dict(inputs or {}),
+        depends_on=list(depends_on or []),
+        parameters=dict(parameters or {}),
+        parameter_schema=dict(parameter_schema or {})
+        if parameter_schema is not None
+        else None,
+        outputs=list(outputs),
+    )
+
+
+def experimental_portable_json_pipeline_spec(
+    *,
+    name: str,
+    steps: Sequence[ExternalPortableStep],
+    outputs: Sequence[PipelineOutputLike] | None = None,
+    parameters: Mapping[str, Any] | None = None,
+) -> ExternalPipelineSpec:
+    """Create a minimal experimental external spec for a static pipeline.
+
+    Args:
+        name: Pipeline name.
+        steps: Portable step specs keyed to Python placeholder invocations.
+        outputs: Optional pipeline outputs.
+        parameters: Optional pipeline-level parameters.
+
+    Returns:
+        A validated external pipeline spec model.
+    """
+    return ExternalPipelineSpec(
+        name=name,
+        steps=list(steps),
+        outputs=[_coerce_pipeline_output(output) for output in outputs or []],
+        parameters=dict(parameters or {}),
+    )
+
+
+def experimental_compile_snapshot(
+    pipeline: Any,
+    external_spec: ExternalSpecLike,
+) -> Any:
+    """Compile a pipeline while the portable JSON bridge is active.
+
+    Args:
+        pipeline: ZenML pipeline object to compile.
+        external_spec: External ZenBabel spec containing portable step metadata.
+
+    Returns:
+        The compiled, not-yet-persisted pipeline snapshot.
+    """
+    with experimental_portable_json_compiler_bridge(external_spec):
+        pipeline.prepare()
+        snapshot, _, _ = pipeline._compile()
+
+    return snapshot
+
+
+def experimental_create_snapshot(
+    pipeline: Any,
+    external_spec: ExternalSpecLike,
+) -> PipelineSnapshotResponse:
+    """Create a persisted pipeline snapshot with portable JSON metadata.
+
+    Args:
+        pipeline: ZenML pipeline object to snapshot.
+        external_spec: External ZenBabel spec containing portable step metadata.
+
+    Returns:
+        The persisted pipeline snapshot returned by the active ZenML store.
+    """
+    with experimental_portable_json_compiler_bridge(external_spec):
+        pipeline.prepare()
+        return pipeline._create_snapshot()
+
+
+def experimental_submit_pipeline(
+    pipeline: Any,
+    external_spec: ExternalSpecLike,
+    *,
+    snapshot_validator: SnapshotValidator | None = None,
+) -> PipelineSnapshotResponse:
+    """Create and submit a portable JSON pipeline snapshot.
+
+    Args:
+        pipeline: ZenML pipeline object to submit.
+        external_spec: External ZenBabel spec containing portable step metadata.
+        snapshot_validator: Optional callback invoked after snapshot creation and
+            before submission. This is useful while servers may still strip
+            experimental fields during persistence.
+
+    Returns:
+        The submitted pipeline snapshot.
+    """
+    snapshot = experimental_create_snapshot(
+        pipeline=pipeline,
+        external_spec=external_spec,
+    )
+    if snapshot_validator is not None:
+        snapshot_validator(snapshot)
+
+    run = create_placeholder_run(snapshot=snapshot)
+    submit_pipeline(
+        snapshot=snapshot,
+        stack=Client().active_stack,
+        placeholder_run=run,
+    )
+    return snapshot
+
+
+def _replace_with_portable_execution(
+    *,
+    compiled_step: Step,
+    portable_step: Step,
+) -> Step:
+    """Copy only portable routing metadata onto a compiled placeholder step."""
+    patched_spec = compiled_step.spec.model_copy(
+        update={
+            "source": portable_step.spec.source,
+            "execution_spec": portable_step.spec.execution_spec,
+        }
+    )
+    return compiled_step.model_copy(update={"spec": patched_spec})
+
+
+def _coerce_pipeline_output(
+    output: PipelineOutputLike,
+) -> ExternalPipelineOutput:
+    """Coerce authoring-friendly output declarations to external models."""
+    if isinstance(output, ExternalPipelineOutput):
+        return output
+    if isinstance(output, tuple):
+        step, output_name = output
+        return ExternalPipelineOutput(step=step, output=output_name)
+
+    return ExternalPipelineOutput.model_validate(output)
+
+
+__all__ = [
+    "ExperimentalPortableStepCompiler",
+    "experimental_compile_snapshot",
+    "experimental_create_snapshot",
+    "experimental_portable_json_compiler_bridge",
+    "experimental_portable_json_pipeline_spec",
+    "experimental_portable_json_step",
+    "experimental_submit_pipeline",
+]

--- a/src/zenml/zenbabel/external_spec.py
+++ b/src/zenml/zenbabel/external_spec.py
@@ -1,0 +1,336 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Experimental external ZenBabel pipeline spec models."""
+
+from typing import Any, Dict, Iterable, List, Mapping, Union
+
+from pydantic import Field, field_validator, model_validator
+
+from zenml.config.frozen_base_model import FrozenBaseModel
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+)
+
+
+def _validate_name(value: str, field_name: str) -> str:
+    """Validate a non-empty spec identifier.
+
+    Args:
+        value: The identifier to validate.
+        field_name: Human-readable field name for error messages.
+
+    Raises:
+        ValueError: If the value is empty.
+
+    Returns:
+        The validated value.
+    """
+    if not value:
+        raise ValueError(f"ZenBabel external spec `{field_name}` is empty.")
+
+    return value
+
+
+class ExternalInputReference(FrozenBaseModel):
+    """Reference to an upstream step output in an external spec."""
+
+    step: str
+    output: str = "output"
+
+    @field_validator("step")
+    @classmethod
+    def _validate_step(cls, step: str) -> str:
+        """Validate the referenced step name."""
+        return _validate_name(step, "input.step")
+
+    @field_validator("output")
+    @classmethod
+    def _validate_output(cls, output: str) -> str:
+        """Validate the referenced output name."""
+        return _validate_name(output, "input.output")
+
+
+ExternalInput = Union[ExternalInputReference, List[ExternalInputReference]]
+
+
+class ExternalPipelineOutput(FrozenBaseModel):
+    """Pipeline-level output exported from an external spec."""
+
+    step: str
+    output: str = "output"
+
+    @field_validator("step")
+    @classmethod
+    def _validate_step(cls, step: str) -> str:
+        """Validate the referenced step name."""
+        return _validate_name(step, "outputs.step")
+
+    @field_validator("output")
+    @classmethod
+    def _validate_output(cls, output: str) -> str:
+        """Validate the referenced output name."""
+        return _validate_name(output, "outputs.output")
+
+
+class ExternalPortableStep(FrozenBaseModel):
+    """Small external spec for one portable TypeScript step."""
+
+    name: str
+    command: List[str]
+    source_identity: str
+    inputs: Dict[str, ExternalInput] = Field(default_factory=dict)
+    depends_on: List[str] = Field(default_factory=list)
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+    parameter_schema: Dict[str, Any] | None = None
+    outputs: List[str] = Field(default_factory=lambda: ["output"])
+    language: StepExecutionLanguage = StepExecutionLanguage.TYPESCRIPT
+    protocol: StepExecutionProtocol = (
+        StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+    )
+
+    @field_validator("name")
+    @classmethod
+    def _validate_step_name(cls, name: str) -> str:
+        """Validate the step name."""
+        return _validate_name(name, "steps.name")
+
+    @field_validator("source_identity")
+    @classmethod
+    def _validate_source_identity(cls, source_identity: str) -> str:
+        """Validate the portable source identity."""
+        return _validate_name(source_identity, "steps.source_identity")
+
+    @field_validator("outputs")
+    @classmethod
+    def _validate_outputs(cls, outputs: List[str]) -> List[str]:
+        """Validate output names."""
+        if not outputs:
+            raise ValueError(
+                "ZenBabel portable steps must declare at least one output."
+            )
+
+        seen = set()
+        for output in outputs:
+            _validate_name(output, "steps.outputs")
+            if output in seen:
+                raise ValueError(
+                    f"ZenBabel step output `{output}` is declared twice."
+                )
+            seen.add(output)
+
+        return outputs
+
+    @field_validator("depends_on")
+    @classmethod
+    def _validate_depends_on(cls, depends_on: List[str]) -> List[str]:
+        """Validate explicit upstream dependencies."""
+        seen = set()
+        for dependency in depends_on:
+            _validate_name(dependency, "steps.depends_on")
+            if dependency in seen:
+                raise ValueError(
+                    "ZenBabel step dependency "
+                    f"`{dependency}` is declared twice."
+                )
+            seen.add(dependency)
+
+        return depends_on
+
+    @field_validator("command")
+    @classmethod
+    def _validate_command(cls, command: List[str]) -> List[str]:
+        """Validate the portable command."""
+        if not command:
+            raise ValueError(
+                "ZenBabel portable step command must not be empty."
+            )
+
+        for argument in command:
+            if not argument:
+                raise ValueError(
+                    "ZenBabel portable step command arguments must not be empty."
+                )
+
+        return command
+
+    @model_validator(mode="after")
+    def _validate_portable_contract(self) -> "ExternalPortableStep":
+        """Reject execution contracts outside the v1 importer scope."""
+        if self.language != StepExecutionLanguage.TYPESCRIPT:
+            raise ValueError(
+                "ZenBabel external specs only support TypeScript portable "
+                "steps in v1."
+            )
+
+        if self.protocol != StepExecutionProtocol.ZENML_PORTABLE_JSON_V1:
+            raise ValueError(
+                "ZenBabel external specs only support the "
+                "zenml-portable-json-v1 protocol in v1."
+            )
+
+        return self
+
+
+class ExternalPipelineSpec(FrozenBaseModel):
+    """Small static external pipeline spec accepted by ZenBabel v1."""
+
+    name: str
+    graph: str = "static"
+    is_dynamic: bool = False
+    steps: List[ExternalPortableStep]
+    outputs: List[ExternalPipelineOutput] = Field(default_factory=list)
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_pipeline_name(cls, name: str) -> str:
+        """Validate the pipeline name."""
+        return _validate_name(name, "name")
+
+    @field_validator("graph")
+    @classmethod
+    def _validate_graph(cls, graph: str) -> str:
+        """Reject graph shapes outside the v1 importer scope."""
+        if graph != "static":
+            raise ValueError(
+                "ZenBabel external specs only support static pipelines in v1."
+            )
+
+        return graph
+
+    @model_validator(mode="after")
+    def _validate_static_pipeline(self) -> "ExternalPipelineSpec":
+        """Validate static graph references."""
+        if self.is_dynamic:
+            raise ValueError(
+                "ZenBabel external specs only support static pipelines in v1."
+            )
+
+        if not self.steps:
+            raise ValueError(
+                "ZenBabel external pipeline specs must declare at least one step."
+            )
+
+        steps_by_name: Dict[str, ExternalPortableStep] = {}
+        for step in self.steps:
+            if step.name in steps_by_name:
+                raise ValueError(
+                    f"ZenBabel step `{step.name}` is declared twice."
+                )
+            steps_by_name[step.name] = step
+
+        for step in self.steps:
+            for upstream_name in _iter_upstream_step_names(step):
+                if upstream_name == step.name:
+                    raise ValueError(
+                        f"ZenBabel step `{step.name}` cannot depend on itself."
+                    )
+                if upstream_name not in steps_by_name:
+                    raise ValueError(
+                        f"ZenBabel step `{step.name}` references unknown "
+                        f"upstream step `{upstream_name}`."
+                    )
+
+            for reference in _iter_input_references(step.inputs):
+                upstream_step = steps_by_name[reference.step]
+                if reference.output not in upstream_step.outputs:
+                    raise ValueError(
+                        f"ZenBabel step `{step.name}` references unknown "
+                        f"output `{reference.output}` on upstream step "
+                        f"`{reference.step}`."
+                    )
+
+        for output in self.outputs:
+            if output.step not in steps_by_name:
+                raise ValueError(
+                    "ZenBabel pipeline output references unknown step "
+                    f"`{output.step}`."
+                )
+            if output.output not in steps_by_name[output.step].outputs:
+                raise ValueError(
+                    "ZenBabel pipeline output references unknown output "
+                    f"`{output.output}` on step `{output.step}`."
+                )
+
+        _topological_step_names(self.steps)
+        return self
+
+
+def _iter_input_references(
+    inputs: Mapping[str, ExternalInput],
+) -> Iterable[ExternalInputReference]:
+    """Iterate over all input references in a step input mapping."""
+    for input_value in inputs.values():
+        if isinstance(input_value, list):
+            yield from input_value
+        else:
+            yield input_value
+
+
+def _iter_upstream_step_names(step: ExternalPortableStep) -> Iterable[str]:
+    """Iterate over all explicit and data upstream step names."""
+    yield from step.depends_on
+    for reference in _iter_input_references(step.inputs):
+        yield reference.step
+
+
+def _topological_step_names(steps: List[ExternalPortableStep]) -> List[str]:
+    """Return step names in topological order.
+
+    Args:
+        steps: The steps to sort.
+
+    Raises:
+        ValueError: If the graph contains a cycle.
+
+    Returns:
+        Step names sorted so every upstream appears before its downstream.
+    """
+    ordered: List[str] = []
+    temporary_marks = set()
+    permanent_marks = set()
+    steps_by_name = {step.name: step for step in steps}
+
+    def visit(step_name: str) -> None:
+        if step_name in permanent_marks:
+            return
+        if step_name in temporary_marks:
+            raise ValueError(
+                "ZenBabel external specs only support acyclic static "
+                "pipelines in v1."
+            )
+
+        temporary_marks.add(step_name)
+        for upstream_name in sorted(
+            set(_iter_upstream_step_names(steps_by_name[step_name]))
+        ):
+            visit(upstream_name)
+        temporary_marks.remove(step_name)
+        permanent_marks.add(step_name)
+        ordered.append(step_name)
+
+    for step in steps:
+        visit(step.name)
+
+    return ordered
+
+
+__all__ = [
+    "ExternalInput",
+    "ExternalInputReference",
+    "ExternalPipelineOutput",
+    "ExternalPipelineSpec",
+    "ExternalPortableStep",
+]

--- a/src/zenml/zenbabel/importer.py
+++ b/src/zenml/zenbabel/importer.py
@@ -1,0 +1,217 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Importer for experimental ZenBabel external specs."""
+
+import hashlib
+from typing import Any, Dict, List, Mapping, Union
+
+from zenml.config.pipeline_configurations import PipelineConfiguration
+from zenml.config.pipeline_spec import OutputSpec, PipelineSpec
+from zenml.config.source import Source
+from zenml.config.step_configurations import (
+    InputSpec,
+    Step,
+    StepConfiguration,
+    StepSpec,
+)
+from zenml.config.step_execution_spec import StepExecutionSpec
+from zenml.materializers.built_in_materializer import (
+    BuiltInContainerMaterializer,
+    BuiltInMaterializer,
+)
+from zenml.models import PipelineSnapshotBase
+from zenml.utils import source_utils
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
+from zenml.zenbabel.external_spec import (
+    ExternalInput,
+    ExternalInputReference,
+    ExternalPipelineSpec,
+    ExternalPortableStep,
+    _iter_input_references,
+    _iter_upstream_step_names,
+    _topological_step_names,
+)
+
+ExternalSpecLike = Union[ExternalPipelineSpec, Mapping[str, Any]]
+
+
+def build_steps(external_spec: ExternalSpecLike) -> Dict[str, Step]:
+    """Build normal ZenML step objects from an external spec.
+
+    Args:
+        external_spec: External ZenBabel spec model or dictionary.
+
+    Returns:
+        ZenML step objects keyed by invocation/step name.
+    """
+    spec = _coerce_external_spec(external_spec)
+    steps_by_name = {step.name: step for step in spec.steps}
+
+    return {
+        step_name: _build_step(steps_by_name[step_name])
+        for step_name in _topological_step_names(spec.steps)
+    }
+
+
+def build_pipeline_spec(external_spec: ExternalSpecLike) -> PipelineSpec:
+    """Build a normal ZenML pipeline spec from an external spec.
+
+    Args:
+        external_spec: External ZenBabel spec model or dictionary.
+
+    Returns:
+        A ZenML pipeline spec that can use conditional portable-step
+        serialization.
+    """
+    spec = _coerce_external_spec(external_spec)
+    steps = build_steps(spec)
+
+    return PipelineSpec(
+        steps=[step.spec for step in steps.values()],
+        outputs=[
+            OutputSpec(step_name=output.step, output_name=output.output)
+            for output in spec.outputs
+        ],
+        parameters=spec.parameters,
+    )
+
+
+def build_pipeline_snapshot(
+    external_spec: ExternalSpecLike,
+    *,
+    run_name_template: str | None = None,
+    client_environment: Dict[str, Any] | None = None,
+    client_version: str | None = None,
+    server_version: str | None = None,
+) -> PipelineSnapshotBase:
+    """Build a minimal ZenML pipeline snapshot from an external spec.
+
+    Args:
+        external_spec: External ZenBabel spec model or dictionary.
+        run_name_template: Optional run name template. Defaults to the pipeline
+            name.
+        client_environment: Optional client environment metadata.
+        client_version: Optional ZenML client version.
+        server_version: Optional ZenML server version.
+
+    Returns:
+        A static ``PipelineSnapshotBase`` with ZenML configuration, steps and
+        pipeline spec populated.
+    """
+    spec = _coerce_external_spec(external_spec)
+    steps = build_steps(spec)
+    pipeline_spec = build_pipeline_spec(spec)
+
+    return PipelineSnapshotBase(
+        run_name_template=run_name_template or spec.name,
+        is_dynamic=False,
+        pipeline_configuration=PipelineConfiguration(name=spec.name),
+        step_configurations=steps,
+        client_environment=client_environment or {},
+        client_version=client_version,
+        server_version=server_version,
+        pipeline_version_hash=_compute_pipeline_version_hash(pipeline_spec),
+        pipeline_spec=pipeline_spec,
+    )
+
+
+def _coerce_external_spec(
+    external_spec: ExternalSpecLike,
+) -> ExternalPipelineSpec:
+    """Validate or return an external spec model."""
+    if isinstance(external_spec, ExternalPipelineSpec):
+        return external_spec
+
+    return ExternalPipelineSpec.model_validate(external_spec)
+
+
+def _build_step(external_step: ExternalPortableStep) -> Step:
+    """Build one ZenML step from one external portable step."""
+    config = StepConfiguration(
+        name=external_step.name,
+        parameters=external_step.parameters,
+        outputs={
+            output_name: {
+                "materializer_source": _portable_json_materializer_sources(),
+            }
+            for output_name in external_step.outputs
+        },
+    )
+
+    return Step(
+        spec=StepSpec(
+            source=PORTABLE_STEP_ADAPTER_SOURCE,
+            upstream_steps=sorted(
+                set(_iter_upstream_step_names(external_step))
+            ),
+            inputs=_build_inputs(external_step.inputs),
+            invocation_id=external_step.name,
+            parameter_spec=external_step.parameter_schema,
+            execution_spec=StepExecutionSpec(
+                language=external_step.language,
+                protocol=external_step.protocol,
+                command=external_step.command,
+                source_identity=external_step.source_identity,
+            ),
+        ),
+        config=config,
+        step_config_overrides=config,
+    )
+
+
+def _build_inputs(
+    inputs: Mapping[str, ExternalInput],
+) -> Dict[str, Union[InputSpec, List[InputSpec]]]:
+    """Build ZenML input specs from external input references."""
+    return {
+        input_name: _build_input(input_value)
+        for input_name, input_value in inputs.items()
+    }
+
+
+def _build_input(
+    input_value: ExternalInput,
+) -> Union[InputSpec, List[InputSpec]]:
+    """Build one ZenML input spec or input-spec collection."""
+    if isinstance(input_value, list):
+        return [_build_scalar_input(reference) for reference in input_value]
+
+    return _build_scalar_input(input_value)
+
+
+def _build_scalar_input(reference: ExternalInputReference) -> InputSpec:
+    """Build one scalar ZenML input spec."""
+    return InputSpec(step_name=reference.step, output_name=reference.output)
+
+
+def _portable_json_materializer_sources() -> tuple[Source, ...]:
+    """Return built-in materializer sources for strict portable JSON values."""
+    return (
+        source_utils.resolve(BuiltInMaterializer),
+        source_utils.resolve(BuiltInContainerMaterializer),
+    )
+
+
+def _compute_pipeline_version_hash(pipeline_spec: PipelineSpec) -> str:
+    """Compute a stable importer-local snapshot hash."""
+    hash_ = hashlib.sha256()
+    hash_.update(pipeline_spec.json_with_string_sources.encode())
+    return hash_.hexdigest()
+
+
+__all__ = [
+    "build_pipeline_snapshot",
+    "build_pipeline_spec",
+    "build_steps",
+]

--- a/tests/unit/config/test_step_configurations.py
+++ b/tests/unit/config/test_step_configurations.py
@@ -13,7 +13,29 @@
 #  permissions and limitations under the License.
 
 
-from zenml.config.step_configurations import InputSpec, StepSpec
+from zenml.config.pipeline_spec import PipelineSpec
+from zenml.config.step_configurations import (
+    InputSpec,
+    Step,
+    StepConfiguration,
+    StepSpec,
+)
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+    StepExecutionSpec,
+)
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
+
+
+def _portable_execution_spec(source_identity: str) -> StepExecutionSpec:
+    """Create a portable execution spec for tests."""
+    return StepExecutionSpec(
+        language=StepExecutionLanguage.TYPESCRIPT,
+        protocol=StepExecutionProtocol.ZENML_PORTABLE_JSON_V1,
+        command=["node", "/app/dist/steps/score.js"],
+        source_identity=source_identity,
+    )
 
 
 def test_step_spec_source_equality():
@@ -114,3 +136,83 @@ def test_step_spec_parameter_spec_equality():
         upstream_steps=[],
         parameter_spec={},
     )
+
+
+def test_step_spec_execution_spec_equality():
+    """Tests equality for portable step execution specs."""
+    adapter_source = PORTABLE_STEP_ADAPTER_SOURCE
+
+    assert StepSpec(
+        source=adapter_source,
+        upstream_steps=[],
+        execution_spec=_portable_execution_spec("ts/src/score.ts#score"),
+    ) == StepSpec(
+        source=adapter_source,
+        upstream_steps=[],
+        execution_spec=_portable_execution_spec("ts/src/score.ts#score"),
+    )
+
+    assert StepSpec(
+        source=adapter_source,
+        upstream_steps=[],
+        execution_spec=_portable_execution_spec("ts/src/score.ts#score"),
+    ) != StepSpec(
+        source=adapter_source,
+        upstream_steps=[],
+        execution_spec=_portable_execution_spec("ts/src/score.ts#other"),
+    )
+
+
+def test_python_pipeline_spec_serialization_omits_empty_execution_spec():
+    """Tests that Python-only specs do not get execution spec churn."""
+    spec = PipelineSpec(
+        steps=[
+            StepSpec(
+                source="tests.unit.config.test_step_configurations.step",
+                upstream_steps=[],
+                invocation_id="step",
+            )
+        ]
+    )
+
+    assert spec.version == "0.5"
+    assert "execution_spec" not in spec.model_dump(mode="json")["steps"][0]
+    assert "execution_spec" not in spec.json_with_string_sources
+
+    step = Step(
+        spec=spec.steps[0],
+        config=StepConfiguration(name="step"),
+        step_config_overrides=StepConfiguration(name="step"),
+    )
+    assert "execution_spec" not in step.model_dump_json(exclude={"config"})
+
+
+def test_portable_pipeline_spec_serialization_sets_version_and_identity():
+    """Tests deterministic serialization for portable step specs."""
+    spec = PipelineSpec(
+        steps=[
+            StepSpec(
+                source=PORTABLE_STEP_ADAPTER_SOURCE,
+                upstream_steps=[],
+                invocation_id="score",
+                execution_spec=_portable_execution_spec(
+                    "examples/zenbabel/ts/src/steps/score.ts#score"
+                ),
+            )
+        ]
+    )
+
+    dumped = spec.model_dump(mode="json")
+    assert spec.version == "0.6"
+    assert dumped["version"] == "0.6"
+    assert dumped["steps"][0]["execution_spec"] == {
+        "language": "typescript",
+        "protocol": "zenml-portable-json-v1",
+        "command": ["node", "/app/dist/steps/score.js"],
+        "source_identity": "examples/zenbabel/ts/src/steps/score.ts#score",
+    }
+
+    serialized = spec.json_with_string_sources
+    assert serialized == spec.json_with_string_sources
+    assert '"version": "0.6"' in serialized
+    assert "examples/zenbabel/ts/src/steps/score.ts#score" in serialized

--- a/tests/unit/orchestrators/test_cache_utils.py
+++ b/tests/unit/orchestrators/test_cache_utils.py
@@ -25,6 +25,11 @@ from zenml.config.compiler import Compiler
 from zenml.config.pipeline_configurations import PipelineConfiguration
 from zenml.config.source import Source
 from zenml.config.step_configurations import Step
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+    StepExecutionSpec,
+)
 from zenml.enums import ExecutionStatus, SorterOps
 from zenml.models import Page, PipelineRequest
 from zenml.orchestrators import cache_utils
@@ -130,6 +135,30 @@ def test_generate_cache_key_considers_step_source(generate_cache_key_kwargs):
         "some.new.source"
     )
     key_2 = cache_utils.generate_cache_key(**generate_cache_key_kwargs)
+    assert key_1 != key_2
+
+
+def test_generate_cache_key_considers_execution_spec(
+    generate_cache_key_kwargs,
+):
+    """Check that portable step identity changes the cache key."""
+    generate_cache_key_kwargs["step"].spec.model_config["frozen"] = False
+    generate_cache_key_kwargs["step"].spec.execution_spec = StepExecutionSpec(
+        language=StepExecutionLanguage.TYPESCRIPT,
+        protocol=StepExecutionProtocol.ZENML_PORTABLE_JSON_V1,
+        command=["node", "/app/dist/steps/score.js"],
+        source_identity="ts/src/score.ts#score",
+    )
+    key_1 = cache_utils.generate_cache_key(**generate_cache_key_kwargs)
+
+    generate_cache_key_kwargs["step"].spec.execution_spec = StepExecutionSpec(
+        language=StepExecutionLanguage.TYPESCRIPT,
+        protocol=StepExecutionProtocol.ZENML_PORTABLE_JSON_V1,
+        command=["node", "/app/dist/steps/score.js"],
+        source_identity="ts/src/score.ts#other",
+    )
+    key_2 = cache_utils.generate_cache_key(**generate_cache_key_kwargs)
+
     assert key_1 != key_2
 
 

--- a/tests/unit/orchestrators/test_portable_step_runner.py
+++ b/tests/unit/orchestrators/test_portable_step_runner.py
@@ -1,0 +1,282 @@
+"""Unit tests for ZenBabel portable JSON step execution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from zenml.config.pipeline_configurations import PipelineConfiguration
+from zenml.config.step_configurations import Step
+from zenml.config.step_run_info import StepRunInfo
+from zenml.models import (
+    PipelineRunResponse,
+    PipelineSnapshotResponse,
+    StepRunResponse,
+)
+from zenml.orchestrators.portable_step_runner import (
+    PortableJSONValueError,
+    PortableStepRunner,
+    validate_portable_json_value,
+)
+from zenml.orchestrators.step_runner import StepRunner
+from zenml.stack import Stack
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
+
+
+def _portable_step(
+    command: list[str],
+    parameters: Dict[str, Any] | None = None,
+    enable_heartbeat: bool = False,
+) -> Step:
+    return Step.model_validate(
+        {
+            "spec": {
+                "source": PORTABLE_STEP_ADAPTER_SOURCE,
+                "upstream_steps": [],
+                "invocation_id": "portable_step",
+                "enable_heartbeat": enable_heartbeat,
+                "execution_spec": {
+                    "language": "typescript",
+                    "protocol": "zenml-portable-json-v1",
+                    "command": command,
+                    "source_identity": "tests/portable_step.ts#portable_step",
+                },
+            },
+            "config": {
+                "name": "portable_step",
+                "parameters": parameters or {},
+                "outputs": {"output": {"materializer_source": []}},
+            },
+        }
+    )
+
+
+def _step_run_info(
+    step: Step,
+    sample_step_run: StepRunResponse,
+    sample_snapshot_response_model: PipelineSnapshotResponse,
+) -> StepRunInfo:
+    return StepRunInfo(
+        step_run_id=uuid4(),
+        run_id=uuid4(),
+        run_name="run_name",
+        pipeline_step_name="portable_step",
+        config=step.config,
+        spec=step.spec,
+        pipeline=PipelineConfiguration(name="pipeline_name"),
+        snapshot=sample_snapshot_response_model,
+        force_write_logs=lambda: None,
+        step_run=sample_step_run,
+    )
+
+
+def _patch_runner_side_effects(
+    mocker: Any, stored_outputs: Dict[str, Any] | None = None
+) -> None:
+    mocker.patch.object(Stack, "prepare_step_run")
+    mocker.patch.object(Stack, "cleanup_step_run")
+    mocker.patch(
+        "zenml.orchestrators.portable_step_runner.publish_step_run_metadata"
+    )
+    mocker.patch(
+        "zenml.orchestrators.portable_step_runner.publish_successful_step_run"
+    )
+    mocker.patch(
+        "zenml.orchestrators.portable_step_runner.publish_failed_step_run",
+        return_value=MagicMock(is_retriable=False),
+    )
+    mocker.patch(
+        "zenml.orchestrators.portable_step_runner.setup_logging_context",
+        return_value=mocker.MagicMock(
+            __enter__=lambda s: None, __exit__=lambda s, *a: None
+        ),
+    )
+
+    def _store_output_artifacts(
+        self: StepRunner, output_data: Dict[str, Any], **_: Any
+    ) -> Dict[str, Any]:
+        if stored_outputs is not None:
+            stored_outputs.update(output_data)
+        return {name: MagicMock(id=uuid4()) for name in output_data}
+
+    mocker.patch.object(
+        StepRunner,
+        "_store_output_artifacts",
+        _store_output_artifacts,
+    )
+
+
+def test_portable_json_validation_rejects_non_json_shapes() -> None:
+    """Strict portable JSON rejects values that Python JSON might coerce."""
+    invalid_values = [
+        ("tuple", (1, 2)),
+        ("set", {1, 2}),
+        ("non_string_key", {1: "one"}),
+        ("nan", float("nan")),
+        ("unsafe_integer", 2**53),
+        ("object", object()),
+    ]
+
+    for label, value in invalid_values:
+        with pytest.raises(PortableJSONValueError, match="Portable JSON"):
+            validate_portable_json_value(value, path=label)
+
+
+def test_running_portable_step_stages_manifest_and_stores_output(
+    tmp_path: Path,
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+    sample_snapshot_response_model: PipelineSnapshotResponse,
+) -> None:
+    """A tiny subprocess can read the manifest and write JSON outputs."""
+    script_path = tmp_path / "portable_step.py"
+    script_path.write_text(
+        """
+import json
+import os
+
+manifest_path = os.environ["ZENML_PORTABLE_STEP_MANIFEST"]
+with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+    manifest = json.load(manifest_file)
+
+with open(manifest["outputs"]["output"], "w", encoding="utf-8") as output_file:
+    json.dump(
+        {
+            "step_name": manifest["step_name"],
+            "parameter": manifest["parameters"]["value"],
+            "protocol": manifest["protocol"],
+        },
+        output_file,
+    )
+""",
+        encoding="utf-8",
+    )
+    step = _portable_step([sys.executable, str(script_path)], {"value": 7})
+    stored_outputs: Dict[str, Any] = {}
+    _patch_runner_side_effects(mocker, stored_outputs=stored_outputs)
+
+    runner = PortableStepRunner(step=step, stack=local_stack)
+    runner.run(
+        pipeline_run=sample_pipeline_run,
+        step_run=sample_step_run,
+        input_artifacts={},
+        output_artifact_uris={"output": str(tmp_path / "artifact")},
+        step_run_info=_step_run_info(
+            step, sample_step_run, sample_snapshot_response_model
+        ),
+    )
+
+    assert stored_outputs == {
+        "output": {
+            "step_name": "portable_step",
+            "parameter": 7,
+            "protocol": "zenml-portable-json-v1",
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("script", "match"),
+    [
+        ("", "did not write expected output"),
+        (
+            'open(manifest["outputs"]["output"], "w").write("{not json")',
+            "invalid JSON",
+        ),
+        (
+            'import sys; print("useful stdout"); print("useful stderr", file=sys.stderr); sys.exit(7)',
+            "exit code 7",
+        ),
+    ],
+)
+def test_portable_step_subprocess_failures_are_clear(
+    script: str,
+    match: str,
+    tmp_path: Path,
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+    sample_snapshot_response_model: PipelineSnapshotResponse,
+) -> None:
+    """Missing output, invalid JSON, and non-zero exits fail clearly."""
+    script_path = tmp_path / "portable_failure.py"
+    script_path.write_text(
+        """
+import json
+import os
+
+manifest_path = os.environ["ZENML_PORTABLE_STEP_MANIFEST"]
+with open(manifest_path, "r", encoding="utf-8") as manifest_file:
+    manifest = json.load(manifest_file)
+"""
+        + script,
+        encoding="utf-8",
+    )
+    step = _portable_step([sys.executable, str(script_path)])
+    _patch_runner_side_effects(mocker)
+
+    runner = PortableStepRunner(step=step, stack=local_stack)
+    with pytest.raises(RuntimeError, match=match):
+        runner.run(
+            pipeline_run=sample_pipeline_run,
+            step_run=sample_step_run,
+            input_artifacts={},
+            output_artifact_uris={"output": str(tmp_path / "artifact")},
+            step_run_info=_step_run_info(
+                step, sample_step_run, sample_snapshot_response_model
+            ),
+        )
+
+
+def test_portable_step_rejects_heartbeat_for_v1(
+    tmp_path: Path,
+    local_stack: Stack,
+    sample_step_run: StepRunResponse,
+) -> None:
+    """Heartbeat-enabled portable steps fail with an explicit v1 limit."""
+    step = _portable_step(
+        [sys.executable, str(tmp_path / "portable_step.py")],
+        enable_heartbeat=True,
+    )
+
+    runner = PortableStepRunner(step=step, stack=local_stack)
+    with pytest.raises(RuntimeError, match="do not support step heartbeat"):
+        runner._validate_step_contract()
+
+
+def test_portable_step_rejects_unsupported_input_json(
+    tmp_path: Path,
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+    sample_snapshot_response_model: PipelineSnapshotResponse,
+) -> None:
+    """Loaded input artifacts must be strict portable JSON before staging."""
+    script_path = tmp_path / "portable_step.py"
+    script_path.write_text("", encoding="utf-8")
+    step = _portable_step([sys.executable, str(script_path)])
+    _patch_runner_side_effects(mocker)
+    mocker.patch.object(
+        StepRunner, "_load_input_artifact", return_value=("not", "json")
+    )
+
+    runner = PortableStepRunner(step=step, stack=local_stack)
+    with pytest.raises(PortableJSONValueError, match="tuple"):
+        runner.run(
+            pipeline_run=sample_pipeline_run,
+            step_run=sample_step_run,
+            input_artifacts={"payload": [MagicMock()]},
+            output_artifact_uris={"output": str(tmp_path / "artifact")},
+            step_run_info=_step_run_info(
+                step, sample_step_run, sample_snapshot_response_model
+            ),
+        )

--- a/tests/unit/orchestrators/test_portable_step_runner.py
+++ b/tests/unit/orchestrators/test_portable_step_runner.py
@@ -13,6 +13,10 @@ import pytest
 from zenml.config.pipeline_configurations import PipelineConfiguration
 from zenml.config.step_configurations import Step
 from zenml.config.step_run_info import StepRunInfo
+from zenml.materializers.built_in_materializer import (
+    BuiltInContainerMaterializer,
+    BuiltInMaterializer,
+)
 from zenml.models import (
     PipelineRunResponse,
     PipelineSnapshotResponse,
@@ -25,6 +29,7 @@ from zenml.orchestrators.portable_step_runner import (
 )
 from zenml.orchestrators.step_runner import StepRunner
 from zenml.stack import Stack
+from zenml.utils import source_utils
 from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
 
 
@@ -32,6 +37,7 @@ def _portable_step(
     command: list[str],
     parameters: Dict[str, Any] | None = None,
     enable_heartbeat: bool = False,
+    output_materializer_source: tuple[Any, ...] = (),
 ) -> Step:
     return Step.model_validate(
         {
@@ -50,7 +56,11 @@ def _portable_step(
             "config": {
                 "name": "portable_step",
                 "parameters": parameters or {},
-                "outputs": {"output": {"materializer_source": []}},
+                "outputs": {
+                    "output": {
+                        "materializer_source": output_materializer_source
+                    }
+                },
             },
         }
     )
@@ -234,6 +244,39 @@ with open(manifest_path, "r", encoding="utf-8") as manifest_file:
                 step, sample_step_run, sample_snapshot_response_model
             ),
         )
+
+
+def test_portable_step_allows_builtin_output_materializers(
+    tmp_path: Path,
+    local_stack: Stack,
+) -> None:
+    """The importer-configured built-in materializer path is allowed."""
+    step = _portable_step(
+        [sys.executable, str(tmp_path / "portable_step.py")],
+        output_materializer_source=(
+            source_utils.resolve(BuiltInMaterializer),
+            source_utils.resolve(BuiltInContainerMaterializer),
+        ),
+    )
+
+    PortableStepRunner(step=step, stack=local_stack)._validate_step_contract()
+
+
+def test_portable_step_rejects_custom_output_materializers(
+    tmp_path: Path,
+    local_stack: Stack,
+) -> None:
+    """Portable JSON v1 rejects custom output materializers clearly."""
+    step = _portable_step(
+        [sys.executable, str(tmp_path / "portable_step.py")],
+        output_materializer_source=(
+            "zenml.materializers.base_materializer.BaseMaterializer",
+        ),
+    )
+
+    runner = PortableStepRunner(step=step, stack=local_stack)
+    with pytest.raises(RuntimeError, match="custom output materializers"):
+        runner._validate_step_contract()
 
 
 def test_portable_step_rejects_heartbeat_for_v1(

--- a/tests/unit/orchestrators/test_step_launcher.py
+++ b/tests/unit/orchestrators/test_step_launcher.py
@@ -11,23 +11,37 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+"""Unit tests for step launcher routing and validation."""
 
 from contextlib import ExitStack as does_not_raise
+from typing import Any, Dict
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
+from zenml.config.pipeline_configurations import PipelineConfiguration
+from zenml.config.step_configurations import Step
+from zenml.config.step_run_info import StepRunInfo
 from zenml.enums import StackComponentType
+from zenml.models import (
+    PipelineRunResponse,
+    PipelineSnapshotResponse,
+    StepRunResponse,
+)
 from zenml.orchestrators.step_launcher import (
+    StepLauncher,
     _get_step_operator,
 )
 from zenml.stack import Stack
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
 
 
 def test_step_operator_validation(local_stack, sample_step_operator):
-    """Tests that the step operator gets correctly extracted and validated
-    from the stack."""
+    """Tests that the step operator gets correctly extracted and validated.
 
+    from the stack.
+    """
     with pytest.raises(RuntimeError):
         _get_step_operator(
             stack=local_stack, step_operator_name="step_operator"
@@ -49,3 +63,177 @@ def test_step_operator_validation(local_stack, sample_step_operator):
             stack=stack_with_step_operator,
             step_operator_name=sample_step_operator.name,
         )
+
+
+def _launcher(
+    step: Step, local_stack: Stack, is_dynamic: bool = False
+) -> StepLauncher:
+    launcher = StepLauncher.__new__(StepLauncher)
+    launcher._step = step
+    launcher._stack = local_stack
+    launcher._invocation_id = step.spec.invocation_id
+    launcher._snapshot = MagicMock(
+        is_dynamic=is_dynamic,
+        pipeline_configuration=PipelineConfiguration(name="pipeline_name"),
+    )
+    return launcher
+
+
+def _python_step(execution_spec: Dict[str, Any] | None = None) -> Step:
+    spec: Dict[str, Any] = {
+        "source": "tests.unit.orchestrators.test_step_runner.successful_step",
+        "upstream_steps": [],
+        "invocation_id": "python_step",
+    }
+    if execution_spec:
+        spec["execution_spec"] = execution_spec
+
+    return Step.model_validate(
+        {
+            "spec": spec,
+            "config": {"name": "python_step"},
+        }
+    )
+
+
+def _portable_step() -> Step:
+    return Step.model_validate(
+        {
+            "spec": {
+                "source": PORTABLE_STEP_ADAPTER_SOURCE,
+                "upstream_steps": [],
+                "invocation_id": "portable_step",
+                "execution_spec": {
+                    "language": "typescript",
+                    "protocol": "zenml-portable-json-v1",
+                    "command": ["node", "/app/dist/step.js"],
+                    "source_identity": "ts/src/step.ts#step",
+                },
+            },
+            "config": {"name": "portable_step"},
+        }
+    )
+
+
+def test_current_thread_routing_keeps_python_steps_on_step_runner(
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+) -> None:
+    """Python/default steps keep the existing StepRunner route."""
+    step = _python_step()
+    launcher = _launcher(step, local_stack)
+    step_runner = mocker.patch("zenml.orchestrators.step_launcher.StepRunner")
+    portable_runner = mocker.patch(
+        "zenml.orchestrators.step_launcher.PortableStepRunner"
+    )
+
+    launcher._run_step_in_current_thread(
+        pipeline_run=sample_pipeline_run,
+        step_run=sample_step_run,
+        step_run_info=MagicMock(spec=StepRunInfo),
+        input_artifacts={},
+        output_artifact_uris={},
+    )
+
+    step_runner.assert_called_once_with(step=step, stack=local_stack)
+    step_runner.return_value.run.assert_called_once()
+    portable_runner.assert_not_called()
+
+
+def test_current_thread_routing_keeps_explicit_python_protocol_on_step_runner(
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+) -> None:
+    """Explicit Python execution specs keep the existing StepRunner route."""
+    step = _python_step(
+        execution_spec={
+            "language": "python",
+            "protocol": "zenml-python-step-v1",
+            "command": ["python", "-m", "zenml.entrypoints.entrypoint"],
+            "source_identity": "tests/python_step.py#python_step",
+        }
+    )
+    launcher = _launcher(step, local_stack)
+    step_runner = mocker.patch("zenml.orchestrators.step_launcher.StepRunner")
+    portable_runner = mocker.patch(
+        "zenml.orchestrators.step_launcher.PortableStepRunner"
+    )
+
+    launcher._run_step_in_current_thread(
+        pipeline_run=sample_pipeline_run,
+        step_run=sample_step_run,
+        step_run_info=MagicMock(spec=StepRunInfo),
+        input_artifacts={},
+        output_artifact_uris={},
+    )
+
+    step_runner.assert_called_once_with(step=step, stack=local_stack)
+    step_runner.return_value.run.assert_called_once()
+    portable_runner.assert_not_called()
+
+
+def test_current_thread_routing_sends_portable_steps_to_portable_runner(
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+) -> None:
+    """Portable JSON steps use the dedicated portable runner."""
+    step = _portable_step()
+    launcher = _launcher(step, local_stack)
+    step_runner = mocker.patch("zenml.orchestrators.step_launcher.StepRunner")
+    portable_runner = mocker.patch(
+        "zenml.orchestrators.step_launcher.PortableStepRunner"
+    )
+
+    launcher._run_step_in_current_thread(
+        pipeline_run=sample_pipeline_run,
+        step_run=sample_step_run,
+        step_run_info=MagicMock(spec=StepRunInfo),
+        input_artifacts={},
+        output_artifact_uris={},
+    )
+
+    portable_runner.assert_called_once_with(step=step, stack=local_stack)
+    portable_runner.return_value.run.assert_called_once()
+    step_runner.assert_not_called()
+
+
+def test_dynamic_portable_steps_are_rejected_before_execution(
+    mocker: Any,
+    local_stack: Stack,
+    sample_pipeline_run: PipelineRunResponse,
+    sample_step_run: StepRunResponse,
+    sample_snapshot_response_model: PipelineSnapshotResponse,
+) -> None:
+    """Portable steps are a static-pipeline-only v1 feature."""
+    step = _portable_step()
+    launcher = _launcher(step, local_stack, is_dynamic=True)
+    launcher._snapshot = sample_snapshot_response_model.model_copy(
+        update={
+            "body": sample_snapshot_response_model.body.model_copy(
+                update={"is_dynamic": True}
+            )
+        }
+    )
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.output_utils.prepare_output_artifact_uris",
+        return_value={},
+    )
+    mocker.patch.object(StepLauncher, "_wait_until_resources_acquired")
+    current_thread = mocker.patch.object(
+        StepLauncher, "_run_step_in_current_thread"
+    )
+
+    with pytest.raises(RuntimeError, match="static pipelines in v1"):
+        launcher._run_step(
+            pipeline_run=sample_pipeline_run,
+            step_run=sample_step_run,
+            force_write_logs=lambda: None,
+        )
+
+    current_thread.assert_not_called()

--- a/tests/unit/zenbabel/test_adapters.py
+++ b/tests/unit/zenbabel/test_adapters.py
@@ -1,0 +1,39 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for ZenBabel adapters."""
+
+import pytest
+
+from zenml.steps.base_step import BaseStep
+from zenml.zenbabel.adapters import (
+    PORTABLE_STEP_ADAPTER_SOURCE,
+    PortableStepAdapter,
+)
+
+
+def test_portable_step_adapter_loads_as_base_step():
+    """Tests that the adapter has the shape pre-execution code expects."""
+    step = BaseStep.load_from_source(PORTABLE_STEP_ADAPTER_SOURCE)
+
+    assert isinstance(step, PortableStepAdapter)
+    assert "PortableStepAdapter" in step.source_code
+    assert "Importable marker step" in (step.docstring or "")
+
+
+def test_portable_step_adapter_rejects_normal_execution():
+    """Tests that accidental normal execution fails clearly."""
+    step = BaseStep.load_from_source(PORTABLE_STEP_ADAPTER_SOURCE)
+
+    with pytest.raises(RuntimeError, match="must not be executed"):
+        step.entrypoint("input", parameter=1)

--- a/tests/unit/zenbabel/test_authoring.py
+++ b/tests/unit/zenbabel/test_authoring.py
@@ -1,0 +1,88 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the experimental ZenBabel authoring helpers."""
+
+import zenml.pipelines.pipeline_definition as pipeline_definition_module
+from zenml.config.step_configurations import InputSpec
+from zenml.utils import source_utils
+from zenml.zenbabel.authoring import (
+    ExperimentalPortableStepCompiler,
+    _replace_with_portable_execution,
+    experimental_portable_json_compiler_bridge,
+    experimental_portable_json_pipeline_spec,
+    experimental_portable_json_step,
+)
+from zenml.zenbabel.importer import build_steps
+
+
+def _placeholder_step() -> None:
+    """Placeholder source used for authoring helper tests."""
+
+
+def _portable_spec() -> object:
+    """Return a tiny portable authoring spec."""
+    return experimental_portable_json_pipeline_spec(
+        name="authoring_demo",
+        steps=[
+            experimental_portable_json_step(
+                name="score",
+                command=["node", "/app/dist/score.js"],
+                source_identity="ts/src/score.ts#score",
+                parameters={"threshold": 0.5},
+            )
+        ],
+        outputs=[("score", "output")],
+    )
+
+
+def test_authoring_bridge_patches_and_restores_pipeline_compiler() -> None:
+    """The compiler bridge is scoped to its context manager."""
+    original_compiler = pipeline_definition_module.Compiler
+
+    with experimental_portable_json_compiler_bridge(_portable_spec()):
+        compiler = pipeline_definition_module.Compiler()
+        assert isinstance(compiler, ExperimentalPortableStepCompiler)
+
+    assert pipeline_definition_module.Compiler is original_compiler
+
+
+def test_authoring_bridge_copies_only_portable_routing_metadata() -> None:
+    """Placeholder graph wiring survives the portable metadata swap."""
+    portable_step = build_steps(_portable_spec())["score"]
+    compiled_spec = portable_step.spec.model_copy(
+        update={
+            "source": source_utils.resolve(_placeholder_step),
+            "execution_spec": None,
+            "inputs": {
+                "records": InputSpec(
+                    step_name="load_data", output_name="output"
+                )
+            },
+            "upstream_steps": ["load_data"],
+        }
+    )
+    compiled_step = portable_step.model_copy(update={"spec": compiled_spec})
+
+    patched_step = _replace_with_portable_execution(
+        compiled_step=compiled_step,
+        portable_step=portable_step,
+    )
+
+    assert patched_step.spec.source == portable_step.spec.source
+    assert (
+        patched_step.spec.execution_spec == portable_step.spec.execution_spec
+    )
+    assert patched_step.spec.inputs == compiled_step.spec.inputs
+    assert patched_step.spec.upstream_steps == ["load_data"]
+    assert patched_step.config == compiled_step.config

--- a/tests/unit/zenbabel/test_importer.py
+++ b/tests/unit/zenbabel/test_importer.py
@@ -1,0 +1,232 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the experimental ZenBabel external spec importer."""
+
+from typing import Any, Dict
+
+import pytest
+
+from zenml.config.step_configurations import InputSpec, Step
+from zenml.config.step_execution_spec import (
+    StepExecutionLanguage,
+    StepExecutionProtocol,
+)
+from zenml.zenbabel.adapters import PORTABLE_STEP_ADAPTER_SOURCE
+from zenml.zenbabel.external_spec import ExternalPipelineSpec
+from zenml.zenbabel.importer import (
+    build_pipeline_snapshot,
+    build_pipeline_spec,
+    build_steps,
+)
+
+
+def _external_spec() -> Dict[str, Any]:
+    """Return a small static external pipeline spec."""
+    return {
+        "name": "zenbabel_demo",
+        "steps": [
+            {
+                "name": "load_data",
+                "command": ["node", "/app/dist/steps/load_data.js"],
+                "source_identity": "ts/src/steps/load_data.ts#loadData",
+                "outputs": ["records"],
+                "parameters": {"limit": 3},
+            },
+            {
+                "name": "score",
+                "command": ["node", "/app/dist/steps/score.js"],
+                "source_identity": "ts/src/steps/score.ts#score",
+                "inputs": {
+                    "records": {"step": "load_data", "output": "records"}
+                },
+                "outputs": ["scores"],
+            },
+        ],
+        "outputs": [{"step": "score", "output": "scores"}],
+    }
+
+
+def test_external_spec_builds_normal_zenml_steps() -> None:
+    """External TypeScript steps become normal ZenML step objects."""
+    steps = build_steps(_external_spec())
+
+    assert list(steps) == ["load_data", "score"]
+    assert all(isinstance(step, Step) for step in steps.values())
+
+    load_data = steps["load_data"]
+    assert load_data.spec.source.import_path == PORTABLE_STEP_ADAPTER_SOURCE
+    assert load_data.spec.invocation_id == "load_data"
+    assert load_data.spec.upstream_steps == []
+    assert load_data.config.name == "load_data"
+    assert load_data.config.parameters == {"limit": 3}
+    assert set(load_data.config.outputs) == {"records"}
+
+    execution_spec = load_data.spec.execution_spec
+    assert execution_spec is not None
+    assert execution_spec.language == StepExecutionLanguage.TYPESCRIPT
+    assert (
+        execution_spec.protocol == StepExecutionProtocol.ZENML_PORTABLE_JSON_V1
+    )
+    assert execution_spec.command == ["node", "/app/dist/steps/load_data.js"]
+    assert (
+        execution_spec.source_identity == "ts/src/steps/load_data.ts#loadData"
+    )
+
+
+def test_external_spec_maps_inputs_and_upstream_dependencies() -> None:
+    """Data inputs become InputSpec objects and upstream step dependencies."""
+    steps = build_steps(
+        {
+            "name": "fan_in_demo",
+            "steps": [
+                {
+                    "name": "first",
+                    "command": ["node", "first.js"],
+                    "source_identity": "ts/first.ts#first",
+                    "outputs": ["value"],
+                },
+                {
+                    "name": "second",
+                    "command": ["node", "second.js"],
+                    "source_identity": "ts/second.ts#second",
+                    "outputs": ["value"],
+                },
+                {
+                    "name": "combine",
+                    "command": ["node", "combine.js"],
+                    "source_identity": "ts/combine.ts#combine",
+                    "inputs": {
+                        "primary": {"step": "first", "output": "value"},
+                        "others": [
+                            {"step": "first", "output": "value"},
+                            {"step": "second", "output": "value"},
+                        ],
+                    },
+                    "depends_on": ["second"],
+                    "outputs": ["combined"],
+                },
+            ],
+        }
+    )
+
+    combine = steps["combine"]
+    assert combine.spec.upstream_steps == ["first", "second"]
+    assert combine.spec.inputs["primary"] == InputSpec(
+        step_name="first", output_name="value"
+    )
+    assert combine.spec.inputs["others"] == [
+        InputSpec(step_name="first", output_name="value"),
+        InputSpec(step_name="second", output_name="value"),
+    ]
+
+
+def test_external_spec_builds_portable_pipeline_spec_serialization() -> None:
+    """Generated pipeline specs use the conditional portable serialization."""
+    pipeline_spec = build_pipeline_spec(_external_spec())
+
+    assert pipeline_spec.version == "0.6"
+    assert [step.invocation_id for step in pipeline_spec.steps] == [
+        "load_data",
+        "score",
+    ]
+    assert pipeline_spec.outputs[0].step_name == "score"
+    assert pipeline_spec.outputs[0].output_name == "scores"
+
+    dumped = pipeline_spec.model_dump(mode="json")
+    score_spec = dumped["steps"][1]
+    assert score_spec["source"]["module"] == "zenml.zenbabel.adapters"
+    assert score_spec["source"]["attribute"] == "PortableStepAdapter"
+    assert score_spec["execution_spec"] == {
+        "language": "typescript",
+        "protocol": "zenml-portable-json-v1",
+        "command": ["node", "/app/dist/steps/score.js"],
+        "source_identity": "ts/src/steps/score.ts#score",
+    }
+
+    serialized = pipeline_spec.json_with_string_sources
+    assert '"version": "0.6"' in serialized
+    assert PORTABLE_STEP_ADAPTER_SOURCE in serialized
+    assert "ts/src/steps/score.ts#score" in serialized
+
+
+def test_external_spec_builds_minimal_static_snapshot() -> None:
+    """The importer can produce a minimal static PipelineSnapshotBase."""
+    snapshot = build_pipeline_snapshot(
+        _external_spec(),
+        run_name_template="portable-run-{date}",
+        client_environment={"runtime": "test"},
+        client_version="0.0.test",
+        server_version="0.0.test",
+    )
+
+    assert snapshot.run_name_template == "portable-run-{date}"
+    assert snapshot.pipeline_configuration.name == "zenbabel_demo"
+    assert snapshot.is_dynamic is False
+    assert snapshot.client_environment == {"runtime": "test"}
+    assert snapshot.client_version == "0.0.test"
+    assert snapshot.server_version == "0.0.test"
+    assert snapshot.pipeline_version_hash
+    assert list(snapshot.step_configurations) == ["load_data", "score"]
+    assert snapshot.pipeline_spec is not None
+    assert snapshot.pipeline_spec.version == "0.6"
+
+
+def test_external_spec_rejects_dynamic_graphs() -> None:
+    """Dynamic pipeline declarations fail before ZenML object creation."""
+    spec = _external_spec()
+    spec["graph"] = "dynamic"
+
+    with pytest.raises(ValueError, match="only support static pipelines"):
+        ExternalPipelineSpec.model_validate(spec)
+
+
+def test_external_spec_rejects_unsupported_step_protocol() -> None:
+    """Non-portable protocols fail clearly."""
+    spec = _external_spec()
+    spec["steps"][0]["protocol"] = "zenml-python-step-v1"
+
+    with pytest.raises(ValueError, match="zenml-portable-json-v1"):
+        ExternalPipelineSpec.model_validate(spec)
+
+
+def test_external_spec_rejects_unknown_or_cyclic_graph_shapes() -> None:
+    """Unsupported static graph references fail with clear messages."""
+    unknown = _external_spec()
+    unknown["steps"][1]["inputs"] = {
+        "records": {"step": "missing", "output": "records"}
+    }
+
+    with pytest.raises(ValueError, match="unknown upstream step `missing`"):
+        ExternalPipelineSpec.model_validate(unknown)
+
+    cyclic = {
+        "name": "cycle_demo",
+        "steps": [
+            {
+                "name": "first",
+                "command": ["node", "first.js"],
+                "source_identity": "ts/first.ts#first",
+                "depends_on": ["second"],
+            },
+            {
+                "name": "second",
+                "command": ["node", "second.js"],
+                "source_identity": "ts/second.ts#second",
+                "depends_on": ["first"],
+            },
+        ],
+    }
+
+    with pytest.raises(ValueError, match="acyclic static pipelines"):
+        ExternalPipelineSpec.model_validate(cyclic)


### PR DESCRIPTION
## Summary

This PR adds an experimental ZenBabel Level 1 path for portable JSON step execution.

The goal is intentionally narrow: keep ZenML's existing Python control plane and orchestrator model, but allow a static pipeline step body to be executed by a non-Python command, demonstrated with TypeScript.

Concretely, this adds:

- an optional `StepExecutionSpec` on `StepSpec` for language/protocol/command/source identity metadata
- an experimental `zenml-portable-json-v1` protocol
- a `PortableStepRunner` sibling to `StepRunner` that stages JSON inputs, launches a subprocess, reads JSON outputs, and stores results through the existing materializer path
- `StepLauncher` routing for portable JSON steps while keeping normal Python steps unchanged
- an experimental `zenml.zenbabel` namespace with adapter/importer/authoring helpers
- a mixed Python + TypeScript example under `examples/zenbabel_mixed_static/`
- a docs page explaining the experimental TypeScript step pattern
- unit coverage for spec identity, cache identity, routing, importer behavior, authoring helpers, and portable runner success/failure cases

## Why

This is a proof of the execution seam for future multi-language ZenML support.

The important architectural claim is not that ZenML has a production TypeScript SDK yet. It does not. The claim is that an existing ZenML orchestrator can still schedule the normal Python entrypoint, and the final step-body execution can route to a portable subprocess when a step declares `zenml-portable-json-v1`.

That keeps the stack/orchestrator model intact while giving us a concrete substrate for later TypeScript-authored pipelines.

## Current limitations

This is experimental and deliberately limited:

- only static pipelines are supported for portable steps
- only JSON-compatible artifact values are supported
- the ZenML control plane and step entrypoint are still Python
- the TypeScript SDK does not exist yet
- dashboard/source display still mostly sees the Python adapter/placeholder surfaces
- subprocess logs are not yet presented as first-class TypeScript logs
- remote validation has been done on Kubernetes/EKS, not every orchestrator

## Validation

Local checks run during the branch work included:

- targeted unit tests for the new config, runner, launcher, cache, and ZenBabel helper/importer paths
- `uv run ruff check examples/zenbabel_mixed_static/run.py`
- `uv run ruff format --check examples/zenbabel_mixed_static/run.py`
- `uv run python examples/zenbabel_mixed_static/run.py --compile-only`
- local Docker end-to-end execution of the mixed Python/TypeScript example
- Kubernetes/EKS end-to-end execution of the same example against a branch-compatible staging server and AWS stack

The Kubernetes validation ran the full pipeline shape:

```text
load_data completed
score_or_transform completed
summarize completed
Orchestrator pod finished
```

## Reviewer notes

The highest-value review areas are:

1. Whether `StepExecutionSpec` is the right place/shape for portable execution identity.
2. Whether routing in `StepLauncher` keeps enough of the existing bookkeeping path intact.
3. Whether `PortableStepRunner` is strict enough about JSON boundaries and subprocess failures.
4. Whether the experimental `zenml.zenbabel` namespace makes the example readable without implying stable SDK support.
5. Whether the docs/example language is honest enough about the current limitations.
