### PR TITLE
Store source snapshot for local replays

### DIFF
--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -1014,6 +1014,10 @@ To avoid this consider setting pipeline parameters only in one place (config or 
 
             code_path = code_utils.upload_code_if_necessary(code_archive)
 
+        source_snapshot_id = None
+        if self._original_run:
+            source_snapshot_id = self._original_run.source_snapshot
+
         request = PipelineSnapshotRequest(
             project=Client().active_project.id,
             stack=stack.id,
@@ -1023,6 +1027,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             code_reference=code_reference,
             code_path=code_path,
             source_code=self.source_code,
+            source_snapshot=source_snapshot_id,
             **snapshot.model_dump(),
             **snapshot_request_kwargs,
         )


### PR DESCRIPTION
## Describe changes
Store the source snapshot when replaying from local code.

Reason this is on hold/a draft still:
A ZenML snapshot is an immutable snapshot of a pipelines code and configuration. The whole point of the replay feature was to enable a debugging flow in which case a user modifies code of a step locally, and the replays from that step onward. Which means in most cases local replays will run using different code, and therefore the link to the source snapshot would be misleading and counterintuitive for users.

One option to improve this would be to detect code if any code was modified, but this would be out of scope of this PR and rather a bigger refactoring working towards pipeline versioning.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

