### PR TITLE
made shutdown_otel function idempotent and added support for individually enabling otel signals

### DIFF
--- a/docs/book/reference/environment-variables.md
+++ b/docs/book/reference/environment-variables.md
@@ -123,6 +123,14 @@ The endpoint should be the base OTLP/HTTP endpoint. ZenML appends
 `/v1/traces`, `/v1/metrics`, and `/v1/logs` for each signal. If this variable
 is not set, server OpenTelemetry instrumentation is disabled.
 
+Each signal is enabled by default when the endpoint is configured. You can disable individual signals with:
+
+```bash
+export ZENML_SERVER_OTEL_TRACES_ENABLED=false
+export ZENML_SERVER_OTEL_METRICS_ENABLED=false
+export ZENML_SERVER_OTEL_LOGS_ENABLED=false
+```
+
 You can also customize the service name reported in OpenTelemetry resource
 attributes:
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -124,11 +124,14 @@ server:
     ZENML_LOGGING_COLORS_DISABLED: "<true|false>" # default is false
     ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
     ZENML_SERVER_OTEL_SERVICE_NAME: "zenml-server" # default is zenml-server
+    ZENML_SERVER_OTEL_TRACES_ENABLED: "<true|false>" # default is true
+    ZENML_SERVER_OTEL_METRICS_ENABLED: "<true|false>" # default is true
+    ZENML_SERVER_OTEL_LOGS_ENABLED: "<true|false>" # default is true
 ```
 
 `ZENML_CONSOLE_LOGGING_FORMAT` controls the server container stdout/stderr output. It can be set to `console`, `json`, or a valid Python `%`-style logging format string. The older `ZENML_LOGGING_FORMAT` environment variable is still supported as a deprecated alias but will be removed in a future version.
 
-OpenTelemetry export is configured separately with `ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT` and exports traces, metrics, and logs using OTLP/HTTP transport.
+OpenTelemetry export is configured separately with `ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT` and exports traces, metrics, and logs using OTLP/HTTP transport. Each signal is enabled by default and can be disabled individually with `ZENML_SERVER_OTEL_TRACES_ENABLED`, `ZENML_SERVER_OTEL_METRICS_ENABLED`, and `ZENML_SERVER_OTEL_LOGS_ENABLED`.
 
 ## Backwards Compatibility
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1124,6 +1124,9 @@ server:
   #   # underlying log record, not as console-formatted text or JSON.
   #   ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
   #   ZENML_SERVER_OTEL_SERVICE_NAME: "zenml-server"
+  #   ZENML_SERVER_OTEL_TRACES_ENABLED: "true"
+  #   ZENML_SERVER_OTEL_METRICS_ENABLED: "true"
+  #   ZENML_SERVER_OTEL_LOGS_ENABLED: "true"
   environment: {}
 
   # Extra environment variables to set in the ZenML server container that

--- a/src/zenml/config/server_config.py
+++ b/src/zenml/config/server_config.py
@@ -261,6 +261,12 @@ class ServerConfiguration(BaseModel):
         otel_service_name: Service name reported in OTel resource attributes.
             Appears as ``service.name`` in traces, metrics, and logs.
             Defaults to 'zenml-server'
+        otel_traces_enabled: Whether to export OpenTelemetry traces when the
+            OTLP endpoint is configured.
+        otel_metrics_enabled: Whether to export OpenTelemetry metrics when the
+            OTLP endpoint is configured.
+        otel_logs_enabled: Whether to export OpenTelemetry logs when the OTLP
+            endpoint is configured.
     """
 
     deployment_type: ServerDeploymentType = ServerDeploymentType.OTHER
@@ -377,6 +383,9 @@ class ServerConfiguration(BaseModel):
 
     otel_exporter_otlp_endpoint: Optional[str] = None
     otel_service_name: str = "zenml-server"
+    otel_traces_enabled: bool = True
+    otel_metrics_enabled: bool = True
+    otel_logs_enabled: bool = True
 
     _deployment_id: Optional[UUID] = None
 

--- a/src/zenml/zen_server/otel.py
+++ b/src/zenml/zen_server/otel.py
@@ -71,8 +71,21 @@ def configure_otel(app: "FastAPI") -> None:
         return
 
     config = server_config()
+
+    # If the endpoint is not configured, then return early.
     endpoint = config.otel_exporter_otlp_endpoint
     if not endpoint:
+        return
+
+    # If all the signals are disabled, then return early.
+    signals_enabled = any(
+        [
+            config.otel_traces_enabled,
+            config.otel_metrics_enabled,
+            config.otel_logs_enabled,
+        ]
+    )
+    if not signals_enabled:
         return
 
     try:
@@ -86,15 +99,23 @@ def configure_otel(app: "FastAPI") -> None:
         )
         return
 
-    traces_configured = _configure_traces(endpoint=endpoint, resource=resource)
+    traces_configured = _configure_traces(
+        endpoint=endpoint,
+        resource=resource,
+        enabled=config.otel_traces_enabled,
+    )
     metrics_configured = _configure_metrics(
-        endpoint=endpoint, resource=resource
+        endpoint=endpoint,
+        resource=resource,
+        enabled=config.otel_metrics_enabled,
     )
     logs_configured = _configure_logs(
         endpoint=endpoint,
         resource=resource,
+        enabled=config.otel_logs_enabled,
     )
 
+    # If all the signals were enabled but none of the exports were configured, then warn.
     if not any([traces_configured, metrics_configured, logs_configured]):
         logger.warning(
             "OpenTelemetry endpoint is configured, but no telemetry signals "
@@ -135,16 +156,23 @@ def shutdown_otel() -> None:
     _otel_configured = False
 
 
-def _configure_traces(endpoint: str, resource: "Resource") -> bool:
+def _configure_traces(
+    endpoint: str, resource: "Resource", enabled: bool
+) -> bool:
     """Configure OpenTelemetry trace export.
 
     Args:
         endpoint: Base OTLP endpoint.
         resource: Resource attributes shared by all telemetry signals.
+        enabled: Whether trace export is enabled.
 
     Returns:
         True if trace export was configured, otherwise False.
     """
+    if not enabled:
+        logger.debug("OpenTelemetry trace export is disabled.")
+        return False
+
     try:
         from opentelemetry import trace
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
@@ -167,16 +195,23 @@ def _configure_traces(endpoint: str, resource: "Resource") -> bool:
         return False
 
 
-def _configure_metrics(endpoint: str, resource: "Resource") -> bool:
+def _configure_metrics(
+    endpoint: str, resource: "Resource", enabled: bool
+) -> bool:
     """Configure OpenTelemetry metric export.
 
     Args:
         endpoint: Base OTLP endpoint.
         resource: Resource attributes shared by all telemetry signals.
+        enabled: Whether metric export is enabled.
 
     Returns:
         True if metric export was configured, otherwise False.
     """
+    if not enabled:
+        logger.debug("OpenTelemetry metric export is disabled.")
+        return False
+
     try:
         from opentelemetry import metrics
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
@@ -204,17 +239,23 @@ def _configure_metrics(endpoint: str, resource: "Resource") -> bool:
 def _configure_logs(
     endpoint: str,
     resource: "Resource",
+    enabled: bool,
 ) -> bool:
     """Configure OpenTelemetry log export.
 
     Args:
         endpoint: Base OTLP endpoint.
         resource: Resource attributes shared by all telemetry signals.
+        enabled: Whether log export is enabled.
 
     Returns:
         True if log export was configured, otherwise False.
     """
     global _otel_log_handler
+
+    if not enabled:
+        logger.debug("OpenTelemetry log export is disabled.")
+        return False
 
     try:
         from opentelemetry._logs import set_logger_provider

--- a/src/zenml/zen_server/otel.py
+++ b/src/zenml/zen_server/otel.py
@@ -114,6 +114,9 @@ def shutdown_otel() -> None:
     """Flush and shut down OpenTelemetry providers configured by ZenML."""
     global _otel_configured, _otel_log_handler
 
+    if not _otel_configured and not _otel_log_handler and not _otel_providers:
+        return
+
     if _otel_log_handler:
         root_logger = logging.getLogger()
         root_logger.removeHandler(_otel_log_handler)


### PR DESCRIPTION
## Describe changes
* Made `shutdown_otel` function idempotent
* Added env vars to individually enable/disable OTel trace, metrics, and logs

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

