### PR TITLE
Extended Kubernetes logs - pod visibility

### DIFF
--- a/src/zenml/integrations/kubernetes/manifest_utils.py
+++ b/src/zenml/integrations/kubernetes/manifest_utils.py
@@ -105,6 +105,7 @@ def build_pod_manifest(
     service_account_name: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
     labels: Optional[Dict[str, str]] = None,
+    annotations: Optional[Dict[str, str]] = None,
     mount_local_stores: bool = False,
     owner_references: Optional[List[k8s_client.V1OwnerReference]] = None,
     termination_grace_period_seconds: Optional[int] = 30,
@@ -123,6 +124,7 @@ def build_pod_manifest(
             run Kubernetes commands from within the cluster.
         env: Environment variables to set.
         labels: Labels to add to the pod.
+        annotations: Annotations to add to the pod.
         mount_local_stores: Whether to mount the local stores path inside the
             pod.
         owner_references: List of owner references for the pod.
@@ -180,14 +182,18 @@ def build_pod_manifest(
     if pod_settings and pod_settings.labels:
         labels.update(pod_settings.labels)
 
+    pod_annotations = {}
+    if pod_settings and pod_settings.annotations:
+        pod_annotations.update(pod_settings.annotations)
+    if annotations:
+        pod_annotations.update(annotations)
+
     pod_metadata = k8s_client.V1ObjectMeta(
         name=pod_name,
         labels=labels,
+        annotations=pod_annotations or None,
         owner_references=owner_references,
     )
-
-    if pod_settings and pod_settings.annotations:
-        pod_metadata.annotations = pod_settings.annotations
 
     pod_manifest = k8s_client.V1Pod(
         kind="Pod",

--- a/src/zenml/integrations/kubernetes/orchestrators/dag_runner.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/dag_runner.py
@@ -100,6 +100,9 @@ class DagRunner:
         interrupt_function: Optional[
             Callable[[], Optional[InterruptMode]]
         ] = None,
+        before_monitoring_iteration: Optional[
+            Callable[[List[Node]], None]
+        ] = None,
         monitoring_interval: float = 1.0,
         monitoring_delay: float = 0.0,
         interrupt_check_interval: float = 1.0,
@@ -114,6 +117,8 @@ class DagRunner:
             node_stop_function: The function to stop a node.
             interrupt_function: Will be periodically called to check if the
                 DAG should be interrupted.
+            before_monitoring_iteration: Function called once before each
+                monitoring iteration with the currently running nodes.
             monitoring_interval: The interval in which the nodes are monitored.
             monitoring_delay: The delay in seconds to wait between monitoring
                 different nodes.
@@ -127,6 +132,7 @@ class DagRunner:
         self.node_monitoring_function = node_monitoring_function
         self.node_stop_function = node_stop_function
         self.interrupt_function = interrupt_function
+        self.before_monitoring_iteration = before_monitoring_iteration
 
         ctx = contextvars.copy_context()
         self.monitoring_thread = threading.Thread(
@@ -310,7 +316,12 @@ class DagRunner:
         """
         while not self.shutdown_event.is_set():
             start_time = time.time()
-            for node in self.running_nodes:
+            running_nodes = self.running_nodes
+
+            if running_nodes and self.before_monitoring_iteration:
+                self.before_monitoring_iteration(running_nodes)
+
+            for node in running_nodes:
                 try:
                     node.status = self.node_monitoring_function(node)
                 except Exception:

--- a/src/zenml/integrations/kubernetes/orchestrators/dag_runner.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/dag_runner.py
@@ -133,6 +133,7 @@ class DagRunner:
         self.node_stop_function = node_stop_function
         self.interrupt_function = interrupt_function
         self.before_monitoring_iteration = before_monitoring_iteration
+        self._logged_hook_failure = False
 
         ctx = contextvars.copy_context()
         self.monitoring_thread = threading.Thread(
@@ -319,7 +320,15 @@ class DagRunner:
             running_nodes = self.running_nodes
 
             if running_nodes and self.before_monitoring_iteration:
-                self.before_monitoring_iteration(running_nodes)
+                try:
+                    self.before_monitoring_iteration(running_nodes)
+                except Exception:
+                    if not self._logged_hook_failure:
+                        logger.debug(
+                            "Failed to run DAG monitoring iteration hook.",
+                            exc_info=True,
+                        )
+                        self._logged_hook_failure = True
 
             for node in running_nodes:
                 try:

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -19,6 +19,7 @@ import socket
 import threading
 import time
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import Any, ContextManager, Dict, List, Optional, Tuple, cast
 from uuid import UUID
 
@@ -83,6 +84,299 @@ from zenml.utils.logging_utils import (
 from zenml.utils.time_utils import utc_now
 
 logger = get_logger(__name__)
+
+_EXPECTED_PENDING_REASONS = {
+    "ContainerCreating",
+    "PodInitializing",
+}
+_TERMINAL_POD_PHASES = {
+    "Failed",
+    "Succeeded",
+}
+
+
+@dataclass(frozen=True)
+class StepPodDiagnostic:
+    """Normalized step pod state used for logging and de-duplication."""
+
+    step_name: str
+    pod_name: str
+    phase: str
+    source: Optional[str] = None
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    pod_start_time: Optional[Any] = None
+    container_start_time: Optional[Any] = None
+
+    @property
+    def is_unexpected_pending(self) -> bool:
+        """Whether a pending state should be surfaced as a warning."""
+        return (
+            self.phase == "Pending"
+            and self.reason is not None
+            and self.reason not in _EXPECTED_PENDING_REASONS
+        )
+
+    @property
+    def signature(self) -> Tuple[Any, ...]:
+        """Stable state signature used to suppress duplicate logs."""
+        if self.phase == "Running":
+            return (
+                self.step_name,
+                self.pod_name,
+                self.phase,
+                self.pod_start_time,
+                self.container_start_time,
+            )
+
+        return (
+            self.step_name,
+            self.pod_name,
+            self.phase,
+            self.source,
+            self.reason,
+        )
+
+
+class KubernetesRunPodStatusIndex:
+    """In-memory index of active step pods for one pipeline run."""
+
+    def __init__(
+        self,
+        core_api: k8s_client.CoreV1Api,
+        namespace: str,
+        run_id: str,
+        api_request_timeout: Optional[int],
+    ) -> None:
+        """Initialize the pod status index.
+
+        Args:
+            core_api: Kubernetes CoreV1Api client.
+            namespace: Kubernetes namespace.
+            run_id: Pipeline run ID used in Kubernetes labels.
+            api_request_timeout: Kubernetes API request timeout.
+        """
+        self.core_api = core_api
+        self.namespace = namespace
+        self.run_id = run_id
+        self.api_request_timeout = api_request_timeout
+        self._pods_by_step_name: Dict[str, k8s_client.V1Pod] = {}
+        self._pods_by_job_name: Dict[str, k8s_client.V1Pod] = {}
+        self._last_logged_signatures: Dict[str, Tuple[Any, ...]] = {}
+
+    def refresh(self, running_nodes: List[Node]) -> None:
+        """Refresh the pod index from one run-level pod list call.
+
+        Args:
+            running_nodes: Currently running DAG nodes.
+        """
+        if not running_nodes:
+            return
+
+        label_selector = (
+            f"run_id={kube_utils.sanitize_label_value(str(self.run_id))}"
+        )
+        try:
+            pod_list: k8s_client.V1PodList = kube_utils.retry_on_api_exception(
+                self.core_api.list_namespaced_pod,
+                api_request_timeout=self.api_request_timeout,
+            )(namespace=self.namespace, label_selector=label_selector)
+        except Exception as e:
+            logger.warning(
+                "Failed to refresh Kubernetes step pod status: %s", e
+            )
+            return
+
+        self._pods_by_step_name = {}
+        self._pods_by_job_name = {}
+
+        for pod in pod_list.items:
+            self._index_pod(pod)
+
+    def log_state_change(self, node: Node) -> None:
+        """Log pod diagnostics for a node if the normalized state changed.
+
+        Args:
+            node: DAG node to log pod diagnostics for.
+        """
+        pod = self._get_pod_for_node(node)
+        if not pod:
+            return
+
+        diagnostic = self._extract_diagnostic(node.id, pod)
+        if not diagnostic:
+            return
+
+        if self._last_logged_signatures.get(node.id) == diagnostic.signature:
+            return
+
+        self._last_logged_signatures[node.id] = diagnostic.signature
+        self._log_diagnostic(diagnostic)
+
+    def _index_pod(self, pod: k8s_client.V1Pod) -> None:
+        """Index an active pod by known step and job identifiers."""
+        if self._is_terminal_pod(pod):
+            return
+
+        metadata = pod.metadata
+        if not metadata:
+            return
+
+        annotations = metadata.annotations or {}
+        labels = metadata.labels or {}
+
+        if step_name := annotations.get(STEP_NAME_ANNOTATION_KEY):
+            self._store_latest_pod(self._pods_by_step_name, step_name, pod)
+        elif step_name := labels.get("step_name"):
+            self._store_latest_pod(self._pods_by_step_name, step_name, pod)
+
+        if job_name := labels.get("job-name"):
+            self._store_latest_pod(self._pods_by_job_name, job_name, pod)
+
+    def _get_pod_for_node(self, node: Node) -> Optional[k8s_client.V1Pod]:
+        """Get the active pod associated with a DAG node."""
+        if pod := self._pods_by_step_name.get(node.id):
+            return pod
+
+        job_name = node.metadata.get("job_name")
+        if isinstance(job_name, str):
+            return self._pods_by_job_name.get(job_name)
+
+        return None
+
+    @staticmethod
+    def _store_latest_pod(
+        pod_index: Dict[str, k8s_client.V1Pod],
+        key: str,
+        pod: k8s_client.V1Pod,
+    ) -> None:
+        """Store the newest active pod for a step or job key."""
+        existing_pod = pod_index.get(key)
+        if not existing_pod:
+            pod_index[key] = pod
+            return
+
+        existing_timestamp = existing_pod.metadata.creation_timestamp
+        new_timestamp = pod.metadata.creation_timestamp
+        if existing_timestamp is None or (
+            new_timestamp is not None and new_timestamp > existing_timestamp
+        ):
+            pod_index[key] = pod
+
+    @staticmethod
+    def _is_terminal_pod(pod: k8s_client.V1Pod) -> bool:
+        """Whether a pod is in a terminal phase."""
+        return bool(pod.status) and pod.status.phase in _TERMINAL_POD_PHASES
+
+    @staticmethod
+    def _extract_diagnostic(
+        step_name: str, pod: k8s_client.V1Pod
+    ) -> Optional[StepPodDiagnostic]:
+        """Extract a normalized diagnostic from a Kubernetes pod."""
+        if not pod.metadata or not pod.metadata.name:
+            return None
+
+        phase = (
+            pod.status.phase if pod.status and pod.status.phase else "Unknown"
+        )
+        if phase == "Running":
+            container_state = kube_utils.get_container_status(pod, "main")
+            running_state = (
+                container_state.running if container_state else None
+            )
+            return StepPodDiagnostic(
+                step_name=step_name,
+                pod_name=pod.metadata.name,
+                phase=phase,
+                pod_start_time=pod.status.start_time if pod.status else None,
+                container_start_time=running_state.started_at
+                if running_state
+                else None,
+            )
+
+        if phase == "Pending":
+            condition_diagnostic = (
+                KubernetesRunPodStatusIndex._extract_pending_condition(
+                    step_name, pod
+                )
+            )
+            if condition_diagnostic:
+                return condition_diagnostic
+
+            container_state = kube_utils.get_container_status(pod, "main")
+            waiting_state = (
+                container_state.waiting if container_state else None
+            )
+            if waiting_state and waiting_state.reason:
+                return StepPodDiagnostic(
+                    step_name=step_name,
+                    pod_name=pod.metadata.name,
+                    phase=phase,
+                    source="container_waiting",
+                    reason=waiting_state.reason,
+                    message=waiting_state.message,
+                )
+
+        return StepPodDiagnostic(
+            step_name=step_name,
+            pod_name=pod.metadata.name,
+            phase=phase,
+        )
+
+    @staticmethod
+    def _extract_pending_condition(
+        step_name: str, pod: k8s_client.V1Pod
+    ) -> Optional[StepPodDiagnostic]:
+        """Extract a pending diagnostic from pod scheduling conditions."""
+        if not pod.status or not pod.status.conditions:
+            return None
+
+        for condition in pod.status.conditions:
+            if condition.status != "False":
+                continue
+
+            if condition.reason or condition.message:
+                return StepPodDiagnostic(
+                    step_name=step_name,
+                    pod_name=pod.metadata.name,
+                    phase="Pending",
+                    source=f"condition:{condition.type}",
+                    reason=condition.reason or condition.type,
+                    message=condition.message,
+                )
+
+        return None
+
+    @staticmethod
+    def _log_diagnostic(diagnostic: StepPodDiagnostic) -> None:
+        """Log a pod diagnostic using the appropriate level."""
+        if diagnostic.phase == "Running":
+            logger.info(
+                "Step pod running: step=%s, pod=%s, pod_start_time=%s, "
+                "container_start_time=%s",
+                diagnostic.step_name,
+                diagnostic.pod_name,
+                diagnostic.pod_start_time,
+                diagnostic.container_start_time,
+            )
+        elif diagnostic.is_unexpected_pending:
+            logger.warning(
+                "Step pod pending unexpectedly: step=%s, pod=%s, phase=%s, "
+                "reason=%s, message=%s",
+                diagnostic.step_name,
+                diagnostic.pod_name,
+                diagnostic.phase,
+                diagnostic.reason,
+                diagnostic.message,
+            )
+        elif diagnostic.phase == "Pending":
+            logger.info(
+                "Step pod pending: step=%s, pod=%s, phase=%s, reason=%s",
+                diagnostic.step_name,
+                diagnostic.pod_name,
+                diagnostic.phase,
+                diagnostic.reason,
+            )
 
 
 def parse_args() -> argparse.Namespace:
@@ -361,6 +655,12 @@ def main() -> None:
                 snapshot.pipeline_configuration.name
             ),
         }
+        pod_status_index = KubernetesRunPodStatusIndex(
+            core_api=core_api,
+            namespace=namespace,
+            run_id=str(pipeline_run.id),
+            api_request_timeout=pipeline_settings.api_request_timeout,
+        )
 
         step_run_skip_hb_set = set()
 
@@ -523,6 +823,7 @@ def main() -> None:
                 mount_local_stores=mount_local_stores,
                 termination_grace_period_seconds=settings.pod_stop_grace_period,
                 labels=step_labels,
+                annotations=step_annotations,
             )
 
             retry_config = step_config.retry
@@ -740,6 +1041,8 @@ def main() -> None:
                 )
                 return NodeStatus.FAILED
 
+            pod_status_index.log_state_change(node)
+
             settings = cast(
                 KubernetesOrchestratorSettings,
                 orchestrator.get_settings(
@@ -833,6 +1136,7 @@ def main() -> None:
                 node_startup_function=start_step_job,
                 node_monitoring_function=check_job_status,
                 interrupt_function=should_interrupt_execution,
+                before_monitoring_iteration=pod_status_index.refresh,
                 monitoring_interval=pipeline_settings.job_monitoring_interval,
                 monitoring_delay=pipeline_settings.job_monitoring_delay,
                 interrupt_check_interval=pipeline_settings.interrupt_check_interval,

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -332,7 +332,7 @@ class KubernetesRunPodStatusIndex:
             return None
 
         for condition in pod.status.conditions:
-            if condition.status != "False":
+            if condition.type != "PodScheduled" or condition.status != "False":
                 continue
 
             if condition.reason or condition.message:
@@ -361,7 +361,7 @@ class KubernetesRunPodStatusIndex:
             )
         elif diagnostic.is_unexpected_pending:
             logger.warning(
-                "Step pod pending unexpectedly: step=%s, pod=%s, phase=%s, "
+                "Step pod pending: step=%s, pod=%s, phase=%s, "
                 "reason=%s, message=%s",
                 diagnostic.step_name,
                 diagnostic.pod_name,

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -163,6 +163,7 @@ class KubernetesRunPodStatusIndex:
         self._pods_by_step_name: Dict[str, k8s_client.V1Pod] = {}
         self._pods_by_job_name: Dict[str, k8s_client.V1Pod] = {}
         self._last_logged_signatures: Dict[str, Tuple[Any, ...]] = {}
+        self._has_logged_refresh_failure = False
 
     def refresh(self, running_nodes: List[Node]) -> None:
         """Refresh the pod index from one run-level pod list call.
@@ -181,17 +182,28 @@ class KubernetesRunPodStatusIndex:
                 self.core_api.list_namespaced_pod,
                 api_request_timeout=self.api_request_timeout,
             )(namespace=self.namespace, label_selector=label_selector)
-        except Exception as e:
-            logger.warning(
-                "Failed to refresh Kubernetes step pod status: %s", e
-            )
+
+            pods_by_step_name: Dict[str, k8s_client.V1Pod] = {}
+            pods_by_job_name: Dict[str, k8s_client.V1Pod] = {}
+            for pod in pod_list.items:
+                self._index_pod(
+                    pod=pod,
+                    pods_by_step_name=pods_by_step_name,
+                    pods_by_job_name=pods_by_job_name,
+                )
+        except Exception:
+            self._pods_by_step_name = {}
+            self._pods_by_job_name = {}
+            if not self._has_logged_refresh_failure:
+                logger.debug(
+                    "Failed to refresh Kubernetes step pod status.",
+                    exc_info=True,
+                )
+                self._has_logged_refresh_failure = True
             return
 
-        self._pods_by_step_name = {}
-        self._pods_by_job_name = {}
-
-        for pod in pod_list.items:
-            self._index_pod(pod)
+        self._pods_by_step_name = pods_by_step_name
+        self._pods_by_job_name = pods_by_job_name
 
     def log_state_change(self, node: Node) -> None:
         """Log pod diagnostics for a node if the normalized state changed.
@@ -213,7 +225,12 @@ class KubernetesRunPodStatusIndex:
         self._last_logged_signatures[node.id] = diagnostic.signature
         self._log_diagnostic(diagnostic)
 
-    def _index_pod(self, pod: k8s_client.V1Pod) -> None:
+    def _index_pod(
+        self,
+        pod: k8s_client.V1Pod,
+        pods_by_step_name: Dict[str, k8s_client.V1Pod],
+        pods_by_job_name: Dict[str, k8s_client.V1Pod],
+    ) -> None:
         """Index an active pod by known step and job identifiers."""
         if self._is_terminal_pod(pod):
             return
@@ -226,12 +243,18 @@ class KubernetesRunPodStatusIndex:
         labels = metadata.labels or {}
 
         if step_name := annotations.get(STEP_NAME_ANNOTATION_KEY):
-            self._store_latest_pod(self._pods_by_step_name, step_name, pod)
+            self._store_latest_pod(
+                pod_index=pods_by_step_name, key=step_name, pod=pod
+            )
         elif step_name := labels.get("step_name"):
-            self._store_latest_pod(self._pods_by_step_name, step_name, pod)
+            self._store_latest_pod(
+                pod_index=pods_by_step_name, key=step_name, pod=pod
+            )
 
         if job_name := labels.get("job-name"):
-            self._store_latest_pod(self._pods_by_job_name, job_name, pod)
+            self._store_latest_pod(
+                pod_index=pods_by_job_name, key=job_name, pod=pod
+            )
 
     def _get_pod_for_node(self, node: Node) -> Optional[k8s_client.V1Pod]:
         """Get the active pod associated with a DAG node."""

--- a/tests/unit/integrations/kubernetes/conftest.py
+++ b/tests/unit/integrations/kubernetes/conftest.py
@@ -1,0 +1,12 @@
+"""Lightweight fixtures for Kubernetes integration unit tests."""
+
+from types import SimpleNamespace
+from typing import Iterator, Tuple
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def auto_environment() -> Iterator[Tuple[SimpleNamespace, SimpleNamespace]]:
+    """Override the global environment fixture for pure Kubernetes unit tests."""
+    yield SimpleNamespace(), SimpleNamespace()

--- a/tests/unit/integrations/kubernetes/test_dag_runner.py
+++ b/tests/unit/integrations/kubernetes/test_dag_runner.py
@@ -1,0 +1,75 @@
+"""Tests for the Kubernetes integration DAG runner."""
+
+from typing import List
+
+from zenml.integrations.kubernetes.orchestrators.dag_runner import (
+    DagRunner,
+    Node,
+    NodeStatus,
+)
+
+
+class _SingleIterationShutdownEvent:
+    """Shutdown event that lets the monitoring loop run once."""
+
+    def __init__(self) -> None:
+        self.waits = 0
+
+    def is_set(self) -> bool:
+        """Whether the loop should stop."""
+        return self.waits > 0
+
+    def wait(self, timeout: float) -> bool:
+        """Record the wait call and stop the next iteration."""
+        self.waits += 1
+        return True
+
+
+def test_monitoring_loop_calls_iteration_hook_once_with_running_nodes() -> (
+    None
+):
+    """Test that the monitoring hook receives all running nodes once."""
+    running_node = Node(id="running", status=NodeStatus.RUNNING)
+    completed_node = Node(id="completed", status=NodeStatus.COMPLETED)
+    observed_hook_nodes: List[List[str]] = []
+    observed_monitor_nodes: List[str] = []
+
+    runner = DagRunner(
+        nodes=[running_node, completed_node],
+        node_startup_function=lambda node: NodeStatus.RUNNING,
+        node_monitoring_function=lambda node: (
+            observed_monitor_nodes.append(node.id) or NodeStatus.RUNNING
+        ),
+        before_monitoring_iteration=lambda nodes: observed_hook_nodes.append(
+            [node.id for node in nodes]
+        ),
+        monitoring_interval=0,
+        monitoring_delay=0,
+    )
+    runner.shutdown_event = _SingleIterationShutdownEvent()  # type: ignore[assignment]
+
+    runner._monitoring_loop()
+
+    assert observed_hook_nodes == [["running"]]
+    assert observed_monitor_nodes == ["running"]
+
+
+def test_monitoring_loop_skips_iteration_hook_without_running_nodes() -> None:
+    """Test that the monitoring hook does no work without running nodes."""
+    observed_hook_nodes: List[List[str]] = []
+
+    runner = DagRunner(
+        nodes=[Node(id="completed", status=NodeStatus.COMPLETED)],
+        node_startup_function=lambda node: NodeStatus.RUNNING,
+        node_monitoring_function=lambda node: NodeStatus.RUNNING,
+        before_monitoring_iteration=lambda nodes: observed_hook_nodes.append(
+            [node.id for node in nodes]
+        ),
+        monitoring_interval=0,
+        monitoring_delay=0,
+    )
+    runner.shutdown_event = _SingleIterationShutdownEvent()  # type: ignore[assignment]
+
+    runner._monitoring_loop()
+
+    assert observed_hook_nodes == []

--- a/tests/unit/integrations/kubernetes/test_dag_runner.py
+++ b/tests/unit/integrations/kubernetes/test_dag_runner.py
@@ -10,14 +10,15 @@ from zenml.integrations.kubernetes.orchestrators.dag_runner import (
 
 
 class _SingleIterationShutdownEvent:
-    """Shutdown event that lets the monitoring loop run once."""
+    """Shutdown event that lets the monitoring loop run a limited time."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_waits: int = 1) -> None:
         self.waits = 0
+        self.max_waits = max_waits
 
     def is_set(self) -> bool:
         """Whether the loop should stop."""
-        return self.waits > 0
+        return self.waits >= self.max_waits
 
     def wait(self, timeout: float) -> bool:
         """Record the wait call and stop the next iteration."""
@@ -73,3 +74,37 @@ def test_monitoring_loop_skips_iteration_hook_without_running_nodes() -> None:
     runner._monitoring_loop()
 
     assert observed_hook_nodes == []
+
+
+def test_monitoring_loop_continues_when_iteration_hook_raises(mocker) -> None:
+    """Test monitoring hook failures do not stop node monitoring."""
+    observed_monitor_nodes: List[str] = []
+    debug = mocker.patch(
+        "zenml.integrations.kubernetes.orchestrators.dag_runner.logger.debug"
+    )
+
+    def failing_hook(nodes: List[Node]) -> None:
+        raise RuntimeError("hook failed")
+
+    runner = DagRunner(
+        nodes=[Node(id="running", status=NodeStatus.RUNNING)],
+        node_startup_function=lambda node: NodeStatus.RUNNING,
+        node_monitoring_function=lambda node: (
+            observed_monitor_nodes.append(node.id) or NodeStatus.RUNNING
+        ),
+        before_monitoring_iteration=failing_hook,
+        monitoring_interval=0,
+        monitoring_delay=0,
+    )
+    runner.shutdown_event = _SingleIterationShutdownEvent(max_waits=2)  # type: ignore[assignment]
+
+    runner._monitoring_loop()
+
+    hook_failure_debug_calls = [
+        call
+        for call in debug.call_args_list
+        if call.args == ("Failed to run DAG monitoring iteration hook.",)
+    ]
+    assert len(hook_failure_debug_calls) == 1
+    assert hook_failure_debug_calls[0].kwargs == {"exc_info": True}
+    assert observed_monitor_nodes == ["running", "running"]

--- a/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
@@ -140,6 +140,30 @@ def test_pod_status_index_refresh_lists_run_pods_once_for_multiple_nodes(
     assert info.call_count == 2
 
 
+def test_pod_status_index_refresh_failure_logs_debug_once(mocker) -> None:
+    """Test pod visibility refresh failures stay quiet for users."""
+    core_api = mocker.Mock()
+    core_api.list_namespaced_pod.side_effect = RuntimeError("cannot list pods")
+    debug = mocker.patch.object(entrypoint.logger, "debug")
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    pod_status_index = entrypoint.KubernetesRunPodStatusIndex(
+        core_api=core_api,
+        namespace="zenml-test",
+        run_id="run-id",
+        api_request_timeout=5,
+    )
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.refresh([node])
+
+    debug.assert_called_once_with(
+        "Failed to refresh Kubernetes step pod status.",
+        exc_info=True,
+    )
+    warning.assert_not_called()
+
+
 def test_pod_status_index_falls_back_to_job_name(mocker) -> None:
     """Test pods without exact step annotations can map through job labels."""
     info = mocker.patch.object(entrypoint.logger, "info")

--- a/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
@@ -332,3 +332,37 @@ def test_pod_scheduled_condition_takes_precedence_over_waiting_reason(
     pod_status_index.log_state_change(node)
 
     assert warning.call_args.args[4] == "Unschedulable"
+
+
+def test_container_readiness_condition_does_not_warn_when_pod_is_starting(
+    mocker,
+) -> None:
+    """Test normal container readiness startup conditions are not warnings."""
+    pod_status_index = _pod_status_index(
+        mocker,
+        [
+            _pending_pod(
+                name="step-pod",
+                step_name="step",
+                reason="ContainerCreating",
+                conditions=[
+                    k8s_client.V1PodCondition(
+                        type="ContainersReady",
+                        status="False",
+                        reason="ContainersNotReady",
+                        message="containers with unready status: [main]",
+                    )
+                ],
+            )
+        ],
+    )
+    info = mocker.patch.object(entrypoint.logger, "info")
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    info.assert_called_once()
+    warning.assert_not_called()
+    assert info.call_args.args[4] == "ContainerCreating"

--- a/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_orchestrator_entrypoint.py
@@ -1,0 +1,334 @@
+"""Tests for the Kubernetes orchestrator entrypoint."""
+
+from datetime import datetime, timezone
+
+from kubernetes import client as k8s_client
+
+from zenml.integrations.kubernetes.constants import STEP_NAME_ANNOTATION_KEY
+from zenml.integrations.kubernetes.orchestrators import (
+    kubernetes_orchestrator_entrypoint as entrypoint,
+)
+from zenml.integrations.kubernetes.orchestrators.dag_runner import Node
+
+
+def _pending_pod(
+    *,
+    name: str,
+    step_name: str | None = None,
+    job_name: str | None = None,
+    reason: str = "ContainerCreating",
+    message: str | None = None,
+    conditions: list[k8s_client.V1PodCondition] | None = None,
+    creation_timestamp: datetime | None = None,
+    phase: str = "Pending",
+) -> k8s_client.V1Pod:
+    annotations = (
+        {STEP_NAME_ANNOTATION_KEY: step_name} if step_name is not None else {}
+    )
+    labels = {}
+    if job_name is not None:
+        labels["job-name"] = job_name
+    elif step_name is not None:
+        labels["job-name"] = f"{step_name}-job"
+
+    return k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            annotations=annotations,
+            labels=labels,
+            creation_timestamp=creation_timestamp
+            or datetime(2026, 5, 21, 10, 30, tzinfo=timezone.utc),
+        ),
+        status=k8s_client.V1PodStatus(
+            phase=phase,
+            conditions=conditions,
+            container_statuses=[
+                k8s_client.V1ContainerStatus(
+                    name="main",
+                    image="image",
+                    image_id="",
+                    ready=False,
+                    restart_count=0,
+                    state=k8s_client.V1ContainerState(
+                        waiting=k8s_client.V1ContainerStateWaiting(
+                            reason=reason,
+                            message=message,
+                        )
+                    ),
+                )
+            ],
+        ),
+    )
+
+
+def _running_pod(
+    *,
+    name: str,
+    step_name: str,
+    pod_start_time: datetime,
+    container_start_time: datetime,
+) -> k8s_client.V1Pod:
+    return k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            annotations={STEP_NAME_ANNOTATION_KEY: step_name},
+            creation_timestamp=pod_start_time,
+        ),
+        status=k8s_client.V1PodStatus(
+            phase="Running",
+            start_time=pod_start_time,
+            container_statuses=[
+                k8s_client.V1ContainerStatus(
+                    name="main",
+                    image="image",
+                    image_id="",
+                    ready=True,
+                    restart_count=0,
+                    state=k8s_client.V1ContainerState(
+                        running=k8s_client.V1ContainerStateRunning(
+                            started_at=container_start_time
+                        )
+                    ),
+                )
+            ],
+        ),
+    )
+
+
+def _pod_status_index(mocker, pods: list[k8s_client.V1Pod]):
+    core_api = mocker.Mock()
+    core_api.list_namespaced_pod.return_value = k8s_client.V1PodList(
+        items=pods
+    )
+    return entrypoint.KubernetesRunPodStatusIndex(
+        core_api=core_api,
+        namespace="zenml-test",
+        run_id="run-id",
+        api_request_timeout=5,
+    )
+
+
+def test_pod_status_index_refresh_lists_run_pods_once_for_multiple_nodes(
+    mocker,
+) -> None:
+    """Test that one pod list snapshot serves multiple running nodes."""
+    core_api = mocker.Mock()
+    core_api.list_namespaced_pod.return_value = k8s_client.V1PodList(
+        items=[
+            _pending_pod(name="first-pod", step_name="first_step"),
+            _pending_pod(name="second-pod", step_name="second_step"),
+        ]
+    )
+    info = mocker.patch.object(entrypoint.logger, "info")
+
+    pod_status_index = entrypoint.KubernetesRunPodStatusIndex(
+        core_api=core_api,
+        namespace="zenml-test",
+        run_id="run-id",
+        api_request_timeout=5,
+    )
+
+    pod_status_index.refresh([Node(id="first_step"), Node(id="second_step")])
+    pod_status_index.log_state_change(Node(id="first_step"))
+    pod_status_index.log_state_change(Node(id="second_step"))
+
+    core_api.list_namespaced_pod.assert_called_once_with(
+        namespace="zenml-test",
+        label_selector="run_id=run-id",
+        _request_timeout=5,
+    )
+    assert info.call_count == 2
+
+
+def test_pod_status_index_falls_back_to_job_name(mocker) -> None:
+    """Test pods without exact step annotations can map through job labels."""
+    info = mocker.patch.object(entrypoint.logger, "info")
+    pod_status_index = _pod_status_index(
+        mocker,
+        [
+            _pending_pod(
+                name="fallback-pod",
+                job_name="fallback-job",
+            )
+        ],
+    )
+    node = Node(id="fallback_step", metadata={"job_name": "fallback-job"})
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    info.assert_called_once()
+
+
+def test_pod_status_index_chooses_latest_active_pod(mocker) -> None:
+    """Test terminal retry pods are ignored in favor of the active pod."""
+    info = mocker.patch.object(entrypoint.logger, "info")
+    old_terminal_pod = _pending_pod(
+        name="old-pod",
+        step_name="retry_step",
+        creation_timestamp=datetime(2026, 5, 21, 10, 30, tzinfo=timezone.utc),
+        phase="Failed",
+    )
+    active_pod = _pending_pod(
+        name="active-pod",
+        step_name="retry_step",
+        creation_timestamp=datetime(2026, 5, 21, 10, 31, tzinfo=timezone.utc),
+    )
+    pod_status_index = _pod_status_index(
+        mocker, [old_terminal_pod, active_pod]
+    )
+
+    pod_status_index.refresh([Node(id="retry_step")])
+    pod_status_index.log_state_change(Node(id="retry_step"))
+
+    assert info.call_args.args[2] == "active-pod"
+
+
+def test_expected_pending_pod_logs_once_at_info_level(mocker) -> None:
+    """Test expected pending states are logged once at info level."""
+    pod_status_index = _pod_status_index(
+        mocker,
+        [_pending_pod(name="step-pod", step_name="step")],
+    )
+    info = mocker.patch.object(entrypoint.logger, "info")
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+    pod_status_index.log_state_change(node)
+
+    info.assert_called_once()
+    warning.assert_not_called()
+
+
+def test_unschedulable_pending_pod_warning_ignores_message_for_deduplication(
+    mocker,
+) -> None:
+    """Test unschedulable message changes do not repeat warnings."""
+    first_pod = _pending_pod(
+        name="step-pod",
+        step_name="step",
+        reason="ContainerCreating",
+        conditions=[
+            k8s_client.V1PodCondition(
+                type="PodScheduled",
+                status="False",
+                reason="Unschedulable",
+                message="0/1 nodes are available: insufficient cpu.",
+            )
+        ],
+    )
+    second_pod = _pending_pod(
+        name="step-pod",
+        step_name="step",
+        reason="ContainerCreating",
+        conditions=[
+            k8s_client.V1PodCondition(
+                type="PodScheduled",
+                status="False",
+                reason="Unschedulable",
+                message="0/2 nodes are available: insufficient cpu.",
+            )
+        ],
+    )
+    pod_status_index = _pod_status_index(mocker, [first_pod])
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+    pod_status_index.core_api.list_namespaced_pod.return_value = (
+        k8s_client.V1PodList(items=[second_pod])
+    )
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    warning.assert_called_once()
+    assert "insufficient cpu" in warning.call_args.args[5]
+
+
+def test_pending_reason_change_logs_again(mocker) -> None:
+    """Test a changed pending reason emits a new log line."""
+    pod_status_index = _pod_status_index(
+        mocker,
+        [_pending_pod(name="step-pod", step_name="step")],
+    )
+    info = mocker.patch.object(entrypoint.logger, "info")
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+    pod_status_index.core_api.list_namespaced_pod.return_value = (
+        k8s_client.V1PodList(
+            items=[
+                _pending_pod(
+                    name="step-pod",
+                    step_name="step",
+                    reason="ImagePullBackOff",
+                )
+            ]
+        )
+    )
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    info.assert_called_once()
+    warning.assert_called_once()
+
+
+def test_running_pod_logs_start_times(mocker) -> None:
+    """Test running pod logs include pod and container start times."""
+    pod_start_time = datetime(2026, 5, 21, 10, 30, tzinfo=timezone.utc)
+    container_start_time = datetime(2026, 5, 21, 10, 31, tzinfo=timezone.utc)
+    pod_status_index = _pod_status_index(
+        mocker,
+        [
+            _running_pod(
+                name="step-pod",
+                step_name="step",
+                pod_start_time=pod_start_time,
+                container_start_time=container_start_time,
+            )
+        ],
+    )
+    info = mocker.patch.object(entrypoint.logger, "info")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    assert info.call_args.args[3] == pod_start_time
+    assert info.call_args.args[4] == container_start_time
+
+
+def test_pod_scheduled_condition_takes_precedence_over_waiting_reason(
+    mocker,
+) -> None:
+    """Test scheduling conditions produce the pending diagnostic reason."""
+    pod_status_index = _pod_status_index(
+        mocker,
+        [
+            _pending_pod(
+                name="step-pod",
+                step_name="step",
+                reason="ContainerCreating",
+                conditions=[
+                    k8s_client.V1PodCondition(
+                        type="PodScheduled",
+                        status="False",
+                        reason="Unschedulable",
+                        message="0/1 nodes are available.",
+                    )
+                ],
+            )
+        ],
+    )
+    warning = mocker.patch.object(entrypoint.logger, "warning")
+    node = Node(id="step")
+
+    pod_status_index.refresh([node])
+    pod_status_index.log_state_change(node)
+
+    assert warning.call_args.args[4] == "Unschedulable"

--- a/tests/unit/integrations/kubernetes/test_manifest_utils.py
+++ b/tests/unit/integrations/kubernetes/test_manifest_utils.py
@@ -1,7 +1,10 @@
 """Tests for Kubernetes manifest utilities."""
 
 from zenml.integrations.kubernetes.constants import STEP_NAME_ANNOTATION_KEY
-from zenml.integrations.kubernetes.manifest_utils import build_pod_manifest
+from zenml.integrations.kubernetes.manifest_utils import (
+    build_pod_manifest,
+    pod_template_manifest_from_pod,
+)
 from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
 
 
@@ -20,6 +23,26 @@ def test_build_pod_manifest_merges_explicit_annotations_with_pod_settings() -> (
     )
 
     assert pod_manifest.metadata.annotations == {
+        "user": "annotation",
+        STEP_NAME_ANNOTATION_KEY: "exact_step_name",
+    }
+
+
+def test_static_step_pod_template_keeps_exact_step_annotation() -> None:
+    """Test static step pod templates preserve exact step annotations."""
+    pod_manifest = build_pod_manifest(
+        pod_name=None,
+        image_name="image",
+        command=["python"],
+        args=["-m", "entrypoint"],
+        privileged=False,
+        pod_settings=KubernetesPodSettings(annotations={"user": "annotation"}),
+        annotations={STEP_NAME_ANNOTATION_KEY: "exact_step_name"},
+    )
+
+    pod_template = pod_template_manifest_from_pod(pod_manifest)
+
+    assert pod_template.metadata.annotations == {
         "user": "annotation",
         STEP_NAME_ANNOTATION_KEY: "exact_step_name",
     }

--- a/tests/unit/integrations/kubernetes/test_manifest_utils.py
+++ b/tests/unit/integrations/kubernetes/test_manifest_utils.py
@@ -1,0 +1,25 @@
+"""Tests for Kubernetes manifest utilities."""
+
+from zenml.integrations.kubernetes.constants import STEP_NAME_ANNOTATION_KEY
+from zenml.integrations.kubernetes.manifest_utils import build_pod_manifest
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+
+
+def test_build_pod_manifest_merges_explicit_annotations_with_pod_settings() -> (
+    None
+):
+    """Test explicit annotations preserve user-provided pod annotations."""
+    pod_manifest = build_pod_manifest(
+        pod_name=None,
+        image_name="image",
+        command=["python"],
+        args=["-m", "entrypoint"],
+        privileged=False,
+        pod_settings=KubernetesPodSettings(annotations={"user": "annotation"}),
+        annotations={STEP_NAME_ANNOTATION_KEY: "exact_step_name"},
+    )
+
+    assert pod_manifest.metadata.annotations == {
+        "user": "annotation",
+        STEP_NAME_ANNOTATION_KEY: "exact_step_name",
+    }


### PR DESCRIPTION
## Describe changes

Improves Kubernetes orchestrator logs to give better visibility on pods launched, pod/step connection, pod status and pod warnings (e.g. pod pending due to insufficient resources).

Example logs looks as follows:

```
[INFO] [2026-05-21T17:59:43.906792Z] Orchestrator pod started.
[INFO] [2026-05-21T17:59:43.906925Z] Node `load_data` started (status: running)
[INFO] [2026-05-21T17:59:43.906967Z] Step pod running: step=load_data, pod=zenml/8f3a21c4-load-data-example-pipeline-k9x2m, pod_start_time=2026-05-21 17:59:39+00:00, container_start_time=2026-05-21 17:59:39+00:00
[INFO] [2026-05-21T18:00:04.494013Z] Node `load_data` completed.
[INFO] [2026-05-21T18:00:09.697482Z] Node `train_model` started (status: running)
[INFO] [2026-05-21T18:00:09.697606Z] Step pod running: step=train_model, pod=zenml/4d7e90ab-train-model-example-pipeline-p6r8q, pod_start_time=2026-05-21 18:00:04+00:00, container_start_time=2026-05-21 18:00:04+00:00
[INFO] [2026-05-21T18:00:29.839098Z] Node `train_model` completed.
[INFO] [2026-05-21T18:00:29.839214Z] Node `evaluate_model` started (status: running)
[WARNING] [2026-05-21T18:00:35.031263Z] Step pod pending: step=evaluate_model, pod=zenml/a12c45ef-evaluate-model-example-pipeline-z3n7t, phase=Pending, reason=Unschedulable, message=0/6 nodes are available: 1 node(s) had untolerated taint {pool: workspaces}, 5 Insufficient cpu, 5 Insufficient memory. preemption: 0/6 nodes are available: 1 Preemption is not helpful for scheduling, 5 No preemption victims found for incoming pod.
[INFO] [2026-05-21T18:04:08.496855Z] Stopping DAG execution because pipeline run is in `stopped` state.
[WARNING] [2026-05-21T18:04:08.496934Z] DAG execution interrupted.
[INFO] [2026-05-21T18:04:08.496968Z] Orchestrator pod finished.
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

