### PR TITLE
Better string parsing during interactive wait condition resolving

### DIFF
--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -41,11 +41,13 @@ from zenml.models import (
     PipelineRunUpdate,
     PipelineSnapshotFilter,
     RunWaitConditionFilter,
+    RunWaitConditionResponse,
     ScheduleFilter,
 )
 from zenml.pipelines.pipeline_definition import Pipeline
 from zenml.utils import run_utils, source_utils, uuid_utils
 from zenml.utils.dashboard_utils import get_deployment_url
+from zenml.utils.json_utils import parse_value_for_schema
 from zenml.utils.yaml_utils import write_yaml
 
 logger = get_logger(__name__)
@@ -1019,7 +1021,7 @@ def _interactive_resolve_wait_conditions(
     skipped_condition_ids: set[UUID] = set()
 
     def _resolve_single_condition_interactively(
-        condition: Any,
+        condition: "RunWaitConditionResponse",
         idx: int,
         total: int,
     ) -> str:
@@ -1093,10 +1095,12 @@ def _interactive_resolve_wait_conditions(
                         result = None
                         break
                     try:
-                        result = json.loads(raw_value)
+                        result = parse_value_for_schema(
+                            raw_value, expected_schema
+                        )
                         break
-                    except json.JSONDecodeError as e:
-                        click.echo(f"Invalid JSON value: {e}", err=True)
+                    except ValueError as e:
+                        click.echo(f"Invalid input: {e}", err=True)
 
             try:
                 client.resolve_run_wait_condition(

--- a/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
+++ b/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
@@ -4,7 +4,7 @@ import json
 import select
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple
 
 from zenml.client import Client
 from zenml.constants import (
@@ -132,6 +132,33 @@ def read_stdin_line_with_timeout(
     return True, raw_value.rstrip("\n")
 
 
+def _schema_allows_string(schema: Dict[str, Any]) -> bool:
+    """Checks whether a JSON schema accepts a string value.
+
+    Args:
+        schema: JSON schema to inspect.
+
+    Returns:
+        True if string values are valid for the schema.
+    """
+    node_type = schema.get("type")
+    if node_type == "string":
+        return True
+    if isinstance(node_type, list) and "string" in node_type:
+        return True
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list):
+            for variant in variants:
+                if isinstance(variant, dict) and _schema_allows_string(
+                    variant
+                ):
+                    return True
+
+    return False
+
+
 def poll_interactive_wait_condition_input(
     condition: "RunWaitConditionResponse",
     poll_interval: int,
@@ -155,9 +182,12 @@ def poll_interactive_wait_condition_input(
             try:
                 result = json.loads(raw_value)
             except json.JSONDecodeError as e:
-                print(f"Invalid JSON input: {e}")
-                print("> ", end="", flush=True)
-                return
+                if _schema_allows_string(condition.data_schema):
+                    result = raw_value
+                else:
+                    print(f"Invalid JSON input: {e}")
+                    print("> ", end="", flush=True)
+                    return
 
     try:
         Client().zen_store.resolve_run_wait_condition(

--- a/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
+++ b/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
@@ -4,7 +4,7 @@ import json
 import select
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
 
 from zenml.client import Client
 from zenml.constants import (
@@ -16,6 +16,7 @@ from zenml.models import (
     RunWaitConditionResolveRequest,
     RunWaitConditionResponse,
 )
+from zenml.utils.json_utils import parse_value_for_schema
 
 if TYPE_CHECKING:
     from zenml.orchestrators import BaseOrchestrator
@@ -132,33 +133,6 @@ def read_stdin_line_with_timeout(
     return True, raw_value.rstrip("\n")
 
 
-def _schema_allows_string(schema: Dict[str, Any]) -> bool:
-    """Checks whether a JSON schema accepts a string value.
-
-    Args:
-        schema: JSON schema to inspect.
-
-    Returns:
-        True if string values are valid for the schema.
-    """
-    node_type = schema.get("type")
-    if node_type == "string":
-        return True
-    if isinstance(node_type, list) and "string" in node_type:
-        return True
-
-    for key in ("anyOf", "oneOf", "allOf"):
-        variants = schema.get(key)
-        if isinstance(variants, list):
-            for variant in variants:
-                if isinstance(variant, dict) and _schema_allows_string(
-                    variant
-                ):
-                    return True
-
-    return False
-
-
 def poll_interactive_wait_condition_input(
     condition: "RunWaitConditionResponse",
     poll_interval: int,
@@ -180,14 +154,13 @@ def poll_interactive_wait_condition_input(
     if raw_value:
         if condition.data_schema is not None:
             try:
-                result = json.loads(raw_value)
-            except json.JSONDecodeError as e:
-                if _schema_allows_string(condition.data_schema):
-                    result = raw_value
-                else:
-                    print(f"Invalid JSON input: {e}")
-                    print("> ", end="", flush=True)
-                    return
+                result = parse_value_for_schema(
+                    raw_value, condition.data_schema
+                )
+            except ValueError as e:
+                print(f"Invalid input: {e}")
+                print("> ", end="", flush=True)
+                return
 
     try:
         Client().zen_store.resolve_run_wait_condition(

--- a/src/zenml/utils/json_utils.py
+++ b/src/zenml/utils/json_utils.py
@@ -11,13 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Carried over version of some functions from the pydantic v1 json module.
+"""JSON helpers, including pydantic v1 encoders and schema-aware parsing.
 
-Check out the latest version here:
+Check out the latest version of the pydantic helpers here:
 https://github.com/pydantic/pydantic/blob/v1.10.15/pydantic/json.py
 """
 
 import datetime
+import json
 from collections import deque
 from decimal import Decimal
 from enum import Enum
@@ -32,13 +33,13 @@ from ipaddress import (
 from pathlib import Path
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable, Dict, Type, Union
+from typing import Any, Callable, Dict, Optional, Set, Type, Union
 from uuid import UUID
 
 from pydantic import NameEmail, SecretBytes, SecretStr
 from pydantic.color import Color
 
-__all__ = "pydantic_encoder"
+__all__ = ["parse_value_for_schema", "pydantic_encoder"]
 
 
 def isoformat(obj: Union[datetime.date, datetime.time]) -> str:
@@ -108,6 +109,17 @@ ENCODERS_BY_TYPE: Dict[Type[Any], Callable[[Any], Any]] = {
 
 
 def pydantic_encoder(obj: Any) -> Any:
+    """JSON encoder that handles Pydantic models and dataclasses.
+
+    Args:
+        obj: The object to encode.
+
+    Raises:
+        TypeError: If the object is not JSON serializable.
+
+    Returns:
+        The encoded object.
+    """
     from dataclasses import asdict, is_dataclass
 
     from pydantic import BaseModel
@@ -129,3 +141,104 @@ def pydantic_encoder(obj: Any) -> Any:
             f"Object of type '{obj.__class__.__name__}' is not JSON "
             f"serializable."
         )
+
+
+# Keep the order, bool is a subclass of int so we need to check it first.
+_PY_TYPE_TO_JSON_TYPE = (
+    (bool, "boolean"),
+    (int, "integer"),
+    (float, "number"),
+    (str, "string"),
+    (list, "array"),
+    (dict, "object"),
+    (type(None), "null"),
+)
+
+
+def _json_type_of(value: Any) -> Optional[str]:
+    """Returns the JSON Schema primitive type name for a Python value."""
+    for py_type, name in _PY_TYPE_TO_JSON_TYPE:
+        if isinstance(value, py_type):
+            return name
+    return None
+
+
+def _schema_allowed_json_types(schema: Dict[str, Any]) -> Set[str]:
+    """Returns the set of JSON Schema primitive types a schema accepts.
+
+    Args:
+        schema: JSON schema to inspect.
+
+    Returns:
+        Set of JSON type names (e.g. {"string", "integer"}).
+    """
+    types: Set[str] = set()
+
+    node_type = schema.get("type")
+    if isinstance(node_type, str):
+        types.add(node_type)
+    elif isinstance(node_type, list):
+        types.update(t for t in node_type if isinstance(t, str))
+
+    for key in ("anyOf", "oneOf", "allOf"):
+        for variant in schema.get(key) or []:
+            if isinstance(variant, dict):
+                types.update(_schema_allowed_json_types(variant))
+
+    return types
+
+
+def parse_value_for_schema(
+    raw_value: str,
+    schema: Dict[str, Any],
+) -> Any:
+    """Parses a raw string input into a value compatible with a JSON schema.
+
+    This does not perform a full JSON Schema validation. It only checks if the
+    parsed **top-level type** matches the schema.
+
+    If the parsed object does not match the schema and the schema accepts
+    strings, the raw string is returned.
+
+    Args:
+        raw_value: The raw user input.
+        schema: JSON schema.
+
+    Raises:
+        ValueError: If the input cannot be coerced to a value matching the
+            schema's top-level types.
+
+    Returns:
+        The coerced value.
+    """  # noqa: DOC503
+    parse_error: Optional[json.JSONDecodeError] = None
+    parsed: Any = None
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError as e:
+        parse_error = e
+
+    allowed = _schema_allowed_json_types(schema)
+
+    if parse_error is None:
+        if not allowed:
+            return parsed
+        parsed_type = _json_type_of(parsed)
+        candidates = {parsed_type} if parsed_type else set()
+        # JSON Schema: integers are also valid numbers.
+        if parsed_type == "integer":
+            candidates.add("number")
+        if candidates & allowed:
+            return parsed
+        if "string" in allowed:
+            return raw_value
+
+        raise ValueError(
+            f"Input does not match expected schema: got "
+            f"{parsed_type}, expected one of {sorted(allowed)}."
+        )
+
+    if "string" in allowed or not allowed:
+        return raw_value
+
+    raise parse_error


### PR DESCRIPTION
## Describe changes
When resolving a wait condition with a string schema using the interactive terminal input, users previously had to input a quoted string (e.g. `"my answer"`, because a raw string would fail the JSON parsing. This PR detects that and uses the raw string as answer in case the schema allows it.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

