### PR TITLE
Support string type annotations

### DIFF
--- a/src/zenml/materializers/materializer_registry.py
+++ b/src/zenml/materializers/materializer_registry.py
@@ -75,13 +75,12 @@ class MaterializerRegistry:
             `BaseMaterializer` subclass that was registered for this key.
         """
         if isinstance(key, str):
+            # This shouldn't happen unless users manually call this method, as
+            # we always resolve output type annotations before trying to get a
+            # materializer.
             raise RuntimeError(
-                "String type annotations (e.g. `def my_step() -> "
-                "'np.ndarray`) are not supported yet for step outputs. Please "
-                "change to actual type annotations (e.g. `def my_step() -> "
-                "np.ndarray`) and remove any "
-                "`from __future__ import annotations` in modules where "
-                "your steps are defined."
+                "Unable to get materializer for a string type annotation. "
+                "Resolve your type annotation before calling this method."
             )
 
         for class_ in key.__mro__:

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -61,6 +61,7 @@ from zenml.steps.step_context import (
 )
 from zenml.steps.utils import (
     OutputSignature,
+    get_resolved_signature,
     parse_return_type_annotations,
     resolve_type_annotation,
 )
@@ -154,12 +155,13 @@ class StepRunner:
         with logs_context:
             step_instance = self._load_step()
             output_materializers = self._load_output_materializers()
-            spec = inspect.getfullargspec(
-                inspect.unwrap(step_instance.entrypoint)
+            resolved_signature = get_resolved_signature(
+                step_instance.entrypoint
             )
 
             output_annotations = parse_return_type_annotations(
-                func=step_instance.entrypoint
+                func=step_instance.entrypoint,
+                resolved_signature=resolved_signature,
             )
 
             self._evaluate_artifact_names_in_collections(
@@ -185,8 +187,7 @@ class StepRunner:
 
             with step_context:
                 function_params = self._parse_inputs(
-                    args=spec.args + spec.kwonlyargs,
-                    annotations=spec.annotations,
+                    signature=resolved_signature,
                     input_artifacts=input_artifacts,
                 )
 
@@ -441,15 +442,13 @@ class StepRunner:
 
     def _parse_inputs(
         self,
-        args: List[str],
-        annotations: Dict[str, Any],
+        signature: inspect.Signature,
         input_artifacts: Dict[str, List["StepRunInputResponse"]],
     ) -> Dict[str, Any]:
         """Parses the inputs for a step entrypoint function.
 
         Args:
-            args: The arguments of the step entrypoint function.
-            annotations: The annotations of the step entrypoint function.
+            signature: The resolved signature of the step entrypoint function.
             input_artifacts: The input artifact versions of the step.
 
         Raises:
@@ -461,11 +460,18 @@ class StepRunner:
         """
         function_params: Dict[str, Any] = {}
 
-        if args and args[0] == "self":
-            args.pop(0)
+        for arg, parameter in signature.parameters.items():
+            if parameter.kind in {
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            }:
+                continue
 
-        for arg in args:
-            annotation = annotations.get(arg, None)
+            annotation = (
+                parameter.annotation
+                if parameter.annotation is not inspect.Parameter.empty
+                else None
+            )
             arg_type = resolve_type_annotation(annotation)
 
             if arg in input_artifacts:

--- a/src/zenml/steps/entrypoint_function_utils.py
+++ b/src/zenml/steps/entrypoint_function_utils.py
@@ -37,8 +37,8 @@ from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.metadata.lazy_load import LazyRunMetadataResponse
 from zenml.steps.utils import (
     OutputSignature,
+    get_resolved_signature,
     parse_return_type_annotations,
-    resolve_type_annotation,
 )
 from zenml.utils import yaml_utils
 
@@ -256,7 +256,7 @@ def validate_entrypoint_function(
     Returns:
         A validated definition of the entrypoint function.
     """
-    signature = inspect.signature(func, follow_wrapped=True)
+    signature = get_resolved_signature(func)
     validate_reserved_arguments(
         signature=signature, reserved_arguments=reserved_arguments
     )
@@ -271,8 +271,7 @@ def validate_entrypoint_function(
                 f"{func.__name__}."
             )
 
-        annotation = parameter.annotation
-        if annotation is parameter.empty:
+        if parameter.annotation is parameter.empty:
             if ENFORCE_TYPE_ANNOTATIONS:
                 raise RuntimeError(
                     f"Missing type annotation for input '{key}' of step "
@@ -282,12 +281,12 @@ def validate_entrypoint_function(
             # If a type annotation is missing, use `Any` instead
             parameter = parameter.replace(annotation=Any)
 
-        annotation = resolve_type_annotation(annotation)
         inputs[key] = parameter
 
     outputs = parse_return_type_annotations(
         func=func,
         enforce_type_annotations=ENFORCE_TYPE_ANNOTATIONS,
+        resolved_signature=signature,
     )
 
     return EntrypointFunctionDefinition(

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -232,8 +232,10 @@ def parse_return_type_annotations(
     return_annotation = signature.return_annotation
     output_name: Optional[str]
 
-    # Return type annotated as `None`
-    if return_annotation is None:
+    # Return type annotated as `None`. Pydantic normalizes a `None`
+    # annotation to `type(None)` when resolving stringized annotations
+    # (e.g. under `from __future__ import annotations`), so handle both.
+    if return_annotation is None or return_annotation is type(None):
         return {}
 
     # Return type not annotated -> check whether `None` or `Any` should be used

--- a/src/zenml/steps/utils.py
+++ b/src/zenml/steps/utils.py
@@ -24,6 +24,8 @@ from typing import (
     Any,
     Callable,
     Dict,
+    ForwardRef,
+    Mapping,
     Optional,
     Tuple,
     TypeVar,
@@ -31,7 +33,8 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, create_model
+from pydantic.errors import PydanticUndefinedAnnotation
 from typing_extensions import Annotated
 
 from zenml.artifacts.artifact_config import ArtifactConfig
@@ -104,9 +107,108 @@ def get_args(obj: Any) -> Tuple[Any, ...]:
     )
 
 
+def _resolve_annotation(annotation: Any, globalns: Mapping[str, Any]) -> Any:
+    """Resolve a single string / ForwardRef annotation to a live type.
+
+    Args:
+        annotation: The annotation to resolve. Live (non-string) annotations
+            are returned unchanged.
+        globalns: Namespace used to resolve forward references against.
+
+    Returns:
+        The resolved annotation. `Annotated[T, ...]` wrappers are
+        reconstructed so metadata (e.g. `ArtifactConfig`) survives.
+    """
+    if not isinstance(annotation, (str, ForwardRef)):
+        return annotation
+
+    model = create_model(
+        "AnnotationResolver",
+        __config__=ConfigDict(arbitrary_types_allowed=True),
+        x=(annotation, ...),
+    )
+    model.model_rebuild(_types_namespace=globalns)
+
+    field = model.model_fields["x"]
+    resolved: Any = field.annotation
+    if field.metadata:
+        resolved = Annotated[(resolved, *field.metadata)]
+    return resolved
+
+
+def get_resolved_signature(func: Callable[..., Any]) -> inspect.Signature:
+    """Return signature with string annotations resolved.
+
+    Parameter annotations that fail to resolve are replaced with `Any` and
+    a warning is logged. An unresolved return annotation raises
+    `StepInterfaceError` because picking the wrong materializer would silently
+    break the run.
+
+    Annotations are resolved against `inspect.unwrap(func).__globals__` -
+    the module where the function is defined. Locally-scoped types (e.g.
+    those defined inside a test function) are not visible and will fall back
+    to `Any` for inputs / raise for the return.
+
+    Args:
+        func: The function whose signature should be resolved.
+
+    Raises:
+        StepInterfaceError: If the return annotation cannot be resolved.
+
+    Returns:
+        The signature with string / ForwardRef annotations replaced by live
+        types where possible.
+    """
+    sig = inspect.signature(func, follow_wrapped=True)
+    globalns = getattr(inspect.unwrap(func), "__globals__", {})
+
+    new_parameters = []
+    for name, parameter in sig.parameters.items():
+        if parameter.annotation is inspect.Parameter.empty:
+            new_parameters.append(parameter)
+            continue
+        try:
+            resolved = _resolve_annotation(parameter.annotation, globalns)
+        except PydanticUndefinedAnnotation as e:
+            logger.warning(
+                "Could not resolve type annotation '%s' for input '%s' of "
+                "function '%s': %s. Falling back to `Any`. Make sure the "
+                "type is importable at runtime in the module where the "
+                "function is defined (e.g. fix typos, missing imports, or "
+                "move imports out of `if TYPE_CHECKING:` blocks).",
+                parameter.annotation,
+                name,
+                func.__name__,
+                e,
+            )
+            resolved = Any
+        new_parameters.append(parameter.replace(annotation=resolved))
+
+    return_annotation = sig.return_annotation
+    if return_annotation is not inspect.Signature.empty:
+        try:
+            return_annotation = _resolve_annotation(
+                return_annotation, globalns
+            )
+        except PydanticUndefinedAnnotation as e:
+            raise StepInterfaceError(
+                f"Could not resolve return type annotation "
+                f"'{sig.return_annotation}' for function '{func.__name__}': "
+                f"{e}. Make sure the type is importable at runtime in the "
+                f"module where the function is defined (e.g. fix typos, "
+                f"missing imports, or move imports out of "
+                f"`if TYPE_CHECKING:` blocks)."
+            ) from e
+
+    return sig.replace(
+        parameters=new_parameters, return_annotation=return_annotation
+    )
+
+
 def parse_return_type_annotations(
     func: Callable[..., Any],
     enforce_type_annotations: bool = False,
+    resolved_signature: Optional[inspect.Signature] = None,
 ) -> Dict[str, OutputSignature]:
     """Parse the return type annotation of a step function.
 
@@ -114,6 +216,9 @@ def parse_return_type_annotations(
         func: The step function.
         enforce_type_annotations: If `True`, raises an exception if a type
             annotation is missing.
+        resolved_signature: A pre-computed resolved signature for `func`. If
+            omitted, the signature is resolved here. Pass this to avoid the
+            (potentially expensive) re-resolution.
 
     Raises:
         RuntimeError: If the output annotation has variable length or contains
@@ -123,7 +228,7 @@ def parse_return_type_annotations(
     Returns:
         - A dictionary mapping output names to their output signatures.
     """
-    signature = inspect.signature(func, follow_wrapped=True)
+    signature = resolved_signature or get_resolved_signature(func)
     return_annotation = signature.return_annotation
     output_name: Optional[str]
 

--- a/src/zenml/utils/pydantic_utils.py
+++ b/src/zenml/utils/pydantic_utils.py
@@ -347,7 +347,9 @@ def validate_function_args(
     Returns:
         The validated arguments.
     """
-    signature = inspect.signature(__func)
+    from zenml.steps.utils import get_resolved_signature
+
+    signature = get_resolved_signature(__func)
 
     validated_args = ()
     validated_kwargs = {}
@@ -360,9 +362,18 @@ def validate_function_args(
         validated_kwargs = kwargs
 
     # We create a dummy function with the original function signature to run
-    # pydantic validation without actually running the function code
+    # pydantic validation without actually running the function code. We
+    # rebuild the annotations dict from the resolved signature so that we use
+    # the resolved type annotations, not any
+    # PEP 563 / `from __future__ import annotations` strings.
     f.__signature__ = signature  # type: ignore[attr-defined]
-    f.__annotations__ = __func.__annotations__
+    f.__annotations__ = {
+        name: parameter.annotation
+        for name, parameter in signature.parameters.items()
+        if parameter.annotation is not inspect.Parameter.empty
+    }
+    if signature.return_annotation is not inspect.Signature.empty:
+        f.__annotations__["return"] = signature.return_annotation
 
     validated_function = validate_call(config=__config, validate_return=False)(
         f

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -34,6 +34,7 @@ from zenml.models import (
 from zenml.pipelines import Schedule, pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
 from zenml.steps import step
+from zenml.utils import source_utils
 
 
 def _compile_spec(p: Pipeline) -> PipelineSpec:
@@ -795,3 +796,26 @@ def test_run_tagging(clean_client, tmp_path, empty_pipeline):  # noqa: F811
     run = p()
 
     assert {tag.name for tag in run.tags} == {"tag_1", "tag_2", "tag_3"}
+
+
+@step
+def stringized_annotations_step() -> "int":
+    return 42
+
+
+@pipeline(enable_cache=False)
+def stringized_annotations_pipeline() -> None:
+    stringized_annotations_step()
+
+
+def test_pipeline_with_stringized_annotations(clean_client):
+    """Tests that stringized type annotations resolve correctly at runtime."""
+    stringized_annotations_pipeline()
+
+    last_run = stringized_annotations_pipeline.model.last_run
+    assert last_run.status == ExecutionStatus.COMPLETED
+
+    artifact = last_run.steps["stringized_annotations_step"].outputs["output"][
+        0
+    ]
+    assert source_utils.load(artifact.data_type) is int

--- a/tests/unit/steps/test_utils.py
+++ b/tests/unit/steps/test_utils.py
@@ -432,3 +432,13 @@ def test_get_resolved_signature_preserves_missing_return_annotation():
 
     sig = get_resolved_signature(f)
     assert sig.return_annotation is inspect.Signature.empty
+
+
+def test_stringized_none_return_produces_no_outputs():
+    """Regression test: `-> "None"` (as under `from __future__ import
+    annotations`) must produce no output artifact, same as `-> None`."""
+
+    def f() -> "None":
+        return None
+
+    assert parse_return_type_annotations(f) == {}

--- a/tests/unit/steps/test_utils.py
+++ b/tests/unit/steps/test_utils.py
@@ -11,7 +11,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-from typing import Any, Dict, List, Set, Tuple
+import inspect
+import logging
+import typing
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import pytest
 from numpy import ndarray
@@ -19,8 +22,10 @@ from typing_extensions import Annotated
 
 from zenml.artifacts.artifact_config import ArtifactConfig
 from zenml.enums import ArtifactType
+from zenml.exceptions import StepInterfaceError
 from zenml.orchestrators.step_runner import OutputSignature
 from zenml.steps.utils import (
+    get_resolved_signature,
     parse_return_type_annotations,
     resolve_type_annotation,
 )
@@ -326,3 +331,104 @@ def func_with_duplicate_output_name() -> Tuple[
 def test_invalid_step_output_annotations(func, exception):
     with pytest.raises(exception):
         parse_return_type_annotations(func, {})
+
+
+def test_get_resolved_signature_resolves_stringized_parameter():
+    def f(x: "int") -> None:
+        pass
+
+    sig = get_resolved_signature(f)
+    assert sig.parameters["x"].annotation is int
+
+
+def test_get_resolved_signature_resolves_stringized_return():
+    def f() -> "int":
+        return 1
+
+    sig = get_resolved_signature(f)
+    assert sig.return_annotation is int
+
+
+def test_get_resolved_signature_preserves_annotated_string_metadata():
+    def f() -> "Annotated[int, 'custom_name']":
+        return 1
+
+    sig = get_resolved_signature(f)
+    assert sig.return_annotation == Annotated[int, "custom_name"]
+
+
+def test_get_resolved_signature_preserves_annotated_artifact_config():
+    def f() -> "Annotated[int, ArtifactConfig(name='custom_name')]":
+        return 1
+
+    sig = get_resolved_signature(f)
+    args = typing.get_args(sig.return_annotation)
+    assert args[0] is int
+    assert isinstance(args[1], ArtifactConfig)
+    assert args[1].name == "custom_name"
+
+
+def test_get_resolved_signature_resolves_stringized_tuple():
+    def f() -> "Tuple[int, str]":
+        return 1, "x"
+
+    sig = get_resolved_signature(f)
+    assert sig.return_annotation == Tuple[int, str]
+
+
+def test_get_resolved_signature_resolves_stringized_optional():
+    def f(x: "Optional[int]") -> None:
+        pass
+
+    sig = get_resolved_signature(f)
+    assert sig.parameters["x"].annotation == Optional[int]
+
+
+def test_get_resolved_signature_preserves_unannotated_parameter():
+    def f(x, y: "int") -> None:
+        pass
+
+    sig = get_resolved_signature(f)
+    assert sig.parameters["x"].annotation is inspect.Parameter.empty
+    assert sig.parameters["y"].annotation is int
+
+
+def test_get_resolved_signature_falls_back_to_any_for_unresolvable_parameter(
+    caplog,
+):
+    def f(x: "MissingType") -> None:  # noqa: F821
+        pass
+
+    with caplog.at_level(logging.WARNING):
+        sig = get_resolved_signature(f)
+
+    assert sig.parameters["x"].annotation is Any
+    assert any("MissingType" in record.message for record in caplog.records)
+
+
+def test_get_resolved_signature_raises_for_unresolvable_return():
+    def my_step_fn() -> "MissingType":  # noqa: F821
+        raise NotImplementedError
+
+    with pytest.raises(StepInterfaceError) as exc_info:
+        get_resolved_signature(my_step_fn)
+
+    assert "my_step_fn" in str(exc_info.value)
+    assert "MissingType" in str(exc_info.value)
+
+
+def test_get_resolved_signature_passes_through_live_annotations():
+    def f(x: int) -> int:
+        return x
+
+    sig = get_resolved_signature(f)
+    assert sig.parameters["x"].annotation is int
+    assert sig.return_annotation is int
+
+
+def test_get_resolved_signature_preserves_missing_return_annotation():
+    def f(x: "int"):
+        pass
+
+    sig = get_resolved_signature(f)
+    assert sig.return_annotation is inspect.Signature.empty


### PR DESCRIPTION
## Describe changes
This PR adds support for string annotations in step/pipeline definitions.

These string annotations could either be explicitly wrapped in quotes or by using `from __future__ import annotations`.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

