### PR TITLE
Document GCP private workspace connectivity

### DIFF
--- a/docs/book/getting-started/zenml-pro/hybrid-deployment.md
+++ b/docs/book/getting-started/zenml-pro/hybrid-deployment.md
@@ -66,6 +66,12 @@ Workspaces initiate outbound-only connections to the control plane, meaning no i
 
 Each workspace can be deployed in separate VPCs or networks, isolated per team, department, or customer. Different workspaces can be configured with different security policies and managed independently by different teams.
 
+#### Private connectivity for Google Cloud workspaces
+
+For organizations that deploy Hybrid workspaces in Google Cloud, it is now possible to connect the Google Cloud workspace VPC privately to the ZenML control plane infrastructure in AWS without sending traffic over the public internet. This can be implemented with [AWS Interconnect - multicloud](https://aws.amazon.com/about-aws/whats-new/2026/04/aws-announces-ga-AWS-interconnect-multicloud/) together with [Google Cloud Cross-Cloud Interconnect](https://docs.cloud.google.com/network-connectivity/docs/interconnect/how-to/cci/aws/connectivity-overview), giving the workspace a dedicated, private network path between Google Cloud and AWS.
+
+This option is useful when your security policy requires the workspace server and metadata store to stay in Google Cloud while control-plane communication must use private cloud networking rather than public internet routing or VPN. The exact topology depends on your Google Cloud VPC, AWS networking setup, region pairing, routing, BGP configuration, and redundancy requirements. Contact [cloud@zenml.io](mailto:cloud@zenml.io) or your ZenML representative to validate the design before implementation.
+
 ### Data Residency
 
 | Data Type | Storage Location | Purpose |

--- a/docs/book/getting-started/zenml-pro/scenarios.md
+++ b/docs/book/getting-started/zenml-pro/scenarios.md
@@ -62,6 +62,7 @@ Choose **Hybrid** if you need to keep sensitive metadata in your infrastructure 
 - 👥 Centralized user management
 - ⚖️ Balance of control and convenience
 - 🏢 Control plane and UI fully maintained and patched by ZenML
+- 🔗 Private cross-cloud networking is possible for Google Cloud workspaces using AWS Interconnect - multicloud and Google Cloud Cross-Cloud Interconnect
 - ✅ Day 1 production ready
 
 **Ideal for:** Organizations with security policies requiring metadata sovereignty, teams wanting simplified identity management without full infrastructure control.
@@ -119,4 +120,3 @@ Not sure which option is right for you? [Book a call](https://www.zenml.io/book-
 - **Require complete isolation?** [Configure Self-hosted Deployment](self-hosted-deployment.md)
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>
-


### PR DESCRIPTION
## Description
- Document that ZenML Pro Hybrid workspaces deployed in Google Cloud can use AWS Interconnect - multicloud with Google Cloud Cross-Cloud Interconnect for private connectivity to the AWS-hosted control plane.
- Add the capability to the Hybrid deployment scenario comparison.

## Verification
- python3 scripts/check_relative_links.py --dir docs/book/getting-started/zenml-pro

## Release notes
- no-release-notes