### PR TITLE
Richer WanDB integration

### DIFF
--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -220,6 +220,8 @@ wandb_settings = WandbExperimentTrackerSettings(
 )
 ```
 
+ZenML truncates W&B tags to 64 characters and removes duplicates after truncation, so long tags with the same first 64 characters collapse into one W&B tag.
+
 When ZenML metadata is enabled, W&B config receives flat keys such as `zenml_pipeline_name`, `zenml_pipeline_run_name`, `zenml_pipeline_run_id`, `zenml_step_name`, `zenml_latest_step_run_id`, and `zenml_latest_step_run_version`. ZenML dashboard links are added when they can be derived from the active server. These values are written to W&B config, not W&B summary, so metric summaries stay focused on experiment results.
 
 To use W&B in a minimal mode without ZenML-added grouping, tags, or config, disable metadata:

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -197,6 +197,17 @@ def my_step(
     ...
 ```
 
+ZenML disables W&B SDK console output by default with settings equivalent to `wandb.Settings(console="off", silent=True)`. This keeps W&B status and progress messages out of ZenML step logs. To show W&B SDK console output again, override these settings:
+
+```python
+wandb_settings = WandbExperimentTrackerSettings(
+    settings=wandb.Settings(
+        console="auto",
+        silent=False,
+    ),
+)
+```
+
 ZenML manages common `wandb.init(...)` fields for you. In addition to the W&B entity and project configured on the stack component, `WandbExperimentTrackerSettings` supports:
 
 ```python

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -164,7 +164,7 @@ Or on the ZenML dashboard as metadata of a step that uses the tracker:
 Alternatively, you can see an overview of all experiment runs at https://wandb.ai/{ENTITY\_NAME}/{PROJECT\_NAME}/runs/.
 
 {% hint style="info" %}
-The naming convention of each Weights & Biases experiment run is `{pipeline_run_name}_{step_name}` (e.g. `wandb_example_pipeline-25_Apr_22-20_06_33_535737_tf_evaluator`) and each experiment run will be tagged with both `pipeline_name` and `pipeline_run_name`, which you can use to group and filter experiment runs.
+The naming convention of each Weights & Biases experiment run is `{pipeline_run_name}_{step_name}` (e.g. `wandb_example_pipeline-25_Apr_22-20_06_33_535737_tf_evaluator`). By default, ZenML groups W&B runs by the ZenML pipeline run name, adds human-readable tags (`zenml`, the pipeline name, and the pipeline run name), and stores durable ZenML identifiers in the W&B config.
 {% endhint %}
 
 #### Additional configuration
@@ -196,6 +196,64 @@ def my_step(
     """Everything in this step is auto-logged"""
     ...
 ```
+
+ZenML manages common `wandb.init(...)` fields for you. In addition to the W&B entity and project configured on the stack component, `WandbExperimentTrackerSettings` supports:
+
+```python
+wandb_settings = WandbExperimentTrackerSettings(
+    run_name="optional-display-name",
+    group="optional-group",
+    tags=["team-a"],
+    job_type="training",
+    run_config={"dataset": "customers-v2"},
+)
+```
+
+When ZenML metadata is enabled, W&B config receives flat keys such as `zenml_pipeline_name`, `zenml_pipeline_run_name`, `zenml_pipeline_run_id`, `zenml_step_name`, `zenml_latest_step_run_id`, and `zenml_latest_step_run_version`. ZenML dashboard links are added when they can be derived from the active server. These values are written to W&B config, not W&B summary, so metric summaries stay focused on experiment results.
+
+To use W&B in a minimal mode without ZenML-added grouping, tags, or config, disable metadata:
+
+```python
+wandb_settings = WandbExperimentTrackerSettings(
+    enable_zenml_metadata=False,
+    tags=["plain-wandb"],
+)
+```
+
+By default, ZenML leaves W&B run IDs unset (`run_id_strategy="wandb_generated"`), preserving W&B-generated IDs. If you want deterministic IDs, choose one of the opt-in strategies. For example, this configuration keeps retries for the same ZenML step invocation attached to the same W&B run:
+
+```python
+retry_collapsed_settings = WandbExperimentTrackerSettings(
+    run_id_strategy="pipeline_step",
+    resume="allow",
+)
+```
+
+If you prefer one W&B run for every ZenML step-run attempt, including retries, use:
+
+```python
+attempt_settings = WandbExperimentTrackerSettings(
+    run_id_strategy="step_run",
+)
+```
+
+ZenML defaults `resume` to `allow` whenever it passes a deterministic or explicit W&B run ID.
+
+Advanced users can attach logging to an existing W&B run, or pass unmanaged W&B initialization fields through `init_kwargs`:
+
+```python
+wandb_settings = WandbExperimentTrackerSettings(
+    run_id="existing-wandb-run-id",
+    init_kwargs={"notes": "Backfill evaluation metrics."},
+)
+```
+
+ZenML validates conflicts early:
+
+* `run_id` cannot be combined with a non-default `run_id_strategy`.
+* `resume="never"` cannot be combined with `run_id_strategy="pipeline_step"`, because retries intentionally reuse the same W&B run ID.
+* `run_config` cannot contain `zenml_*` keys, which are reserved for ZenML metadata.
+* `init_kwargs` cannot override ZenML-managed `wandb.init(...)` keys such as `entity`, `project`, `name`, `id`, `resume`, `group`, `job_type`, `tags`, `config`, or `settings`.
 
 ### Using Weights & Biases Weave
 

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -220,7 +220,15 @@ wandb_settings = WandbExperimentTrackerSettings(
 )
 ```
 
-By default, ZenML leaves W&B run IDs unset (`run_id_strategy="wandb_generated"`), preserving W&B-generated IDs. If you want deterministic IDs, choose one of the opt-in strategies. For example, this configuration keeps retries for the same ZenML step invocation attached to the same W&B run:
+By default, ZenML leaves W&B run IDs unset (`run_id_strategy="wandb_generated"`), preserving W&B-generated IDs. The supported `run_id_strategy` values are:
+
+| Strategy | Behavior |
+| --- | --- |
+| `wandb_generated` | Let W&B generate the run ID. |
+| `pipeline_step` | Use one deterministic W&B run ID for each ZenML pipeline-step invocation, so retries for the same invocation resume the same W&B run. |
+| `step_run` | Use one deterministic W&B run ID for each ZenML step-run attempt, including retries. |
+
+For example, this configuration keeps retries for the same ZenML step invocation attached to the same W&B run:
 
 ```python
 retry_collapsed_settings = WandbExperimentTrackerSettings(
@@ -236,6 +244,8 @@ attempt_settings = WandbExperimentTrackerSettings(
     run_id_strategy="step_run",
 )
 ```
+
+When `run_id_strategy="step_run"` is used without an explicit `run_name`, ZenML appends the ZenML step-run version to the W&B display name so retry attempts are easier to distinguish in the W&B UI.
 
 ZenML defaults `resume` to `allow` whenever it passes a deterministic or explicit W&B run ID.
 

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -197,7 +197,7 @@ def my_step(
     ...
 ```
 
-ZenML disables W&B SDK console output by default with settings equivalent to `wandb.Settings(console="off", silent=True)`. This keeps W&B status and progress messages out of ZenML step logs. To show W&B SDK console output again, override these settings:
+ZenML disables W&B SDK console output by default with settings equivalent to `wandb.Settings(console="off", silent=True)`. W&B writes normal status and progress messages to stderr and uses carriage returns to redraw progress output. ZenML log stores preserve stderr as error-level logs, which can create confusing entries and trigger error-based log alerts even when W&B is working correctly. Metrics logged with `wandb.log(...)` are still sent to W&B. To show W&B SDK console output again, override these settings:
 
 ```python
 wandb_settings = WandbExperimentTrackerSettings(
@@ -207,6 +207,8 @@ wandb_settings = WandbExperimentTrackerSettings(
     ),
 )
 ```
+
+If you enable W&B SDK console output again, expect W&B login, sync, and progress messages to appear in ZenML step logs. Some of these messages may be stored as error-level logs because they are emitted through stderr by the W&B SDK.
 
 ZenML manages common `wandb.init(...)` fields for you. In addition to the W&B entity and project configured on the stack component, `WandbExperimentTrackerSettings` supports:
 
@@ -238,14 +240,14 @@ By default, ZenML leaves W&B run IDs unset (`run_id_strategy="wandb_generated"`)
 | Strategy | Behavior |
 | --- | --- |
 | `wandb_generated` | Let W&B generate the run ID. |
-| `pipeline_step` | Use one deterministic W&B run ID for each ZenML pipeline-step invocation, so retries for the same invocation resume the same W&B run. |
-| `step_run` | Use one deterministic W&B run ID for each ZenML step-run attempt, including retries. |
+| `reuse_on_retry` | Use one deterministic W&B run ID for each ZenML pipeline-step invocation, so retries for the same invocation resume the same W&B run. |
+| `new_on_retry` | Use one deterministic W&B run ID for each ZenML step-run attempt, including retries. |
 
 For example, this configuration keeps retries for the same ZenML step invocation attached to the same W&B run:
 
 ```python
 retry_collapsed_settings = WandbExperimentTrackerSettings(
-    run_id_strategy="pipeline_step",
+    run_id_strategy="reuse_on_retry",
     resume="allow",
 )
 ```
@@ -254,11 +256,11 @@ If you prefer one W&B run for every ZenML step-run attempt, including retries, u
 
 ```python
 attempt_settings = WandbExperimentTrackerSettings(
-    run_id_strategy="step_run",
+    run_id_strategy="new_on_retry",
 )
 ```
 
-When `run_id_strategy="step_run"` is used without an explicit `run_name`, ZenML appends the ZenML step-run version to the W&B display name so retry attempts are easier to distinguish in the W&B UI.
+When `run_id_strategy="new_on_retry"` is used without an explicit `run_name`, ZenML appends the ZenML step-run version to the W&B display name so retry attempts are easier to distinguish in the W&B UI.
 
 ZenML defaults `resume` to `allow` whenever it passes a deterministic or explicit W&B run ID.
 
@@ -274,7 +276,7 @@ wandb_settings = WandbExperimentTrackerSettings(
 ZenML validates conflicts early:
 
 * `run_id` cannot be combined with a non-default `run_id_strategy`.
-* `resume="never"` cannot be combined with `run_id_strategy="pipeline_step"`, because retries intentionally reuse the same W&B run ID.
+* `resume="never"` cannot be combined with `run_id_strategy="reuse_on_retry"`, because retries intentionally reuse the same W&B run ID.
 * `resume="must"` requires either an explicit `run_id` or a deterministic `run_id_strategy`.
 * `run_config` cannot contain `zenml_*` keys, which are reserved for ZenML metadata.
 * `init_kwargs` cannot override ZenML-managed `wandb.init(...)` keys such as `entity`, `project`, `name`, `id`, `resume`, `group`, `job_type`, `tags`, `config`, or `settings`.

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -273,6 +273,7 @@ ZenML validates conflicts early:
 
 * `run_id` cannot be combined with a non-default `run_id_strategy`.
 * `resume="never"` cannot be combined with `run_id_strategy="pipeline_step"`, because retries intentionally reuse the same W&B run ID.
+* `resume="must"` requires either an explicit `run_id` or a deterministic `run_id_strategy`.
 * `run_config` cannot contain `zenml_*` keys, which are reserved for ZenML metadata.
 * `init_kwargs` cannot override ZenML-managed `wandb.init(...)` keys such as `entity`, `project`, `name`, `id`, `resume`, `group`, `job_type`, `tags`, `config`, or `settings`.
 

--- a/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
@@ -1,0 +1,206 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Helpers for constructing Wandb run initialization arguments."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from uuid import NAMESPACE_URL, uuid5
+
+from zenml.integrations.wandb.flavors.wandb_experiment_tracker_flavor import (
+    WandbExperimentTrackerConfig,
+    WandbExperimentTrackerSettings,
+)
+from zenml.logger import get_logger
+from zenml.utils import dashboard_utils
+
+if TYPE_CHECKING:
+    from zenml.config.step_run_info import StepRunInfo
+
+
+logger = get_logger(__name__)
+
+
+def sanitize_tag(tag: str) -> str:
+    """Sanitize a tag to be a valid Wandb tag.
+
+    Args:
+        tag: The tag to sanitize.
+
+    Returns:
+        The sanitized tag.
+    """
+    return tag[:64]
+
+
+@dataclass(frozen=True)
+class WandbInitialization:
+    """Wandb initialization arguments and ZenML metadata."""
+
+    init_kwargs: Dict[str, Any]
+
+
+def build_wandb_initialization(
+    *,
+    config: WandbExperimentTrackerConfig,
+    settings: WandbExperimentTrackerSettings,
+    info: "StepRunInfo",
+) -> WandbInitialization:
+    """Build Wandb initialization arguments for a ZenML step run.
+
+    Args:
+        config: The Wandb experiment tracker configuration.
+        settings: Runtime settings for the step.
+        info: Information about the ZenML step run.
+
+    Returns:
+        Wandb initialization arguments.
+    """
+    init_kwargs = dict(settings.init_kwargs)
+    init_kwargs.update(
+        {
+            "entity": config.entity,
+            "project": config.project_name,
+            "name": _get_run_name(settings=settings, info=info),
+            "tags": _get_tags(settings=settings, info=info),
+            "settings": settings.settings,
+        }
+    )
+
+    run_id = _get_run_id(settings=settings, info=info)
+    if run_id:
+        init_kwargs["id"] = run_id
+
+    resume = settings.resume or ("allow" if run_id else None)
+    if resume:
+        init_kwargs["resume"] = resume
+
+    if group := _get_group(settings=settings, info=info):
+        init_kwargs["group"] = group
+
+    if settings.job_type:
+        init_kwargs["job_type"] = settings.job_type
+
+    run_config = _get_run_config(settings=settings, info=info)
+    if run_config:
+        init_kwargs["config"] = run_config
+
+    return WandbInitialization(init_kwargs=init_kwargs)
+
+
+def _get_run_name(
+    *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
+) -> str:
+    """Get the Wandb display name for a ZenML step run."""
+    return settings.run_name or f"{info.run_name}_{info.pipeline_step_name}"
+
+
+def _get_run_id(
+    *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
+) -> Optional[str]:
+    """Get the Wandb run ID for a ZenML step run."""
+    if settings.run_id:
+        return settings.run_id
+
+    if settings.run_id_strategy == "step_run":
+        return uuid5(
+            NAMESPACE_URL,
+            f"zenml:wandb:step-run:{info.step_run_id}",
+        ).hex
+
+    if settings.run_id_strategy == "pipeline_step":
+        return uuid5(
+            NAMESPACE_URL,
+            "zenml:wandb:pipeline-step:"
+            f"{info.run_id}:{info.pipeline_step_name}",
+        ).hex
+
+    return None
+
+
+def _get_group(
+    *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
+) -> Optional[str]:
+    """Get the Wandb group for a ZenML step run."""
+    if settings.group:
+        return settings.group
+
+    if settings.enable_zenml_metadata:
+        return info.run_name
+
+    return None
+
+
+def _get_tags(
+    *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
+) -> List[str]:
+    """Get Wandb tags for a ZenML step run."""
+    tags = list(settings.tags)
+
+    if settings.enable_zenml_metadata:
+        tags.extend(["zenml", info.pipeline.name, info.run_name])
+
+    return _deduplicate_tags(tags)
+
+
+def _deduplicate_tags(tags: List[str]) -> List[str]:
+    """Deduplicate tags after applying Wandb length limits."""
+    deduplicated_tags: List[str] = []
+    for tag in tags:
+        sanitized_tag = sanitize_tag(tag)
+        if sanitized_tag not in deduplicated_tags:
+            deduplicated_tags.append(sanitized_tag)
+
+    return deduplicated_tags
+
+
+def _get_run_config(
+    *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
+) -> Dict[str, Any]:
+    """Get the Wandb run config for a ZenML step run."""
+    run_config = dict(settings.run_config)
+
+    if not settings.enable_zenml_metadata:
+        return run_config
+
+    run_config.update(
+        {
+            "zenml_pipeline_name": info.pipeline.name,
+            "zenml_pipeline_run_id": str(info.run_id),
+            "zenml_pipeline_run_name": info.run_name,
+            "zenml_step_name": info.pipeline_step_name,
+            "zenml_latest_step_run_id": str(info.step_run_id),
+            "zenml_latest_step_run_version": info.step_run.version,
+        }
+    )
+
+    if settings.enable_zenml_dashboard_links:
+        run_config.update(_get_dashboard_links(info=info))
+
+    return run_config
+
+
+def _get_dashboard_links(info: "StepRunInfo") -> Dict[str, str]:
+    """Get dashboard links for a ZenML step run if they are available."""
+    dashboard_links: Dict[str, str] = {}
+
+    try:
+        from zenml.client import Client
+
+        run = Client().zen_store.get_run(info.run_id)
+        if run_url := dashboard_utils.get_run_url(run):
+            dashboard_links["zenml_pipeline_run_url"] = run_url
+    except Exception as e:
+        logger.debug("Failed to derive ZenML dashboard links: %s", e)
+
+    return dashboard_links

--- a/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
@@ -102,7 +102,14 @@ def _get_run_name(
     *, settings: WandbExperimentTrackerSettings, info: "StepRunInfo"
 ) -> str:
     """Get the Wandb display name for a ZenML step run."""
-    return settings.run_name or f"{info.run_name}_{info.pipeline_step_name}"
+    if settings.run_name:
+        return settings.run_name
+
+    run_name = f"{info.run_name}_{info.pipeline_step_name}"
+    if settings.run_id_strategy == "step_run":
+        return f"{run_name}_v{info.step_run.version}"
+
+    return run_name
 
 
 def _get_run_id(

--- a/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Helpers for constructing Wandb run initialization arguments."""
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import NAMESPACE_URL, uuid5
 
@@ -48,19 +47,12 @@ def sanitize_tag(tag: str) -> str:
     return tag[:64]
 
 
-@dataclass(frozen=True)
-class WandbInitialization:
-    """Wandb initialization arguments and ZenML metadata."""
-
-    init_kwargs: Dict[str, Any]
-
-
 def build_wandb_initialization(
     *,
     config: WandbExperimentTrackerConfig,
     settings: WandbExperimentTrackerSettings,
     info: "StepRunInfo",
-) -> WandbInitialization:
+) -> Dict[str, Any]:
     """Build Wandb initialization arguments for a ZenML step run.
 
     Args:
@@ -100,7 +92,7 @@ def build_wandb_initialization(
     if run_config:
         init_kwargs["config"] = run_config
 
-    return WandbInitialization(init_kwargs=init_kwargs)
+    return init_kwargs
 
 
 def _get_run_name(

--- a/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
@@ -103,7 +103,7 @@ def _get_run_name(
         return settings.run_name
 
     run_name = f"{info.run_name}_{info.pipeline_step_name}"
-    if settings.run_id_strategy == "step_run":
+    if settings.run_id_strategy == "new_on_retry":
         return f"{run_name}_v{info.step_run.version}"
 
     return run_name
@@ -116,13 +116,13 @@ def _get_run_id(
     if settings.run_id:
         return settings.run_id
 
-    if settings.run_id_strategy == "step_run":
+    if settings.run_id_strategy == "new_on_retry":
         return uuid5(
             NAMESPACE_URL,
             f"zenml:wandb:step-run:{info.step_run_id}",
         ).hex
 
-    if settings.run_id_strategy == "pipeline_step":
+    if settings.run_id_strategy == "reuse_on_retry":
         return uuid5(
             NAMESPACE_URL,
             "zenml:wandb:pipeline-step:"

--- a/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/run_initialization.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+DEFAULT_WANDB_SETTINGS: Dict[str, Any] = {
+    "console": "off",
+    "silent": True,
+}
+
 
 def sanitize_tag(tag: str) -> str:
     """Sanitize a tag to be a valid Wandb tag.
@@ -73,7 +78,7 @@ def build_wandb_initialization(
             "project": config.project_name,
             "name": _get_run_name(settings=settings, info=info),
             "tags": _get_tags(settings=settings, info=info),
-            "settings": settings.settings,
+            "settings": {**DEFAULT_WANDB_SETTINGS, **settings.settings},
         }
     )
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -73,12 +73,12 @@ class WandbExperimentTracker(BaseExperimentTracker):
         settings = cast(
             WandbExperimentTrackerSettings, self.get_settings(info)
         )
-        initialization = build_wandb_initialization(
+        init_kwargs = build_wandb_initialization(
             config=self.config,
             settings=settings,
             info=info,
         )
-        self._initialize_wandb(info=info, **initialization.init_kwargs)
+        self._initialize_wandb(info=info, **init_kwargs)
 
     def get_step_run_metadata(
         self, info: "StepRunInfo"

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -14,13 +14,16 @@
 """Implementation for the wandb experiment tracker."""
 
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, cast
 
 import wandb
 
 from zenml.constants import METADATA_EXPERIMENT_TRACKER_URL
 from zenml.experiment_trackers.base_experiment_tracker import (
     BaseExperimentTracker,
+)
+from zenml.integrations.wandb.experiment_trackers.run_initialization import (
+    build_wandb_initialization,
 )
 from zenml.integrations.wandb.flavors.wandb_experiment_tracker_flavor import (
     WandbExperimentTrackerConfig,
@@ -37,18 +40,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 WANDB_API_KEY = "WANDB_API_KEY"
-
-
-def sanitize_tag(tag: str) -> str:
-    """Sanitize a tag to be a valid Wandb tag.
-
-    Args:
-        tag: The tag to sanitize.
-
-    Returns:
-        The sanitized tag.
-    """
-    return tag[:64]
 
 
 class WandbExperimentTracker(BaseExperimentTracker):
@@ -82,15 +73,12 @@ class WandbExperimentTracker(BaseExperimentTracker):
         settings = cast(
             WandbExperimentTrackerSettings, self.get_settings(info)
         )
-        tags = settings.tags + [
-            sanitize_tag(info.run_name),
-            sanitize_tag(info.pipeline.name),
-        ]
-
-        wandb_run_name = (
-            settings.run_name or f"{info.run_name}_{info.pipeline_step_name}"
+        initialization = build_wandb_initialization(
+            config=self.config,
+            settings=settings,
+            info=info,
         )
-        self._initialize_wandb(run_name=wandb_run_name, tags=tags, info=info)
+        self._initialize_wandb(info=info, **initialization.init_kwargs)
 
     def get_step_run_metadata(
         self, info: "StepRunInfo"
@@ -103,14 +91,26 @@ class WandbExperimentTracker(BaseExperimentTracker):
         Returns:
             A dictionary of metadata.
         """
+        run_id: Optional[str] = None
+        run_path: Optional[str] = None
         run_url: Optional[str] = None
         run_name: Optional[str] = None
+        run_group: Optional[str] = None
+        run_project: Optional[str] = None
+        run_entity: Optional[str] = None
+        run_job_type: Optional[str] = None
 
         # Try to get the run name and URL from WandB directly
         current_wandb_run = wandb.run
         if current_wandb_run:
+            run_id = getattr(current_wandb_run, "id", None)
+            run_path = getattr(current_wandb_run, "path", None)
             run_url = current_wandb_run.get_url()
-            run_name = current_wandb_run.name
+            run_name = getattr(current_wandb_run, "name", None)
+            run_group = getattr(current_wandb_run, "group", None)
+            run_project = getattr(current_wandb_run, "project", None)
+            run_entity = getattr(current_wandb_run, "entity", None)
+            run_job_type = getattr(current_wandb_run, "job_type", None)
 
         # If the URL cannot be retrieved, use the default run URL
         default_run_url = (
@@ -125,11 +125,32 @@ class WandbExperimentTracker(BaseExperimentTracker):
             WandbExperimentTrackerSettings, self.get_settings(info)
         )
         run_name = run_name or settings.run_name or default_run_name
+        default_group = (
+            info.run_name if settings.enable_zenml_metadata else None
+        )
 
-        return {
+        metadata: Dict[str, "MetadataType"] = {
             METADATA_EXPERIMENT_TRACKER_URL: Uri(run_url),
             "wandb_run_name": run_name,
         }
+        optional_metadata = {
+            "wandb_run_id": run_id,
+            "wandb_run_path": run_path,
+            "wandb_project": run_project or self.config.project_name,
+            "wandb_entity": run_entity or self.config.entity,
+            "wandb_group": run_group or settings.group or default_group,
+            "wandb_job_type": run_job_type or settings.job_type,
+            "wandb_url": run_url,
+        }
+        metadata.update(
+            {
+                key: value
+                for key, value in optional_metadata.items()
+                if value is not None
+            }
+        )
+
+        return metadata
 
     def cleanup_step_run(self, info: "StepRunInfo", step_failed: bool) -> None:
         """Stops the Wandb run.
@@ -144,31 +165,24 @@ class WandbExperimentTracker(BaseExperimentTracker):
     def _initialize_wandb(
         self,
         info: "StepRunInfo",
-        run_name: str,
-        tags: List[str],
+        **init_kwargs: Any,
     ) -> None:
         """Initializes a wandb run.
 
         Args:
             info: Step run information.
-            run_name: Name of the wandb run to create.
-            tags: Tags to attach to the wandb run.
+            init_kwargs: Keyword arguments passed to `wandb.init`.
         """
         logger.info(
             f"Initializing wandb with entity {self.config.entity}, project "
-            f"name: {self.config.project_name}, run_name: {run_name}."
+            f"name: {self.config.project_name}, run_name: "
+            f"{init_kwargs.get('name')}."
         )
+        wandb.init(**init_kwargs)
+
         settings = cast(
             WandbExperimentTrackerSettings, self.get_settings(info)
         )
-        wandb.init(
-            entity=self.config.entity,
-            project=self.config.project_name,
-            name=run_name,
-            tags=tags,
-            settings=settings.settings,
-        )
-
         if settings.enable_weave:
             import weave
 

--- a/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
+++ b/src/zenml/integrations/wandb/experiment_trackers/wandb_experiment_tracker.py
@@ -105,7 +105,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
         if current_wandb_run:
             run_id = getattr(current_wandb_run, "id", None)
             run_path = getattr(current_wandb_run, "path", None)
-            run_url = current_wandb_run.get_url()
+            run_url = current_wandb_run.url
             run_name = getattr(current_wandb_run, "name", None)
             run_group = getattr(current_wandb_run, "group", None)
             run_project = getattr(current_wandb_run, "project", None)

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -16,14 +16,16 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     List,
+    Literal,
     Optional,
     Type,
     cast,
 )
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from zenml.config.base_settings import BaseSettings
 from zenml.experiment_trackers.base_experiment_tracker import (
@@ -42,16 +44,69 @@ if TYPE_CHECKING:
 class WandbExperimentTrackerSettings(BaseSettings):
     """Settings for the Wandb experiment tracker."""
 
+    _MANAGED_INIT_KWARGS: ClassVar[set[str]] = {
+        "config",
+        "entity",
+        "group",
+        "id",
+        "job_type",
+        "name",
+        "project",
+        "project_name",
+        "resume",
+        "settings",
+        "tags",
+    }
+
     run_name: Optional[str] = Field(
         None, description="The Wandb run name to use for tracking experiments."
+    )
+    run_id: Optional[str] = Field(
+        None,
+        description="Explicit Wandb run ID to use for advanced resume flows.",
+    )
+    run_id_strategy: Literal[
+        "wandb_generated", "step_run", "pipeline_step"
+    ] = Field(
+        "wandb_generated",
+        description=(
+            "Strategy used to derive Wandb run IDs. The default leaves IDs "
+            "to Wandb."
+        ),
+    )
+    resume: Optional[Literal["allow", "must", "never", "auto"]] = Field(
+        None,
+        description="Wandb resume policy. Defaults to 'allow' when ZenML sets a run ID.",
+    )
+    group: Optional[str] = Field(
+        None, description="Wandb group to use for the run."
+    )
+    job_type: Optional[str] = Field(
+        None, description="Optional Wandb job type for the run."
     )
     tags: List[str] = Field(
         default_factory=list,
         description="Tags to attach to the Wandb run for categorization and filtering.",
     )
+    run_config: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="User-provided Wandb config values to attach to the run.",
+    )
+    init_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Advanced Wandb init keyword arguments not managed by ZenML.",
+    )
     settings: Dict[str, Any] = Field(
         default_factory=dict,
         description="Additional settings for the Wandb run configuration.",
+    )
+    enable_zenml_metadata: bool = Field(
+        True,
+        description="Whether to add ZenML context to Wandb tags and config.",
+    )
+    enable_zenml_dashboard_links: bool = Field(
+        True,
+        description="Whether to add ZenML dashboard links to Wandb config when available.",
     )
     enable_weave: bool = Field(
         False,
@@ -91,6 +146,43 @@ class WandbExperimentTrackerSettings(BaseSettings):
                 raise ValueError("Unable to convert wandb settings to dict.")
         else:
             return value
+
+    @model_validator(mode="after")
+    def _validate_wandb_init_settings(
+        self,
+    ) -> "WandbExperimentTrackerSettings":
+        """Validate Wandb identity and config settings."""
+        if self.run_id and self.run_id_strategy != "wandb_generated":
+            raise ValueError(
+                "The 'run_id' setting cannot be combined with a "
+                "non-default 'run_id_strategy'."
+            )
+
+        if self.run_id_strategy == "pipeline_step" and self.resume == "never":
+            raise ValueError(
+                "The 'pipeline_step' run ID strategy is incompatible with "
+                "resume='never'."
+            )
+
+        reserved_config_keys = [
+            key for key in self.run_config if key.startswith("zenml_")
+        ]
+        if reserved_config_keys:
+            raise ValueError(
+                "The 'run_config' setting cannot contain ZenML-reserved "
+                f"config keys: {reserved_config_keys}."
+            )
+
+        managed_init_keys = sorted(
+            self._MANAGED_INIT_KWARGS.intersection(self.init_kwargs)
+        )
+        if managed_init_keys:
+            raise ValueError(
+                "The 'init_kwargs' setting cannot contain Wandb init keys "
+                f"managed by ZenML: {managed_init_keys}."
+            )
+
+        return self
 
 
 class WandbExperimentTrackerConfig(

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -164,6 +164,16 @@ class WandbExperimentTrackerSettings(BaseSettings):
                 "resume='never'."
             )
 
+        if (
+            self.resume == "must"
+            and not self.run_id
+            and self.run_id_strategy == "wandb_generated"
+        ):
+            raise ValueError(
+                "The resume='must' setting requires either an explicit "
+                "'run_id' or a deterministic 'run_id_strategy'."
+            )
+
         reserved_config_keys = [
             key for key in self.run_config if key.startswith("zenml_")
         ]

--- a/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/wandb/flavors/wandb_experiment_tracker_flavor.py
@@ -66,12 +66,13 @@ class WandbExperimentTrackerSettings(BaseSettings):
         description="Explicit Wandb run ID to use for advanced resume flows.",
     )
     run_id_strategy: Literal[
-        "wandb_generated", "step_run", "pipeline_step"
+        "wandb_generated", "new_on_retry", "reuse_on_retry"
     ] = Field(
         "wandb_generated",
         description=(
             "Strategy used to derive Wandb run IDs. The default leaves IDs "
-            "to Wandb."
+            "to Wandb, 'reuse_on_retry' resumes the same run for retries, "
+            "and 'new_on_retry' creates a new deterministic run for retries."
         ),
     )
     resume: Optional[Literal["allow", "must", "never", "auto"]] = Field(
@@ -158,9 +159,9 @@ class WandbExperimentTrackerSettings(BaseSettings):
                 "non-default 'run_id_strategy'."
             )
 
-        if self.run_id_strategy == "pipeline_step" and self.resume == "never":
+        if self.run_id_strategy == "reuse_on_retry" and self.resume == "never":
             raise ValueError(
-                "The 'pipeline_step' run ID strategy is incompatible with "
+                "The 'reuse_on_retry' run ID strategy is incompatible with "
                 "resume='never'."
             )
 

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -82,13 +82,11 @@ def _info(
 
 def test_default_initialization_adds_zenml_metadata_without_run_id() -> None:
     """Test default Wandb kwargs include ZenML metadata but no run ID."""
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=_settings(),
         info=_info(),
     )
-
-    init_kwargs = initialization.init_kwargs
 
     assert init_kwargs["entity"] == "entity"
     assert init_kwargs["project"] == "project"
@@ -118,7 +116,7 @@ def test_default_initialization_adds_zenml_metadata_without_run_id() -> None:
 
 def test_wandb_console_output_can_be_enabled_with_settings() -> None:
     """Test W&B console settings can override ZenML's quiet defaults."""
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
             settings={
@@ -130,7 +128,7 @@ def test_wandb_console_output_can_be_enabled_with_settings() -> None:
         info=_info(),
     )
 
-    assert initialization.init_kwargs["settings"] == {
+    assert init_kwargs["settings"] == {
         "console": "auto",
         "show_info": True,
         "silent": False,
@@ -139,7 +137,7 @@ def test_wandb_console_output_can_be_enabled_with_settings() -> None:
 
 def test_user_tags_merge_with_human_readable_zenml_tags() -> None:
     """Test user tags are merged with readable ZenML tags."""
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
             tags=["team", "zenml"],
@@ -147,7 +145,7 @@ def test_user_tags_merge_with_human_readable_zenml_tags() -> None:
         info=_info(),
     )
 
-    assert initialization.init_kwargs["tags"] == [
+    assert init_kwargs["tags"] == [
         "team",
         "zenml",
         "training_pipeline",
@@ -157,7 +155,7 @@ def test_user_tags_merge_with_human_readable_zenml_tags() -> None:
 
 def test_minimal_mode_omits_zenml_group_tags_and_config() -> None:
     """Test disabling ZenML metadata keeps Wandb initialization minimal."""
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
             enable_zenml_metadata=False,
@@ -166,8 +164,6 @@ def test_minimal_mode_omits_zenml_group_tags_and_config() -> None:
         ),
         info=_info(),
     )
-
-    init_kwargs = initialization.init_kwargs
 
     assert "group" not in init_kwargs
     assert init_kwargs["tags"] == ["team"]
@@ -183,7 +179,7 @@ def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
             step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
             version=1,
         ),
-    ).init_kwargs
+    )
     second = _build_wandb_initialization(
         config=_config(),
         settings=_settings(run_id_strategy="step_run"),
@@ -191,7 +187,7 @@ def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
             step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
             version=2,
         ),
-    ).init_kwargs
+    )
 
     assert first["id"] != second["id"]
     assert first["name"] == "training_pipeline-2026_05_14_train_model_v1"
@@ -211,7 +207,7 @@ def test_pipeline_step_strategy_collapses_retries() -> None:
             step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
             version=1,
         ),
-    ).init_kwargs
+    )
     retry = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
@@ -221,7 +217,7 @@ def test_pipeline_step_strategy_collapses_retries() -> None:
             step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
             version=2,
         ),
-    ).init_kwargs
+    )
 
     assert first["id"] == retry["id"]
     assert first["name"] == retry["name"]
@@ -241,12 +237,12 @@ def test_pipeline_step_strategy_separates_invocation_names() -> None:
         config=_config(),
         settings=settings,
         info=_info(pipeline_step_name="train_model"),
-    ).init_kwargs
+    )
     second = _build_wandb_initialization(
         config=_config(),
         settings=settings,
         info=_info(pipeline_step_name="train_model_2"),
-    ).init_kwargs
+    )
 
     assert first["id"] != second["id"]
 
@@ -255,14 +251,14 @@ def test_explicit_run_id_sets_resume_allow_by_default() -> None:
     """Test explicit Wandb run IDs default to resume allow."""
     settings = _settings(run_id="external-run-id")
 
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=settings,
         info=_info(),
     )
 
-    assert initialization.init_kwargs["id"] == "external-run-id"
-    assert initialization.init_kwargs["resume"] == "allow"
+    assert init_kwargs["id"] == "external-run-id"
+    assert init_kwargs["resume"] == "allow"
 
 
 def test_job_type_is_only_passed_when_configured() -> None:
@@ -271,12 +267,12 @@ def test_job_type_is_only_passed_when_configured() -> None:
         config=_config(),
         settings=_settings(),
         info=_info(),
-    ).init_kwargs
+    )
     with_job_type = _build_wandb_initialization(
         config=_config(),
         settings=_settings(job_type="training"),
         info=_info(),
-    ).init_kwargs
+    )
 
     assert "job_type" not in without_job_type
     assert with_job_type["job_type"] == "training"
@@ -296,13 +292,13 @@ def test_dashboard_links_are_added_when_available(monkeypatch) -> None:
         WandbExperimentTrackerSettings,
     )
 
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=WandbExperimentTrackerSettings(),
         info=_info(),
     )
 
-    assert initialization.init_kwargs["config"]["zenml_pipeline_run_url"] == (
+    assert init_kwargs["config"]["zenml_pipeline_run_url"] == (
         "https://zenml.example/runs/1"
     )
 
@@ -382,7 +378,7 @@ def test_invalid_settings_fail_early(
 
 def test_unmanaged_init_kwargs_pass_through() -> None:
     """Test unmanaged Wandb init kwargs are passed through."""
-    initialization = _build_wandb_initialization(
+    init_kwargs = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
             init_kwargs={"mode": "offline"},
@@ -390,4 +386,4 @@ def test_unmanaged_init_kwargs_pass_through() -> None:
         info=_info(),
     )
 
-    assert initialization.init_kwargs["mode"] == "offline"
+    assert init_kwargs["mode"] == "offline"

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -359,6 +359,10 @@ def test_step_metadata_includes_richer_wandb_identifiers(monkeypatch) -> None:
             "run_id",
         ),
         (
+            {"resume": "must"},
+            "resume='must'",
+        ),
+        (
             {"run_config": {"zenml_pipeline_name": "override"}},
             "run_config",
         ),

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -95,6 +95,10 @@ def test_default_initialization_adds_zenml_metadata_without_run_id() -> None:
     assert init_kwargs["name"] == "training_pipeline-2026_05_14_train_model"
     assert "id" not in init_kwargs
     assert "resume" not in init_kwargs
+    assert init_kwargs["settings"] == {
+        "console": "off",
+        "silent": True,
+    }
     assert init_kwargs["group"] == "training_pipeline-2026_05_14"
     assert init_kwargs["tags"] == [
         "zenml",
@@ -110,6 +114,27 @@ def test_default_initialization_adds_zenml_metadata_without_run_id() -> None:
         "zenml_latest_step_run_version": 1,
     }
     assert "job_type" not in init_kwargs
+
+
+def test_wandb_console_output_can_be_enabled_with_settings() -> None:
+    """Test W&B console settings can override ZenML's quiet defaults."""
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            settings={
+                "console": "auto",
+                "show_info": True,
+                "silent": False,
+            },
+        ),
+        info=_info(),
+    )
+
+    assert initialization.init_kwargs["settings"] == {
+        "console": "auto",
+        "show_info": True,
+        "silent": False,
+    }
 
 
 def test_user_tags_merge_with_human_readable_zenml_tags() -> None:

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -322,7 +322,7 @@ def test_step_metadata_includes_richer_wandb_identifiers(monkeypatch) -> None:
         project="project",
         entity="entity",
         job_type="training",
-        get_url=lambda: "https://wandb.ai/entity/project/runs/wandb-id",
+        url="https://wandb.ai/entity/project/runs/wandb-id",
     )
     monkeypatch.setattr(tracker_module.wandb, "run", wandb_run)
 

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -170,11 +170,11 @@ def test_minimal_mode_omits_zenml_group_tags_and_config() -> None:
     assert init_kwargs["config"] == {"owner": "ml-platform"}
 
 
-def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
-    """Test step-run IDs produce one Wandb ID per ZenML attempt."""
+def test_new_on_retry_strategy_sets_deterministic_run_id_and_resume() -> None:
+    """Test retry attempts produce separate deterministic W&B run IDs."""
     first = _build_wandb_initialization(
         config=_config(),
-        settings=_settings(run_id_strategy="step_run"),
+        settings=_settings(run_id_strategy="new_on_retry"),
         info=_info(
             step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
             version=1,
@@ -182,7 +182,7 @@ def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
     )
     second = _build_wandb_initialization(
         config=_config(),
-        settings=_settings(run_id_strategy="step_run"),
+        settings=_settings(run_id_strategy="new_on_retry"),
         info=_info(
             step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
             version=2,
@@ -196,12 +196,12 @@ def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
     assert second["resume"] == "allow"
 
 
-def test_pipeline_step_strategy_collapses_retries() -> None:
-    """Test pipeline-step IDs resume one Wandb run across retries."""
+def test_reuse_on_retry_strategy_collapses_retries() -> None:
+    """Test retries resume one W&B run for the same step invocation."""
     first = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
-            run_id_strategy="pipeline_step",
+            run_id_strategy="reuse_on_retry",
         ),
         info=_info(
             step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
@@ -211,7 +211,7 @@ def test_pipeline_step_strategy_collapses_retries() -> None:
     retry = _build_wandb_initialization(
         config=_config(),
         settings=_settings(
-            run_id_strategy="pipeline_step",
+            run_id_strategy="reuse_on_retry",
         ),
         info=_info(
             step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
@@ -227,10 +227,10 @@ def test_pipeline_step_strategy_collapses_retries() -> None:
     assert retry["config"]["zenml_latest_step_run_version"] == 2
 
 
-def test_pipeline_step_strategy_separates_invocation_names() -> None:
-    """Test pipeline-step IDs include concrete invocation names."""
+def test_reuse_on_retry_strategy_separates_invocation_names() -> None:
+    """Test reused retry IDs still include concrete invocation names."""
     settings = _settings(
-        run_id_strategy="pipeline_step",
+        run_id_strategy="reuse_on_retry",
     )
 
     first = _build_wandb_initialization(
@@ -347,11 +347,11 @@ def test_step_metadata_includes_richer_wandb_identifiers(monkeypatch) -> None:
     "settings_kwargs,error_match",
     [
         (
-            {"run_id_strategy": "pipeline_step", "resume": "never"},
+            {"run_id_strategy": "reuse_on_retry", "resume": "never"},
             "resume='never'",
         ),
         (
-            {"run_id": "explicit", "run_id_strategy": "step_run"},
+            {"run_id": "explicit", "run_id_strategy": "new_on_retry"},
             "run_id",
         ),
         (

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -154,15 +154,23 @@ def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
     first = _build_wandb_initialization(
         config=_config(),
         settings=_settings(run_id_strategy="step_run"),
-        info=_info(step_run_id=UUID("00000000-0000-0000-0000-000000000002")),
+        info=_info(
+            step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
+            version=1,
+        ),
     ).init_kwargs
     second = _build_wandb_initialization(
         config=_config(),
         settings=_settings(run_id_strategy="step_run"),
-        info=_info(step_run_id=UUID("00000000-0000-0000-0000-000000000003")),
+        info=_info(
+            step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
+            version=2,
+        ),
     ).init_kwargs
 
     assert first["id"] != second["id"]
+    assert first["name"] == "training_pipeline-2026_05_14_train_model_v1"
+    assert second["name"] == "training_pipeline-2026_05_14_train_model_v2"
     assert first["resume"] == "allow"
     assert second["resume"] == "allow"
 
@@ -191,6 +199,7 @@ def test_pipeline_step_strategy_collapses_retries() -> None:
     ).init_kwargs
 
     assert first["id"] == retry["id"]
+    assert first["name"] == retry["name"]
     assert retry["config"]["zenml_latest_step_run_id"] == (
         "00000000-0000-0000-0000-000000000003"
     )

--- a/tests/integration/integrations/wandb_tests/test_run_initialization.py
+++ b/tests/integration/integrations/wandb_tests/test_run_initialization.py
@@ -1,0 +1,355 @@
+"""Tests for Wandb run initialization helpers."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+wandb_module = ModuleType("wandb")
+wandb_module.run = None
+wandb_module.Settings = type("Settings", (), {})
+wandb_module.init = lambda **_: None
+wandb_module.finish = lambda **_: None
+
+weave_module = ModuleType("weave")
+weave_module.init = lambda **_: None
+
+sys.modules.setdefault("wandb", wandb_module)
+sys.modules.setdefault("weave", weave_module)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def auto_environment():
+    """Override the global ZenML test environment fixture."""
+    return SimpleNamespace(), SimpleNamespace()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def check_module_requirements():
+    """Skip stack requirement checks for isolated Wandb integration tests."""
+    return None
+
+
+def _config() -> Any:
+    from zenml.integrations.wandb.flavors.wandb_experiment_tracker_flavor import (
+        WandbExperimentTrackerConfig,
+    )
+
+    return WandbExperimentTrackerConfig(
+        api_key="key",
+        entity="entity",
+        project_name="project",
+    )
+
+
+def _settings(**kwargs: Any) -> Any:
+    from zenml.integrations.wandb.flavors.wandb_experiment_tracker_flavor import (
+        WandbExperimentTrackerSettings,
+    )
+
+    return WandbExperimentTrackerSettings(
+        enable_zenml_dashboard_links=False,
+        **kwargs,
+    )
+
+
+def _build_wandb_initialization(**kwargs: Any) -> Any:
+    from zenml.integrations.wandb.experiment_trackers.run_initialization import (
+        build_wandb_initialization,
+    )
+
+    return build_wandb_initialization(**kwargs)
+
+
+def _info(
+    *,
+    run_id: UUID = UUID("00000000-0000-0000-0000-000000000001"),
+    step_run_id: UUID = UUID("00000000-0000-0000-0000-000000000002"),
+    pipeline_step_name: str = "train_model",
+    version: int = 1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        step_run_id=step_run_id,
+        run_id=run_id,
+        run_name="training_pipeline-2026_05_14",
+        pipeline_step_name=pipeline_step_name,
+        pipeline=SimpleNamespace(name="training_pipeline"),
+        step_run=SimpleNamespace(version=version),
+    )
+
+
+def test_default_initialization_adds_zenml_metadata_without_run_id() -> None:
+    """Test default Wandb kwargs include ZenML metadata but no run ID."""
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(),
+        info=_info(),
+    )
+
+    init_kwargs = initialization.init_kwargs
+
+    assert init_kwargs["entity"] == "entity"
+    assert init_kwargs["project"] == "project"
+    assert init_kwargs["name"] == "training_pipeline-2026_05_14_train_model"
+    assert "id" not in init_kwargs
+    assert "resume" not in init_kwargs
+    assert init_kwargs["group"] == "training_pipeline-2026_05_14"
+    assert init_kwargs["tags"] == [
+        "zenml",
+        "training_pipeline",
+        "training_pipeline-2026_05_14",
+    ]
+    assert init_kwargs["config"] == {
+        "zenml_pipeline_name": "training_pipeline",
+        "zenml_pipeline_run_id": "00000000-0000-0000-0000-000000000001",
+        "zenml_pipeline_run_name": "training_pipeline-2026_05_14",
+        "zenml_step_name": "train_model",
+        "zenml_latest_step_run_id": "00000000-0000-0000-0000-000000000002",
+        "zenml_latest_step_run_version": 1,
+    }
+    assert "job_type" not in init_kwargs
+
+
+def test_user_tags_merge_with_human_readable_zenml_tags() -> None:
+    """Test user tags are merged with readable ZenML tags."""
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            tags=["team", "zenml"],
+        ),
+        info=_info(),
+    )
+
+    assert initialization.init_kwargs["tags"] == [
+        "team",
+        "zenml",
+        "training_pipeline",
+        "training_pipeline-2026_05_14",
+    ]
+
+
+def test_minimal_mode_omits_zenml_group_tags_and_config() -> None:
+    """Test disabling ZenML metadata keeps Wandb initialization minimal."""
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            enable_zenml_metadata=False,
+            tags=["team"],
+            run_config={"owner": "ml-platform"},
+        ),
+        info=_info(),
+    )
+
+    init_kwargs = initialization.init_kwargs
+
+    assert "group" not in init_kwargs
+    assert init_kwargs["tags"] == ["team"]
+    assert init_kwargs["config"] == {"owner": "ml-platform"}
+
+
+def test_step_run_strategy_sets_deterministic_run_id_and_resume() -> None:
+    """Test step-run IDs produce one Wandb ID per ZenML attempt."""
+    first = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(run_id_strategy="step_run"),
+        info=_info(step_run_id=UUID("00000000-0000-0000-0000-000000000002")),
+    ).init_kwargs
+    second = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(run_id_strategy="step_run"),
+        info=_info(step_run_id=UUID("00000000-0000-0000-0000-000000000003")),
+    ).init_kwargs
+
+    assert first["id"] != second["id"]
+    assert first["resume"] == "allow"
+    assert second["resume"] == "allow"
+
+
+def test_pipeline_step_strategy_collapses_retries() -> None:
+    """Test pipeline-step IDs resume one Wandb run across retries."""
+    first = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            run_id_strategy="pipeline_step",
+        ),
+        info=_info(
+            step_run_id=UUID("00000000-0000-0000-0000-000000000002"),
+            version=1,
+        ),
+    ).init_kwargs
+    retry = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            run_id_strategy="pipeline_step",
+        ),
+        info=_info(
+            step_run_id=UUID("00000000-0000-0000-0000-000000000003"),
+            version=2,
+        ),
+    ).init_kwargs
+
+    assert first["id"] == retry["id"]
+    assert retry["config"]["zenml_latest_step_run_id"] == (
+        "00000000-0000-0000-0000-000000000003"
+    )
+    assert retry["config"]["zenml_latest_step_run_version"] == 2
+
+
+def test_pipeline_step_strategy_separates_invocation_names() -> None:
+    """Test pipeline-step IDs include concrete invocation names."""
+    settings = _settings(
+        run_id_strategy="pipeline_step",
+    )
+
+    first = _build_wandb_initialization(
+        config=_config(),
+        settings=settings,
+        info=_info(pipeline_step_name="train_model"),
+    ).init_kwargs
+    second = _build_wandb_initialization(
+        config=_config(),
+        settings=settings,
+        info=_info(pipeline_step_name="train_model_2"),
+    ).init_kwargs
+
+    assert first["id"] != second["id"]
+
+
+def test_explicit_run_id_sets_resume_allow_by_default() -> None:
+    """Test explicit Wandb run IDs default to resume allow."""
+    settings = _settings(run_id="external-run-id")
+
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=settings,
+        info=_info(),
+    )
+
+    assert initialization.init_kwargs["id"] == "external-run-id"
+    assert initialization.init_kwargs["resume"] == "allow"
+
+
+def test_job_type_is_only_passed_when_configured() -> None:
+    """Test job type is omitted unless explicitly configured."""
+    without_job_type = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(),
+        info=_info(),
+    ).init_kwargs
+    with_job_type = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(job_type="training"),
+        info=_info(),
+    ).init_kwargs
+
+    assert "job_type" not in without_job_type
+    assert with_job_type["job_type"] == "training"
+
+
+def test_dashboard_links_are_added_when_available(monkeypatch) -> None:
+    """Test available ZenML dashboard links are added to Wandb config."""
+    monkeypatch.setattr(
+        "zenml.integrations.wandb.experiment_trackers.run_initialization"
+        "._get_dashboard_links",
+        lambda info: {
+            "zenml_pipeline_run_url": "https://zenml.example/runs/1"
+        },
+    )
+
+    from zenml.integrations.wandb.flavors.wandb_experiment_tracker_flavor import (
+        WandbExperimentTrackerSettings,
+    )
+
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=WandbExperimentTrackerSettings(),
+        info=_info(),
+    )
+
+    assert initialization.init_kwargs["config"]["zenml_pipeline_run_url"] == (
+        "https://zenml.example/runs/1"
+    )
+
+
+def test_step_metadata_includes_richer_wandb_identifiers(monkeypatch) -> None:
+    """Test ZenML step metadata stores durable Wandb identifiers."""
+    from zenml.constants import METADATA_EXPERIMENT_TRACKER_URL
+    from zenml.integrations.wandb.experiment_trackers import (
+        wandb_experiment_tracker as tracker_module,
+    )
+
+    wandb_run = SimpleNamespace(
+        id="wandb-id",
+        path="entity/project/wandb-id",
+        name="display-name",
+        group="group",
+        project="project",
+        entity="entity",
+        job_type="training",
+        get_url=lambda: "https://wandb.ai/entity/project/runs/wandb-id",
+    )
+    monkeypatch.setattr(tracker_module.wandb, "run", wandb_run)
+
+    tracker = object.__new__(tracker_module.WandbExperimentTracker)
+    tracker._config = _config()
+    monkeypatch.setattr(tracker, "get_settings", lambda info: _settings())
+
+    metadata = tracker.get_step_run_metadata(_info())
+
+    assert metadata[METADATA_EXPERIMENT_TRACKER_URL] == (
+        "https://wandb.ai/entity/project/runs/wandb-id"
+    )
+    assert metadata["wandb_run_id"] == "wandb-id"
+    assert metadata["wandb_run_path"] == "entity/project/wandb-id"
+    assert metadata["wandb_run_name"] == "display-name"
+    assert metadata["wandb_group"] == "group"
+    assert metadata["wandb_project"] == "project"
+    assert metadata["wandb_entity"] == "entity"
+    assert metadata["wandb_job_type"] == "training"
+    assert metadata["wandb_url"] == (
+        "https://wandb.ai/entity/project/runs/wandb-id"
+    )
+
+
+@pytest.mark.parametrize(
+    "settings_kwargs,error_match",
+    [
+        (
+            {"run_id_strategy": "pipeline_step", "resume": "never"},
+            "resume='never'",
+        ),
+        (
+            {"run_id": "explicit", "run_id_strategy": "step_run"},
+            "run_id",
+        ),
+        (
+            {"run_config": {"zenml_pipeline_name": "override"}},
+            "run_config",
+        ),
+        (
+            {"init_kwargs": {"config": {"owner": "team"}}},
+            "init_kwargs",
+        ),
+    ],
+)
+def test_invalid_settings_fail_early(
+    settings_kwargs: dict, error_match: str
+) -> None:
+    """Test invalid Wandb settings combinations fail during validation."""
+    with pytest.raises(ValueError, match=error_match):
+        _settings(**settings_kwargs)
+
+
+def test_unmanaged_init_kwargs_pass_through() -> None:
+    """Test unmanaged Wandb init kwargs are passed through."""
+    initialization = _build_wandb_initialization(
+        config=_config(),
+        settings=_settings(
+            init_kwargs={"mode": "offline"},
+        ),
+        info=_info(),
+    )
+
+    assert initialization.init_kwargs["mode"] == "offline"


### PR DESCRIPTION
## Describe changes

Improved the W&B experiment tracker with richer ZenML context and run control.

ZenML now adds pipeline and step metadata to W&B runs by default, groups runs by pipeline run, records richer W&B identifiers back on ZenML step metadata, and supports advanced settings such as custom groups, job types, run config, explicit or deterministic run IDs, resume behavior, and safe passthrough wandb.init kwargs. This makes W&B runs easier to filter, trace back to ZenML, and manage across retries.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

