### PR TITLE
Add cloud artifact IO acceleration hooks

### DIFF
--- a/docs/book/component-guide/log-stores/artifact.md
+++ b/docs/book/component-guide/log-stores/artifact.md
@@ -40,6 +40,16 @@ The Artifact Log Store handles different artifact store backends intelligently:
 
 This ensures consistent behavior across all supported artifact store types.
 
+#### Cloud IO acceleration
+
+For cloud-backed artifact stores, ZenML can use optional provider-native helpers behind the same public APIs. The log format, artifact locations, and SDK methods do not change; the difference is that ZenML can ask the cloud provider to do fewer, larger operations instead of many small file-like operations.
+
+- **GCS**: Immutable log fragments can be finalized with GCS compose operations. This avoids downloading every fragment into the ZenML process and re-uploading the merged log. GCS only composes up to 32 source objects at a time, so ZenML uses temporary intermediate compose objects for larger fragment sets and then cleans them up. If compose or cleanup is not available, ZenML falls back to the portable artifact-store path. The stored logs are still NDJSON and existing `.log` files or directory-style log URIs remain readable.
+- **S3**: ZenML can use native object listing, bulk deletion, ranged reads, and boto3 transfer helpers. This is especially useful for many-file artifact downloads and cleanup of log objects. On versioned buckets, cleanup may need to account for object versions; if the provider-specific path cannot handle a case safely, ZenML falls back to existing file-like behavior.
+- **Azure Blob Storage**: ZenML can use append blobs for log writes, blob batch deletion for cleanup, ranged reads, and native download helpers. Append blobs have provider limits on append block size and block count, so ZenML falls back to the existing `adlfs` path when append blobs are not suitable or not supported for the target URI.
+
+Raw artifact downloads through `ArtifactVersionResponse.download_files()` still create a local ZIP file with the same public API and ZIP entry names as before. When supported by the artifact store, ZenML lists objects once and downloads them to a temporary local directory with provider-native transfer helpers before building the ZIP. Stores without these helpers keep the existing streaming behavior. This does not add provider-side ZIP creation, and it does not change non-recursive artifact download behavior.
+
 ### Environment Variables
 
 The Artifact Log Store uses OpenTelemetry's batch processing under the hood. You can tune the batching behavior using these environment variables:

--- a/src/zenml/artifact_stores/__init__.py
+++ b/src/zenml/artifact_stores/__init__.py
@@ -31,6 +31,9 @@ from zenml.artifact_stores.base_artifact_store import (
     BaseArtifactStore,
     BaseArtifactStoreConfig,
     BaseArtifactStoreFlavor,
+    BulkDeleteResult,
+    ObjectDeleteFailure,
+    ObjectInfo,
 )
 from zenml.artifact_stores.local_artifact_store import (
     LocalArtifactStore,
@@ -42,6 +45,9 @@ __all__ = [
     "BaseArtifactStore",
     "BaseArtifactStoreConfig",
     "BaseArtifactStoreFlavor",
+    "BulkDeleteResult",
+    "ObjectDeleteFailure",
+    "ObjectInfo",
     "LocalArtifactStore",
     "LocalArtifactStoreConfig",
     "LocalArtifactStoreFlavor",

--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -17,6 +17,8 @@ import inspect
 import os
 import textwrap
 from abc import abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import (
     Any,
@@ -26,6 +28,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -54,6 +57,128 @@ logger = get_logger(__name__)
 PathType = Union[bytes, str]
 
 
+@dataclass(frozen=True)
+class ObjectInfo:
+    """Metadata for an object stored in an artifact store.
+
+    Attributes:
+        uri: Absolute artifact store URI/path for the object.
+        relative_path: Object path relative to the listed prefix.
+        size: Optional object size in bytes.
+        etag: Optional provider object checksum/entity tag.
+        generation: Optional provider generation identifier.
+        version: Optional provider version identifier.
+        last_modified: Optional provider modification timestamp.
+    """
+
+    uri: str
+    relative_path: str
+    size: Optional[int] = None
+    etag: Optional[str] = None
+    generation: Optional[str] = None
+    version: Optional[str] = None
+    last_modified: Optional[datetime] = None
+
+
+@dataclass(frozen=True)
+class ObjectDeleteFailure:
+    """A failed object deletion attempt."""
+
+    path: str
+    error: Exception
+
+
+@dataclass(frozen=True)
+class BulkDeleteResult:
+    """Result of deleting multiple objects from an artifact store."""
+
+    deleted_paths: List[str]
+    failures: List[ObjectDeleteFailure]
+
+    @property
+    def successful(self) -> bool:
+        """Whether all requested objects were deleted successfully."""
+        return not self.failures
+
+
+def _allow_local_file_access() -> bool:
+    """Return whether local artifact paths may be accessed."""
+    if ENV_ZENML_SERVER in os.environ:
+        return handle_bool_env_var(
+            ENV_ZENML_SERVER_ALLOW_LOCAL_FILE_ACCESS, False
+        )
+    return True
+
+
+def _validate_artifact_store_path(
+    path: str,
+    fixed_root_path: str,
+    allow_local_file_access: bool,
+) -> None:
+    """Validate that a path stays within an artifact store root."""
+    if path.startswith(IN_MEMORY_ARTIFACT_URI_PREFIX):
+        return
+
+    if not allow_local_file_access and not io_utils.is_remote(path):
+        raise IllegalOperationError(
+            "Files in a local artifact store cannot be accessed from the "
+            "server."
+        )
+
+    if not path.startswith(fixed_root_path):
+        raise FileNotFoundError(
+            f"File `{path}` is outside of "
+            f"artifact store bounds `{fixed_root_path}`"
+        )
+
+
+def _sanitize_artifact_store_path(
+    potential_path: Any,
+    fixed_root_path: str,
+    allow_local_file_access: bool,
+) -> Any:
+    """Sanitize a potential artifact store path."""
+    if isinstance(potential_path, bytes):
+        path = fileio.convert_to_str(potential_path)
+    elif isinstance(potential_path, str):
+        path = potential_path
+    else:
+        return potential_path
+
+    if path.startswith(IN_MEMORY_ARTIFACT_URI_PREFIX):
+        return path
+
+    if io_utils.is_remote(path):
+        import ntpath
+        import posixpath
+
+        path = path.replace(ntpath.sep, posixpath.sep)
+        _validate_artifact_store_path(
+            path, fixed_root_path, allow_local_file_access
+        )
+    else:
+        _validate_artifact_store_path(
+            str(Path(path).absolute().resolve()),
+            fixed_root_path,
+            allow_local_file_access,
+        )
+
+    return path
+
+
+def _get_relative_object_path(uri: str, prefix: str) -> str:
+    """Get an object path relative to a listing prefix."""
+    normalized_prefix = prefix.rstrip("/\\")
+    if uri == normalized_prefix:
+        return os.path.basename(uri)
+
+    prefix_with_separator = f"{normalized_prefix}/"
+    if uri.startswith(prefix_with_separator):
+        return uri[len(prefix_with_separator) :]
+
+    return os.path.basename(uri)
+
+
 class _sanitize_paths:
     """Sanitizes path inputs before calling the original function.
 
@@ -70,12 +195,7 @@ class _sanitize_paths:
         """
         self.func = func
         self.fixed_root_path = fixed_root_path
-        if ENV_ZENML_SERVER in os.environ:
-            self.allow_local_file_access = handle_bool_env_var(
-                ENV_ZENML_SERVER_ALLOW_LOCAL_FILE_ACCESS, False
-            )
-        else:
-            self.allow_local_file_access = True
+        self.allow_local_file_access = _allow_local_file_access()
 
         self.path_args: List[int] = []
         self.path_kwargs: List[str] = []
@@ -99,21 +219,9 @@ class _sanitize_paths:
             IllegalOperationError: If the path is a local file and the server
                 is not configured to allow local file access.
         """
-        if path.startswith(IN_MEMORY_ARTIFACT_URI_PREFIX):
-            # No need to validate in-memory URIs
-            return
-
-        if not self.allow_local_file_access and not io_utils.is_remote(path):
-            raise IllegalOperationError(
-                "Files in a local artifact store cannot be accessed from the "
-                "server."
-            )
-
-        if not path.startswith(self.fixed_root_path):
-            raise FileNotFoundError(
-                f"File `{path}` is outside of "
-                f"artifact store bounds `{self.fixed_root_path}`"
-            )
+        _validate_artifact_store_path(
+            path, self.fixed_root_path, self.allow_local_file_access
+        )
 
     def _sanitize_potential_path(self, potential_path: Any) -> Any:
         """Sanitizes the input if it is a path.
@@ -128,29 +236,9 @@ class _sanitize_paths:
             The original input or a sanitized version of it in case of a remote
             path.
         """
-        if isinstance(potential_path, bytes):
-            path = fileio.convert_to_str(potential_path)
-        elif isinstance(potential_path, str):
-            path = potential_path
-        else:
-            # Neither string nor bytes, this is not a path
-            return potential_path
-
-        if path.startswith(IN_MEMORY_ARTIFACT_URI_PREFIX):
-            return path
-
-        if io_utils.is_remote(path):
-            # If we have a remote path, replace windows path separators with
-            # slashes
-            import ntpath
-            import posixpath
-
-            path = path.replace(ntpath.sep, posixpath.sep)
-            self._validate_path(path)
-        else:
-            self._validate_path(str(Path(path).absolute().resolve()))
-
-        return path
+        return _sanitize_artifact_store_path(
+            potential_path, self.fixed_root_path, self.allow_local_file_access
+        )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Decorator function that sanitizes paths before calling the original function.
@@ -452,6 +540,187 @@ class BaseArtifactStore(StackComponent):
         Returns:
             The iterator that walks the contents of the given directory.
         """
+
+    def _sanitize_path(self, path: PathType) -> str:
+        """Sanitize a path for optional non-abstract helper methods.
+
+        Optional artifact-store hooks are intentionally not abstract so custom
+        stores remain compatible. They therefore do not get wrapped by the
+        abstract-method sanitizer and must validate path inputs explicitly.
+
+        Args:
+            path: The path to sanitize.
+
+        Returns:
+            The sanitized path as a string.
+        """
+        return cast(
+            str,
+            _sanitize_artifact_store_path(
+                path, self.path, _allow_local_file_access()
+            ),
+        )
+
+    def _get_object_info(self, uri: str, prefix: str) -> ObjectInfo:
+        """Build object metadata using portable artifact-store methods."""
+        return ObjectInfo(
+            uri=uri,
+            relative_path=_get_relative_object_path(uri, prefix),
+            size=self.size(uri),
+        )
+
+    def list_objects(
+        self, prefix: PathType, recursive: bool = False
+    ) -> Iterable[ObjectInfo]:
+        """List objects below a prefix with optional metadata.
+
+        Artifact stores can override this to use provider-native paginated
+        listing APIs. The default fallback uses the existing mandatory
+        filesystem-like methods.
+
+        Args:
+            prefix: The file or directory/prefix to list.
+            recursive: Whether to recursively list objects below directories.
+
+        Returns:
+            An iterable of object metadata.
+        """
+        sanitized_prefix = self._sanitize_path(prefix)
+
+        if not self.exists(sanitized_prefix):
+            return []
+
+        if not self.isdir(sanitized_prefix):
+            return [self._get_object_info(sanitized_prefix, sanitized_prefix)]
+
+        if recursive:
+            objects: List[ObjectInfo] = []
+            for directory, _, files in self.walk(sanitized_prefix):
+                for file_name in files:
+                    uri = os.path.join(str(directory), str(file_name))
+                    objects.append(
+                        self._get_object_info(uri, sanitized_prefix)
+                    )
+            return objects
+
+        objects = []
+        for file_name in self.listdir(sanitized_prefix):
+            uri = os.path.join(sanitized_prefix, str(file_name))
+            if not self.isdir(uri):
+                objects.append(self._get_object_info(uri, sanitized_prefix))
+        return objects
+
+    def delete_objects(self, paths: Iterable[PathType]) -> BulkDeleteResult:
+        """Delete multiple objects from the artifact store.
+
+        Artifact stores can override this to use provider-native bulk deletion.
+        The default fallback loops over the existing ``remove`` method and
+        captures per-path failures instead of failing the whole batch.
+
+        Args:
+            paths: Object paths to delete.
+
+        Returns:
+            Per-object deletion results.
+        """
+        deleted_paths: List[str] = []
+        failures: List[ObjectDeleteFailure] = []
+
+        for path in paths:
+            sanitized_path = self._sanitize_path(path)
+            try:
+                self.remove(sanitized_path)
+            except Exception as e:
+                failures.append(
+                    ObjectDeleteFailure(path=sanitized_path, error=e)
+                )
+            else:
+                deleted_paths.append(sanitized_path)
+
+        return BulkDeleteResult(deleted_paths=deleted_paths, failures=failures)
+
+    def read_range(
+        self, path: PathType, offset: int, length: Optional[int] = None
+    ) -> bytes:
+        """Read a byte range from an object.
+
+        Artifact stores can override this to use provider-native range reads.
+        The default fallback uses ``open`` and ``seek``.
+
+        Args:
+            path: Object path to read.
+            offset: Zero-based byte offset to start reading from.
+            length: Optional maximum number of bytes to read.
+
+        Returns:
+            The requested bytes.
+
+        Raises:
+            ValueError: If ``offset`` or ``length`` is negative.
+        """
+        if offset < 0:
+            raise ValueError("Range read offset must be non-negative.")
+        if length is not None and length < 0:
+            raise ValueError("Range read length must be non-negative.")
+
+        sanitized_path = self._sanitize_path(path)
+        with self.open(sanitized_path, "rb") as file:
+            file.seek(offset)
+            if length is None:
+                return cast(bytes, file.read())
+            return cast(bytes, file.read(length))
+
+    def compose_objects(
+        self,
+        sources: Sequence[PathType],
+        destination: PathType,
+        overwrite: bool = False,
+    ) -> bool:
+        """Compose source objects into one destination object.
+
+        Artifact stores can override this for server-side object composition.
+        The default returns ``False`` so callers can fall back to the portable
+        Python merge path.
+
+        Args:
+            sources: Ordered source object paths.
+            destination: Destination object path.
+            overwrite: Whether an existing destination may be overwritten.
+
+        Returns:
+            Whether composition happened successfully.
+        """
+        for source in sources:
+            self._sanitize_path(source)
+        self._sanitize_path(destination)
+        return False
+
+    def download_objects_to_directory(
+        self,
+        objects: Iterable[ObjectInfo],
+        local_dir: PathType,
+        max_workers: Optional[int] = None,
+    ) -> bool:
+        """Download objects into a local directory.
+
+        Artifact stores can override this to use provider transfer managers.
+        The default returns ``False`` so callers can keep their existing
+        streaming download behavior.
+
+        Args:
+            objects: Objects to download.
+            local_dir: Local directory to download into.
+            max_workers: Optional provider-specific worker count.
+
+        Returns:
+            Whether the provider handled the downloads.
+        """
+        for object_info in objects:
+            self._sanitize_path(object_info.uri)
+        local_path = fileio.convert_to_str(local_dir)
+        if io_utils.is_remote(local_path):
+            raise ValueError("Download directory must be a local path.")
+        return False
 
     # --- Internal interface ---
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -24,6 +24,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Optional,
     Type,
@@ -32,6 +33,10 @@ from typing import (
 )
 from uuid import UUID, uuid4
 
+from zenml.artifact_stores.base_artifact_store import (
+    BaseArtifactStore,
+    ObjectInfo,
+)
 from zenml.artifacts.preexisting_data_materializer import (
     PreexistingDataMaterializer,
 )
@@ -74,7 +79,6 @@ from zenml.utils import source_utils
 from zenml.utils.yaml_utils import read_yaml, write_yaml
 
 if TYPE_CHECKING:
-    from zenml.artifact_stores.base_artifact_store import BaseArtifactStore
     from zenml.config.source import Source
     from zenml.materializers.base_materializer import BaseMaterializer
     from zenml.metadata.metadata_types import MetadataType
@@ -83,6 +87,8 @@ if TYPE_CHECKING:
     MaterializerClassOrSource = Union[str, Source, Type[BaseMaterializer]]
 
 logger = get_logger(__name__)
+
+_ARTIFACT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
 
 # ----------
@@ -584,6 +590,100 @@ def load_artifact_from_response(artifact: "ArtifactVersionResponse") -> Any:
     )
 
 
+def _overrides_artifact_store_method(
+    artifact_store: "BaseArtifactStore", method_name: str
+) -> bool:
+    """Return whether an artifact store overrides an optional helper."""
+    store_method = getattr(type(artifact_store), method_name, None)
+    base_method = getattr(BaseArtifactStore, method_name)
+    return store_method is not None and store_method is not base_method
+
+
+def _get_artifact_zip_entry_name(path: Union[bytes, str]) -> str:
+    """Get the ZIP entry name for an artifact-store relative path."""
+    return path.decode() if isinstance(path, bytes) else path
+
+
+def _list_artifact_objects_with_listdir(
+    artifact_store: "BaseArtifactStore", artifact_uri: str
+) -> List[ObjectInfo]:
+    """List artifact files with the pre-acceleration listdir behavior."""
+    objects: List[ObjectInfo] = []
+    for file in artifact_store.listdir(artifact_uri):
+        file_name = _get_artifact_zip_entry_name(file)
+        objects.append(
+            ObjectInfo(
+                uri=str(Path(artifact_uri) / file_name),
+                relative_path=file_name,
+            )
+        )
+    return objects
+
+
+def _list_artifact_objects_for_download(
+    artifact_store: "BaseArtifactStore", artifact_uri: str
+) -> List[ObjectInfo]:
+    """List artifact files, using native object listing when available."""
+    if _overrides_artifact_store_method(artifact_store, "list_objects"):
+        return list(artifact_store.list_objects(artifact_uri, recursive=False))
+
+    return _list_artifact_objects_with_listdir(artifact_store, artifact_uri)
+
+
+def _get_local_artifact_download_path(
+    local_dir: str, relative_path: str
+) -> Path:
+    """Get a safe path for a provider-downloaded artifact file."""
+    download_root = Path(local_dir).resolve()
+    local_path = (download_root / relative_path).resolve()
+    if not local_path.is_relative_to(download_root):
+        raise ValueError(
+            f"Object relative path `{relative_path}` escapes the local "
+            "download directory."
+        )
+    return local_path
+
+
+def _write_downloaded_artifact_objects_to_zip(
+    zipf: zipfile.ZipFile,
+    objects: Iterable[ObjectInfo],
+    local_dir: str,
+) -> None:
+    """Write provider-downloaded artifact objects to a ZIP file."""
+    for object_info in objects:
+        entry_name = _get_artifact_zip_entry_name(object_info.relative_path)
+        local_path = _get_local_artifact_download_path(local_dir, entry_name)
+        zipf.write(local_path, arcname=entry_name)
+
+
+def _stream_artifact_objects_to_zip(
+    zipf: zipfile.ZipFile,
+    artifact_store: "BaseArtifactStore",
+    objects: Iterable[ObjectInfo],
+) -> None:
+    """Stream artifact objects from the artifact store into a ZIP file."""
+    for object_info in objects:
+        entry_name = _get_artifact_zip_entry_name(object_info.relative_path)
+        with artifact_store.open(object_info.uri, mode="rb") as store_file:
+            with zipf.open(entry_name, mode="w") as zip_file:
+                while chunk := store_file.read(_ARTIFACT_DOWNLOAD_CHUNK_SIZE):
+                    zip_file.write(chunk)
+
+
+def _download_artifact_objects_to_directory(
+    artifact_store: "BaseArtifactStore",
+    objects: List[ObjectInfo],
+    local_dir: str,
+) -> bool:
+    """Download objects with a native transfer helper when available."""
+    if not _overrides_artifact_store_method(
+        artifact_store, "download_objects_to_directory"
+    ):
+        return False
+
+    return artifact_store.download_objects_to_directory(objects, local_dir)
+
+
 def download_artifact_files_from_response(
     artifact: "ArtifactVersionResponse",
     path: str,
@@ -608,37 +708,29 @@ def download_artifact_files_from_response(
     artifact_store = _get_artifact_store_from_response_or_from_active_stack(
         artifact=artifact
     )
+    objects = _list_artifact_objects_for_download(artifact_store, artifact.uri)
 
-    if filepaths := artifact_store.listdir(artifact.uri):
-        # save a zipfile to 'path' containing all the files
-        # in 'filepaths' with compression
-        try:
-            with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zipf:
-                for file in filepaths:
-                    # Ensure 'file' is a string for path operations
-                    # and ZIP entry naming
-                    file_str = (
-                        file.decode() if isinstance(file, bytes) else file
+    if not objects:
+        return
+
+    try:
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                if _download_artifact_objects_to_directory(
+                    artifact_store, objects, temp_dir
+                ):
+                    _write_downloaded_artifact_objects_to_zip(
+                        zipf, objects, temp_dir
                     )
-                    file_path = str(Path(artifact.uri) / file_str)
-                    with artifact_store.open(
-                        file_path, mode="rb"
-                    ) as store_file:
-                        # Stream file in chunks directly to ZIP without loading
-                        # entire file into memory
-                        CHUNK_SIZE = 8192
-                        with zipf.open(file_str, mode="w") as zip_file:
-                            while True:
-                                if chunk := store_file.read(CHUNK_SIZE):
-                                    zip_file.write(chunk)
-                                else:
-                                    break
-        except Exception as e:
-            logger.error(
-                f"Failed to save artifact '{artifact.id}' to zip file "
-                f" '{path}': {e}"
-            )
-            raise
+                    return
+
+            _stream_artifact_objects_to_zip(zipf, artifact_store, objects)
+    except Exception as e:
+        logger.error(
+            f"Failed to save artifact '{artifact.id}' to zip file "
+            f" '{path}': {e}"
+        )
+        raise
 
 
 def get_producer_step_of_artifact(

--- a/src/zenml/integrations/azure/artifact_stores/azure_artifact_store.py
+++ b/src/zenml/integrations/azure/artifact_stores/azure_artifact_store.py
@@ -13,7 +13,10 @@
 #  permissions and limitations under the License.
 """Implementation of the Azure Artifact Store integration."""
 
+import posixpath
+from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -27,21 +30,111 @@ from typing import (
 
 import adlfs
 
-from zenml.artifact_stores import BaseArtifactStore
+from zenml.artifact_stores import (
+    BaseArtifactStore,
+    BulkDeleteResult,
+    ObjectDeleteFailure,
+    ObjectInfo,
+)
 from zenml.integrations.azure.flavors.azure_artifact_store_flavor import (
     AzureArtifactStoreConfig,
 )
 from zenml.io.fileio import convert_to_str
 from zenml.secret.schemas import AzureSecretSchema
 from zenml.stack.authentication_mixin import AuthenticationMixin
+from zenml.utils import io_utils
+
+if TYPE_CHECKING:
+    from azure.storage.blob import BlobServiceClient
 
 PathType = Union[bytes, str]
+
+AZURE_APPEND_BLOB_MAX_BLOCK_BYTES = 4 * 1024 * 1024
+AZURE_APPEND_BLOB_MAX_BLOCKS = 50000
+AZURE_BLOB_BATCH_DELETE_LIMIT = 256
+
+
+class _AzureAppendBlobWriter:
+    """Small file-like writer backed by Azure append blobs."""
+
+    def __init__(
+        self,
+        blob_client: Any,
+        committed_block_count: int,
+    ) -> None:
+        """Initialize the append blob writer."""
+        self._blob_client = blob_client
+        self._committed_block_count = committed_block_count
+        self._closed = False
+
+    def __enter__(self) -> "_AzureAppendBlobWriter":
+        """Enter the writer context manager."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Close the writer when leaving the context manager."""
+        self.close()
+
+    def writable(self) -> bool:
+        """Return whether this object supports writing."""
+        return True
+
+    def write(self, data: Union[str, bytes]) -> int:
+        """Append data to the backing append blob in provider-safe blocks."""
+        if self._closed:
+            raise ValueError(
+                "I/O operation on closed Azure append blob writer."
+            )
+
+        if isinstance(data, str):
+            encoded_data = data.encode("utf-8")
+            written_length = len(data)
+        else:
+            encoded_data = data
+            written_length = len(data)
+
+        if not encoded_data:
+            return written_length
+
+        block_count = (
+            len(encoded_data) + AZURE_APPEND_BLOB_MAX_BLOCK_BYTES - 1
+        ) // AZURE_APPEND_BLOB_MAX_BLOCK_BYTES
+        if (
+            self._committed_block_count + block_count
+            > AZURE_APPEND_BLOB_MAX_BLOCKS
+        ):
+            raise OSError(
+                "Azure append blob block limit reached; falling back to "
+                "the regular adlfs append path is required."
+            )
+
+        for start in range(
+            0, len(encoded_data), AZURE_APPEND_BLOB_MAX_BLOCK_BYTES
+        ):
+            block = encoded_data[
+                start : start + AZURE_APPEND_BLOB_MAX_BLOCK_BYTES
+            ]
+            self._blob_client.append_block(block)
+            self._committed_block_count += 1
+
+        return written_length
+
+    def flush(self) -> None:
+        """Flush pending data.
+
+        Writes are sent immediately by ``write()``, so there is nothing to do.
+        """
+
+    def close(self) -> None:
+        """Close the writer."""
+        self._closed = True
 
 
 class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
     """Artifact Store for Microsoft Azure based artifacts."""
 
     _filesystem: Optional[adlfs.AzureBlobFileSystem] = None
+    _blob_service_client: Optional["BlobServiceClient"] = None
 
     @property
     def config(self) -> AzureArtifactStoreConfig:
@@ -105,6 +198,78 @@ class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
         return secret
 
     @property
+    def blob_service_client(self) -> "BlobServiceClient":
+        """The native Azure Blob Storage client for object operations.
+
+        Returns:
+            An Azure Blob service client configured with the same connector or
+            secret credentials as the adlfs filesystem.
+        """
+        if self._blob_service_client and not self.connector_has_expired():
+            return self._blob_service_client
+
+        from azure.identity import (
+            ClientSecretCredential,
+            DefaultAzureCredential,
+        )
+        from azure.storage.blob import BlobServiceClient
+
+        connector = self.get_connector()
+        if connector:
+            client = connector.connect()
+            if not isinstance(client, BlobServiceClient):
+                raise RuntimeError(
+                    f"Expected a {BlobServiceClient.__module__}."
+                    f"{BlobServiceClient.__name__} object while "
+                    f"trying to use the linked connector, but got "
+                    f"{type(client)}."
+                )
+            self._blob_service_client = client
+            return self._blob_service_client
+
+        secret = self.get_typed_authentication_secret(
+            expected_schema_type=AzureSecretSchema
+        )
+        if secret and secret.connection_string:
+            self._blob_service_client = (
+                BlobServiceClient.from_connection_string(
+                    secret.connection_string
+                )
+            )
+            return self._blob_service_client
+
+        credentials = secret.get_values() if secret else {}
+        account_name = credentials.get("account_name")
+        if not account_name:
+            account_name = getattr(self.filesystem, "account_name", None)
+        if not account_name:
+            raise RuntimeError(
+                "Cannot create an Azure BlobServiceClient without an "
+                "account name. Configure Azure artifact store credentials "
+                "with an account_name or use a service connector."
+            )
+
+        if credentials.get("client_id") and credentials.get("client_secret"):
+            credential: Any = ClientSecretCredential(
+                client_id=credentials["client_id"],
+                client_secret=credentials["client_secret"],
+                tenant_id=credentials["tenant_id"],
+            )
+        else:
+            credential = credentials.get("account_key") or credentials.get(
+                "sas_token"
+            )
+            if credential is None:
+                credential = DefaultAzureCredential()
+
+        account_url = f"https://{account_name}.blob.core.windows.net/"
+        self._blob_service_client = BlobServiceClient(
+            account_url=account_url,
+            credential=credential,
+        )
+        return self._blob_service_client
+
+    @property
     def filesystem(self) -> adlfs.AzureBlobFileSystem:
         """The adlfs filesystem to access this artifact store.
 
@@ -147,6 +312,325 @@ class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
 
         return prefix, path
 
+    def _split_azure_uri(self, uri: str) -> Tuple[str, str, str]:
+        """Split an Azure artifact URI into scheme, container, and blob path."""
+        scheme, path = self._split_path(uri)
+        if not scheme:
+            raise ValueError(f"Expected an Azure URI, got `{uri}`.")
+
+        container_name, _, blob_name = path.partition("/")
+        if not container_name:
+            raise ValueError(
+                f"Azure URI `{uri}` does not include a container."
+            )
+
+        return scheme, container_name, blob_name
+
+    @staticmethod
+    def _build_azure_uri(
+        scheme: str, container_name: str, blob_name: str
+    ) -> str:
+        """Build an Azure artifact URI from path parts."""
+        if blob_name:
+            return f"{scheme}{container_name}/{blob_name}"
+        return f"{scheme}{container_name}"
+
+    @staticmethod
+    def _blob_matches_prefix(blob_name: str, prefix_blob_name: str) -> bool:
+        """Return whether a blob belongs to a requested file/directory prefix."""
+        if not prefix_blob_name:
+            return True
+
+        normalized_prefix = prefix_blob_name.rstrip("/")
+        return blob_name == normalized_prefix or blob_name.startswith(
+            f"{normalized_prefix}/"
+        )
+
+    @staticmethod
+    def _get_relative_blob_path(blob_name: str, prefix_blob_name: str) -> str:
+        """Get a blob path relative to a listed Azure prefix."""
+        normalized_prefix = prefix_blob_name.rstrip("/")
+        if not normalized_prefix:
+            return blob_name
+        if blob_name == normalized_prefix:
+            return posixpath.basename(blob_name)
+
+        prefix_with_separator = f"{normalized_prefix}/"
+        if blob_name.startswith(prefix_with_separator):
+            return blob_name[len(prefix_with_separator) :]
+
+        return posixpath.basename(blob_name)
+
+    def _get_container_client(self, container_name: str) -> Any:
+        """Return a native Azure container client."""
+        return self.blob_service_client.get_container_client(container_name)
+
+    def _get_blob_client(self, uri: str) -> Any:
+        """Return a native Azure blob client for an artifact URI."""
+        _, container_name, blob_name = self._split_azure_uri(uri)
+        if not blob_name:
+            raise ValueError(
+                f"Azure URI `{uri}` does not include a blob path."
+            )
+        return self.blob_service_client.get_blob_client(
+            container=container_name, blob=blob_name
+        )
+
+    def _get_blob_info(
+        self,
+        blob: Any,
+        scheme: str,
+        container_name: str,
+        prefix_blob_name: str,
+    ) -> ObjectInfo:
+        """Build object metadata from native Azure blob properties."""
+        blob_name = cast(str, blob.name)
+        size = getattr(blob, "size", None)
+        if size is None:
+            size = getattr(blob, "content_length", None)
+
+        return ObjectInfo(
+            uri=self._build_azure_uri(scheme, container_name, blob_name),
+            relative_path=self._get_relative_blob_path(
+                blob_name, prefix_blob_name
+            ),
+            size=size,
+            etag=getattr(blob, "etag", None),
+            version=getattr(blob, "version_id", None),
+            last_modified=getattr(blob, "last_modified", None),
+        )
+
+    @staticmethod
+    def _is_append_blob_type(blob_type: Any) -> bool:
+        """Return whether an Azure blob type value describes an append blob."""
+        value = getattr(blob_type, "value", blob_type)
+        normalized_value = (
+            str(value)
+            .lower()
+            .replace("blobtype.", "")
+            .replace("_", "")
+            .replace("-", "")
+        )
+        return normalized_value == "appendblob"
+
+    def _get_append_blob_writer(
+        self, path: PathType, mode: str
+    ) -> Optional[_AzureAppendBlobWriter]:
+        """Create an append-blob writer or return None for adlfs fallback."""
+        try:
+            sanitized_path = self._sanitize_path(path)
+            blob_client = self._get_blob_client(sanitized_path)
+            committed_block_count = 0
+
+            from azure.core.exceptions import (
+                ResourceExistsError,
+                ResourceNotFoundError,
+            )
+
+            try:
+                properties = blob_client.get_blob_properties()
+            except ResourceNotFoundError:
+                try:
+                    blob_client.create_append_blob()
+                except ResourceExistsError:
+                    properties = blob_client.get_blob_properties()
+                    if not self._is_append_blob_type(
+                        getattr(properties, "blob_type", "")
+                    ):
+                        return None
+                    committed_block_count = cast(
+                        int,
+                        getattr(
+                            properties,
+                            "append_blob_committed_block_count",
+                            0,
+                        )
+                        or 0,
+                    )
+            else:
+                if not self._is_append_blob_type(
+                    getattr(properties, "blob_type", "")
+                ):
+                    return None
+
+                committed_block_count = cast(
+                    int,
+                    getattr(
+                        properties,
+                        "append_blob_committed_block_count",
+                        0,
+                    )
+                    or 0,
+                )
+
+            return _AzureAppendBlobWriter(
+                blob_client=blob_client,
+                committed_block_count=committed_block_count,
+            )
+        except Exception:
+            return None
+
+    def list_objects(
+        self, prefix: PathType, recursive: bool = False
+    ) -> Iterable[ObjectInfo]:
+        """List Azure blobs below a prefix with native object metadata."""
+        sanitized_prefix = self._sanitize_path(prefix)
+        scheme, container_name, prefix_blob_name = self._split_azure_uri(
+            sanitized_prefix
+        )
+        listing_prefix = prefix_blob_name.rstrip("/")
+        container_client = self._get_container_client(container_name)
+
+        objects: List[ObjectInfo] = []
+        for blob in container_client.list_blobs(
+            name_starts_with=listing_prefix
+        ):
+            blob_name = cast(str, blob.name)
+            if blob_name.endswith("/"):
+                continue
+            if not self._blob_matches_prefix(blob_name, prefix_blob_name):
+                continue
+
+            object_info = self._get_blob_info(
+                blob, scheme, container_name, prefix_blob_name
+            )
+            if recursive or "/" not in object_info.relative_path.strip("/"):
+                objects.append(object_info)
+
+        return objects
+
+    def delete_objects(self, paths: Iterable[PathType]) -> BulkDeleteResult:
+        """Delete multiple Azure blobs with native batch deletion."""
+        deleted_paths: List[str] = []
+        failures: List[ObjectDeleteFailure] = []
+        grouped_paths: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
+
+        for path in paths:
+            sanitized_path = self._sanitize_path(path)
+            try:
+                scheme, container_name, blob_name = self._split_azure_uri(
+                    sanitized_path
+                )
+                if not blob_name:
+                    raise ValueError(
+                        f"Cannot delete Azure container root `{sanitized_path}`."
+                    )
+            except Exception as e:
+                failures.append(
+                    ObjectDeleteFailure(path=sanitized_path, error=e)
+                )
+                continue
+
+            grouped_paths.setdefault((scheme, container_name), []).append(
+                (sanitized_path, blob_name)
+            )
+
+        for (_, container_name), path_group in grouped_paths.items():
+            container_client = self._get_container_client(container_name)
+            for batch_start in range(
+                0, len(path_group), AZURE_BLOB_BATCH_DELETE_LIMIT
+            ):
+                batch = path_group[
+                    batch_start : batch_start + AZURE_BLOB_BATCH_DELETE_LIMIT
+                ]
+                try:
+                    responses = container_client.delete_blobs(
+                        *[blob_name for _, blob_name in batch],
+                        delete_snapshots="include",
+                    )
+                    for _ in responses:
+                        pass
+                except Exception:
+                    self._delete_blob_batch_individually(
+                        container_client=container_client,
+                        batch=batch,
+                        deleted_paths=deleted_paths,
+                        failures=failures,
+                    )
+                else:
+                    deleted_paths.extend(path for path, _ in batch)
+
+        return BulkDeleteResult(deleted_paths=deleted_paths, failures=failures)
+
+    def _delete_blob_batch_individually(
+        self,
+        container_client: Any,
+        batch: List[Tuple[str, str]],
+        deleted_paths: List[str],
+        failures: List[ObjectDeleteFailure],
+    ) -> None:
+        """Delete blobs one by one after a batch delete failure."""
+        from azure.core.exceptions import ResourceNotFoundError
+
+        for sanitized_path, blob_name in batch:
+            try:
+                container_client.delete_blob(
+                    blob_name, delete_snapshots="include"
+                )
+            except ResourceNotFoundError:
+                deleted_paths.append(sanitized_path)
+            except Exception as e:
+                failures.append(
+                    ObjectDeleteFailure(path=sanitized_path, error=e)
+                )
+            else:
+                deleted_paths.append(sanitized_path)
+
+    def read_range(
+        self, path: PathType, offset: int, length: Optional[int] = None
+    ) -> bytes:
+        """Read a byte range from an Azure blob."""
+        if offset < 0:
+            raise ValueError("Range read offset must be non-negative.")
+        if length is not None and length < 0:
+            raise ValueError("Range read length must be non-negative.")
+
+        sanitized_path = self._sanitize_path(path)
+        blob_client = self._get_blob_client(sanitized_path)
+        return cast(
+            bytes,
+            blob_client.download_blob(offset=offset, length=length).readall(),
+        )
+
+    def download_objects_to_directory(
+        self,
+        objects: Iterable[ObjectInfo],
+        local_dir: PathType,
+        max_workers: Optional[int] = None,
+    ) -> bool:
+        """Download Azure blobs into a local directory."""
+        local_dir_str = (
+            convert_to_str(local_dir)
+            if isinstance(local_dir, bytes)
+            else str(local_dir)
+        )
+        if io_utils.is_remote(local_dir_str):
+            raise ValueError("Download directory must be a local path.")
+        local_path = Path(local_dir_str)
+        download_root = local_path.resolve()
+
+        for object_info in objects:
+            destination = (download_root / object_info.relative_path).resolve()
+            if not destination.is_relative_to(download_root):
+                raise ValueError(
+                    "Refusing to download Azure blob outside target "
+                    f"directory: {object_info.relative_path}"
+                )
+
+            sanitized_uri = self._sanitize_path(object_info.uri)
+            blob_client = self._get_blob_client(sanitized_uri)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            download_kwargs = {}
+            if max_workers is not None:
+                download_kwargs["max_concurrency"] = max_workers
+
+            with destination.open("wb") as file:
+                file.write(
+                    blob_client.download_blob(**download_kwargs).readall()
+                )
+
+        return True
+
     def open(self, path: PathType, mode: str = "r") -> Any:
         """Open a file at the given path.
 
@@ -158,6 +642,11 @@ class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Returns:
             A file-like object.
         """
+        if mode in ("a", "ab"):
+            append_blob_writer = self._get_append_blob_writer(path, mode)
+            if append_blob_writer:
+                return append_blob_writer
+
         return self.filesystem.open(path=path, mode=mode)
 
     def copyfile(

--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Implementation of the GCP Artifact Store."""
 
+import posixpath
 from typing import (
     Any,
     Callable,
@@ -20,16 +21,24 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
 )
+from uuid import uuid4
 
 import gcsfs
+from google.api_core.exceptions import NotFound, PreconditionFailed
 from google.cloud import storage
 from google.oauth2 import credentials as gcp_credentials
 
-from zenml.artifact_stores import BaseArtifactStore
+from zenml.artifact_stores import (
+    BaseArtifactStore,
+    BulkDeleteResult,
+    ObjectDeleteFailure,
+    ObjectInfo,
+)
 from zenml.integrations.gcp.flavors.gcp_artifact_store_flavor import (
     GCP_PATH_PREFIX,
     GCPArtifactStoreConfig,
@@ -42,11 +51,15 @@ from zenml.stack.authentication_mixin import AuthenticationMixin
 logger = get_logger(__name__)
 PathType = Union[bytes, str]
 
+GCS_COMPOSE_MAX_SOURCES = 32
+GCS_COMPOSE_TEMPORARY_PREFIX = ".zenml-compose-"
+
 
 class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
     """Artifact Store for Google Cloud Storage based artifacts."""
 
     _filesystem: Optional[gcsfs.GCSFileSystem] = None
+    _storage_client: Optional[storage.Client] = None
 
     @property
     def config(self) -> GCPArtifactStoreConfig:
@@ -99,6 +112,289 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         self._filesystem = gcsfs.GCSFileSystem(token=token)
 
         return self._filesystem
+
+    @property
+    def storage_client(self) -> storage.Client:
+        """The native GCS client for provider-side object operations.
+
+        Returns:
+            A Google Cloud Storage client configured with the same connector or
+            secret credentials as the gcsfs filesystem.
+
+        Raises:
+            RuntimeError: If the linked connector returns the wrong client type.
+        """
+        if self._storage_client and not self.connector_has_expired():
+            return self._storage_client
+
+        connector = self.get_connector()
+        if connector:
+            client = connector.connect()
+            if not isinstance(client, storage.Client):
+                raise RuntimeError(
+                    f"Expected a google.cloud.storage.Client while trying to "
+                    f"use the linked connector, but got {type(client)}."
+                )
+            self._storage_client = client
+            return self._storage_client
+
+        secret = self.get_typed_authentication_secret(
+            expected_schema_type=GCPSecretSchema
+        )
+        if secret:
+            self._storage_client = storage.Client.from_service_account_info(
+                secret.get_credential_dict()
+            )
+        else:
+            self._storage_client = storage.Client()
+
+        return self._storage_client
+
+    @staticmethod
+    def _split_gcs_uri(uri: str) -> Tuple[str, str]:
+        """Split a GCS URI into bucket and object path parts."""
+        if not uri.startswith(GCP_PATH_PREFIX):
+            raise ValueError(f"Expected a GCS URI, got `{uri}`.")
+
+        path_without_prefix = uri[len(GCP_PATH_PREFIX) :]
+        bucket_name, _, blob_name = path_without_prefix.partition("/")
+        if not bucket_name:
+            raise ValueError(f"GCS URI `{uri}` does not include a bucket.")
+
+        return bucket_name, blob_name
+
+    @staticmethod
+    def _build_gcs_uri(bucket_name: str, blob_name: str) -> str:
+        """Build a GCS URI from bucket and object path parts."""
+        if blob_name:
+            return f"{GCP_PATH_PREFIX}{bucket_name}/{blob_name}"
+        return f"{GCP_PATH_PREFIX}{bucket_name}"
+
+    @staticmethod
+    def _blob_matches_prefix(blob_name: str, prefix_blob_name: str) -> bool:
+        """Return whether a blob belongs to a requested file/directory prefix."""
+        if not prefix_blob_name:
+            return True
+
+        normalized_prefix = prefix_blob_name.rstrip("/")
+        return blob_name == normalized_prefix or blob_name.startswith(
+            f"{normalized_prefix}/"
+        )
+
+    @staticmethod
+    def _get_relative_blob_path(blob_name: str, prefix_blob_name: str) -> str:
+        """Get a blob path relative to a listed GCS prefix."""
+        normalized_prefix = prefix_blob_name.rstrip("/")
+        if not normalized_prefix:
+            return blob_name
+        if blob_name == normalized_prefix:
+            return posixpath.basename(blob_name)
+
+        prefix_with_separator = f"{normalized_prefix}/"
+        if blob_name.startswith(prefix_with_separator):
+            return blob_name[len(prefix_with_separator) :]
+
+        return posixpath.basename(blob_name)
+
+    def _get_blob_info(
+        self, blob: storage.Blob, bucket_name: str, prefix_blob_name: str
+    ) -> ObjectInfo:
+        """Build object metadata from a native GCS blob."""
+        return ObjectInfo(
+            uri=self._build_gcs_uri(bucket_name, blob.name),
+            relative_path=self._get_relative_blob_path(
+                blob.name, prefix_blob_name
+            ),
+            size=blob.size,
+            etag=blob.etag,
+            generation=str(blob.generation) if blob.generation else None,
+            last_modified=blob.updated,
+        )
+
+    def _compose_blob(
+        self,
+        bucket: storage.Bucket,
+        source_blob_names: Sequence[str],
+        destination_blob_name: str,
+        overwrite: bool,
+    ) -> None:
+        """Compose source blobs into one destination blob."""
+        source_blobs = [bucket.blob(name) for name in source_blob_names]
+        destination_blob = bucket.blob(destination_blob_name)
+        if_generation_match = None if overwrite else 0
+        destination_blob.compose(
+            source_blobs,
+            client=self.storage_client,
+            if_generation_match=if_generation_match,
+        )
+
+    def _cleanup_intermediate_compose_objects(
+        self, object_uris: Sequence[str], destination_uri: str
+    ) -> None:
+        """Best-effort cleanup for temporary GCS compose objects."""
+        if not object_uris:
+            return
+
+        cleanup_result = self.delete_objects(object_uris)
+        if cleanup_result.failures:
+            logger.warning(
+                "Composed GCS object %s, but failed to clean up %d "
+                "temporary compose objects: %s",
+                destination_uri,
+                len(cleanup_result.failures),
+                [failure.path for failure in cleanup_result.failures],
+            )
+
+    def list_objects(
+        self, prefix: PathType, recursive: bool = False
+    ) -> Iterable[ObjectInfo]:
+        """List GCS objects below a prefix with native object metadata."""
+        sanitized_prefix = self._sanitize_path(prefix)
+        bucket_name, prefix_blob_name = self._split_gcs_uri(sanitized_prefix)
+        listing_prefix = prefix_blob_name.rstrip("/")
+
+        objects: List[ObjectInfo] = []
+        for blob in self.storage_client.list_blobs(
+            bucket_name, prefix=listing_prefix
+        ):
+            if blob.name.endswith("/"):
+                continue
+            if not self._blob_matches_prefix(blob.name, prefix_blob_name):
+                continue
+
+            object_info = self._get_blob_info(
+                blob, bucket_name, prefix_blob_name
+            )
+            if recursive or "/" not in object_info.relative_path.strip("/"):
+                objects.append(object_info)
+
+        return objects
+
+    def delete_objects(self, paths: Iterable[PathType]) -> BulkDeleteResult:
+        """Delete multiple GCS objects with native delete calls."""
+        deleted_paths: List[str] = []
+        failures: List[ObjectDeleteFailure] = []
+
+        for path in paths:
+            sanitized_path = self._sanitize_path(path)
+            try:
+                bucket_name, blob_name = self._split_gcs_uri(sanitized_path)
+                if not blob_name:
+                    raise ValueError(
+                        f"Cannot delete GCS bucket root `{sanitized_path}`."
+                    )
+
+                bucket = self.storage_client.bucket(bucket_name)
+                bucket.blob(blob_name).delete(client=self.storage_client)
+            except NotFound:
+                deleted_paths.append(sanitized_path)
+            except Exception as e:
+                failures.append(
+                    ObjectDeleteFailure(path=sanitized_path, error=e)
+                )
+            else:
+                deleted_paths.append(sanitized_path)
+
+        return BulkDeleteResult(deleted_paths=deleted_paths, failures=failures)
+
+    def compose_objects(
+        self,
+        sources: Sequence[PathType],
+        destination: PathType,
+        overwrite: bool = False,
+    ) -> bool:
+        """Compose GCS source objects into a destination object in order."""
+        sanitized_sources = [self._sanitize_path(source) for source in sources]
+        sanitized_destination = self._sanitize_path(destination)
+        if not sanitized_sources:
+            return False
+
+        destination_bucket_name, destination_blob_name = self._split_gcs_uri(
+            sanitized_destination
+        )
+        bucket = self.storage_client.bucket(destination_bucket_name)
+        source_blob_names: List[str] = []
+        for source in sanitized_sources:
+            source_bucket_name, source_blob_name = self._split_gcs_uri(source)
+            if source_bucket_name != destination_bucket_name:
+                raise ValueError(
+                    "GCS compose requires all source and destination objects "
+                    "to be in the same bucket."
+                )
+            source_blob_names.append(source_blob_name)
+
+        destination_directory = posixpath.dirname(destination_blob_name)
+        compose_id = uuid4().hex
+        intermediate_uris: List[str] = []
+        current_blob_names = source_blob_names
+        level = 0
+
+        try:
+            while len(current_blob_names) > GCS_COMPOSE_MAX_SOURCES:
+                next_blob_names: List[str] = []
+                for batch_index in range(
+                    0, len(current_blob_names), GCS_COMPOSE_MAX_SOURCES
+                ):
+                    batch = current_blob_names[
+                        batch_index : batch_index + GCS_COMPOSE_MAX_SOURCES
+                    ]
+                    temporary_blob_name = posixpath.join(
+                        destination_directory,
+                        f"{GCS_COMPOSE_TEMPORARY_PREFIX}"
+                        f"{compose_id}-{level}-{len(next_blob_names):06d}.log",
+                    )
+                    self._compose_blob(
+                        bucket=bucket,
+                        source_blob_names=batch,
+                        destination_blob_name=temporary_blob_name,
+                        overwrite=False,
+                    )
+                    next_blob_names.append(temporary_blob_name)
+                    intermediate_uris.append(
+                        self._build_gcs_uri(
+                            destination_bucket_name, temporary_blob_name
+                        )
+                    )
+
+                current_blob_names = next_blob_names
+                level += 1
+        except Exception:
+            self._cleanup_intermediate_compose_objects(
+                intermediate_uris, sanitized_destination
+            )
+            raise
+
+        try:
+            self._compose_blob(
+                bucket=bucket,
+                source_blob_names=current_blob_names,
+                destination_blob_name=destination_blob_name,
+                overwrite=overwrite,
+            )
+        except PreconditionFailed:
+            destination_blob = bucket.blob(destination_blob_name)
+            if not overwrite and destination_blob.exists(
+                client=self.storage_client
+            ):
+                self._cleanup_intermediate_compose_objects(
+                    intermediate_uris, sanitized_destination
+                )
+                return True
+
+            self._cleanup_intermediate_compose_objects(
+                intermediate_uris, sanitized_destination
+            )
+            raise
+        except Exception:
+            self._cleanup_intermediate_compose_objects(
+                intermediate_uris, sanitized_destination
+            )
+            raise
+
+        self._cleanup_intermediate_compose_objects(
+            intermediate_uris, sanitized_destination
+        )
+        return True
 
     def open(self, path: PathType, mode: str = "r") -> Any:
         """Open a file at the given path.

--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -13,7 +13,9 @@
 #  permissions and limitations under the License.
 """Implementation of the GCP Artifact Store."""
 
+import os
 import posixpath
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -31,6 +33,7 @@ from uuid import uuid4
 import gcsfs
 from google.api_core.exceptions import NotFound, PreconditionFailed
 from google.cloud import storage
+from google.cloud.storage import transfer_manager
 from google.oauth2 import credentials as gcp_credentials
 
 from zenml.artifact_stores import (
@@ -47,12 +50,14 @@ from zenml.io.fileio import convert_to_str
 from zenml.logger import get_logger
 from zenml.secret.schemas import GCPSecretSchema
 from zenml.stack.authentication_mixin import AuthenticationMixin
+from zenml.utils import io_utils
 
 logger = get_logger(__name__)
 PathType = Union[bytes, str]
 
 GCS_COMPOSE_MAX_SOURCES = 32
 GCS_COMPOSE_TEMPORARY_PREFIX = ".zenml-compose-"
+DEFAULT_GCS_DOWNLOAD_WORKERS = 8
 
 
 class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
@@ -196,6 +201,27 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
 
         return posixpath.basename(blob_name)
 
+    @staticmethod
+    def _get_safe_download_path(local_dir: str, relative_path: str) -> str:
+        """Build a local download path that stays inside ``local_dir``."""
+        relative_path_object = Path(relative_path)
+        if relative_path_object.is_absolute():
+            raise ValueError(
+                f"Object relative path `{relative_path}` escapes the local "
+                "download directory."
+            )
+
+        download_root = Path(local_dir).resolve()
+        destination = (download_root / relative_path_object).resolve()
+        if destination == download_root:
+            raise ValueError("Object relative path cannot be empty.")
+        if not destination.is_relative_to(download_root):
+            raise ValueError(
+                f"Object relative path `{relative_path}` escapes the local "
+                "download directory."
+            )
+        return str(destination)
+
     def _get_blob_info(
         self, blob: storage.Blob, bucket_name: str, prefix_blob_name: str
     ) -> ObjectInfo:
@@ -306,7 +332,7 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         """Compose GCS source objects into a destination object in order."""
         sanitized_sources = [self._sanitize_path(source) for source in sources]
         sanitized_destination = self._sanitize_path(destination)
-        if not sanitized_sources:
+        if len(sanitized_sources) < 2:
             return False
 
         destination_bucket_name, destination_blob_name = self._split_gcs_uri(
@@ -393,6 +419,55 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
 
         self._cleanup_intermediate_compose_objects(
             intermediate_uris, sanitized_destination
+        )
+        return True
+
+    def download_objects_to_directory(
+        self,
+        objects: Iterable[ObjectInfo],
+        local_dir: PathType,
+        max_workers: Optional[int] = None,
+    ) -> bool:
+        """Download GCS objects into a local directory with transfer manager."""
+        object_list = list(objects)
+        local_directory = convert_to_str(local_dir)
+        if io_utils.is_remote(local_directory):
+            raise ValueError("Download directory must be a local path.")
+        if max_workers is not None and max_workers < 1:
+            raise ValueError("Download worker count must be positive.")
+
+        os.makedirs(local_directory, exist_ok=True)
+        blob_file_pairs: List[Tuple[storage.Blob, str]] = []
+        for object_info in object_list:
+            sanitized_uri = self._sanitize_path(object_info.uri)
+            bucket_name, blob_name = self._split_gcs_uri(sanitized_uri)
+            if not blob_name:
+                raise ValueError(
+                    f"Cannot download GCS bucket root `{sanitized_uri}`."
+                )
+
+            destination = self._get_safe_download_path(
+                local_directory, object_info.relative_path
+            )
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            generation = (
+                int(object_info.generation)
+                if object_info.generation is not None
+                else None
+            )
+            bucket = self.storage_client.bucket(bucket_name)
+            blob_file_pairs.append(
+                (bucket.blob(blob_name, generation=generation), destination)
+            )
+
+        if not blob_file_pairs:
+            return True
+
+        transfer_manager.download_many(
+            blob_file_pairs,
+            raise_exception=True,
+            worker_type=transfer_manager.THREAD,
+            max_workers=max_workers or DEFAULT_GCS_DOWNLOAD_WORKERS,
         )
         return True
 

--- a/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
+++ b/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
@@ -13,6 +13,9 @@
 #  permissions and limitations under the License.
 """Implementation of the S3 Artifact Store."""
 
+import os
+import posixpath
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -22,6 +25,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
@@ -29,10 +33,17 @@ from typing import (
 
 import boto3
 import s3fs
+from boto3.s3.transfer import TransferConfig
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from fsspec.asyn import FSTimeoutError, sync, sync_wrapper
 
-from zenml.artifact_stores import BaseArtifactStore
+from zenml.artifact_stores import (
+    BaseArtifactStore,
+    BulkDeleteResult,
+    ObjectDeleteFailure,
+    ObjectInfo,
+)
 from zenml.integrations.s3.flavors.s3_artifact_store_flavor import (
     S3ArtifactStoreConfig,
 )
@@ -41,10 +52,13 @@ from zenml.io.fileio import convert_to_str
 from zenml.logger import get_logger
 from zenml.secret.schemas import AWSSecretSchema
 from zenml.stack.authentication_mixin import AuthenticationMixin
+from zenml.utils import io_utils
 
 logger = get_logger(__name__)
 
 PathType = Union[bytes, str]
+S3_DELETE_MAX_OBJECTS = 1000
+DEFAULT_S3_DOWNLOAD_WORKERS = 8
 
 
 def _normalize_s3_path(path: str) -> str:
@@ -164,6 +178,7 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
     """Artifact Store for S3 based artifacts."""
 
     _filesystem: Optional[ZenMLS3Filesystem] = None
+    _boto3_client_holder: Optional[Any] = None
 
     is_versioned: bool = False
 
@@ -180,6 +195,7 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         """
         super().__init__(*args, **kwargs)
         self._boto3_bucket_holder = None
+        self._boto3_client_holder = None
 
         # determine bucket versioning status
         versioning = self._boto3_bucket.Versioning()
@@ -503,6 +519,284 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         for directory, subdirectories, files in self.filesystem.walk(path=top):
             yield f"s3://{directory}", subdirectories, files
 
+    @staticmethod
+    def _build_s3_uri(bucket_name: str, key: str) -> str:
+        """Build an S3 URI from bucket and key parts."""
+        if key:
+            return f"s3://{bucket_name}/{key}"
+        return f"s3://{bucket_name}"
+
+    @staticmethod
+    def _object_matches_prefix(key: str, prefix_key: str) -> bool:
+        """Return whether an S3 object belongs to a requested prefix."""
+        if not prefix_key:
+            return True
+
+        normalized_prefix = prefix_key.rstrip("/")
+        return key == normalized_prefix or key.startswith(
+            f"{normalized_prefix}/"
+        )
+
+    @staticmethod
+    def _get_relative_key_path(key: str, prefix_key: str) -> str:
+        """Get an S3 key path relative to a listed prefix."""
+        normalized_prefix = prefix_key.rstrip("/")
+        if not normalized_prefix:
+            return key
+        if key == normalized_prefix:
+            return posixpath.basename(key)
+
+        prefix_with_separator = f"{normalized_prefix}/"
+        if key.startswith(prefix_with_separator):
+            return key[len(prefix_with_separator) :]
+
+        return posixpath.basename(key)
+
+    @staticmethod
+    def _get_safe_download_path(local_dir: str, relative_path: str) -> str:
+        """Build a local download path that stays inside ``local_dir``."""
+        normalized_relative_path = os.path.normpath(relative_path)
+        if normalized_relative_path in ("", "."):
+            raise ValueError("Object relative path cannot be empty.")
+        if os.path.isabs(normalized_relative_path) or (
+            normalized_relative_path == ".."
+            or normalized_relative_path.startswith(f"..{os.sep}")
+        ):
+            raise ValueError(
+                f"Object relative path `{relative_path}` escapes the local "
+                "download directory."
+            )
+
+        destination = os.path.abspath(
+            os.path.join(local_dir, normalized_relative_path)
+        )
+        local_dir_absolute = os.path.abspath(local_dir)
+        if os.path.commonpath([local_dir_absolute, destination]) != local_dir_absolute:
+            raise ValueError(
+                f"Object relative path `{relative_path}` escapes the local "
+                "download directory."
+            )
+
+        return destination
+
+    @staticmethod
+    def _chunked(
+        items: Sequence[Dict[str, str]], chunk_size: int
+    ) -> Iterable[Sequence[Dict[str, str]]]:
+        """Yield fixed-size chunks from a sequence."""
+        for index in range(0, len(items), chunk_size):
+            yield items[index : index + chunk_size]
+
+    def _get_object_info(
+        self, object_data: Dict[str, Any], bucket_name: str, prefix_key: str
+    ) -> ObjectInfo:
+        """Build object metadata from a native S3 listing entry."""
+        key = cast(str, object_data["Key"])
+        return ObjectInfo(
+            uri=self._build_s3_uri(bucket_name, key),
+            relative_path=self._get_relative_key_path(key, prefix_key),
+            size=object_data.get("Size"),
+            etag=object_data.get("ETag"),
+            last_modified=object_data.get("LastModified"),
+        )
+
+    def _delete_s3_object_identifiers(
+        self,
+        bucket_name: str,
+        object_identifiers: Sequence[Dict[str, str]],
+        capture_exceptions: bool = True,
+    ) -> BulkDeleteResult:
+        """Delete S3 objects or versions in provider-safe batches."""
+        deleted_paths: List[str] = []
+        failures: List[ObjectDeleteFailure] = []
+
+        for batch in self._chunked(
+            object_identifiers, S3_DELETE_MAX_OBJECTS
+        ):
+            try:
+                response = self._boto3_client.delete_objects(
+                    Bucket=bucket_name,
+                    Delete={"Objects": list(batch), "Quiet": False},
+                )
+            except Exception as e:
+                if not capture_exceptions:
+                    raise
+                failures.extend(
+                    ObjectDeleteFailure(
+                        path=self._build_s3_uri(bucket_name, object_["Key"]),
+                        error=e,
+                    )
+                    for object_ in batch
+                )
+                continue
+
+            failed_identifiers = set()
+            for error_data in response.get("Errors", []):
+                key = cast(str, error_data["Key"])
+                version_id = error_data.get("VersionId")
+                failed_identifiers.add((key, version_id))
+                error = RuntimeError(
+                    f"{error_data.get('Code', 'Unknown')}: "
+                    f"{error_data.get('Message', 'S3 object deletion failed')}"
+                )
+                failures.append(
+                    ObjectDeleteFailure(
+                        path=self._build_s3_uri(bucket_name, key), error=error
+                    )
+                )
+
+            deleted_objects = response.get("Deleted", [])
+            if deleted_objects:
+                deleted_paths.extend(
+                    self._build_s3_uri(bucket_name, cast(str, object_["Key"]))
+                    for object_ in deleted_objects
+                )
+                continue
+
+            deleted_paths.extend(
+                self._build_s3_uri(bucket_name, object_["Key"])
+                for object_ in batch
+                if (object_["Key"], object_.get("VersionId"))
+                not in failed_identifiers
+            )
+
+        return BulkDeleteResult(
+            deleted_paths=deleted_paths, failures=failures
+        )
+
+    def list_objects(
+        self, prefix: PathType, recursive: bool = False
+    ) -> Iterable[ObjectInfo]:
+        """List S3 objects below a prefix with native object metadata."""
+        sanitized_prefix = self._sanitize_path(prefix)
+        bucket_name, prefix_key = split_s3_path(sanitized_prefix)
+        listing_prefix = prefix_key.rstrip("/")
+        objects: List[ObjectInfo] = []
+
+        paginator = self._boto3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(
+            Bucket=bucket_name, Prefix=listing_prefix
+        ):
+            for object_data in page.get("Contents", []):
+                key = cast(str, object_data["Key"])
+                if key.endswith("/"):
+                    continue
+                if not self._object_matches_prefix(key, prefix_key):
+                    continue
+
+                object_info = self._get_object_info(
+                    object_data, bucket_name, prefix_key
+                )
+                if recursive or "/" not in object_info.relative_path.strip(
+                    "/"
+                ):
+                    objects.append(object_info)
+
+        return objects
+
+    def delete_objects(self, paths: Iterable[PathType]) -> BulkDeleteResult:
+        """Delete multiple S3 objects with native batch delete calls."""
+        objects_by_bucket: Dict[str, List[Dict[str, str]]] = {}
+        failures: List[ObjectDeleteFailure] = []
+
+        for path in paths:
+            sanitized_path = self._sanitize_path(path)
+            try:
+                bucket_name, key = split_s3_path(sanitized_path)
+                if not key:
+                    raise ValueError(
+                        f"Cannot delete S3 bucket root `{sanitized_path}`."
+                    )
+            except Exception as e:
+                failures.append(
+                    ObjectDeleteFailure(path=sanitized_path, error=e)
+                )
+                continue
+
+            objects_by_bucket.setdefault(bucket_name, []).append({"Key": key})
+
+        deleted_paths: List[str] = []
+        for bucket_name, object_identifiers in objects_by_bucket.items():
+            result = self._delete_s3_object_identifiers(
+                bucket_name=bucket_name,
+                object_identifiers=object_identifiers,
+            )
+            deleted_paths.extend(result.deleted_paths)
+            failures.extend(result.failures)
+
+        return BulkDeleteResult(
+            deleted_paths=deleted_paths, failures=failures
+        )
+
+    def read_range(
+        self, path: PathType, offset: int, length: Optional[int] = None
+    ) -> bytes:
+        """Read a byte range from S3 using a native ranged GetObject call."""
+        if offset < 0:
+            raise ValueError("Range read offset must be non-negative.")
+        if length is not None and length < 0:
+            raise ValueError("Range read length must be non-negative.")
+        if length == 0:
+            return b""
+
+        sanitized_path = self._sanitize_path(path)
+        bucket_name, key = split_s3_path(sanitized_path)
+        range_header = f"bytes={offset}-"
+        if length is not None:
+            range_header = f"bytes={offset}-{offset + length - 1}"
+
+        response = self._boto3_client.get_object(
+            Bucket=bucket_name,
+            Key=key,
+            Range=range_header,
+        )
+        body = response["Body"]
+        try:
+            return cast(bytes, body.read())
+        finally:
+            body.close()
+
+    def download_objects_to_directory(
+        self,
+        objects: Iterable[ObjectInfo],
+        local_dir: PathType,
+        max_workers: Optional[int] = None,
+    ) -> bool:
+        """Download S3 objects into a local directory with boto3 transfers."""
+        object_list = list(objects)
+        local_directory = convert_to_str(local_dir)
+        if io_utils.is_remote(local_directory):
+            raise ValueError("Download directory must be a local path.")
+        if max_workers is not None and max_workers < 1:
+            raise ValueError("Download worker count must be positive.")
+
+        os.makedirs(local_directory, exist_ok=True)
+        transfer_config = TransferConfig(
+            max_concurrency=max_workers or DEFAULT_S3_DOWNLOAD_WORKERS
+        )
+
+        def _download_object(object_info: ObjectInfo) -> None:
+            sanitized_uri = self._sanitize_path(object_info.uri)
+            bucket_name, key = split_s3_path(sanitized_uri)
+            destination = self._get_safe_download_path(
+                local_directory, object_info.relative_path
+            )
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            self._boto3_client.download_file(
+                Bucket=bucket_name,
+                Key=key,
+                Filename=destination,
+                Config=transfer_config,
+            )
+
+        worker_count = max_workers or min(
+            DEFAULT_S3_DOWNLOAD_WORKERS, max(1, len(object_list))
+        )
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            list(executor.map(_download_object, object_list))
+
+        return True
+
     def _remove_previous_file_versions(self, path: PathType) -> None:
         """Keep only the latest file version in the given path.
 
@@ -512,21 +806,62 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Args:
             path: The path to the file.
         """
-        if self.is_versioned:
-            if isinstance(path, bytes):
-                path = path.decode()
-            _, prefix = split_s3_path(path)
-            with self._shield_lack_of_versioning_permissions(
-                "s3:ListBucketVersions"
-            ):
-                for version in self._boto3_bucket.object_versions.filter(
-                    Prefix=prefix
-                ):
-                    if not version.is_latest:
-                        with self._shield_lack_of_versioning_permissions(
-                            "s3:DeleteObjectVersion"
-                        ):
-                            version.delete()
+        if not self.is_versioned:
+            return
+
+        if isinstance(path, bytes):
+            path = path.decode()
+        bucket_name, prefix = split_s3_path(path)
+        object_identifiers: List[Dict[str, str]] = []
+
+        with self._shield_lack_of_versioning_permissions(
+            "s3:ListBucketVersions"
+        ):
+            paginator = self._boto3_client.get_paginator(
+                "list_object_versions"
+            )
+            for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+                for version_data in page.get("Versions", []):
+                    if version_data.get("Key") != prefix:
+                        continue
+                    if not version_data.get("IsLatest", False):
+                        object_identifiers.append(
+                            {
+                                "Key": cast(str, version_data["Key"]),
+                                "VersionId": cast(
+                                    str, version_data["VersionId"]
+                                ),
+                            }
+                        )
+                for marker_data in page.get("DeleteMarkers", []):
+                    if marker_data.get("Key") != prefix:
+                        continue
+                    if not marker_data.get("IsLatest", False):
+                        object_identifiers.append(
+                            {
+                                "Key": cast(str, marker_data["Key"]),
+                                "VersionId": cast(str, marker_data["VersionId"]),
+                            }
+                        )
+
+        if not object_identifiers:
+            return
+
+        with self._shield_lack_of_versioning_permissions(
+            "s3:DeleteObjectVersion"
+        ):
+            result = self._delete_s3_object_identifiers(
+                bucket_name=bucket_name,
+                object_identifiers=object_identifiers,
+                capture_exceptions=False,
+            )
+            if result.failures:
+                logger.warning(
+                    "Failed to remove %d previous S3 object versions for %s: %s",
+                    len(result.failures),
+                    path,
+                    [failure.path for failure in result.failures],
+                )
 
     def _build_boto3_kwargs(self) -> Dict[str, Any]:
         """Build boto3 kwargs by layering config overrides over connector credentials.
@@ -550,8 +885,21 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
             kwargs["aws_session_token"] = token
         if region is not None and "region_name" not in kwargs:
             kwargs["region_name"] = region
+        if self.config.config_kwargs and "config" not in kwargs:
+            kwargs["config"] = Config(**self.config.config_kwargs)
 
         return kwargs
+
+    @property
+    def _boto3_client(self) -> Any:
+        """Get the boto3 S3 client."""
+        if self._boto3_client_holder and not self.connector_has_expired():
+            return self._boto3_client_holder
+
+        self._boto3_client_holder = boto3.client(
+            "s3", **self._build_boto3_kwargs()
+        )
+        return self._boto3_client_holder
 
     @property
     def _boto3_bucket(self) -> Any:
@@ -567,6 +915,28 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         self._boto3_bucket_holder = s3.Bucket(self.config.bucket)
         return self._boto3_bucket_holder
 
+    @staticmethod
+    def _is_missing_versioning_permission_error(
+        error: ClientError, auth_missing: str
+    ) -> bool:
+        """Return whether an AWS error indicates missing version permissions."""
+        error_data = error.response.get("Error", {})
+        error_code = error_data.get("Code", "")
+        error_message = str(error)
+        if error_data.get("Message"):
+            error_message = f"{error_message} {error_data['Message']}"
+        error_message = error_message.lower()
+
+        if error_code in {"AccessDenied", "UnauthorizedOperation"}:
+            return True
+        return (
+            auth_missing.lower() in error_message
+            and (
+                "not authorized" in error_message
+                or "access denied" in error_message
+            )
+        )
+
     @contextmanager
     def _shield_lack_of_versioning_permissions(
         self, auth_missing: str
@@ -574,7 +944,7 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         try:
             yield
         except ClientError as e:
-            if "not authorized" in e.args[0] and auth_missing in e.args[0]:
+            if self._is_missing_versioning_permission_error(e, auth_missing):
                 logger.warning(
                     "Your AWS Connector is lacking critical Versioning permissions. "
                     f"Please check that `{auth_missing}` is granted."
@@ -582,3 +952,5 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
                     "Artifact Store bucket."
                 )
                 self.is_versioned = False
+                return
+            raise

--- a/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
+++ b/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
@@ -769,6 +769,9 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
             raise ValueError("Download directory must be a local path.")
         if max_workers is not None and max_workers < 1:
             raise ValueError("Download worker count must be positive.")
+        if len(object_list) == 1:
+            self._sanitize_path(object_list[0].uri)
+            return False
 
         os.makedirs(local_directory, exist_ok=True)
         transfer_config = TransferConfig(

--- a/src/zenml/log_stores/artifact/artifact_log_exporter.py
+++ b/src/zenml/log_stores/artifact/artifact_log_exporter.py
@@ -25,7 +25,13 @@ from zenml.artifact_stores.base_artifact_store import BaseArtifactStore
 from zenml.enums import LoggingLevels
 from zenml.log_stores.artifact.artifact_log_store import (
     END_OF_STREAM_MESSAGE,
+    MERGED_LOG_FILE_NAME,
+    is_deterministic_merged_log_object,
+    is_log_fragment_object,
+    is_temporary_log_object,
+    list_log_objects,
     remove_ansi_escape_codes,
+    sort_log_objects,
 )
 from zenml.logger import get_logger
 from zenml.utils.logging_utils import LogEntry
@@ -307,45 +313,149 @@ class ArtifactLogExporter(LogExporter):
         Args:
             log_uri: The URI of the log files to merge.
         """
+        log_objects = list_log_objects(self.artifact_store, log_uri)
+        fragment_objects = sort_log_objects(
+            [
+                object_info
+                for object_info in log_objects
+                if is_log_fragment_object(object_info)
+            ]
+        )
+        temporary_objects = [
+            object_info
+            for object_info in log_objects
+            if is_temporary_log_object(object_info)
+        ]
+        cleanup_uris = [
+            object_info.uri
+            for object_info in [*fragment_objects, *temporary_objects]
+        ]
+
+        if any(
+            is_deterministic_merged_log_object(object_info)
+            for object_info in log_objects
+        ):
+            self._cleanup_log_objects(
+                cleanup_uris,
+                context_uri=log_uri,
+                cleanup_description="leftover log fragments",
+            )
+            return
+
+        if not fragment_objects:
+            return
+
+        if self._try_compose_merge(
+            fragment_uris=[
+                object_info.uri for object_info in fragment_objects
+            ],
+            temporary_uris=[
+                object_info.uri for object_info in temporary_objects
+            ],
+            destination_uri=os.path.join(log_uri, MERGED_LOG_FILE_NAME),
+        ):
+            return
+
+        if len(fragment_objects) > 1:
+            self._python_merge(
+                log_uri=log_uri,
+                fragment_uris=[
+                    object_info.uri for object_info in fragment_objects
+                ],
+            )
+
+    def _try_compose_merge(
+        self,
+        fragment_uris: List[str],
+        temporary_uris: List[str],
+        destination_uri: str,
+    ) -> bool:
+        """Try to merge log fragments using provider-side composition."""
+        try:
+            composed = self.artifact_store.compose_objects(
+                sources=fragment_uris,
+                destination=destination_uri,
+                overwrite=False,
+            )
+        except Exception as e:
+            logger.warning(
+                "Provider-side log composition failed for %s; falling back "
+                "to Python merge: %s",
+                destination_uri,
+                e,
+            )
+            return False
+
+        if not composed:
+            return False
+
+        self._cleanup_log_objects(
+            [*fragment_uris, *temporary_uris],
+            context_uri=destination_uri,
+            cleanup_description="log fragments",
+        )
+        return True
+
+    def _cleanup_log_objects(
+        self,
+        object_uris: List[str],
+        context_uri: str,
+        cleanup_description: str,
+    ) -> None:
+        """Best-effort cleanup for fragments left after log finalization."""
+        if not object_uris:
+            return
+
+        cleanup_result = self.artifact_store.delete_objects(object_uris)
+        if cleanup_result.failures:
+            failed_paths = [
+                failure.path for failure in cleanup_result.failures
+            ]
+            logger.warning(
+                "Finalized logs for %s, but failed to clean up %d %s: %s",
+                context_uri,
+                len(failed_paths),
+                cleanup_description,
+                failed_paths,
+            )
+
+    def _python_merge(
+        self,
+        log_uri: str,
+        fragment_uris: List[str],
+    ) -> None:
+        """Merge log fragments through Python using the legacy behavior."""
         from zenml.artifacts.utils import _load_file_from_artifact_store
         from zenml.exceptions import DoesNotExistException
 
-        # Check if the log directory exists - it may not if no logs
-        # were written yet. The URI folder gets created only when the
-        # first log message is sent.
-        if not self.artifact_store.exists(log_uri):
-            return
-
-        files_ = self.artifact_store.listdir(log_uri)
-        if len(files_) > 1:
-            files_.sort()
-
-            missing_files = set()
-            # dump all logs to a local file first
-            with self.artifact_store.open(
-                os.path.join(log_uri, f"{time.time()}_merged{LOGS_EXTENSION}"),
-                "w",
-            ) as merged_file:
-                for file in files_:
-                    try:
-                        merged_file.write(
-                            str(
-                                _load_file_from_artifact_store(
-                                    os.path.join(log_uri, str(file)),
-                                    artifact_store=self.artifact_store,
-                                    mode="r",
-                                )
+        missing_uris = set()
+        with self.artifact_store.open(
+            os.path.join(log_uri, f"{time.time()}_merged{LOGS_EXTENSION}"),
+            "w",
+        ) as merged_file:
+            for fragment_uri in fragment_uris:
+                try:
+                    merged_file.write(
+                        str(
+                            _load_file_from_artifact_store(
+                                fragment_uri,
+                                artifact_store=self.artifact_store,
+                                mode="r",
                             )
                         )
-                    except DoesNotExistException:
-                        missing_files.add(file)
-
-            # clean up left over files
-            for file in files_:
-                if file not in missing_files:
-                    self.artifact_store.remove(
-                        os.path.join(log_uri, str(file))
                     )
+                except DoesNotExistException:
+                    missing_uris.add(fragment_uri)
+
+        self._cleanup_log_objects(
+            [
+                fragment_uri
+                for fragment_uri in fragment_uris
+                if fragment_uri not in missing_uris
+            ],
+            context_uri=log_uri,
+            cleanup_description="log fragments",
+        )
 
     def shutdown(self) -> None:
         """Shutdown the exporter."""

--- a/src/zenml/log_stores/artifact/artifact_log_store.py
+++ b/src/zenml/log_stores/artifact/artifact_log_store.py
@@ -29,7 +29,7 @@ from uuid import UUID
 
 from opentelemetry.sdk._logs.export import LogExporter
 
-from zenml.artifact_stores import BaseArtifactStore
+from zenml.artifact_stores import BaseArtifactStore, ObjectInfo
 from zenml.enums import LoggingLevels, StackComponentType
 from zenml.exceptions import DoesNotExistException
 from zenml.log_stores import BaseLogStore
@@ -50,7 +50,113 @@ logger = get_logger(__name__)
 
 
 LOGS_EXTENSION = ".log"
+MERGED_LOG_FILE_NAME = f"merged{LOGS_EXTENSION}"
+LEGACY_MERGED_LOG_SUFFIX = f"_merged{LOGS_EXTENSION}"
+TEMPORARY_COMPOSE_LOG_PREFIX = ".zenml-compose-"
 END_OF_STREAM_MESSAGE = "END_OF_STREAM"
+
+
+def _get_log_object_name(object_info: "ObjectInfo") -> str:
+    """Get the normalized name of a listed log object."""
+    return object_info.relative_path.strip("/")
+
+
+def is_temporary_log_object(object_info: "ObjectInfo") -> bool:
+    """Whether a listed object is a temporary log compose object."""
+    return _get_log_object_name(object_info).startswith(
+        TEMPORARY_COMPOSE_LOG_PREFIX
+    )
+
+
+def is_deterministic_merged_log_object(
+    object_info: "ObjectInfo",
+) -> bool:
+    """Whether a listed object is the deterministic merged log file."""
+    return _get_log_object_name(object_info) == MERGED_LOG_FILE_NAME
+
+
+def is_merged_log_object(object_info: "ObjectInfo") -> bool:
+    """Whether a listed object is a merged log file."""
+    name = _get_log_object_name(object_info)
+    return is_deterministic_merged_log_object(object_info) or name.endswith(
+        LEGACY_MERGED_LOG_SUFFIX
+    )
+
+
+def is_log_fragment_object(object_info: "ObjectInfo") -> bool:
+    """Whether a listed object is a log fragment."""
+    name = _get_log_object_name(object_info)
+    return (
+        name.endswith(LOGS_EXTENSION)
+        and not is_merged_log_object(object_info)
+        and not is_temporary_log_object(object_info)
+    )
+
+
+def sort_log_objects(objects: List["ObjectInfo"]) -> List["ObjectInfo"]:
+    """Sort log objects in the same order as the previous filename sort."""
+    return sorted(objects, key=_get_log_object_name)
+
+
+def list_log_objects(
+    artifact_store: "BaseArtifactStore", logs_uri: str
+) -> List["ObjectInfo"]:
+    """List log objects with a legacy fallback for custom stores.
+
+    The optional artifact-store methods are new extension points. If a custom
+    store already had an unrelated ``list_objects`` helper with a different
+    return shape, this function falls back to the older filesystem-like log
+    listing behavior instead of breaking log fetch/finalization.
+    """
+    try:
+        objects = list(artifact_store.list_objects(logs_uri))
+    except Exception as e:
+        logger.debug(
+            "Could not list log objects for %s through list_objects(): %s",
+            logs_uri,
+            e,
+        )
+    else:
+        if all(isinstance(object_info, ObjectInfo) for object_info in objects):
+            return objects
+        logger.debug(
+            "Artifact store %s returned unexpected list_objects() values for "
+            "%s. Falling back to listdir().",
+            artifact_store.name,
+            logs_uri,
+        )
+
+    return _list_log_objects_with_legacy_methods(artifact_store, logs_uri)
+
+
+def _list_log_objects_with_legacy_methods(
+    artifact_store: "BaseArtifactStore", logs_uri: str
+) -> List["ObjectInfo"]:
+    """List log objects through the pre-acceleration artifact-store API."""
+    if not artifact_store.exists(logs_uri):
+        return []
+
+    if not artifact_store.isdir(logs_uri):
+        return [
+            ObjectInfo(
+                uri=logs_uri,
+                relative_path=os.path.basename(logs_uri),
+                size=artifact_store.size(logs_uri),
+            )
+        ]
+
+    objects: List[ObjectInfo] = []
+    for file_name in artifact_store.listdir(logs_uri):
+        uri = os.path.join(logs_uri, str(file_name))
+        if not artifact_store.isdir(uri):
+            objects.append(
+                ObjectInfo(
+                    uri=uri,
+                    relative_path=str(file_name),
+                    size=artifact_store.size(uri),
+                )
+            )
+    return objects
 
 
 def prepare_logs_uri(
@@ -115,6 +221,44 @@ def fetch_log_records(
     return log_entries
 
 
+def _stream_file_line_by_line(
+    artifact_store: "BaseArtifactStore",
+    logs_uri: str,
+) -> Generator[str, None, None]:
+    """Stream a single log file line by line."""
+    with artifact_store.open(logs_uri, "r") as file:
+        for line in file:
+            yield line.rstrip("\n\r")
+
+
+def _select_log_objects(objects: List["ObjectInfo"]) -> List["ObjectInfo"]:
+    """Select which listed log objects should be read."""
+    merged_objects = sort_log_objects(
+        [
+            object_info
+            for object_info in objects
+            if is_merged_log_object(object_info)
+        ]
+    )
+    deterministic_merged_objects = [
+        object_info
+        for object_info in merged_objects
+        if is_deterministic_merged_log_object(object_info)
+    ]
+    if deterministic_merged_objects:
+        return deterministic_merged_objects
+    if merged_objects:
+        return merged_objects
+
+    return sort_log_objects(
+        [
+            object_info
+            for object_info in objects
+            if is_log_fragment_object(object_info)
+        ]
+    )
+
+
 def _stream_logs_line_by_line(
     artifact_store: "BaseArtifactStore",
     logs_uri: str,
@@ -130,35 +274,26 @@ def _stream_logs_line_by_line(
 
     Yields:
         Individual log lines as strings.
-
-    Raises:
-        DoesNotExistException: If the artifact does not exist in the artifact store.
     """
-    if not artifact_store.exists(logs_uri):
+    if logs_uri.endswith(LOGS_EXTENSION):
+        try:
+            yield from _stream_file_line_by_line(artifact_store, logs_uri)
+        except (DoesNotExistException, FileNotFoundError, IsADirectoryError):
+            pass
+        else:
+            return
+
+    log_objects = list_log_objects(artifact_store, logs_uri)
+    if not log_objects:
         return
 
-    if not artifact_store.isdir(logs_uri):
-        # Single file case
-        with artifact_store.open(logs_uri, "r") as file:
-            for line in file:
-                yield line.rstrip("\n\r")
-    else:
-        # Directory case - may contain multiple log files
-        files = artifact_store.listdir(logs_uri)
-        if not files:
-            raise DoesNotExistException(
-                f"Folder '{logs_uri}' is empty in artifact store "
-                f"'{artifact_store.name}'."
+    for object_info in _select_log_objects(log_objects):
+        try:
+            yield from _stream_file_line_by_line(
+                artifact_store, object_info.uri
             )
-
-        # Sort files to read them in order
-        files.sort()
-
-        for file in files:
-            file_path = os.path.join(logs_uri, str(file))
-            with artifact_store.open(file_path, "r") as f:
-                for line in f:
-                    yield line.rstrip("\n\r")
+        except (DoesNotExistException, FileNotFoundError):
+            continue
 
 
 def parse_log_entry(log_line: str) -> Optional[LogEntry]:

--- a/tests/integration/functional/artifacts/test_utils.py
+++ b/tests/integration/functional/artifacts/test_utils.py
@@ -331,13 +331,14 @@ def test_download_artifact_files_from_response_fails_if_exists(
 
 
 def test_download_artifact_files_with_large_file(clean_client):
-    """Test downloading artifact files larger than chunk size (8192 bytes).
+    """Test downloading artifact files larger than the stream chunk size.
 
-    This test ensures that files larger than the internal CHUNK_SIZE are
-    downloaded correctly without data loss. Regression test for issue #4349.
+    This test ensures that files larger than the internal streaming chunk size
+    are downloaded correctly without data loss. Regression test for issue
+    #4349.
     """
-    # Create a large artifact (> 8192 bytes to trigger chunking)
-    large_data = b"X" * 10000 + b"Y" * 10000 + b"Z" * 5000  # 25,000 bytes
+    # Create a large artifact (> 1 MiB to trigger chunking)
+    large_data = b"X" * 1_000_000 + b"Y" * 1_000_000 + b"Z" * 500_000
 
     # Save the artifact
     artifact_name = "large_test_artifact"
@@ -369,7 +370,7 @@ def test_download_artifact_files_with_large_file(clean_client):
             extracted_data = f.read()
 
         # Verify the complete data was preserved (not just the last chunk)
-        assert len(extracted_data) > 8192, (
+        assert len(extracted_data) > 1_000_000, (
             f"Extracted file is only {len(extracted_data)} bytes, "
             "suggesting only one chunk was preserved"
         )

--- a/tests/integration/integrations/azure/artifact_stores/test_azure_artifact_store.py
+++ b/tests/integration/integrations/azure/artifact_stores/test_azure_artifact_store.py
@@ -11,20 +11,249 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+"""Tests for Azure artifact store behavior."""
 
+import sys
 from datetime import datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import pytest
 
-from zenml.enums import StackComponentType
-from zenml.exceptions import ArtifactStoreInterfaceError
-from zenml.integrations.azure.artifact_stores.azure_artifact_store import (
+
+class _DummyAzureBlobFileSystem:
+    """Import-time stand-in for the optional adlfs filesystem class."""
+
+
+adlfs_module = ModuleType("adlfs")
+adlfs_module.AzureBlobFileSystem = _DummyAzureBlobFileSystem  # type: ignore[attr-defined]
+sys.modules.setdefault("adlfs", adlfs_module)
+
+from zenml.artifact_stores import ObjectInfo  # noqa: E402
+from zenml.enums import StackComponentType  # noqa: E402
+from zenml.exceptions import ArtifactStoreInterfaceError  # noqa: E402
+from zenml.integrations.azure.artifact_stores.azure_artifact_store import (  # noqa: E402
     AzureArtifactStore,
 )
-from zenml.integrations.azure.flavors.azure_artifact_store_flavor import (
+from zenml.integrations.azure.flavors.azure_artifact_store_flavor import (  # noqa: E402
     AzureArtifactStoreConfig,
 )
+
+
+class ResourceExistsError(Exception):
+    """Fake Azure resource-exists exception."""
+
+
+class ResourceNotFoundError(Exception):
+    """Fake Azure resource-not-found exception."""
+
+
+@pytest.fixture(autouse=True)
+def _mock_azure_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide Azure exception classes without requiring Azure SDK installs."""
+    azure_module = ModuleType("azure")
+    core_module = ModuleType("azure.core")
+    exceptions_module = ModuleType("azure.core.exceptions")
+    exceptions_module.ResourceExistsError = ResourceExistsError  # type: ignore[attr-defined]
+    exceptions_module.ResourceNotFoundError = ResourceNotFoundError  # type: ignore[attr-defined]
+    core_module.exceptions = exceptions_module  # type: ignore[attr-defined]
+    azure_module.core = core_module  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "azure", azure_module)
+    monkeypatch.setitem(sys.modules, "azure.core", core_module)
+    monkeypatch.setitem(
+        sys.modules, "azure.core.exceptions", exceptions_module
+    )
+
+
+class _FakeDownload:
+    """In-memory Azure blob download response."""
+
+    def __init__(self, content: bytes) -> None:
+        """Initialize a fake download response."""
+        self.content = content
+
+    def readall(self) -> bytes:
+        """Return all downloaded bytes."""
+        return self.content
+
+
+class _FakeBlobClient:
+    """In-memory stand-in for an Azure BlobClient."""
+
+    def __init__(self, container: "_FakeContainerClient", name: str) -> None:
+        """Initialize the fake blob client."""
+        self.container = container
+        self.name = name
+        self.download_calls: List[Dict[str, Optional[int]]] = []
+
+    def get_blob_properties(self):  # type: ignore[no-untyped-def]
+        """Return fake blob properties or raise if the blob is absent."""
+        if self.name not in self.container.objects:
+            raise ResourceNotFoundError("missing")
+
+        return SimpleNamespace(
+            blob_type=self.container.blob_types.get(self.name, "BlockBlob"),
+            append_blob_committed_block_count=self.container.append_counts.get(
+                self.name, 0
+            ),
+        )
+
+    def create_append_blob(self) -> None:
+        """Create an empty append blob."""
+        self.container.create_append_blob_calls.append(self.name)
+        if self.name in self.container.objects:
+            raise ResourceExistsError("exists")
+
+        self.container.objects[self.name] = b""
+        self.container.blob_types[self.name] = "AppendBlob"
+        self.container.append_counts[self.name] = 0
+
+    def append_block(self, data: bytes) -> None:
+        """Append bytes to the fake append blob."""
+        self.container.append_block_calls.append((self.name, data))
+        self.container.objects[self.name] += data
+        self.container.append_counts[self.name] = (
+            self.container.append_counts.get(self.name, 0) + 1
+        )
+
+    def download_blob(self, **kwargs):  # type: ignore[no-untyped-def]
+        """Download fake blob bytes, optionally using a byte range."""
+        self.download_calls.append(kwargs)
+        content = self.container.objects[self.name]
+        offset = kwargs.get("offset", 0) or 0
+        length = kwargs.get("length")
+        if length is None:
+            return _FakeDownload(content[offset:])
+        return _FakeDownload(content[offset : offset + length])
+
+
+class _FakeContainerClient:
+    """In-memory stand-in for an Azure ContainerClient."""
+
+    def __init__(self, objects: Dict[str, bytes]) -> None:
+        """Initialize the fake container client."""
+        self.objects = objects
+        self.blob_types: Dict[str, Any] = {
+            name: "BlockBlob" for name in objects
+        }
+        self.append_counts: Dict[str, int] = {}
+        self.list_calls: List[str] = []
+        self.delete_batch_calls: List[List[str]] = []
+        self.delete_blob_calls: List[str] = []
+        self.delete_failures: set[str] = set()
+        self.fail_batch_delete = False
+        self.create_append_blob_calls: List[str] = []
+        self.append_block_calls: List[tuple[str, bytes]] = []
+
+    def list_blobs(self, name_starts_with: str):  # type: ignore[no-untyped-def]
+        """List fake blob metadata by prefix."""
+        self.list_calls.append(name_starts_with)
+        return [
+            SimpleNamespace(
+                name=name,
+                size=len(content),
+                etag=f"etag-{name}",
+                version_id=f"version-{name}",
+                last_modified=datetime(2026, 5, 14),
+            )
+            for name, content in sorted(self.objects.items())
+            if name.startswith(name_starts_with)
+        ]
+
+    def delete_blobs(self, *blob_names: str, **kwargs):  # type: ignore[no-untyped-def]
+        """Delete fake blobs in a batch."""
+        self.delete_batch_calls.append(list(blob_names))
+        if self.fail_batch_delete:
+            raise RuntimeError("batch failed")
+
+        for blob_name in blob_names:
+            self.objects.pop(blob_name, None)
+        return [SimpleNamespace(status_code=202) for _ in blob_names]
+
+    def delete_blob(self, blob_name: str, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        """Delete one fake blob."""
+        self.delete_blob_calls.append(blob_name)
+        if blob_name in self.delete_failures:
+            raise RuntimeError("delete failed")
+        if blob_name not in self.objects:
+            raise ResourceNotFoundError("missing")
+        self.objects.pop(blob_name)
+
+
+class _FakeBlobServiceClient:
+    """In-memory stand-in for an Azure BlobServiceClient."""
+
+    def __init__(self, container: _FakeContainerClient) -> None:
+        """Initialize the fake blob service client."""
+        self.container = container
+        self.blob_clients: Dict[str, _FakeBlobClient] = {}
+
+    def get_container_client(
+        self, container_name: str
+    ) -> _FakeContainerClient:
+        """Return the fake container client."""
+        assert container_name == "container"
+        return self.container
+
+    def get_blob_client(self, container: str, blob: str) -> _FakeBlobClient:
+        """Return a stable fake blob client."""
+        assert container == "container"
+        if blob not in self.blob_clients:
+            self.blob_clients[blob] = _FakeBlobClient(
+                container=self.container, name=blob
+            )
+        return self.blob_clients[blob]
+
+
+class _FakeFilesystem:
+    """Small fake adlfs filesystem used to assert append fallback."""
+
+    def __init__(self) -> None:
+        """Initialize the fake filesystem."""
+        self.open_calls: List[tuple[str, str]] = []
+        self.open_return_value = object()
+
+    def open(self, path: str, mode: str):  # type: ignore[no-untyped-def]
+        """Record and return a fake file object."""
+        self.open_calls.append((path, mode))
+        return self.open_return_value
+
+
+class _FakeBlobType:
+    """Azure enum-like blob type with a value attribute."""
+
+    value = "AppendBlob"
+
+
+def _get_azure_artifact_store(path: str = "az://container/root"):
+    """Create an Azure artifact store for tests."""
+    return AzureArtifactStore(
+        name="",
+        id=uuid4(),
+        config=AzureArtifactStoreConfig(path=path),
+        flavor="azure",
+        type=StackComponentType.ARTIFACT_STORE,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+
+
+def _get_fake_azure_artifact_store(
+    container: _FakeContainerClient,
+    path: str = "az://container/root",
+):
+    """Create an Azure artifact store wired to an in-memory blob client."""
+    artifact_store = _get_azure_artifact_store(path=path)
+    object.__setattr__(
+        artifact_store,
+        "_blob_service_client",
+        _FakeBlobServiceClient(container),
+    )
+    return artifact_store
 
 
 def test_azure_artifact_store_attributes():
@@ -44,8 +273,10 @@ def test_azure_artifact_store_attributes():
 
 
 def test_must_be_azure_path():
-    """Checks that an azure artifact store can only be initialized with a valid
-    path."""
+    """Checks that an azure artifact store can only use valid paths.
+
+    Invalid local and non-Azure remote paths are rejected.
+    """
     with pytest.raises(ArtifactStoreInterfaceError):
         AzureArtifactStore(
             name="",
@@ -93,3 +324,261 @@ def test_must_be_azure_path():
         updated=datetime.now(),
     )
     assert artifact_store.path == "abfs://mycontainer"
+
+
+def test_list_objects_uses_native_azure_listing_and_metadata():
+    """Tests Azure list_objects returns direct children and metadata."""
+    container = _FakeContainerClient(
+        objects={
+            "root/logs/1.log": b"one",
+            "root/logs/nested/2.log": b"two",
+            "root/logs2/3.log": b"three",
+        }
+    )
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    objects = list(artifact_store.list_objects("az://container/root/logs"))
+
+    assert container.list_calls == ["root/logs"]
+    assert [object_info.relative_path for object_info in objects] == ["1.log"]
+    assert objects[0].uri == "az://container/root/logs/1.log"
+    assert objects[0].size == 3
+    assert objects[0].etag == "etag-root/logs/1.log"
+    assert objects[0].version == "version-root/logs/1.log"
+
+    recursive_objects = list(
+        artifact_store.list_objects("az://container/root/logs", recursive=True)
+    )
+
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == [
+        "1.log",
+        "nested/2.log",
+    ]
+
+
+def test_list_objects_preserves_abfs_scheme_and_bucket_root_paths():
+    """Tests Azure listings preserve abfs:// URIs and root relative paths."""
+    container = _FakeContainerClient(
+        objects={
+            "top.log": b"top",
+            "a/file.txt": b"a",
+            "b/file.txt": b"b",
+        }
+    )
+    artifact_store = _get_fake_azure_artifact_store(
+        container, path="abfs://container"
+    )
+
+    objects = list(artifact_store.list_objects("abfs://container"))
+    recursive_objects = list(
+        artifact_store.list_objects("abfs://container", recursive=True)
+    )
+
+    assert [object_info.uri for object_info in objects] == [
+        "abfs://container/top.log"
+    ]
+    assert [object_info.relative_path for object_info in objects] == [
+        "top.log"
+    ]
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == [
+        "a/file.txt",
+        "b/file.txt",
+        "top.log",
+    ]
+
+
+def test_delete_objects_uses_batch_delete():
+    """Tests Azure delete_objects batches native delete requests."""
+    container = _FakeContainerClient(
+        objects={
+            "root/logs/1.log": b"one",
+            "root/logs/2.log": b"two",
+        }
+    )
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    result = artifact_store.delete_objects(
+        ["az://container/root/logs/1.log", "az://container/root/logs/2.log"]
+    )
+
+    assert result.successful
+    assert result.deleted_paths == [
+        "az://container/root/logs/1.log",
+        "az://container/root/logs/2.log",
+    ]
+    assert container.delete_batch_calls == [
+        ["root/logs/1.log", "root/logs/2.log"]
+    ]
+    assert container.objects == {}
+
+
+def test_delete_objects_reports_per_object_failures_after_batch_failure():
+    """Tests Azure delete_objects falls back to per-object failure reporting."""
+    container = _FakeContainerClient(
+        objects={
+            "root/logs/1.log": b"one",
+            "root/logs/2.log": b"two",
+        }
+    )
+    container.fail_batch_delete = True
+    container.delete_failures.add("root/logs/2.log")
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    result = artifact_store.delete_objects(
+        ["az://container/root/logs/1.log", "az://container/root/logs/2.log"]
+    )
+
+    assert result.deleted_paths == ["az://container/root/logs/1.log"]
+    assert [failure.path for failure in result.failures] == [
+        "az://container/root/logs/2.log"
+    ]
+    assert container.delete_blob_calls == [
+        "root/logs/1.log",
+        "root/logs/2.log",
+    ]
+    assert container.objects == {"root/logs/2.log": b"two"}
+
+
+@pytest.mark.parametrize("scheme", ["az://", "abfs://"])
+def test_read_range_uses_native_azure_range_download(scheme: str):
+    """Tests Azure read_range forwards offset and length to download_blob."""
+    container = _FakeContainerClient(objects={"root/file.txt": b"abcdef"})
+    artifact_store = _get_fake_azure_artifact_store(
+        container, path=f"{scheme}container/root"
+    )
+
+    content = artifact_store.read_range(
+        f"{scheme}container/root/file.txt", offset=2, length=3
+    )
+
+    blob_client = artifact_store.blob_service_client.get_blob_client(
+        container="container", blob="root/file.txt"
+    )
+    assert content == b"cde"
+    assert blob_client.download_calls == [{"offset": 2, "length": 3}]
+
+
+def test_download_objects_to_directory_uses_blob_downloads(tmp_path: Path):
+    """Tests Azure download_objects_to_directory preserves relative paths."""
+    container = _FakeContainerClient(
+        objects={
+            "root/file.txt": b"file",
+            "root/nested/other.txt": b"other",
+        }
+    )
+    artifact_store = _get_fake_azure_artifact_store(container)
+    objects = [
+        ObjectInfo(
+            uri="az://container/root/file.txt",
+            relative_path="file.txt",
+            size=4,
+        ),
+        ObjectInfo(
+            uri="az://container/root/nested/other.txt",
+            relative_path="nested/other.txt",
+            size=5,
+        ),
+    ]
+
+    downloaded = artifact_store.download_objects_to_directory(
+        objects, tmp_path, max_workers=3
+    )
+
+    assert downloaded is True
+    assert (tmp_path / "file.txt").read_bytes() == b"file"
+    assert (tmp_path / "nested" / "other.txt").read_bytes() == b"other"
+    blob_client = artifact_store.blob_service_client.get_blob_client(
+        container="container", blob="root/file.txt"
+    )
+    assert blob_client.download_calls == [{"max_concurrency": 3}]
+
+
+def test_download_objects_to_directory_rejects_path_traversal(
+    tmp_path: Path,
+):
+    """Tests Azure downloads cannot escape the target directory."""
+    container = _FakeContainerClient(objects={"root/file.txt": b"file"})
+    artifact_store = _get_fake_azure_artifact_store(container)
+    objects = [
+        ObjectInfo(
+            uri="az://container/root/file.txt",
+            relative_path="../outside.txt",
+            size=4,
+        )
+    ]
+
+    with pytest.raises(ValueError, match="outside target directory"):
+        artifact_store.download_objects_to_directory(objects, tmp_path)
+
+    assert not (tmp_path.parent / "outside.txt").exists()
+
+
+def test_open_append_uses_append_blob_for_new_blob(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests append mode writes through Azure append blobs when safe."""
+    from zenml.integrations.azure.artifact_stores import azure_artifact_store
+
+    monkeypatch.setattr(
+        azure_artifact_store, "AZURE_APPEND_BLOB_MAX_BLOCK_BYTES", 3
+    )
+    container = _FakeContainerClient(objects={})
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    with artifact_store.open("az://container/root/logs/run.log", "a") as file:
+        assert file.write("abcdef") == 6
+
+    assert container.create_append_blob_calls == ["root/logs/run.log"]
+    assert container.append_block_calls == [
+        ("root/logs/run.log", b"abc"),
+        ("root/logs/run.log", b"def"),
+    ]
+    assert container.objects["root/logs/run.log"] == b"abcdef"
+
+
+def test_open_append_uses_existing_append_blob_with_enum_like_blob_type():
+    """Tests append mode accepts SDK enum-like AppendBlob blob types."""
+    container = _FakeContainerClient(objects={"root/logs/run.log": b"old"})
+    container.blob_types["root/logs/run.log"] = _FakeBlobType()
+    container.append_counts["root/logs/run.log"] = 1
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    with artifact_store.open("az://container/root/logs/run.log", "ab") as file:
+        assert file.write(b"new") == 3
+
+    assert container.create_append_blob_calls == []
+    assert container.objects["root/logs/run.log"] == b"oldnew"
+    assert container.append_counts["root/logs/run.log"] == 2
+
+
+def test_open_append_falls_back_to_adlfs_for_existing_block_blob():
+    """Tests append mode keeps the adlfs fallback for non-append blobs."""
+    container = _FakeContainerClient(objects={"root/logs/run.log": b"old"})
+    artifact_store = _get_fake_azure_artifact_store(container)
+    filesystem = _FakeFilesystem()
+    object.__setattr__(artifact_store, "_filesystem", filesystem)
+
+    file = artifact_store.open("az://container/root/logs/run.log", "a")
+
+    assert file is filesystem.open_return_value
+    assert filesystem.open_calls == [("az://container/root/logs/run.log", "a")]
+    assert container.append_block_calls == []
+
+
+def test_append_blob_writer_rejects_writes_past_block_limit():
+    """Tests append blob writer checks block limits before appending."""
+    container = _FakeContainerClient(objects={"root/logs/run.log": b"old"})
+    container.blob_types["root/logs/run.log"] = "AppendBlob"
+    container.append_counts["root/logs/run.log"] = 50000
+    artifact_store = _get_fake_azure_artifact_store(container)
+
+    with artifact_store.open("az://container/root/logs/run.log", "a") as file:
+        with pytest.raises(OSError, match="block limit"):
+            file.write("new")
+
+    assert container.append_block_calls == []
+    assert container.objects["root/logs/run.log"] == b"old"

--- a/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
+++ b/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
@@ -14,6 +14,8 @@
 
 
 from datetime import datetime
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Sequence
 from uuid import uuid4
 
 import pytest
@@ -52,3 +54,406 @@ def test_must_be_gcs_path():
 
     artifact_store = _get_gcp_artifact_store(path="gs://mybucket")
     assert artifact_store.path == "gs://mybucket"
+
+
+class _FakePreconditionFailed(Exception):
+    """Fake GCS precondition error used by compose tests."""
+
+
+class _FakeBlob:
+    """In-memory stand-in for a google.cloud.storage Blob."""
+
+    def __init__(self, bucket: "_FakeBucket", name: str) -> None:
+        """Initialize a fake blob."""
+        self.bucket = bucket
+        self.name = name
+
+    @property
+    def size(self) -> Optional[int]:
+        """Return the fake object size."""
+        content = self.bucket.objects.get(self.name)
+        return len(content) if content is not None else None
+
+    @property
+    def etag(self) -> Optional[str]:
+        """Return a stable fake etag for existing objects."""
+        if self.name in self.bucket.objects:
+            return f"etag-{self.name}"
+        return None
+
+    @property
+    def generation(self) -> Optional[int]:
+        """Return a stable fake generation for existing objects."""
+        return 1 if self.name in self.bucket.objects else None
+
+    @property
+    def updated(self) -> datetime:
+        """Return a stable fake updated timestamp."""
+        return datetime(2026, 5, 14)
+
+    def compose(
+        self,
+        sources: Sequence["_FakeBlob"],
+        client: "_FakeGCSClient",
+        if_generation_match: Optional[int] = None,
+    ) -> None:
+        """Compose source blobs by concatenating their bytes in order."""
+        self.bucket.compose_calls.append(
+            (
+                [source.name for source in sources],
+                self.name,
+                if_generation_match,
+            )
+        )
+        if self.name == self.bucket.fail_compose_destination:
+            raise RuntimeError("compose failed")
+        if if_generation_match == 0 and self.name in self.bucket.objects:
+            raise _FakePreconditionFailed("destination exists")
+
+        self.bucket.objects[self.name] = b"".join(
+            self.bucket.objects[source.name] for source in sources
+        )
+
+    def exists(self, client: "_FakeGCSClient") -> bool:
+        """Return whether the fake object exists."""
+        return self.name in self.bucket.objects
+
+    def delete(self, client: "_FakeGCSClient") -> None:
+        """Delete the fake object or raise a configured cleanup error."""
+        self.bucket.delete_calls.append(self.name)
+        if self.name in self.bucket.delete_failures:
+            raise RuntimeError("delete failed")
+        self.bucket.objects.pop(self.name, None)
+
+
+class _FakeBucket:
+    """In-memory stand-in for a GCS bucket."""
+
+    def __init__(self, objects: Dict[str, bytes]) -> None:
+        """Initialize a fake bucket."""
+        self.objects = objects
+        self.compose_calls: List[tuple[List[str], str, Optional[int]]] = []
+        self.delete_calls: List[str] = []
+        self.delete_failures: set[str] = set()
+        self.fail_compose_destination: Optional[str] = None
+
+    def blob(self, name: str) -> _FakeBlob:
+        """Return a fake blob handle."""
+        return _FakeBlob(bucket=self, name=name)
+
+
+class _FakeGCSClient:
+    """In-memory stand-in for a GCS storage client."""
+
+    def __init__(self, objects: Dict[str, bytes]) -> None:
+        """Initialize a fake GCS client with one bucket."""
+        self.bucket_ = _FakeBucket(objects=objects)
+        self.list_calls: List[tuple[str, str]] = []
+
+    def bucket(self, bucket_name: str) -> _FakeBucket:
+        """Return the fake bucket."""
+        assert bucket_name == "bucket"
+        return self.bucket_
+
+    def list_blobs(self, bucket_name: str, prefix: str):  # type: ignore[no-untyped-def]
+        """List fake blobs by prefix."""
+        assert bucket_name == "bucket"
+        self.list_calls.append((bucket_name, prefix))
+        return [
+            self.bucket_.blob(name)
+            for name in sorted(self.bucket_.objects)
+            if name.startswith(prefix)
+        ]
+
+
+def _get_fake_gcp_artifact_store(
+    client: _FakeGCSClient, path: str = "gs://bucket/root"
+):  # type: ignore[no-untyped-def]
+    """Create a GCP artifact store wired to an in-memory storage client."""
+    artifact_store = _get_gcp_artifact_store(path=path)
+    object.__setattr__(artifact_store, "_storage_client", client)
+    return artifact_store
+
+
+def _fragment_objects(count: int) -> Dict[str, bytes]:
+    """Build ordered fake log fragments for compose tests."""
+    return {
+        f"root/logs/{index:04d}.log": f"{index:04d}\n".encode()
+        for index in range(count)
+    }
+
+
+def test_list_objects_uses_native_gcs_listing_and_metadata():
+    """Tests GCS list_objects returns direct children and metadata."""
+    client = _FakeGCSClient(
+        objects={
+            "root/logs/1.log": b"one",
+            "root/logs/nested/2.log": b"two",
+            "root/logs2/3.log": b"three",
+        }
+    )
+    artifact_store = _get_fake_gcp_artifact_store(client)
+
+    objects = list(artifact_store.list_objects("gs://bucket/root/logs"))
+
+    assert client.list_calls == [("bucket", "root/logs")]
+    assert [object_info.relative_path for object_info in objects] == ["1.log"]
+    assert objects[0].uri == "gs://bucket/root/logs/1.log"
+    assert objects[0].size == 3
+    assert objects[0].etag == "etag-root/logs/1.log"
+    assert objects[0].generation == "1"
+
+    recursive_objects = list(
+        artifact_store.list_objects("gs://bucket/root/logs", recursive=True)
+    )
+
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == [
+        "1.log",
+        "nested/2.log",
+    ]
+
+
+def test_list_objects_at_bucket_root_preserves_relative_paths():
+    """Tests bucket-root listings keep nested relative paths intact."""
+    client = _FakeGCSClient(
+        objects={
+            "top.log": b"top",
+            "a/file.txt": b"a",
+            "b/file.txt": b"b",
+        }
+    )
+    artifact_store = _get_fake_gcp_artifact_store(client, path="gs://bucket")
+
+    objects = list(artifact_store.list_objects("gs://bucket"))
+    recursive_objects = list(
+        artifact_store.list_objects("gs://bucket", recursive=True)
+    )
+
+    assert [object_info.relative_path for object_info in objects] == [
+        "top.log"
+    ]
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == [
+        "a/file.txt",
+        "b/file.txt",
+        "top.log",
+    ]
+
+
+def test_delete_objects_reports_per_object_cleanup_failures():
+    """Tests GCS delete_objects keeps successful and failed deletes separate."""
+    client = _FakeGCSClient(
+        objects={
+            "root/logs/1.log": b"one",
+            "root/logs/2.log": b"two",
+        }
+    )
+    client.bucket_.delete_failures.add("root/logs/2.log")
+    artifact_store = _get_fake_gcp_artifact_store(client)
+
+    result = artifact_store.delete_objects(
+        ["gs://bucket/root/logs/1.log", "gs://bucket/root/logs/2.log"]
+    )
+
+    assert result.deleted_paths == ["gs://bucket/root/logs/1.log"]
+    assert [failure.path for failure in result.failures] == [
+        "gs://bucket/root/logs/2.log"
+    ]
+    assert "root/logs/1.log" not in client.bucket_.objects
+    assert client.bucket_.objects["root/logs/2.log"] == b"two"
+
+
+def test_compose_objects_returns_false_for_empty_source_list():
+    """Tests empty GCS compose requests are treated as unsupported."""
+    client = _FakeGCSClient(objects={})
+    artifact_store = _get_fake_gcp_artifact_store(client)
+
+    composed = artifact_store.compose_objects(
+        [], "gs://bucket/root/logs/merged.log"
+    )
+
+    assert composed is False
+    assert client.bucket_.compose_calls == []
+
+
+@pytest.mark.parametrize("fragment_count", [1, 32])
+def test_compose_objects_uses_single_gcs_compose_for_up_to_32_sources(
+    fragment_count: int,
+):
+    """Tests GCS compose preserves source order without intermediates."""
+    client = _FakeGCSClient(objects=_fragment_objects(fragment_count))
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    sources = [
+        f"gs://bucket/root/logs/{index:04d}.log"
+        for index in range(fragment_count)
+    ]
+
+    composed = artifact_store.compose_objects(
+        sources, "gs://bucket/root/logs/merged.log"
+    )
+
+    assert composed is True
+    assert client.bucket_.objects["root/logs/merged.log"] == b"".join(
+        f"{index:04d}\n".encode() for index in range(fragment_count)
+    )
+    assert client.bucket_.compose_calls == [
+        (
+            [f"root/logs/{index:04d}.log" for index in range(fragment_count)],
+            "root/logs/merged.log",
+            0,
+        )
+    ]
+    assert client.bucket_.delete_calls == []
+
+
+@pytest.mark.parametrize("fragment_count", [33, 1025])
+def test_compose_objects_uses_tree_composition_for_more_than_32_sources(
+    fragment_count: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests GCS compose trees keep ordering and remove intermediates."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    monkeypatch.setattr(
+        gcp_artifact_store, "uuid4", lambda: SimpleNamespace(hex="fixed")
+    )
+    client = _FakeGCSClient(objects=_fragment_objects(fragment_count))
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    sources = [
+        f"gs://bucket/root/logs/{index:04d}.log"
+        for index in range(fragment_count)
+    ]
+
+    composed = artifact_store.compose_objects(
+        sources, "gs://bucket/root/logs/merged.log"
+    )
+
+    assert composed is True
+    assert client.bucket_.objects["root/logs/merged.log"] == b"".join(
+        f"{index:04d}\n".encode() for index in range(fragment_count)
+    )
+    assert all(
+        not name.startswith("root/logs/.zenml-compose-")
+        for name in client.bucket_.objects
+    )
+    assert client.bucket_.compose_calls[0][0] == [
+        f"root/logs/{index:04d}.log" for index in range(32)
+    ]
+    assert client.bucket_.compose_calls[-1][1] == "root/logs/merged.log"
+    assert client.bucket_.delete_calls
+
+
+def test_compose_objects_treats_existing_destination_as_successful_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests duplicate finalization does not fall back after GCS precondition failure."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    monkeypatch.setattr(
+        gcp_artifact_store, "PreconditionFailed", _FakePreconditionFailed
+    )
+    client = _FakeGCSClient(
+        objects={
+            "root/logs/1.log": b"fragment",
+            "root/logs/merged.log": b"existing",
+        }
+    )
+    artifact_store = _get_fake_gcp_artifact_store(client)
+
+    composed = artifact_store.compose_objects(
+        ["gs://bucket/root/logs/1.log"],
+        "gs://bucket/root/logs/merged.log",
+    )
+
+    assert composed is True
+    assert client.bucket_.objects["root/logs/merged.log"] == b"existing"
+
+
+def test_compose_objects_reraises_intermediate_precondition_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests only final destination precondition errors are idempotent."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    monkeypatch.setattr(
+        gcp_artifact_store, "PreconditionFailed", _FakePreconditionFailed
+    )
+    monkeypatch.setattr(
+        gcp_artifact_store, "uuid4", lambda: SimpleNamespace(hex="fixed")
+    )
+    objects = _fragment_objects(33)
+    objects["root/logs/.zenml-compose-fixed-0-000000.log"] = b"old-temp"
+    objects["root/logs/merged.log"] = b"existing"
+    client = _FakeGCSClient(objects=objects)
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    sources = [f"gs://bucket/root/logs/{index:04d}.log" for index in range(33)]
+
+    with pytest.raises(_FakePreconditionFailed):
+        artifact_store.compose_objects(
+            sources, "gs://bucket/root/logs/merged.log"
+        )
+
+    assert client.bucket_.objects["root/logs/merged.log"] == b"existing"
+
+
+def test_compose_objects_cleans_intermediates_after_final_compose_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests temporary GCS compose objects are removed on fallback errors."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    monkeypatch.setattr(
+        gcp_artifact_store, "uuid4", lambda: SimpleNamespace(hex="fixed")
+    )
+    client = _FakeGCSClient(objects=_fragment_objects(33))
+    client.bucket_.fail_compose_destination = "root/logs/merged.log"
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    sources = [f"gs://bucket/root/logs/{index:04d}.log" for index in range(33)]
+
+    with pytest.raises(RuntimeError, match="compose failed"):
+        artifact_store.compose_objects(
+            sources, "gs://bucket/root/logs/merged.log"
+        )
+
+    assert all(
+        not name.startswith("root/logs/.zenml-compose-")
+        for name in client.bucket_.objects
+    )
+    assert client.bucket_.delete_calls == [
+        "root/logs/.zenml-compose-fixed-0-000000.log",
+        "root/logs/.zenml-compose-fixed-0-000001.log",
+    ]
+
+
+def test_compose_objects_warns_but_succeeds_when_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Tests cleanup errors after final compose do not fail finalization."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    monkeypatch.setattr(
+        gcp_artifact_store, "uuid4", lambda: SimpleNamespace(hex="fixed")
+    )
+    client = _FakeGCSClient(objects=_fragment_objects(33))
+    client.bucket_.delete_failures.add(
+        "root/logs/.zenml-compose-fixed-0-000001.log"
+    )
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    sources = [f"gs://bucket/root/logs/{index:04d}.log" for index in range(33)]
+
+    composed = artifact_store.compose_objects(
+        sources, "gs://bucket/root/logs/merged.log"
+    )
+
+    assert composed is True
+    assert client.bucket_.objects["root/logs/merged.log"] == b"".join(
+        f"{index:04d}\n".encode() for index in range(33)
+    )
+    assert "failed to clean up 1 temporary compose objects" in caplog.text
+    assert (
+        "root/logs/.zenml-compose-fixed-0-000001.log" in client.bucket_.objects
+    )

--- a/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
+++ b/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
@@ -14,12 +14,14 @@
 
 
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from uuid import uuid4
 
 import pytest
 
+from zenml.artifact_stores import ObjectInfo
 from zenml.enums import StackComponentType
 from zenml.exceptions import ArtifactStoreInterfaceError
 
@@ -63,10 +65,16 @@ class _FakePreconditionFailed(Exception):
 class _FakeBlob:
     """In-memory stand-in for a google.cloud.storage Blob."""
 
-    def __init__(self, bucket: "_FakeBucket", name: str) -> None:
+    def __init__(
+        self,
+        bucket: "_FakeBucket",
+        name: str,
+        requested_generation: Optional[int] = None,
+    ) -> None:
         """Initialize a fake blob."""
         self.bucket = bucket
         self.name = name
+        self.requested_generation = requested_generation
 
     @property
     def size(self) -> Optional[int]:
@@ -137,9 +145,11 @@ class _FakeBucket:
         self.delete_failures: set[str] = set()
         self.fail_compose_destination: Optional[str] = None
 
-    def blob(self, name: str) -> _FakeBlob:
+    def blob(self, name: str, generation: Optional[int] = None) -> _FakeBlob:
         """Return a fake blob handle."""
-        return _FakeBlob(bucket=self, name=name)
+        return _FakeBlob(
+            bucket=self, name=name, requested_generation=generation
+        )
 
 
 class _FakeGCSClient:
@@ -266,6 +276,114 @@ def test_delete_objects_reports_per_object_cleanup_failures():
     assert client.bucket_.objects["root/logs/2.log"] == b"two"
 
 
+def test_download_objects_to_directory_uses_gcs_transfer_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Tests GCS downloads many objects without ZenML file opens."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    client = _FakeGCSClient(
+        objects={
+            "root/artifact/a.txt": b"a",
+            "root/artifact/nested/b.txt": b"b",
+        }
+    )
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    download_calls: List[
+        Tuple[List[Tuple[_FakeBlob, str]], Dict[str, Any]]
+    ] = []
+
+    def fail_open(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("download_objects_to_directory must not use open")
+
+    def fake_download_many(
+        blob_file_pairs: Sequence[Tuple[_FakeBlob, str]],
+        **kwargs: Any,
+    ) -> List[None]:
+        pairs = list(blob_file_pairs)
+        download_calls.append((pairs, kwargs))
+        for blob, destination in pairs:
+            Path(destination).write_bytes(blob.bucket.objects[blob.name])
+        return [None for _ in pairs]
+
+    monkeypatch.setattr(gcp_artifact_store.GCPArtifactStore, "open", fail_open)
+    monkeypatch.setattr(
+        gcp_artifact_store.transfer_manager,
+        "download_many",
+        fake_download_many,
+    )
+
+    downloaded = artifact_store.download_objects_to_directory(
+        [
+            ObjectInfo(
+                uri="gs://bucket/root/artifact/a.txt",
+                relative_path="a.txt",
+                generation="11",
+            ),
+            ObjectInfo(
+                uri="gs://bucket/root/artifact/nested/b.txt",
+                relative_path="nested/b.txt",
+                generation="12",
+            ),
+        ],
+        str(tmp_path),
+        max_workers=4,
+    )
+
+    assert downloaded is True
+    assert (tmp_path / "a.txt").read_bytes() == b"a"
+    assert (tmp_path / "nested" / "b.txt").read_bytes() == b"b"
+    assert len(download_calls) == 1
+    pairs, kwargs = download_calls[0]
+    assert [blob.name for blob, _ in pairs] == [
+        "root/artifact/a.txt",
+        "root/artifact/nested/b.txt",
+    ]
+    assert [blob.requested_generation for blob, _ in pairs] == [11, 12]
+    assert kwargs["raise_exception"] is True
+    assert kwargs["worker_type"] == gcp_artifact_store.transfer_manager.THREAD
+    assert kwargs["max_workers"] == 4
+
+
+def test_download_objects_to_directory_rejects_path_traversal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Tests GCS downloads refuse object paths outside the target dir."""
+    from zenml.integrations.gcp.artifact_stores import gcp_artifact_store
+
+    client = _FakeGCSClient(objects={"root/artifact/evil.txt": b"evil"})
+    artifact_store = _get_fake_gcp_artifact_store(client)
+    download_calls: List[object] = []
+
+    def fake_download_many(*args: Any, **kwargs: Any) -> List[None]:
+        download_calls.append((args, kwargs))
+        return []
+
+    monkeypatch.setattr(
+        gcp_artifact_store.transfer_manager,
+        "download_many",
+        fake_download_many,
+    )
+
+    with pytest.raises(
+        ValueError, match="escapes the local download directory"
+    ):
+        artifact_store.download_objects_to_directory(
+            [
+                ObjectInfo(
+                    uri="gs://bucket/root/artifact/evil.txt",
+                    relative_path="../evil.txt",
+                )
+            ],
+            str(tmp_path),
+        )
+
+    assert download_calls == []
+    assert not (tmp_path.parent / "evil.txt").exists()
+
+
 def test_compose_objects_returns_false_for_empty_source_list():
     """Tests empty GCS compose requests are treated as unsupported."""
     client = _FakeGCSClient(objects={})
@@ -279,7 +397,22 @@ def test_compose_objects_returns_false_for_empty_source_list():
     assert client.bucket_.compose_calls == []
 
 
-@pytest.mark.parametrize("fragment_count", [1, 32])
+def test_compose_objects_returns_false_for_single_source():
+    """Tests one-fragment GCS merges avoid provider compose overhead."""
+    client = _FakeGCSClient(objects={"root/logs/1.log": b"fragment"})
+    artifact_store = _get_fake_gcp_artifact_store(client)
+
+    composed = artifact_store.compose_objects(
+        ["gs://bucket/root/logs/1.log"],
+        "gs://bucket/root/logs/merged.log",
+    )
+
+    assert composed is False
+    assert "root/logs/merged.log" not in client.bucket_.objects
+    assert client.bucket_.compose_calls == []
+
+
+@pytest.mark.parametrize("fragment_count", [2, 32])
 def test_compose_objects_uses_single_gcs_compose_for_up_to_32_sources(
     fragment_count: int,
 ):
@@ -357,14 +490,15 @@ def test_compose_objects_treats_existing_destination_as_successful_retry(
     )
     client = _FakeGCSClient(
         objects={
-            "root/logs/1.log": b"fragment",
+            "root/logs/1.log": b"fragment-1",
+            "root/logs/2.log": b"fragment-2",
             "root/logs/merged.log": b"existing",
         }
     )
     artifact_store = _get_fake_gcp_artifact_store(client)
 
     composed = artifact_store.compose_objects(
-        ["gs://bucket/root/logs/1.log"],
+        ["gs://bucket/root/logs/1.log", "gs://bucket/root/logs/2.log"],
         "gs://bucket/root/logs/merged.log",
     )
 

--- a/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
+++ b/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
@@ -456,8 +456,31 @@ def test_read_range_uses_native_s3_range_header():
     ]
 
 
-def test_download_objects_to_directory_uses_boto3_transfers(tmp_path):
-    """Tests S3 download_objects_to_directory preserves relative paths."""
+def test_download_objects_to_directory_declines_single_object(tmp_path):
+    """Tests S3 single-object downloads fall back to streaming."""
+    client = _FakeS3Client()
+    artifact_store = _get_mocked_s3_artifact_store(client)
+    local_dir = tmp_path / "downloads"
+    objects = [
+        ObjectInfo(
+            uri="s3://bucket/root/large.bin",
+            relative_path="large.bin",
+        )
+    ]
+
+    handled = artifact_store.download_objects_to_directory(
+        objects, str(local_dir), max_workers=1
+    )
+
+    assert handled is False
+    assert client.download_calls == []
+    assert not local_dir.exists()
+
+
+def test_download_objects_to_directory_uses_boto3_transfers_for_multiple_objects(
+    tmp_path,
+):
+    """Tests S3 multi-object downloads use transfers and preserve paths."""
     client = _FakeS3Client()
     artifact_store = _get_mocked_s3_artifact_store(client)
     objects = [
@@ -495,11 +518,17 @@ def test_download_objects_to_directory_rejects_path_traversal(tmp_path):
                 ObjectInfo(
                     uri="s3://bucket/root/a.txt",
                     relative_path="../a.txt",
-                )
+                ),
+                ObjectInfo(
+                    uri="s3://bucket/root/b.txt",
+                    relative_path="b.txt",
+                ),
             ],
             str(tmp_path),
             max_workers=1,
         )
+
+    assert client.download_calls == []
 
 
 def test_remove_previous_file_versions_batches_versioned_deletes():

--- a/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
+++ b/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
@@ -11,14 +11,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+"""Tests for the S3 artifact store."""
 
 import asyncio
+import io
 from datetime import datetime
+from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from botocore.exceptions import ClientError
 
+from zenml.artifact_stores import ObjectInfo
 from zenml.enums import StackComponentType
 from zenml.exceptions import ArtifactStoreInterfaceError
 from zenml.integrations.s3.artifact_stores.s3_artifact_store import (
@@ -28,6 +33,76 @@ from zenml.integrations.s3.artifact_stores.s3_artifact_store import (
 from zenml.integrations.s3.flavors.s3_artifact_store_flavor import (
     S3ArtifactStoreConfig,
 )
+
+
+class _FakePaginator:
+    """Fake boto3 paginator that records pagination calls."""
+
+    def __init__(self, pages: List[Dict[str, Any]]) -> None:
+        self.pages = pages
+        self.calls: List[Dict[str, Any]] = []
+
+    def paginate(self, **kwargs: Any) -> List[Dict[str, Any]]:
+        """Record and return configured pages."""
+        self.calls.append(kwargs)
+        return self.pages
+
+
+class _FakeS3Client:
+    """Fake S3 client for mocked native artifact-store tests."""
+
+    def __init__(self) -> None:
+        self.paginators: Dict[str, _FakePaginator] = {}
+        self.delete_calls: List[Dict[str, Any]] = []
+        self.delete_responses: List[Dict[str, Any]] = []
+        self.get_object_calls: List[Dict[str, Any]] = []
+        self.get_object_bodies: List[bytes] = []
+        self.download_calls: List[Dict[str, Any]] = []
+
+    def get_paginator(self, name: str) -> _FakePaginator:
+        """Return a configured fake paginator."""
+        return self.paginators[name]
+
+    def delete_objects(self, **kwargs: Any) -> Dict[str, Any]:
+        """Record delete calls and return queued responses."""
+        self.delete_calls.append(kwargs)
+        if self.delete_responses:
+            return self.delete_responses.pop(0)
+        return {"Deleted": kwargs["Delete"]["Objects"]}
+
+    def get_object(self, **kwargs: Any) -> Dict[str, Any]:
+        """Record ranged get calls and return queued bytes."""
+        self.get_object_calls.append(kwargs)
+        return {"Body": io.BytesIO(self.get_object_bodies.pop(0))}
+
+    def download_file(self, **kwargs: Any) -> None:
+        """Record transfer downloads and write a small local file."""
+        self.download_calls.append(kwargs)
+        with open(kwargs["Filename"], "wb") as file:
+            file.write(kwargs["Key"].encode())
+
+
+def _get_mocked_s3_artifact_store(
+    client: _FakeS3Client, path: str = "s3://bucket/root"
+) -> S3ArtifactStore:
+    """Create an S3 artifact store wired to a fake native S3 client."""
+    with patch("boto3.resource") as mock_resource:
+        bucket = MagicMock()
+        bucket.Versioning.return_value.status = "Disabled"
+        mock_resource.return_value.Bucket.return_value = bucket
+        artifact_store = S3ArtifactStore(
+            name="",
+            id=uuid4(),
+            config=S3ArtifactStoreConfig(path=path),
+            flavor="s3",
+            type=StackComponentType.ARTIFACT_STORE,
+            user=uuid4(),
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+
+    artifact_store._boto3_client_holder = client
+    return artifact_store
 
 
 def test_s3_artifact_store_attributes():
@@ -117,12 +192,14 @@ def test_boto3_resource_receives_client_kwargs():
     assert mock_resource.call_args.kwargs["foo"] == "bar"
 
 
-def test_remove_previous_versions_uses_client_kwargs():
-    """Tests that _remove_previous_file_versions uses client_kwargs when creating boto3 resource."""
-    with patch("boto3.resource") as mock_resource:
+def test_boto3_client_receives_client_kwargs():
+    """Tests that native S3 clients preserve configured endpoint kwargs."""
+    with (
+        patch("boto3.resource") as mock_resource,
+        patch("boto3.client") as mock_client,
+    ):
         bucket = MagicMock()
-        bucket.Versioning.return_value.status = "Enabled"
-        bucket.object_versions.filter.return_value = []
+        bucket.Versioning.return_value.status = "Disabled"
         mock_resource.return_value.Bucket.return_value = bucket
 
         artifact_store = S3ArtifactStore(
@@ -139,14 +216,40 @@ def test_remove_previous_versions_uses_client_kwargs():
             updated=datetime.now(),
         )
 
-        artifact_store.is_versioned = True
-        artifact_store._boto3_bucket_holder = None
+        _ = artifact_store._boto3_client
 
-        artifact_store._remove_previous_file_versions("s3://mybucket/path")
+    assert mock_client.call_args.args == ("s3",)
+    assert mock_client.call_args.kwargs["endpoint_url"] == "http://minio:9000"
 
-    assert len(mock_resource.call_args_list) == 2
-    for call in mock_resource.call_args_list:
-        assert call.kwargs["endpoint_url"] == "http://minio:9000"
+
+def test_boto3_client_receives_config_kwargs():
+    """Tests that native S3 clients preserve botocore config kwargs."""
+    with (
+        patch("boto3.resource") as mock_resource,
+        patch("boto3.client") as mock_client,
+    ):
+        bucket = MagicMock()
+        bucket.Versioning.return_value.status = "Disabled"
+        mock_resource.return_value.Bucket.return_value = bucket
+
+        artifact_store = S3ArtifactStore(
+            name="",
+            id=uuid4(),
+            config=S3ArtifactStoreConfig(
+                path="s3://mybucket",
+                config_kwargs={"s3": {"addressing_style": "path"}},
+            ),
+            flavor="s3",
+            type=StackComponentType.ARTIFACT_STORE,
+            user=uuid4(),
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+
+        _ = artifact_store._boto3_client
+
+    config = mock_client.call_args.kwargs["config"]
+    assert config.s3 == {"addressing_style": "path"}
 
 
 def test_client_kwargs_region_overrides_credentials_region():
@@ -185,6 +288,311 @@ def test_client_kwargs_region_overrides_credentials_region():
     assert mock_resource.call_args.kwargs["aws_access_key_id"] == "key"
     assert mock_resource.call_args.kwargs["aws_secret_access_key"] == "secret"
     assert mock_resource.call_args.kwargs["aws_session_token"] == "token"
+
+
+def test_list_objects_uses_native_s3_listing_and_metadata():
+    """Tests S3 list_objects returns direct children and metadata."""
+    last_modified = datetime.now()
+    client = _FakeS3Client()
+    paginator = _FakePaginator(
+        pages=[
+            {
+                "Contents": [
+                    {
+                        "Key": "root/logs/1.log",
+                        "Size": 3,
+                        "ETag": '"etag-1"',
+                        "LastModified": last_modified,
+                    },
+                    {
+                        "Key": "root/logs/nested/2.log",
+                        "Size": 3,
+                        "ETag": '"etag-2"',
+                    },
+                    {"Key": "root/logs2/3.log", "Size": 5},
+                    {"Key": "root/logs/", "Size": 0},
+                ]
+            }
+        ]
+    )
+    client.paginators["list_objects_v2"] = paginator
+    artifact_store = _get_mocked_s3_artifact_store(client)
+
+    objects = list(artifact_store.list_objects("s3://bucket/root/logs"))
+
+    assert paginator.calls == [{"Bucket": "bucket", "Prefix": "root/logs"}]
+    assert [object_info.relative_path for object_info in objects] == ["1.log"]
+    assert objects[0].uri == "s3://bucket/root/logs/1.log"
+    assert objects[0].size == 3
+    assert objects[0].etag == '"etag-1"'
+    assert objects[0].last_modified == last_modified
+
+    recursive_objects = list(
+        artifact_store.list_objects("s3://bucket/root/logs", recursive=True)
+    )
+
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == ["1.log", "nested/2.log"]
+
+
+def test_list_objects_at_bucket_root_preserves_relative_paths():
+    """Tests bucket-root S3 listings keep nested relative paths intact."""
+    client = _FakeS3Client()
+    client.paginators["list_objects_v2"] = _FakePaginator(
+        pages=[
+            {
+                "Contents": [
+                    {"Key": "a/file.txt", "Size": 1},
+                    {"Key": "b/file.txt", "Size": 1},
+                    {"Key": "top.log", "Size": 3},
+                ]
+            }
+        ]
+    )
+    artifact_store = _get_mocked_s3_artifact_store(
+        client, path="s3://bucket"
+    )
+
+    objects = list(artifact_store.list_objects("s3://bucket"))
+    recursive_objects = list(
+        artifact_store.list_objects("s3://bucket", recursive=True)
+    )
+
+    assert [object_info.relative_path for object_info in objects] == [
+        "top.log"
+    ]
+    assert [
+        object_info.relative_path for object_info in recursive_objects
+    ] == ["a/file.txt", "b/file.txt", "top.log"]
+
+
+def test_delete_objects_batches_native_s3_deletes_and_reports_failures():
+    """Tests S3 delete_objects chunks requests and preserves failures."""
+    client = _FakeS3Client()
+    first_batch_deleted = [
+        {"Key": f"root/file-{index:04d}.txt"} for index in range(1000)
+    ]
+    client.delete_responses = [
+        {"Deleted": first_batch_deleted},
+        {
+            "Errors": [
+                {
+                    "Key": "root/file-1000.txt",
+                    "Code": "AccessDenied",
+                    "Message": "denied",
+                }
+            ]
+        },
+    ]
+    artifact_store = _get_mocked_s3_artifact_store(client)
+    paths = [
+        f"s3://bucket/root/file-{index:04d}.txt" for index in range(1001)
+    ]
+
+    result = artifact_store.delete_objects(paths)
+
+    assert len(client.delete_calls) == 2
+    assert len(client.delete_calls[0]["Delete"]["Objects"]) == 1000
+    assert client.delete_calls[1]["Delete"]["Objects"] == [
+        {"Key": "root/file-1000.txt"}
+    ]
+    assert len(result.deleted_paths) == 1000
+    assert [failure.path for failure in result.failures] == [
+        "s3://bucket/root/file-1000.txt"
+    ]
+
+
+def test_delete_objects_handles_mixed_success_and_errors():
+    """Tests one S3 delete response can include successes and failures."""
+    client = _FakeS3Client()
+    client.delete_responses = [
+        {
+            "Deleted": [{"Key": "root/a.txt"}],
+            "Errors": [
+                {
+                    "Key": "root/b.txt",
+                    "Code": "AccessDenied",
+                    "Message": "denied",
+                }
+            ],
+        }
+    ]
+    artifact_store = _get_mocked_s3_artifact_store(client)
+
+    result = artifact_store.delete_objects(
+        ["s3://bucket/root/a.txt", "s3://bucket/root/b.txt"]
+    )
+
+    assert result.deleted_paths == ["s3://bucket/root/a.txt"]
+    assert [failure.path for failure in result.failures] == [
+        "s3://bucket/root/b.txt"
+    ]
+
+
+def test_read_range_uses_native_s3_range_header():
+    """Tests S3 read_range sends the expected HTTP range header."""
+    client = _FakeS3Client()
+    client.get_object_bodies = [b"bcd", b"def"]
+    artifact_store = _get_mocked_s3_artifact_store(client)
+
+    assert (
+        artifact_store.read_range(
+            "s3://bucket/root/file.txt", offset=1, length=3
+        )
+        == b"bcd"
+    )
+    assert (
+        artifact_store.read_range("s3://bucket/root/file.txt", offset=3)
+        == b"def"
+    )
+    assert artifact_store.read_range(
+        "s3://bucket/root/file.txt", offset=3, length=0
+    ) == b""
+
+    assert client.get_object_calls == [
+        {"Bucket": "bucket", "Key": "root/file.txt", "Range": "bytes=1-3"},
+        {"Bucket": "bucket", "Key": "root/file.txt", "Range": "bytes=3-"},
+    ]
+
+
+def test_download_objects_to_directory_uses_boto3_transfers(tmp_path):
+    """Tests S3 download_objects_to_directory preserves relative paths."""
+    client = _FakeS3Client()
+    artifact_store = _get_mocked_s3_artifact_store(client)
+    objects = [
+        ObjectInfo(
+            uri="s3://bucket/root/a.txt",
+            relative_path="a.txt",
+        ),
+        ObjectInfo(
+            uri="s3://bucket/root/nested/b.txt",
+            relative_path="nested/b.txt",
+        ),
+    ]
+
+    handled = artifact_store.download_objects_to_directory(
+        objects, str(tmp_path), max_workers=1
+    )
+
+    assert handled is True
+    assert (tmp_path / "a.txt").read_bytes() == b"root/a.txt"
+    assert (tmp_path / "nested" / "b.txt").read_bytes() == b"root/nested/b.txt"
+    assert [call["Key"] for call in client.download_calls] == [
+        "root/a.txt",
+        "root/nested/b.txt",
+    ]
+
+
+def test_download_objects_to_directory_rejects_path_traversal(tmp_path):
+    """Tests S3 transfer downloads cannot escape the local target."""
+    client = _FakeS3Client()
+    artifact_store = _get_mocked_s3_artifact_store(client)
+
+    with pytest.raises(ValueError, match="escapes"):
+        artifact_store.download_objects_to_directory(
+            [
+                ObjectInfo(
+                    uri="s3://bucket/root/a.txt",
+                    relative_path="../a.txt",
+                )
+            ],
+            str(tmp_path),
+            max_workers=1,
+        )
+
+
+def test_remove_previous_file_versions_batches_versioned_deletes():
+    """Tests versioned S3 cleanup deletes old version IDs in batches."""
+    client = _FakeS3Client()
+    paginator = _FakePaginator(
+        pages=[
+            {
+                "Versions": [
+                    {
+                        "Key": "root/log.txt",
+                        "VersionId": "latest",
+                        "IsLatest": True,
+                    },
+                    {
+                        "Key": "root/log.txt",
+                        "VersionId": "old-version",
+                        "IsLatest": False,
+                    },
+                    {
+                        "Key": "root/log.txt.backup",
+                        "VersionId": "backup-old-version",
+                        "IsLatest": False,
+                    },
+                ],
+                "DeleteMarkers": [
+                    {
+                        "Key": "root/log.txt",
+                        "VersionId": "old-marker",
+                        "IsLatest": False,
+                    },
+                    {
+                        "Key": "root/log.txt.backup",
+                        "VersionId": "backup-old-marker",
+                        "IsLatest": False,
+                    },
+                ],
+            }
+        ]
+    )
+    client.paginators["list_object_versions"] = paginator
+    artifact_store = _get_mocked_s3_artifact_store(client)
+    artifact_store.is_versioned = True
+
+    artifact_store._remove_previous_file_versions("s3://bucket/root/log.txt")
+
+    assert paginator.calls == [
+        {"Bucket": "bucket", "Prefix": "root/log.txt"}
+    ]
+    assert client.delete_calls == [
+        {
+            "Bucket": "bucket",
+            "Delete": {
+                "Objects": [
+                    {"Key": "root/log.txt", "VersionId": "old-version"},
+                    {"Key": "root/log.txt", "VersionId": "old-marker"},
+                ],
+                "Quiet": False,
+            },
+        }
+    ]
+
+
+def test_versioning_permission_shield_reraises_unrelated_client_errors():
+    """Tests unrelated S3 ClientErrors are not silently swallowed."""
+    artifact_store = _get_mocked_s3_artifact_store(_FakeS3Client())
+    error = ClientError(
+        {"Error": {"Code": "NoSuchBucket", "Message": "missing bucket"}},
+        "ListObjectVersions",
+    )
+
+    with pytest.raises(ClientError, match="NoSuchBucket"):
+        with artifact_store._shield_lack_of_versioning_permissions(
+            "s3:ListBucketVersions"
+        ):
+            raise error
+
+
+def test_versioning_permission_shield_suppresses_access_denied():
+    """Tests missing versioning permissions disable versioned cleanup."""
+    artifact_store = _get_mocked_s3_artifact_store(_FakeS3Client())
+    artifact_store.is_versioned = True
+    error = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+        "ListObjectVersions",
+    )
+
+    with artifact_store._shield_lack_of_versioning_permissions(
+        "s3:ListBucketVersions"
+    ):
+        raise error
+
+    assert artifact_store.is_versioned is False
 
 
 class _StubS3Creator:

--- a/tests/unit/artifact_stores/test_base_artifact_store.py
+++ b/tests/unit/artifact_stores/test_base_artifact_store.py
@@ -11,9 +11,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import os
+from datetime import datetime
+from uuid import uuid4
+
 import pytest
 
+from zenml.artifact_stores import LocalArtifactStore, LocalArtifactStoreConfig
 from zenml.artifact_stores.base_artifact_store import BaseArtifactStoreConfig
+from zenml.enums import StackComponentType
 from zenml.exceptions import ArtifactStoreInterfaceError
 
 
@@ -44,3 +50,54 @@ class TestBaseArtifactStoreConfig:
     def test_invalid_path(self, path):
         with pytest.raises(ArtifactStoreInterfaceError):
             self.AriaArtifactStoreConfig(path=path)
+
+
+def test_optional_object_helpers_fall_back_to_filesystem_methods(tmp_path):
+    """Tests optional artifact-store helper fallbacks on a local store."""
+    local_artifact_store = LocalArtifactStore(
+        name="test-artifact-store",
+        id=uuid4(),
+        config=LocalArtifactStoreConfig(path=str(tmp_path)),
+        flavor="local",
+        type=StackComponentType.ARTIFACT_STORE,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+    root = os.path.join(local_artifact_store.path, "objects")
+    nested = os.path.join(root, "nested")
+    local_artifact_store.makedirs(nested)
+
+    first_path = os.path.join(root, "first.txt")
+    second_path = os.path.join(nested, "second.txt")
+    with local_artifact_store.open(first_path, "w") as file:
+        file.write("abcdef")
+    with local_artifact_store.open(second_path, "w") as file:
+        file.write("nested")
+
+    non_recursive_objects = list(local_artifact_store.list_objects(root))
+    recursive_objects = list(
+        local_artifact_store.list_objects(root, recursive=True)
+    )
+
+    assert [obj.relative_path for obj in non_recursive_objects] == [
+        "first.txt"
+    ]
+    assert [obj.relative_path for obj in recursive_objects] == [
+        "first.txt",
+        "nested/second.txt",
+    ]
+    assert non_recursive_objects[0].size == 6
+    assert (
+        local_artifact_store.read_range(first_path, offset=1, length=3)
+        == b"bcd"
+    )
+    assert local_artifact_store.read_range(first_path, offset=3) == b"def"
+
+    missing_path = os.path.join(root, "missing.txt")
+    result = local_artifact_store.delete_objects([first_path, missing_path])
+
+    assert result.deleted_paths == [first_path]
+    assert [failure.path for failure in result.failures] == [missing_path]
+    assert not local_artifact_store.exists(first_path)
+    assert local_artifact_store.exists(second_path)

--- a/tests/unit/artifacts/test_utils.py
+++ b/tests/unit/artifacts/test_utils.py
@@ -11,16 +11,20 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import io
 import os
 import shutil
 import tempfile
+import zipfile
 
 import pytest
 from pydantic import BaseModel
 
+from zenml.artifact_stores.base_artifact_store import ObjectInfo
 from zenml.artifacts.utils import (
     _load_artifact_from_uri,
     _strip_timestamp_from_multiline_string,
+    download_artifact_files_from_response,
     load_artifact_from_response,
     load_model_from_metadata,
     save_model_metadata,
@@ -118,6 +122,176 @@ def test_load_artifact_from_response(mocker, model_artifact):
 
     # Ensure the _load_artifact_from_uri function is called
     mocker_load_artifact.assert_called_once()
+
+
+class _ListdirOnlyArtifactStore:
+    """Small fake store that only supports the legacy download path."""
+
+    def __init__(self, artifact_uri: str, files: dict[str, bytes]) -> None:
+        self.artifact_uri = artifact_uri
+        self.files = files
+        self.listdir_calls: list[str] = []
+        self.open_calls: list[str] = []
+
+    def listdir(self, path: str) -> list[str]:
+        self.listdir_calls.append(path)
+        return list(self.files)
+
+    def open(self, path: str, mode: str = "rb") -> io.BytesIO:
+        self.open_calls.append(path)
+        relative_path = os.path.relpath(path, self.artifact_uri)
+        return io.BytesIO(self.files[relative_path])
+
+
+class _NativeListStreamingArtifactStore:
+    """Small fake store with native listing but no native download."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.list_objects_calls: list[tuple[str, bool]] = []
+        self.open_calls: list[str] = []
+        self.download_calls = 0
+
+    def list_objects(
+        self, prefix: str, recursive: bool = False
+    ) -> list[ObjectInfo]:
+        self.list_objects_calls.append((prefix, recursive))
+        return [
+            ObjectInfo(uri=uri, relative_path=os.path.basename(uri))
+            for uri in self.objects
+        ]
+
+    def download_objects_to_directory(
+        self,
+        objects: list[ObjectInfo],
+        local_dir: str,
+        max_workers: int | None = None,
+    ) -> bool:
+        self.download_calls += 1
+        return False
+
+    def open(self, path: str, mode: str = "rb") -> io.BytesIO:
+        self.open_calls.append(path)
+        return io.BytesIO(self.objects[path])
+
+
+class _AcceleratedArtifactStore:
+    """Small fake store that handles bulk artifact downloads."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self.objects = objects
+        self.downloaded_relative_paths: list[str] = []
+
+    def list_objects(
+        self, prefix: str, recursive: bool = False
+    ) -> list[ObjectInfo]:
+        return [
+            ObjectInfo(uri=uri, relative_path=os.path.basename(uri))
+            for uri in self.objects
+        ]
+
+    def download_objects_to_directory(
+        self,
+        objects: list[ObjectInfo],
+        local_dir: str,
+        max_workers: int | None = None,
+    ) -> bool:
+        for object_info in objects:
+            self.downloaded_relative_paths.append(object_info.relative_path)
+            destination = os.path.join(local_dir, object_info.relative_path)
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            with open(destination, "wb") as file:
+                file.write(self.objects[object_info.uri])
+        return True
+
+    def open(self, path: str, mode: str = "rb") -> io.BytesIO:
+        raise AssertionError("Accelerated downloads should not stream files.")
+
+
+def _patch_artifact_store(mocker, artifact_store):
+    return mocker.patch(
+        "zenml.artifacts.utils."
+        "_get_artifact_store_from_response_or_from_active_stack",
+        return_value=artifact_store,
+    )
+
+
+def _read_zip_contents(path: str) -> dict[str, bytes]:
+    with zipfile.ZipFile(path, "r") as zip_file:
+        return {
+            entry_name: zip_file.read(entry_name)
+            for entry_name in zip_file.namelist()
+        }
+
+
+def test_download_artifact_files_uses_listdir_streaming_fallback(
+    tmp_path, mocker
+):
+    """Test that stores without optional hooks keep listdir/open behavior."""
+    artifact_uri = str(tmp_path / "artifact")
+    files = {
+        f"file-{index}.txt": f"value-{index}".encode() for index in range(20)
+    }
+    artifact_store = _ListdirOnlyArtifactStore(artifact_uri, files)
+    artifact = mocker.Mock(id="artifact-id", uri=artifact_uri)
+    _patch_artifact_store(mocker, artifact_store)
+
+    zipfile_path = str(tmp_path / "artifact.zip")
+    download_artifact_files_from_response(artifact, path=zipfile_path)
+
+    assert _read_zip_contents(zipfile_path) == files
+    assert artifact_store.listdir_calls == [artifact_uri]
+    assert artifact_store.open_calls == [
+        str(os.path.join(artifact_uri, file_name)) for file_name in files
+    ]
+
+
+def test_download_artifact_files_streams_after_native_list_if_download_unsupported(
+    tmp_path, mocker
+):
+    """Test native listing with streaming fallback for stores like GCS."""
+    artifact_uri = "gs://bucket/artifact"
+    objects = {
+        f"{artifact_uri}/file-{index}.txt": f"value-{index}".encode()
+        for index in range(3)
+    }
+    artifact_store = _NativeListStreamingArtifactStore(objects)
+    artifact = mocker.Mock(id="artifact-id", uri=artifact_uri)
+    _patch_artifact_store(mocker, artifact_store)
+
+    zipfile_path = str(tmp_path / "artifact.zip")
+    download_artifact_files_from_response(artifact, path=zipfile_path)
+
+    assert _read_zip_contents(zipfile_path) == {
+        os.path.basename(uri): content for uri, content in objects.items()
+    }
+    assert artifact_store.list_objects_calls == [(artifact_uri, False)]
+    assert artifact_store.download_calls == 1
+    assert artifact_store.open_calls == list(objects)
+
+
+def test_download_artifact_files_uses_accelerated_download_helper(
+    tmp_path, mocker
+):
+    """Test native list/download helper path before ZIP creation."""
+    artifact_uri = "s3://bucket/artifact"
+    objects = {
+        f"{artifact_uri}/file-{index}.txt": f"value-{index}".encode()
+        for index in range(25)
+    }
+    artifact_store = _AcceleratedArtifactStore(objects)
+    artifact = mocker.Mock(id="artifact-id", uri=artifact_uri)
+    _patch_artifact_store(mocker, artifact_store)
+
+    zipfile_path = str(tmp_path / "artifact.zip")
+    download_artifact_files_from_response(artifact, path=zipfile_path)
+
+    assert _read_zip_contents(zipfile_path) == {
+        os.path.basename(uri): content for uri, content in objects.items()
+    }
+    assert artifact_store.downloaded_relative_paths == [
+        os.path.basename(uri) for uri in objects
+    ]
 
 
 class TempClass(BaseModel):

--- a/tests/unit/log_stores/artifact/test_artifact_log_store.py
+++ b/tests/unit/log_stores/artifact/test_artifact_log_store.py
@@ -1,0 +1,204 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for artifact-backed log storage helpers."""
+
+import os
+from datetime import datetime
+from typing import ClassVar, Iterable, List, Sequence
+from uuid import uuid4
+
+from zenml.artifact_stores import LocalArtifactStore, LocalArtifactStoreConfig
+from zenml.enums import StackComponentType
+from zenml.log_stores.artifact.artifact_log_exporter import ArtifactLogExporter
+from zenml.log_stores.artifact.artifact_log_store import (
+    MERGED_LOG_FILE_NAME,
+    fetch_log_records,
+)
+
+
+class ImmutableLocalArtifactStoreConfig(LocalArtifactStoreConfig):
+    """Local artifact-store config that uses immutable log directories."""
+
+    IS_IMMUTABLE_FILESYSTEM: ClassVar[bool] = True
+
+
+class ConflictingListObjectsLocalArtifactStore(LocalArtifactStore):
+    """Local fake with a pre-existing incompatible list_objects helper."""
+
+    def list_objects(  # type: ignore[override]
+        self, prefix: str, recursive: bool = False
+    ) -> List[str]:
+        """Return the wrong shape to simulate an existing custom helper."""
+        return ["not-object-info"]
+
+
+class AcceleratedImmutableLocalArtifactStore(LocalArtifactStore):
+    """Local fake that exposes provider-side log compose support."""
+
+    def compose_objects(
+        self,
+        sources: Sequence[str],
+        destination: str,
+        overwrite: bool = False,
+    ) -> bool:
+        """Compose source files into a destination file."""
+        self.compose_calls.append((list(sources), destination, overwrite))
+        if not overwrite and self.exists(destination):
+            return False
+
+        with self.open(destination, "w") as destination_file:
+            for source in sources:
+                with self.open(source, "r") as source_file:
+                    destination_file.write(source_file.read())
+        return True
+
+    def delete_objects(self, paths: Iterable[str]):  # type: ignore[no-untyped-def]
+        """Record bulk-delete calls before using the fallback implementation."""
+        path_list = list(paths)
+        self.deleted_batches.append(path_list)
+        return super().delete_objects(path_list)
+
+
+def _store(path, cls=LocalArtifactStore):  # type: ignore[no-untyped-def]
+    store = cls(
+        name="test-artifact-store",
+        id=uuid4(),
+        config=ImmutableLocalArtifactStoreConfig(path=str(path)),
+        flavor="local",
+        type=StackComponentType.ARTIFACT_STORE,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+    object.__setattr__(store, "compose_calls", [])
+    object.__setattr__(store, "deleted_batches", [])
+    return store
+
+
+def _write(store, path: str, content: str) -> None:  # type: ignore[no-untyped-def]
+    parent = os.path.dirname(path)
+    if not store.exists(parent):
+        store.makedirs(parent)
+    with store.open(path, "w") as file:
+        file.write(content)
+
+
+def test_immutable_log_merge_uses_python_fallback_without_compose(tmp_path):
+    """Tests immutable log finalization on stores with no compose override."""
+    store = _store(tmp_path)
+    log_uri = os.path.join(store.path, "logs", "run")
+    _write(store, os.path.join(log_uri, "2.log"), "second\n")
+    _write(store, os.path.join(log_uri, "1.log"), "first\n")
+
+    ArtifactLogExporter(store)._merge(log_uri)
+
+    objects = list(store.list_objects(log_uri))
+    assert len(objects) == 1
+    assert objects[0].relative_path.endswith("_merged.log")
+    with store.open(objects[0].uri, "r") as file:
+        assert file.read() == "first\nsecond\n"
+
+
+def test_immutable_log_merge_uses_compose_and_bulk_delete(tmp_path):
+    """Tests immutable log finalization when compose support is available."""
+    store = _store(tmp_path, cls=AcceleratedImmutableLocalArtifactStore)
+    log_uri = os.path.join(store.path, "logs", "run")
+    first = os.path.join(log_uri, "1.log")
+    second = os.path.join(log_uri, "2.log")
+    temporary = os.path.join(log_uri, ".zenml-compose-old.log")
+    _write(store, second, "second\n")
+    _write(store, first, "first\n")
+    _write(store, temporary, "temporary\n")
+
+    ArtifactLogExporter(store)._merge(log_uri)
+
+    destination = os.path.join(log_uri, MERGED_LOG_FILE_NAME)
+    assert store.compose_calls == [([first, second], destination, False)]
+    assert store.deleted_batches == [[first, second, temporary]]
+    with store.open(destination, "r") as file:
+        assert file.read() == "first\nsecond\n"
+    assert not store.exists(first)
+    assert not store.exists(second)
+    assert not store.exists(temporary)
+
+
+def test_immutable_log_merge_with_existing_merged_log_only_cleans_up(
+    tmp_path,
+):
+    """Tests retry finalization is cleanup-only after merged.log exists."""
+    store = _store(tmp_path, cls=AcceleratedImmutableLocalArtifactStore)
+    log_uri = os.path.join(store.path, "logs", "run")
+    first = os.path.join(log_uri, "1.log")
+    merged = os.path.join(log_uri, MERGED_LOG_FILE_NAME)
+    _write(store, first, "fragment\n")
+    _write(store, merged, "merged\n")
+
+    ArtifactLogExporter(store)._merge(log_uri)
+
+    assert store.compose_calls == []
+    assert store.deleted_batches == [[first]]
+    with store.open(merged, "r") as file:
+        assert file.read() == "merged\n"
+    assert not store.exists(first)
+
+
+def test_fetch_prefers_merged_log_object_over_fragments(tmp_path):
+    """Tests directory fetch reads the final merged log object first."""
+    store = _store(tmp_path)
+    log_uri = os.path.join(store.path, "logs", "run")
+    _write(store, os.path.join(log_uri, "1.log"), "fragment\n")
+    _write(store, os.path.join(log_uri, MERGED_LOG_FILE_NAME), "merged\n")
+
+    entries = fetch_log_records(store, log_uri, limit=10)
+
+    assert [entry.message for entry in entries] == ["merged"]
+
+
+def test_fetch_reads_sorted_fragments_and_ignores_compose_temporary_files(
+    tmp_path,
+):
+    """Tests directory fetch fallback when no merged object exists."""
+    store = _store(tmp_path)
+    log_uri = os.path.join(store.path, "logs", "run")
+    _write(store, os.path.join(log_uri, "2.log"), "second\n")
+    _write(store, os.path.join(log_uri, "1.log"), "first\n")
+    _write(store, os.path.join(log_uri, ".zenml-compose-old.log"), "temp\n")
+
+    entries = fetch_log_records(store, log_uri, limit=1)
+
+    assert [entry.message for entry in entries] == ["first"]
+
+
+def test_fetch_missing_log_file_returns_empty_entries(tmp_path):
+    """Tests missing single-file log URIs behave like empty logs."""
+    store = _store(tmp_path)
+
+    entries = fetch_log_records(
+        store,
+        os.path.join(store.path, "logs", "missing.log"),
+        limit=10,
+    )
+
+    assert entries == []
+
+
+def test_fetch_falls_back_when_custom_list_objects_has_old_shape(tmp_path):
+    """Tests existing custom list_objects helpers do not break log fetch."""
+    store = _store(tmp_path, cls=ConflictingListObjectsLocalArtifactStore)
+    log_uri = os.path.join(store.path, "logs", "run")
+    _write(store, os.path.join(log_uri, "1.log"), "fragment\n")
+
+    entries = fetch_log_records(store, log_uri, limit=10)
+
+    assert [entry.message for entry in entries] == ["fragment"]


### PR DESCRIPTION
(*While this PR has been heavily benchmarked, I'm just opening this up so it doesn't get lost. Mostly POC following some discussions.*)

This PR adds optional provider-native artifact-store acceleration hooks and wires them into artifact-backed logs plus raw artifact ZIP downloads. Local live-cloud benchmarks against S3 and GCS showed the largest wins for GCS/S3 many-small-file ZIP downloads and GCS log finalization:

| Scenario | develop | this branch | Result |
|---|---:|---:|---:|
| GCS ZIP, 64 MiB artifact | 13.5s | 2.6s | ~5.2x faster |
| GCS ZIP, 1000 small files | 173.0s | 23.8s | ~7.3x faster |
| S3 ZIP, 1000 small files | 107.9s | 25.1s | ~4.3x faster |
| GCS log merge, 1000 fragments | 446.9s | 318.0s | ~1.4x faster |
| S3 log merge, 1000 fragments | 202.8s | 188.0s | ~1.1x faster |

For GCS log merge, the more important shape change is that the branch avoids reading/writing log fragments through the Python process when provider-side compose can be used.

The ad hoc benchmark script is intentionally **not included in this PR**. It was kept out of the repo so this PR only contains product code, tests, and user-facing docs. I can share the script separately if useful.

## What changed

- Added optional, non-abstract artifact-store acceleration hooks:
  - `list_objects(...)`
  - `delete_objects(...)`
  - `read_range(...)`
  - `compose_objects(...)`
  - `download_objects_to_directory(...)`
- Added shared result/data shapes for object metadata and bulk delete results.
- Refactored artifact-backed log finalization to:
  - list fragments once,
  - try provider-side composition,
  - bulk-delete fragments where available,
  - safely fall back to the existing Python merge path.
- Refactored artifact log fetch to avoid some `exists + isdir + listdir` probing and prefer merged log objects when available.
- Added provider-native implementations:
  - GCS: list, bulk delete, compose, native download helper via `google.cloud.storage.transfer_manager`.
  - S3: paginated list, bulk delete, range reads, transfer helper for multi-object downloads.
  - Azure: list, blob batch delete, range reads, native downloads, append-blob writes for append-friendly log storage.
- Updated raw artifact ZIP downloads to use optional list/download helpers when available, while preserving the public API and legacy fallback.
- Added docs for artifact log store cloud IO acceleration behavior and caveats.

## Benchmark notes

Live benchmarks were run locally against scratch S3/GCS prefixes using the same command shape on `develop` and this branch.

Important interpretation details:

- `develop`'s raw ZIP path failed on direct cloud URI benchmarking because it builds paths with `Path("s3://...") / name`, which mangles `s3://` / `gs://` into local-looking paths. A script-local URI-safe legacy baseline was used for ZIP comparison.
- S3 has no GCS-style server-side compose primitive, so log merge improvements are expected to be modest there.
- Single-object S3 ZIP downloads now fall back to direct streaming because the transfer helper overhead did not pay off for one large file.
- Single-source GCS compose is skipped because compose overhead did not pay off for one log fragment.

## Validation

Focused checks run during implementation included:

- `uv run pytest tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py -q` → `16 passed`
- `uv run pytest tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py` → `20 passed`
- `uv run pytest --no-provision tests/integration/integrations/azure/artifact_stores/test_azure_artifact_store.py` → `14 passed`
- Focused unit/integration tests for raw artifact ZIP download behavior.
- Targeted Ruff/format checks on touched files.

Given the provider surface area, this should still get full CI / integration attention before merge.

## Notes for reviewers

- The new hooks are optional and have fallback behavior, so existing custom artifact stores should remain compatible.
- Provider-specific helpers are intentionally opportunistic: callers tolerate unsupported helpers and fall back to portable behavior.
- Cleanup after successful log composition is best-effort. If the final merged log exists but temporary cleanup fails, finalization should not fail the user path.
