### PR TITLE
Fix GKE private cluster access via DNS control plane endpoint in GCP service connector

### DIFF
--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -2237,7 +2237,7 @@ class GCPServiceConnector(ServiceConnector):
             )
             if dns_endpoint_config:
                 dns_host = dns_endpoint_config.endpoint.strip()
-                if dns_host and dns_endpoint_config.allow_external_traffic:
+                if dns_host:
                     logger.debug(
                         "Using GKE DNS control plane endpoint for Kubernetes API "
                         "access: %s",

--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -46,6 +46,7 @@ from google.auth._default import (
 )
 from google.auth.transport.requests import Request
 from google.cloud import artifactregistry_v1, container_v1, storage
+from google.cloud.container_v1.types import Cluster as GKECluster
 from google.cloud.location import locations_pb2
 from google.oauth2 import credentials as gcp_oauth2_credentials
 from google.oauth2 import service_account as gcp_service_account
@@ -2201,6 +2202,56 @@ class GCPServiceConnector(ServiceConnector):
 
         return []
 
+    @staticmethod
+    def _resolve_gke_kubernetes_api_connection(
+        cluster: GKECluster,
+    ) -> Tuple[str, Optional[str]]:
+        """Resolve the Kubernetes API server URL and CA certificate for GKE.
+
+        Prefers the DNS-based control plane endpoint when configured, matching
+        ``gcloud container clusters get-credentials --dns-endpoint``. Falls
+        back to the legacy IP-based ``cluster.endpoint`` with the
+        cluster-issued CA.
+
+        Args:
+            cluster: A GKE cluster object returned by the Container API.
+
+        Returns:
+            A tuple of ``(server_url, certificate_authority)``. The
+            certificate authority is the base64-encoded cluster CA for
+            IP-based endpoints, or ``None`` for DNS-based endpoints (clients
+            should use the system CA bundle).
+
+        Raises:
+            AuthorizationException: If no Kubernetes API endpoint is available.
+        """
+        dns_host = (
+            cluster.control_plane_endpoints_config.dns_endpoint_config.endpoint.strip()
+        )
+        if dns_host:
+            logger.debug(
+                "Using GKE DNS control plane endpoint for Kubernetes API "
+                "access: %s",
+                dns_host,
+            )
+            return f"https://{dns_host}", None
+
+        ip_endpoint = cluster.endpoint.strip()
+        if not ip_endpoint:
+            raise AuthorizationException(
+                "The GKE cluster does not expose a Kubernetes API endpoint "
+                "that this connector can use. Enable the DNS-based control "
+                "plane endpoint or ensure the cluster endpoint is configured."
+            )
+
+        logger.debug(
+            "Using GKE IP-based control plane endpoint for Kubernetes API "
+            "access: %s",
+            ip_endpoint,
+        )
+        ca_cert = cluster.master_auth.cluster_ca_certificate or None
+        return f"https://{ip_endpoint}", ca_cert
+
     def _get_connector_client(
         self,
         resource_type: str,
@@ -2345,9 +2396,9 @@ class GCPServiceConnector(ServiceConnector):
 
             cluster = cluster_map[cluster_name]
 
-            # get cluster details
-            cluster_server = cluster.endpoint
-            cluster_ca_cert = cluster.master_auth.cluster_ca_certificate
+            cluster_server, cluster_ca_cert = (
+                self._resolve_gke_kubernetes_api_connection(cluster)
+            )
             bearer_token = credentials.token
 
             # Create a client-side Kubernetes connector instance with the
@@ -2372,7 +2423,7 @@ class GCPServiceConnector(ServiceConnector):
                 config=KubernetesTokenConfig(
                     cluster_name=f"gke_{self.config.gcp_project_id}_{cluster_name}",
                     certificate_authority=cluster_ca_cert,
-                    server=f"https://{cluster_server}",
+                    server=cluster_server,
                     token=bearer_token,
                 ),
                 expires_at=expires_at,

--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -2225,16 +2225,25 @@ class GCPServiceConnector(ServiceConnector):
         Raises:
             AuthorizationException: If no Kubernetes API endpoint is available.
         """
-        dns_host = (
-            cluster.control_plane_endpoints_config.dns_endpoint_config.endpoint.strip()
+        # Important: The `control_plane_endpoints_config` is only available with the
+        # google-cloud-container>=2.52.0 package. Until we can update the dependencies,
+        # we need to handle this gracefully.
+        control_plane_endpoints_config = getattr(
+            cluster, "control_plane_endpoints_config", None
         )
-        if dns_host:
-            logger.debug(
-                "Using GKE DNS control plane endpoint for Kubernetes API "
-                "access: %s",
-                dns_host,
+        if control_plane_endpoints_config:
+            dns_endpoint_config = getattr(
+                control_plane_endpoints_config, "dns_endpoint_config", None
             )
-            return f"https://{dns_host}", None
+            if dns_endpoint_config:
+                dns_host = dns_endpoint_config.endpoint.strip()
+                if dns_host and dns_endpoint_config.allow_external_traffic:
+                    logger.debug(
+                        "Using GKE DNS control plane endpoint for Kubernetes API "
+                        "access: %s",
+                        dns_host,
+                    )
+                    return f"https://{dns_host}", None
 
         ip_endpoint = cluster.endpoint.strip()
         if not ip_endpoint:

--- a/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
+++ b/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
@@ -2,6 +2,7 @@
 
 import pytest
 from google.cloud.container_v1.types import Cluster as GKECluster
+from google.cloud.container_v1.types import MasterAuth
 
 from zenml.exceptions import AuthorizationException
 from zenml.integrations.gcp.service_connectors.gcp_service_connector import (
@@ -14,15 +15,16 @@ def _cluster(
     endpoint: str = "10.0.0.1",
     cluster_ca: str = "Y2x1c3Rlci1jYQ==",
     dns_endpoint: str | None = None,
+    allow_external_traffic: bool = False,
 ) -> GKECluster:
     cluster = GKECluster(
         endpoint=endpoint,
-        master_auth=GKECluster.MasterAuth(cluster_ca_certificate=cluster_ca),
+        master_auth=MasterAuth(cluster_ca_certificate=cluster_ca),
     )
     if dns_endpoint is not None:
-        cluster.control_plane_endpoints_config.dns_endpoint_config.endpoint = (
-            dns_endpoint
-        )
+        dns_config = cluster.control_plane_endpoints_config.dns_endpoint_config
+        dns_config.endpoint = dns_endpoint
+        dns_config.allow_external_traffic = allow_external_traffic
     return cluster
 
 
@@ -30,10 +32,11 @@ def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
     cluster = _cluster(
         endpoint="10.128.0.13",
         dns_endpoint="gke-abc-123.europe-west4.gke.goog",
+        allow_external_traffic=True,
     )
 
-    server, ca_cert = GCPServiceConnector._resolve_gke_kubernetes_api_connection(
-        cluster
+    server, ca_cert = (
+        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
     )
 
     assert server == "https://gke-abc-123.europe-west4.gke.goog"
@@ -43,8 +46,8 @@ def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
 def test_falls_back_to_ip_endpoint_without_dns() -> None:
     cluster = _cluster(endpoint="34.1.2.3", cluster_ca="Y2E=")
 
-    server, ca_cert = GCPServiceConnector._resolve_gke_kubernetes_api_connection(
-        cluster
+    server, ca_cert = (
+        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
     )
 
     assert server == "https://34.1.2.3"
@@ -56,3 +59,19 @@ def test_raises_when_no_endpoint_is_available() -> None:
 
     with pytest.raises(AuthorizationException):
         GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
+
+
+def test_falls_back_to_ip_endpoint_when_dns_external_traffic_is_disabled() -> (
+    None
+):
+    cluster = _cluster(
+        endpoint="34.1.2.3",
+        cluster_ca="Y2E=",
+        dns_endpoint="gke-abc-123.europe-west4.gke.goog",
+        allow_external_traffic=False,
+    )
+    server, ca_cert = (
+        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
+    )
+    assert server == "https://34.1.2.3"
+    assert ca_cert == "Y2E="

--- a/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
+++ b/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
@@ -1,0 +1,58 @@
+"""Tests for GKE Kubernetes API endpoint resolution in the GCP service connector."""
+
+import pytest
+from google.cloud.container_v1.types import Cluster as GKECluster
+
+from zenml.exceptions import AuthorizationException
+from zenml.integrations.gcp.service_connectors.gcp_service_connector import (
+    GCPServiceConnector,
+)
+
+
+def _cluster(
+    *,
+    endpoint: str = "10.0.0.1",
+    cluster_ca: str = "Y2x1c3Rlci1jYQ==",
+    dns_endpoint: str | None = None,
+) -> GKECluster:
+    cluster = GKECluster(
+        endpoint=endpoint,
+        master_auth=GKECluster.MasterAuth(cluster_ca_certificate=cluster_ca),
+    )
+    if dns_endpoint is not None:
+        cluster.control_plane_endpoints_config.dns_endpoint_config.endpoint = (
+            dns_endpoint
+        )
+    return cluster
+
+
+def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
+    cluster = _cluster(
+        endpoint="10.128.0.13",
+        dns_endpoint="gke-abc-123.europe-west4.gke.goog",
+    )
+
+    server, ca_cert = GCPServiceConnector._resolve_gke_kubernetes_api_connection(
+        cluster
+    )
+
+    assert server == "https://gke-abc-123.europe-west4.gke.goog"
+    assert ca_cert is None
+
+
+def test_falls_back_to_ip_endpoint_without_dns() -> None:
+    cluster = _cluster(endpoint="34.1.2.3", cluster_ca="Y2E=")
+
+    server, ca_cert = GCPServiceConnector._resolve_gke_kubernetes_api_connection(
+        cluster
+    )
+
+    assert server == "https://34.1.2.3"
+    assert ca_cert == "Y2E="
+
+
+def test_raises_when_no_endpoint_is_available() -> None:
+    cluster = _cluster(endpoint="")
+
+    with pytest.raises(AuthorizationException):
+        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)

--- a/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
+++ b/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
@@ -15,7 +15,6 @@ def _cluster(
     endpoint: str = "10.0.0.1",
     cluster_ca: str = "Y2x1c3Rlci1jYQ==",
     dns_endpoint: str | None = None,
-    allow_external_traffic: bool = False,
 ) -> GKECluster:
     cluster = GKECluster(
         endpoint=endpoint,
@@ -24,15 +23,14 @@ def _cluster(
     if dns_endpoint is not None:
         dns_config = cluster.control_plane_endpoints_config.dns_endpoint_config
         dns_config.endpoint = dns_endpoint
-        dns_config.allow_external_traffic = allow_external_traffic
     return cluster
 
 
 def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
+    """Prefers the DNS endpoint whenever GKE exposes a DNS hostname."""
     cluster = _cluster(
         endpoint="10.128.0.13",
         dns_endpoint="gke-abc-123.europe-west4.gke.goog",
-        allow_external_traffic=True,
     )
 
     server, ca_cert = (
@@ -44,6 +42,7 @@ def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
 
 
 def test_falls_back_to_ip_endpoint_without_dns() -> None:
+    """Falls back to the IP endpoint when no DNS hostname is available."""
     cluster = _cluster(endpoint="34.1.2.3", cluster_ca="Y2E=")
 
     server, ca_cert = (
@@ -55,23 +54,8 @@ def test_falls_back_to_ip_endpoint_without_dns() -> None:
 
 
 def test_raises_when_no_endpoint_is_available() -> None:
+    """Raises when neither DNS nor IP endpoints are available."""
     cluster = _cluster(endpoint="")
 
     with pytest.raises(AuthorizationException):
         GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
-
-
-def test_falls_back_to_ip_endpoint_when_dns_external_traffic_is_disabled() -> (
-    None
-):
-    cluster = _cluster(
-        endpoint="34.1.2.3",
-        cluster_ca="Y2E=",
-        dns_endpoint="gke-abc-123.europe-west4.gke.goog",
-        allow_external_traffic=False,
-    )
-    server, ca_cert = (
-        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
-    )
-    assert server == "https://34.1.2.3"
-    assert ca_cert == "Y2E="


### PR DESCRIPTION
## Summary

Fixes GCP service connector failures for **private GKE clusters** that use Google’s **DNS-based control plane endpoint**. ZenML now connects the same way as `gcloud container clusters get-credentials --dns-endpoint`, instead of always using the cluster’s private IP.

## Problem

When you use a GCP service connector to get Kubernetes credentials for a GKE cluster, ZenML must reach the cluster API to verify access and to hand runners a usable `server` URL.

For many **private** clusters (common in newer GCP setups), `cluster.endpoint` is a **private IP** only reachable from inside the VPC. The ZenML server (for example ZenML Cloud) is usually **outside** that network, so credential requests **time out** even when:

- GCP credentials are valid
- The cluster is healthy
- `kubectl` works locally with `--dns-endpoint`

Those local flows use the cluster’s **DNS hostname** (`*.gke.goog`), not the private IP. The connector did not.

## What changes for users

When issuing Kubernetes client credentials for GKE, the connector now:

1. **Uses the DNS control plane hostname** when GKE exposes `control_plane_endpoints_config.dns_endpoint_config.endpoint` (same FQDN as in the GCP API and `gcloud --dns-endpoint`).
2. **Falls back** to the previous behavior (`cluster.endpoint` + cluster CA) when no DNS endpoint is configured (public clusters and older setups).

You should be able to verify connectors, fetch connector clients, and run stack components against private GKE clusters that rely on the DNS endpoint—without putting the ZenML server on the cluster’s private network.

## Technical notes

- DNS path: `https://<fqdn>`, no cluster CA (system/Google PKI, aligned with DNS endpoint access).
- IP path: unchanged (`https://<cluster.endpoint>` + `master_auth.cluster_ca_certificate`).
- Unit tests added for DNS preference, IP fallback, and missing endpoint.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

