### PR TITLE
Run statistics endpoint

### DIFF
--- a/src/zenml/models/__init__.py
+++ b/src/zenml/models/__init__.py
@@ -17,61 +17,60 @@
 
 # V2 Base
 from zenml.models.v2.base.base import (
-    BaseZenModel,
+    BaseDatedResponseBody,
+    BaseIdentifiedResponse,
     BaseRequest,
     BaseResponse,
-    BaseUpdate,
-    BaseIdentifiedResponse,
     BaseResponseBody,
     BaseResponseMetadata,
     BaseResponseResources,
-    BaseDatedResponseBody,
+    BaseUpdate,
+    BaseZenModel,
 )
+from zenml.models.v2.base.filter import (
+    BaseFilter,
+    BoolFilter,
+    NumericFilter,
+    StrFilter,
+    UUIDFilter,
+)
+from zenml.models.v2.base.page import Page
 from zenml.models.v2.base.scoped import (
-    TaggableFilter,
-    RunMetadataFilterMixin,
-    UserScopedRequest,
-    UserScopedFilter,
-    UserScopedResponse,
-    UserScopedResponseBody,
-    UserScopedResponseMetadata,
-    ProjectScopedRequest,
     ProjectScopedFilter,
+    ProjectScopedRequest,
     ProjectScopedResponse,
     ProjectScopedResponseBody,
     ProjectScopedResponseMetadata,
     ProjectScopedResponseResources,
-    ProjectScopedFilter,
+    RunMetadataFilterMixin,
+    TaggableFilter,
+    UserScopedFilter,
+    UserScopedRequest,
+    UserScopedResponse,
+    UserScopedResponseBody,
+    UserScopedResponseMetadata,
 )
-from zenml.models.v2.base.filter import (
-    BaseFilter,
-    StrFilter,
-    BoolFilter,
-    NumericFilter,
-    UUIDFilter,
-)
-from zenml.models.v2.base.page import Page
 
 # V2 Core
 from zenml.models.v2.core.api_key import (
     APIKey,
-    APIKeyRequest,
-    APIKeyUpdate,
     APIKeyFilter,
+    APIKeyInternalResponse,
+    APIKeyInternalUpdate,
+    APIKeyRequest,
     APIKeyResponse,
     APIKeyResponseBody,
     APIKeyResponseMetadata,
-    APIKeyInternalResponse,
-    APIKeyInternalUpdate,
     APIKeyRotateRequest,
+    APIKeyUpdate,
 )
 from zenml.models.v2.core.api_transaction import (
     ApiTransactionRequest,
-    ApiTransactionUpdate,
     ApiTransactionResponse,
     ApiTransactionResponseBody,
     ApiTransactionResponseMetadata,
     ApiTransactionResponseResources,
+    ApiTransactionUpdate,
 )
 from zenml.models.v2.core.artifact import (
     ArtifactFilter,
@@ -83,14 +82,14 @@ from zenml.models.v2.core.artifact import (
     ArtifactUpdate,
 )
 from zenml.models.v2.core.artifact_version import (
-    ArtifactVersionRequest,
     ArtifactVersionFilter,
+    ArtifactVersionRequest,
     ArtifactVersionResponse,
     ArtifactVersionResponseBody,
     ArtifactVersionResponseMetadata,
     ArtifactVersionResponseResources,
     ArtifactVersionUpdate,
-    LazyArtifactVersionResponse
+    LazyArtifactVersionResponse,
 )
 from zenml.models.v2.core.artifact_visualization import (
     ArtifactVisualizationRequest,
@@ -99,15 +98,6 @@ from zenml.models.v2.core.artifact_visualization import (
     ArtifactVisualizationResponseMetadata,
     ArtifactVisualizationResponseResources,
 )
-from zenml.models.v2.core.service import (
-    ServiceResponse,
-    ServiceResponseBody,
-    ServiceResponseMetadata,
-    ServiceUpdate,
-    ServiceFilter,
-    ServiceRequest,
-    ServiceResponseResources,
-)
 from zenml.models.v2.core.code_reference import (
     CodeReferenceRequest,
     CodeReferenceResponse,
@@ -115,34 +105,24 @@ from zenml.models.v2.core.code_reference import (
     CodeReferenceResponseMetadata,
 )
 from zenml.models.v2.core.code_repository import (
-    CodeRepositoryRequest,
-    CodeRepositoryUpdate,
     CodeRepositoryFilter,
+    CodeRepositoryRequest,
     CodeRepositoryResponse,
     CodeRepositoryResponseBody,
     CodeRepositoryResponseMetadata,
     CodeRepositoryResponseResources,
+    CodeRepositoryUpdate,
 )
 from zenml.models.v2.core.component import (
     ComponentBase,
-    ComponentRequest,
-    ComponentUpdate,
     ComponentFilter,
+    ComponentRequest,
     ComponentResponse,
     ComponentResponseBody,
     ComponentResponseMetadata,
     ComponentResponseResources,
+    ComponentUpdate,
     DefaultComponentRequest,
-)
-from zenml.models.v2.core.deployment import (
-    DeploymentRequest,
-    DeploymentUpdate,
-    DeploymentFilter,
-    DeploymentOperationalState,
-    DeploymentResponse,
-    DeploymentResponseBody,
-    DeploymentResponseMetadata,
-    DeploymentResponseResources,
 )
 from zenml.models.v2.core.curated_visualization import (
     CuratedVisualizationRequest,
@@ -152,51 +132,61 @@ from zenml.models.v2.core.curated_visualization import (
     CuratedVisualizationResponseResources,
     CuratedVisualizationUpdate,
 )
+from zenml.models.v2.core.deployment import (
+    DeploymentFilter,
+    DeploymentOperationalState,
+    DeploymentRequest,
+    DeploymentResponse,
+    DeploymentResponseBody,
+    DeploymentResponseMetadata,
+    DeploymentResponseResources,
+    DeploymentUpdate,
+)
 from zenml.models.v2.core.device import (
-    OAuthDeviceUpdate,
     OAuthDeviceFilter,
+    OAuthDeviceInternalRequest,
+    OAuthDeviceInternalResponse,
+    OAuthDeviceInternalUpdate,
     OAuthDeviceResponse,
     OAuthDeviceResponseBody,
     OAuthDeviceResponseMetadata,
     OAuthDeviceResponseResources,
-    OAuthDeviceInternalRequest,
-    OAuthDeviceInternalUpdate,
-    OAuthDeviceInternalResponse,
+    OAuthDeviceUpdate,
 )
 from zenml.models.v2.core.flavor import (
-    FlavorRequest,
-    FlavorUpdate,
     FlavorFilter,
+    FlavorRequest,
     FlavorResponse,
     FlavorResponseBody,
     FlavorResponseMetadata,
     FlavorResponseResources,
+    FlavorUpdate,
 )
 from zenml.models.v2.core.logs import (
     LogsRequest,
-    LogsUpdate,
     LogsResponse,
     LogsResponseBody,
     LogsResponseMetadata,
     LogsResponseResources,
+    LogsUpdate,
 )
 from zenml.models.v2.core.model import (
     ModelFilter,
+    ModelRequest,
     ModelResponse,
     ModelResponseBody,
     ModelResponseMetadata,
     ModelResponseResources,
-    ModelRequest,
     ModelUpdate,
 )
 from zenml.models.v2.core.model_version import (
-    ModelVersionResponse,
+    ModelVersionFilter,
     ModelVersionRequest,
+    ModelVersionResponse,
     ModelVersionResponseBody,
     ModelVersionResponseMetadata,
-    ModelVersionFilter,
-    ModelVersionUpdate,
     ModelVersionResponseResources,
+    ModelVersionUpdate,
 )
 from zenml.models.v2.core.model_version_artifact import (
     ModelVersionArtifactFilter,
@@ -211,124 +201,62 @@ from zenml.models.v2.core.model_version_pipeline_run import (
     ModelVersionPipelineRunResponseBody,
 )
 from zenml.models.v2.core.pipeline import (
-    PipelineRequest,
-    PipelineUpdate,
     PipelineFilter,
+    PipelineRequest,
     PipelineResponse,
     PipelineResponseBody,
     PipelineResponseMetadata,
-    PipelineResponseResources
+    PipelineResponseResources,
+    PipelineUpdate,
 )
 from zenml.models.v2.core.pipeline_build import (
     PipelineBuildBase,
-    PipelineBuildRequest,
     PipelineBuildFilter,
+    PipelineBuildRequest,
     PipelineBuildResponse,
     PipelineBuildResponseBody,
     PipelineBuildResponseMetadata,
     PipelineBuildResponseResources,
 )
-from zenml.models.v2.core.pipeline_snapshot import (
-    PipelineSnapshotBase,
-    PipelineSnapshotRequest,
-    PipelineSnapshotUpdate,
-    PipelineSnapshotFilter,
-    PipelineSnapshotResponse,
-    PipelineSnapshotResponseBody,
-    PipelineSnapshotResponseMetadata,
-    PipelineSnapshotResponseResources,
-    PipelineSnapshotRunRequest,
-)
 from zenml.models.v2.core.pipeline_run import (
-    PipelineRunRequest,
-    PipelineRunUpdate,
     PipelineRunFilter,
+    PipelineRunRequest,
     PipelineRunResponse,
     PipelineRunResponseBody,
     PipelineRunResponseMetadata,
     PipelineRunResponseResources,
     PipelineRunTriggerInfo,
+    PipelineRunUpdate,
 )
-from zenml.models.v2.core.run_template import (
-    RunTemplateRequest,
-    RunTemplateUpdate,
-    RunTemplateResponse,
-    RunTemplateResponseBody,
-    RunTemplateResponseMetadata,
-    RunTemplateResponseResources,
-    RunTemplateFilter,
+from zenml.models.v2.core.pipeline_snapshot import (
+    PipelineSnapshotBase,
+    PipelineSnapshotFilter,
+    PipelineSnapshotRequest,
+    PipelineSnapshotResponse,
+    PipelineSnapshotResponseBody,
+    PipelineSnapshotResponseMetadata,
+    PipelineSnapshotResponseResources,
+    PipelineSnapshotRunRequest,
+    PipelineSnapshotUpdate,
 )
-from zenml.models.v2.core.run_wait_condition import (
-    RunWaitConditionFilter,
-    RunWaitConditionRequest,
-    RunWaitConditionResolveRequest,
-    RunWaitConditionResponse,
-    RunWaitConditionResponseBody,
-    RunWaitConditionResponseMetadata,
-    RunWaitConditionResponseResources,
-    RunWaitConditionLeaseUpdate,
-)
-from zenml.models.v2.core.run_metadata import (
-    RunMetadataRequest,
-)
-from zenml.models.v2.core.schedule import (
-    ScheduleRequest,
-    ScheduleUpdate,
-    ScheduleFilter,
-    ScheduleResponse,
-    ScheduleResponseBody,
-    ScheduleResponseMetadata,
-    ScheduleResponseResources,
-)
-from zenml.models.v2.core.secret import (
-    SecretFilter,
-    SecretRequest,
-    SecretResponse,
-    SecretResponseBody,
-    SecretResponseMetadata,
-    SecretResponseResources,
-    SecretUpdate,
-)
-from zenml.models.v2.core.service_account import (
-    ServiceAccountFilter,
-    ServiceAccountResponseBody,
-    ServiceAccountResponseMetadata,
-    ServiceAccountUpdate,
-    ServiceAccountRequest,
-    ServiceAccountInternalRequest,
-    ServiceAccountInternalUpdate,
-    ServiceAccountResponse,
-)
-from zenml.models.v2.core.service_connector import (
-    ServiceConnectorConfiguration,
-    ServiceConnectorRequest,
-    ServiceConnectorUpdate,
-    ServiceConnectorFilter,
-    ServiceConnectorResponse,
-    ServiceConnectorResponseBody,
-    ServiceConnectorResponseMetadata,
-    ServiceConnectorResponseResources,
-)
-from zenml.models.v2.core.stack import (
-    DefaultStackRequest,
-    StackRequest,
-    StackUpdate,
-    StackFilter,
-    StackResponse,
-    StackResponseBody,
-    StackResponseMetadata,
-    StackResponseResources
+from zenml.models.v2.core.project import (
+    ProjectFilter,
+    ProjectRequest,
+    ProjectResponse,
+    ProjectResponseBody,
+    ProjectResponseMetadata,
+    ProjectUpdate,
 )
 from zenml.models.v2.core.resource_pool import (
-    ResourcePoolRequest,
-    ResourcePoolUpdate,
+    ResourcePoolAllocation,
     ResourcePoolFilter,
+    ResourcePoolQueueItem,
+    ResourcePoolRequest,
     ResourcePoolResponse,
     ResourcePoolResponseBody,
     ResourcePoolResponseMetadata,
     ResourcePoolResponseResources,
-    ResourcePoolAllocation,
-    ResourcePoolQueueItem,
+    ResourcePoolUpdate,
 )
 from zenml.models.v2.core.resource_pool_subject_policy import (
     ResourcePoolSubjectPolicyFilter,
@@ -340,57 +268,109 @@ from zenml.models.v2.core.resource_pool_subject_policy import (
     ResourcePoolSubjectPolicyUpdate,
 )
 from zenml.models.v2.core.resource_request import (
-    ResourceRequestRequest,
     ResourceRequestFilter,
+    ResourceRequestRequest,
     ResourceRequestResponse,
     ResourceRequestResponseBody,
     ResourceRequestResponseMetadata,
     ResourceRequestResponseResources,
 )
-from zenml.models.v2.core.triggers import (
-    TriggerRequest,
-    TriggerUpdate,
-    TriggerResponseBody,
-    TriggerResponseMetadata,
-    TriggerResponseResources,
-    TriggerFilter,
-    TriggerSnapshotDispatchState,
-    TriggerDispatchErrorSeverity,
-    TriggerDispatchStatusCode,
-    ScheduleTriggerRequest,
-    ScheduleTriggerResponseBody,
-    ScheduleTriggerResponse,
-    ScheduleTriggerUpdate,
-    PlatformEventTriggerRequest,
-    PlatformEventTriggerUpdate,
-    PlatformEventTriggerResponse,
-    PlatformEventTriggerResponseBody,
-    PlatformEventTrigger,
-    SourceEntity,
-    TRIGGER_UPDATE_TYPE_UNION,
-    TRIGGER_CREATE_TYPE_UNION,
-    TRIGGER_RETURN_TYPE_UNION,
-    TriggerExecutionInfo,
+from zenml.models.v2.core.run_metadata import (
+    RunMetadataRequest,
 )
-from zenml.models.v2.misc.param_groups import (
-    PipelineRunIdentifier,
-    StepRunIdentifier,
-    ArtifactVersionIdentifier,
-    ModelVersionIdentifier,
+from zenml.models.v2.core.run_template import (
+    RunTemplateFilter,
+    RunTemplateRequest,
+    RunTemplateResponse,
+    RunTemplateResponseBody,
+    RunTemplateResponseMetadata,
+    RunTemplateResponseResources,
+    RunTemplateUpdate,
 )
-from zenml.models.v2.misc.statistics import (
-    ProjectStatistics,
-    ServerStatistics,
+from zenml.models.v2.core.run_wait_condition import (
+    RunWaitConditionFilter,
+    RunWaitConditionLeaseUpdate,
+    RunWaitConditionRequest,
+    RunWaitConditionResolveRequest,
+    RunWaitConditionResponse,
+    RunWaitConditionResponseBody,
+    RunWaitConditionResponseMetadata,
+    RunWaitConditionResponseResources,
+)
+from zenml.models.v2.core.schedule import (
+    ScheduleFilter,
+    ScheduleRequest,
+    ScheduleResponse,
+    ScheduleResponseBody,
+    ScheduleResponseMetadata,
+    ScheduleResponseResources,
+    ScheduleUpdate,
+)
+from zenml.models.v2.core.secret import (
+    SecretFilter,
+    SecretRequest,
+    SecretResponse,
+    SecretResponseBody,
+    SecretResponseMetadata,
+    SecretResponseResources,
+    SecretUpdate,
+)
+from zenml.models.v2.core.server_settings import (
+    ServerActivationRequest,
+    ServerSettingsResponse,
+    ServerSettingsResponseBody,
+    ServerSettingsResponseMetadata,
+    ServerSettingsResponseResources,
+    ServerSettingsUpdate,
+)
+from zenml.models.v2.core.service import (
+    ServiceFilter,
+    ServiceRequest,
+    ServiceResponse,
+    ServiceResponseBody,
+    ServiceResponseMetadata,
+    ServiceResponseResources,
+    ServiceUpdate,
+)
+from zenml.models.v2.core.service_account import (
+    ServiceAccountFilter,
+    ServiceAccountInternalRequest,
+    ServiceAccountInternalUpdate,
+    ServiceAccountRequest,
+    ServiceAccountResponse,
+    ServiceAccountResponseBody,
+    ServiceAccountResponseMetadata,
+    ServiceAccountUpdate,
+)
+from zenml.models.v2.core.service_connector import (
+    ServiceConnectorConfiguration,
+    ServiceConnectorFilter,
+    ServiceConnectorRequest,
+    ServiceConnectorResponse,
+    ServiceConnectorResponseBody,
+    ServiceConnectorResponseMetadata,
+    ServiceConnectorResponseResources,
+    ServiceConnectorUpdate,
+)
+from zenml.models.v2.core.stack import (
+    DefaultStackRequest,
+    StackFilter,
+    StackRequest,
+    StackResponse,
+    StackResponseBody,
+    StackResponseMetadata,
+    StackResponseResources,
+    StackUpdate,
 )
 from zenml.models.v2.core.step_run import (
-    StepRunRequest,
-    StepRunUpdate,
+    StepHeartbeatResponse,
     StepRunFilter,
+    StepRunRequest,
     StepRunResponse,
     StepRunResponseBody,
     StepRunResponseMetadata,
     StepRunResponseResources,
-    StepHeartbeatResponse,
+    StepRunUpdate,
 )
 from zenml.models.v2.core.stream_event import (
     StreamEvent,
@@ -399,53 +379,51 @@ from zenml.models.v2.core.stream_event import (
 )
 from zenml.models.v2.core.tag import (
     TagFilter,
+    TagRequest,
     TagResponse,
     TagResponseBody,
     TagResponseMetadata,
     TagResponseResources,
-    TagRequest,
     TagUpdate,
 )
 from zenml.models.v2.core.tag_resource import (
+    TagResourceRequest,
     TagResourceResponse,
     TagResourceResponseBody,
-    TagResourceRequest,
+)
+from zenml.models.v2.core.triggers import (
+    TRIGGER_CREATE_TYPE_UNION,
+    TRIGGER_RETURN_TYPE_UNION,
+    TRIGGER_UPDATE_TYPE_UNION,
+    PlatformEventTrigger,
+    PlatformEventTriggerRequest,
+    PlatformEventTriggerResponse,
+    PlatformEventTriggerResponseBody,
+    PlatformEventTriggerUpdate,
+    ScheduleTriggerRequest,
+    ScheduleTriggerResponse,
+    ScheduleTriggerResponseBody,
+    ScheduleTriggerUpdate,
+    SourceEntity,
+    TriggerDispatchErrorSeverity,
+    TriggerDispatchStatusCode,
+    TriggerExecutionInfo,
+    TriggerFilter,
+    TriggerRequest,
+    TriggerResponseBody,
+    TriggerResponseMetadata,
+    TriggerResponseResources,
+    TriggerSnapshotDispatchState,
+    TriggerUpdate,
 )
 from zenml.models.v2.core.user import (
-    UserRequest,
-    UserUpdate,
     UserFilter,
+    UserRequest,
     UserResponse,
     UserResponseBody,
     UserResponseMetadata,
+    UserUpdate,
 )
-from zenml.models.v2.core.project import (
-    ProjectRequest,
-    ProjectUpdate,
-    ProjectFilter,
-    ProjectResponse,
-    ProjectResponseBody,
-    ProjectResponseMetadata,
-)
-
-# V2 Misc
-from zenml.models.v2.misc.service_connector_type import (
-    AuthenticationMethodModel,
-    ServiceConnectorResourcesModel,
-    ServiceConnectorRequirements,
-    ServiceConnectorTypeModel,
-    ServiceConnectorTypedResourcesModel,
-    ResourceTypeModel,
-)
-from zenml.models.v2.misc.server_models import (
-    ServerDatabaseType,
-    ServerLoadInfo,
-    ServerModel,
-)
-from zenml.models.v2.misc.user_auth import UserAuthModel
-from zenml.models.v2.misc.build_item import BuildItem
-from zenml.models.v2.misc.loaded_visualization import LoadedVisualization
-from zenml.models.v2.misc.external_user import ExternalUserModel
 from zenml.models.v2.misc.auth_models import (
     OAuthDeviceAuthorizationRequest,
     OAuthDeviceAuthorizationResponse,
@@ -455,40 +433,73 @@ from zenml.models.v2.misc.auth_models import (
     OAuthRedirectResponse,
     OAuthTokenResponse,
 )
+from zenml.models.v2.misc.build_item import BuildItem
+from zenml.models.v2.misc.exception_info import ExceptionInfo
+from zenml.models.v2.misc.external_user import ExternalUserModel
+from zenml.models.v2.misc.info_models import (
+    ComponentInfo,
+    ResourcesInfo,
+    ServiceConnectorInfo,
+    ServiceConnectorResourcesInfo,
+)
+from zenml.models.v2.misc.loaded_visualization import LoadedVisualization
+from zenml.models.v2.misc.param_groups import (
+    ArtifactVersionIdentifier,
+    ModelVersionIdentifier,
+    PipelineRunIdentifier,
+    StepRunIdentifier,
+)
 from zenml.models.v2.misc.pipeline_run_dag import PipelineRunDAG
 from zenml.models.v2.misc.run_metadata import (
     RunMetadataEntry,
     RunMetadataResource,
 )
+from zenml.models.v2.misc.run_statistics import (
+    MetadataGrouping,
+    MetadataMetric,
+    RunStatisticsGroup,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
+    SimpleGrouping,
+    SimpleMetric,
+    StatisticsAggregation,
+    StatisticsGrouping,
+    StatisticsGroupingType,
+    StatisticsMetric,
+    StatisticsMetricSource,
+    StatisticsTimeGranularity,
+    TimeGrouping,
+)
 from zenml.models.v2.misc.server_models import (
-    ServerModel,
     ServerDatabaseType,
     ServerDeploymentType,
+    ServerLoadInfo,
+    ServerModel,
 )
 from zenml.models.v2.misc.service import ServiceType
-from zenml.models.v2.core.server_settings import (
-    ServerActivationRequest,
-    ServerSettingsResponse,
-    ServerSettingsResponseResources,
-    ServerSettingsResponseBody,
-    ServerSettingsResponseMetadata,
-    ServerSettingsUpdate,
+
+# V2 Misc
+from zenml.models.v2.misc.service_connector_type import (
+    AuthenticationMethodModel,
+    ResourceTypeModel,
+    ServiceConnectorRequirements,
+    ServiceConnectorResourcesModel,
+    ServiceConnectorTypedResourcesModel,
+    ServiceConnectorTypeModel,
 )
 from zenml.models.v2.misc.stack_deployment import (
     DeployedStack,
     StackDeploymentConfig,
     StackDeploymentInfo,
 )
+from zenml.models.v2.misc.statistics import (
+    ProjectStatistics,
+    ServerStatistics,
+)
 from zenml.models.v2.misc.tag import (
     TagResource,
 )
-from zenml.models.v2.misc.info_models import (
-    ComponentInfo,
-    ServiceConnectorInfo,
-    ServiceConnectorResourcesInfo,
-    ResourcesInfo,
-)
-from zenml.models.v2.misc.exception_info import ExceptionInfo
+from zenml.models.v2.misc.user_auth import UserAuthModel
 
 # ----------------------------- Forward References -----------------------------
 
@@ -963,6 +974,20 @@ __all__ = [
     "RunMetadataEntry",
     "RunMetadataResource",
     "ProjectStatistics",
+    "MetadataGrouping",
+    "MetadataMetric",
+    "RunStatisticsGroup",
+    "RunStatisticsRequest",
+    "RunStatisticsResponse",
+    "SimpleGrouping",
+    "SimpleMetric",
+    "StatisticsAggregation",
+    "StatisticsGrouping",
+    "StatisticsGroupingType",
+    "StatisticsMetric",
+    "StatisticsMetricSource",
+    "StatisticsTimeGranularity",
+    "TimeGrouping",
     "PipelineRunDAG",
     "ExceptionInfo",
     "PipelineRunIdentifier",

--- a/src/zenml/models/v2/misc/run_statistics.py
+++ b/src/zenml/models/v2/misc/run_statistics.py
@@ -1,0 +1,224 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Run statistics request and response models."""
+
+from typing import Annotated, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+from zenml.models.v2.base.base import BaseZenModel
+from zenml.models.v2.core.pipeline_run import PipelineRunFilter
+from zenml.utils.enum_utils import StrEnum
+
+
+class StatisticsTimeGranularity(StrEnum):
+    """Time bucket granularity for run statistics."""
+
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+class StatisticsGroupingType(StrEnum):
+    """Grouping dimension for run statistics."""
+
+    STATUS = "status"
+    PIPELINE = "pipeline"
+    SNAPSHOT = "snapshot"
+    SOURCE_SNAPSHOT = "source_snapshot"
+    STACK = "stack"
+    TRIGGER = "trigger"
+    USER = "user"
+    TIME = "time"
+    METADATA = "metadata"
+    TAG = "tag"
+
+
+class StatisticsAggregation(StrEnum):
+    """Aggregation operator for run statistics."""
+
+    AVG = "avg"
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+
+
+class StatisticsMetricSource(StrEnum):
+    """Value source for a run statistics metric."""
+
+    DURATION = "duration"
+    STEP_COUNT = "step_count"
+    CACHED_STEP_COUNT = "cached_step_count"
+    OUTPUT_ARTIFACT_COUNT = "output_artifact_count"
+    METADATA = "metadata"
+
+
+class _GroupingBase(BaseModel):
+    """Run statistics grouping base."""
+
+    name: str = Field(
+        description="Output key under 'group_keys' in the response. Must be "
+        "unique within the request.",
+    )
+
+
+class SimpleGrouping(_GroupingBase):
+    """Run statistics grouping."""
+
+    type: Literal[
+        StatisticsGroupingType.STATUS,
+        StatisticsGroupingType.PIPELINE,
+        StatisticsGroupingType.SNAPSHOT,
+        StatisticsGroupingType.SOURCE_SNAPSHOT,
+        StatisticsGroupingType.STACK,
+        StatisticsGroupingType.TRIGGER,
+        StatisticsGroupingType.USER,
+        StatisticsGroupingType.TAG,
+    ] = Field(description="Dimension to group runs by.")
+
+
+class TimeGrouping(_GroupingBase):
+    """Run statistics time grouping."""
+
+    type: Literal[StatisticsGroupingType.TIME] = Field(
+        description="Dimension to group runs by.",
+    )
+    granularity: StatisticsTimeGranularity = Field(
+        description="Time bucket granularity.",
+    )
+
+
+class MetadataGrouping(_GroupingBase):
+    """Run statistics metadata grouping."""
+
+    type: Literal[StatisticsGroupingType.METADATA] = Field(
+        description="Dimension to group runs by.",
+    )
+    metadata_key: str = Field(
+        description="Metadata key to group on.",
+    )
+
+
+StatisticsGrouping = Annotated[
+    Union[SimpleGrouping, TimeGrouping, MetadataGrouping],
+    Field(discriminator="type"),
+]
+
+
+class _MetricBase(BaseModel):
+    """Run statistics metric base."""
+
+    name: str = Field(
+        description="Output key under 'metrics' in the response. Must be "
+        "unique within the request.",
+    )
+    aggregation: StatisticsAggregation = Field(
+        description="Aggregation operator.",
+    )
+
+
+class SimpleMetric(_MetricBase):
+    """Run statistics metric."""
+
+    source: Literal[
+        StatisticsMetricSource.DURATION,
+        StatisticsMetricSource.STEP_COUNT,
+        StatisticsMetricSource.CACHED_STEP_COUNT,
+        StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT,
+    ] = Field(description="Value source.")
+
+
+class MetadataMetric(_MetricBase):
+    """Run statistics metadata metric."""
+
+    source: Literal[StatisticsMetricSource.METADATA] = Field(
+        description="Value source.",
+    )
+    metadata_key: str = Field(
+        description="Metadata key to aggregate.",
+    )
+
+
+StatisticsMetric = Annotated[
+    Union[SimpleMetric, MetadataMetric],
+    Field(discriminator="source"),
+]
+
+
+class RunStatisticsRequest(BaseZenModel):
+    """Run statistics request."""
+
+    filter: PipelineRunFilter = Field(
+        description="Pipeline run filter applied before aggregation.",
+    )
+    groupings: List[StatisticsGrouping] = Field(
+        default_factory=list,
+        description="Group-by dimensions. Empty list produces a single global "
+        "aggregate row.",
+    )
+    metrics: List[StatisticsMetric] = Field(
+        default_factory=list,
+        description="Aggregate metrics to compute per group. May be empty if "
+        "the caller only wants per-group run counts.",
+    )
+    max_groups: int = Field(
+        default=1000,
+        le=10_000,
+        gt=0,
+        description="Maximum number of groups to return. Excess groups are "
+        "dropped and 'truncated' is set to true.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_unique_names(self) -> "RunStatisticsRequest":
+        grouping_names = [g.name for g in self.groupings]
+        if len(grouping_names) != len(set(grouping_names)):
+            raise ValueError("Duplicate grouping names are not allowed.")
+        metric_names = [m.name for m in self.metrics]
+        if len(metric_names) != len(set(metric_names)):
+            raise ValueError("Duplicate metric names are not allowed.")
+        return self
+
+
+class RunStatisticsGroup(BaseModel):
+    """Run statistics group."""
+
+    group_keys: Dict[str, Optional[Union[str, int, float, bool]]] = Field(
+        default_factory=dict,
+        description="Group key values keyed by grouping name. Empty when the "
+        "request had no groupings.",
+    )
+    metrics: Dict[str, Optional[float]] = Field(
+        default_factory=dict,
+        description="Metric values keyed by metric name. Null when the group "
+        "has no rows contributing to the aggregate.",
+    )
+    run_count: int = Field(
+        description="Distinct pipeline runs in this group.",
+    )
+
+
+class RunStatisticsResponse(BaseZenModel):
+    """Run statistics response."""
+
+    groups: List[RunStatisticsGroup] = Field(
+        default_factory=list,
+        description="Resulting groups. Ordered by time bucket ascending when "
+        "a time grouping is present, otherwise by run count descending.",
+    )
+    truncated: bool = Field(
+        default=False,
+        description="True when more groups existed than 'max_groups' allowed.",
+    )

--- a/src/zenml/models/v2/misc/run_statistics.py
+++ b/src/zenml/models/v2/misc/run_statistics.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Run statistics request and response models."""
+"""Run statistics models."""
 
 from typing import Annotated, Dict, List, Literal, Optional, Union
 
@@ -69,8 +69,9 @@ class _GroupingBase(BaseModel):
     """Run statistics grouping base."""
 
     name: str = Field(
-        description="Output key under 'group_keys' in the response. Must be "
+        description="Output key under `group_keys` in the response. Must be "
         "unique within the request.",
+        min_length=1,
     )
 
 
@@ -121,8 +122,9 @@ class _MetricBase(BaseModel):
     """Run statistics metric base."""
 
     name: str = Field(
-        description="Output key under 'metrics' in the response. Must be "
+        description="Output key under `metrics` in the response. Must be "
         "unique within the request.",
+        min_length=1,
     )
     aggregation: StatisticsAggregation = Field(
         description="Aggregation operator.",
@@ -177,18 +179,25 @@ class RunStatisticsRequest(BaseZenModel):
         default=1000,
         le=10_000,
         gt=0,
-        description="Maximum number of groups to return. Excess groups are "
-        "dropped and 'truncated' is set to true.",
+        description="Maximum number of groups to return.",
     )
 
     @model_validator(mode="after")
-    def _validate_unique_names(self) -> "RunStatisticsRequest":
+    def _validate_request(self) -> "RunStatisticsRequest":
         grouping_names = [g.name for g in self.groupings]
         if len(grouping_names) != len(set(grouping_names)):
             raise ValueError("Duplicate grouping names are not allowed.")
+
         metric_names = [m.name for m in self.metrics]
         if len(metric_names) != len(set(metric_names)):
             raise ValueError("Duplicate metric names are not allowed.")
+
+        time_groupings = sum(
+            1 for g in self.groupings if isinstance(g, TimeGrouping)
+        )
+        if time_groupings > 1:
+            raise ValueError("At most one time grouping is allowed.")
+
         return self
 
 
@@ -220,5 +229,5 @@ class RunStatisticsResponse(BaseZenModel):
     )
     truncated: bool = Field(
         default=False,
-        description="True when more groups existed than 'max_groups' allowed.",
+        description="True when more groups existed than `max_groups` allowed.",
     )

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -49,6 +49,7 @@ from zenml.constants import (
     REPLAY,
     RUN_TEMPLATE_TRIGGERS_FEATURE_NAME,
     RUNS,
+    STATISTICS,
     STATUS,
     STEPS,
     STOP,
@@ -64,6 +65,8 @@ from zenml.models import (
     PipelineRunRequest,
     PipelineRunResponse,
     PipelineRunUpdate,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
     StepRunFilter,
     StepRunResponse,
     StreamBatchRequest,
@@ -94,6 +97,7 @@ from zenml.zen_server.rbac.endpoint_utils import (
 from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import (
     dehydrate_response_model,
+    get_allowed_resource_ids,
     verify_permission,
     verify_permission_for_model,
 )
@@ -123,6 +127,7 @@ from zenml.zen_server.utils import (
     server_config,
     stream_broadcaster,
     stream_broker,
+    set_filter_project_scope,
     workload_manager,
     zen_store,
 )
@@ -229,6 +234,45 @@ def list_runs(
         hydrate=hydrate,
         include_full_metadata=include_full_metadata,
     )
+
+
+@router.post(
+    STATISTICS,
+    responses={401: error_response, 403: error_response, 422: error_response},
+)
+@async_fastapi_endpoint_wrapper
+def get_run_statistics(
+    request: RunStatisticsRequest,
+    auth_context: AuthContext = Security(authorize),
+) -> RunStatisticsResponse:
+    """Compute grouped statistics over pipeline runs.
+
+    Args:
+        request: Statistics request.
+        auth_context: Authentication context.
+
+    Raises:
+        ValueError: If the project scope is not set correctly.
+
+    Returns:
+        Grouped statistics.
+    """
+    set_filter_project_scope(request.filter)
+    project_id = request.filter.project
+    if not isinstance(project_id, UUID):
+        raise ValueError(
+            f"Project scope must be a UUID, got {type(project_id)}."
+        )
+
+    request.filter.configure_rbac(
+        authenticated_user_id=auth_context.user.id,
+        id=get_allowed_resource_ids(
+            resource_type=ResourceType.PIPELINE_RUN,
+            project_id=project_id,
+        ),
+    )
+
+    return zen_store().get_run_statistics(request)
 
 
 @router.get(

--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -125,9 +125,9 @@ from zenml.zen_server.utils import (
     async_handle_endpoint_errors,
     make_dependable,
     server_config,
+    set_filter_project_scope,
     stream_broadcaster,
     stream_broker,
-    set_filter_project_scope,
     workload_manager,
     zen_store,
 )
@@ -238,7 +238,12 @@ def list_runs(
 
 @router.post(
     STATISTICS,
-    responses={401: error_response, 403: error_response, 422: error_response},
+    responses={
+        401: error_response,
+        403: error_response,
+        404: error_response,
+        422: error_response,
+    },
 )
 @async_fastapi_endpoint_wrapper
 def get_run_statistics(

--- a/src/zenml/zen_stores/migrations/versions/b9c4f2e1d3a8_add_run_metadata_key_index.py
+++ b/src/zenml/zen_stores/migrations/versions/b9c4f2e1d3a8_add_run_metadata_key_index.py
@@ -1,0 +1,27 @@
+"""Add run metadata key index [b9c4f2e1d3a8].
+
+Revision ID: b9c4f2e1d3a8
+Revises: 0.94.4
+Create Date: 2026-05-27 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b9c4f2e1d3a8"
+down_revision = "0.94.4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("run_metadata", schema=None) as batch_op:
+        batch_op.create_index("ix_run_metadata_key", ["key"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("run_metadata", schema=None) as batch_op:
+        batch_op.drop_index("ix_run_metadata_key")

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -117,6 +117,7 @@ from zenml.constants import (
     STACK_COMPONENTS,
     STACK_DEPLOYMENT,
     STACKS,
+    STATISTICS,
     STEPS,
     TAG_RESOURCES,
     TAGS,
@@ -240,6 +241,8 @@ from zenml.models import (
     ResourceRequestFilter,
     ResourceRequestResponse,
     RunMetadataRequest,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
     RunTemplateFilter,
     RunTemplateRequest,
     RunTemplateResponse,
@@ -2337,6 +2340,20 @@ class RestZenStore(BaseZenStore):
                 "include_full_metadata": include_full_metadata,
             },
         )
+
+    def get_run_statistics(
+        self, request: RunStatisticsRequest
+    ) -> RunStatisticsResponse:
+        """Compute grouped statistics over pipeline runs.
+
+        Args:
+            request: Statistics request.
+
+        Returns:
+            Grouped statistics.
+        """
+        response_body = self.post(f"{RUNS}{STATISTICS}", body=request)
+        return RunStatisticsResponse.model_validate(response_body)
 
     def update_run(
         self, run_id: UUID, run_update: PipelineRunUpdate

--- a/src/zenml/zen_stores/schemas/run_metadata_schemas.py
+++ b/src/zenml/zen_stores/schemas/run_metadata_schemas.py
@@ -34,6 +34,12 @@ class RunMetadataSchema(BaseSchema, table=True):
     """SQL Model for run metadata."""
 
     __tablename__ = "run_metadata"
+    __table_args__ = (
+        build_index(
+            table_name=__tablename__,
+            column_names=["key"],
+        ),
+    )
 
     stack_component_id: Optional[UUID] = build_foreign_key_field(
         source=__tablename__,

--- a/src/zenml/zen_stores/sql_run_statistics.py
+++ b/src/zenml/zen_stores/sql_run_statistics.py
@@ -1,0 +1,709 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""SQL aggregation query for pipeline run statistics."""
+
+import json
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+from sqlalchemy import Numeric, case, distinct, func, text
+from sqlalchemy import cast as sql_cast
+from sqlalchemy.engine import Row
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql import Subquery
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import Session, col, select
+
+from zenml.enums import (
+    ExecutionStatus,
+    MetadataResourceTypes,
+    TaggableResourceTypes,
+)
+from zenml.metadata.metadata_types import MetadataTypeEnum
+from zenml.models import (
+    MetadataGrouping,
+    MetadataMetric,
+    RunStatisticsGroup,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
+    SimpleGrouping,
+    SimpleMetric,
+    StatisticsAggregation,
+    StatisticsGroupingType,
+    StatisticsMetricSource,
+    StatisticsTimeGranularity,
+    TimeGrouping,
+)
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    PipelineSnapshotSchema,
+    RunMetadataResourceSchema,
+    RunMetadataSchema,
+    StepRunOutputArtifactSchema,
+    StepRunSchema,
+    TagResourceSchema,
+    TagSchema,
+    TriggerExecutionSchema,
+)
+from zenml.zen_stores.sql_zen_store import SQLDatabaseDriver
+
+JsonScalar = Optional[Union[str, int, float, bool]]
+GroupingDecoder = Callable[[Any], JsonScalar]
+Grouping = Union[SimpleGrouping, TimeGrouping, MetadataGrouping]
+Metric = Union[SimpleMetric, MetadataMetric]
+
+_SIMPLE_GROUPING_COLUMNS: Dict[StatisticsGroupingType, str] = {
+    StatisticsGroupingType.STATUS: "status",
+    StatisticsGroupingType.PIPELINE: "pipeline_id",
+    StatisticsGroupingType.SNAPSHOT: "snapshot_id",
+    StatisticsGroupingType.SOURCE_SNAPSHOT: "source_snapshot_id",
+    StatisticsGroupingType.STACK: "stack_id",
+    StatisticsGroupingType.TRIGGER: "trigger_id",
+    StatisticsGroupingType.USER: "user_id",
+}
+
+_SIMPLE_METRIC_COLUMNS: Dict[StatisticsMetricSource, str] = {
+    StatisticsMetricSource.DURATION: "duration_seconds",
+    StatisticsMetricSource.STEP_COUNT: "step_count",
+    StatisticsMetricSource.CACHED_STEP_COUNT: "cached_step_count",
+    StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT: "output_artifact_count",
+}
+
+_AGGREGATE_FUNCTIONS: Dict[StatisticsAggregation, Any] = {
+    StatisticsAggregation.AVG: func.avg,
+    StatisticsAggregation.SUM: func.sum,
+    StatisticsAggregation.MIN: func.min,
+    StatisticsAggregation.MAX: func.max,
+}
+
+
+def compute_run_statistics(
+    session: Session,
+    request: RunStatisticsRequest,
+    driver: Optional[SQLDatabaseDriver],
+) -> RunStatisticsResponse:
+    """Aggregate pipeline run statistics for the request.
+
+    Args:
+        session: Open SQL session, scoped to the request's project.
+        request: Statistics request.
+        driver: SQL dialect.
+
+    Returns:
+        Grouped statistics.
+    """
+    runs_subquery = _filtered_runs_subquery(request=request, driver=driver)
+    query, decoders, reverse_for_display = _aggregation_query(
+        request=request, runs_subquery=runs_subquery, driver=driver
+    )
+
+    rows = session.execute(query).all()
+    truncated = len(rows) > request.max_groups
+    if truncated:
+        rows = rows[: request.max_groups]
+
+    if reverse_for_display:
+        rows = list(reversed(rows))
+
+    return RunStatisticsResponse(
+        groups=[
+            _row_to_group(row=row, request=request, decoders=decoders)
+            for row in rows
+        ],
+        truncated=truncated,
+    )
+
+
+def _filtered_runs_subquery(
+    request: RunStatisticsRequest,
+    driver: Optional[SQLDatabaseDriver],
+) -> Subquery:
+    """One row per filtered pipeline run with grouping and metric values.
+
+    Args:
+        request: Statistics request.
+        driver: SQL dialect.
+
+    Returns:
+        Subquery.
+    """
+    grouping_types = {g.type for g in request.groupings}
+    metric_sources = {m.source for m in request.metrics}
+
+    columns: List[ColumnElement[Any]] = [
+        col(PipelineRunSchema.id).label("run_id"),
+        col(PipelineRunSchema.status).label("status"),
+        col(PipelineRunSchema.pipeline_id).label("pipeline_id"),
+        col(PipelineRunSchema.snapshot_id).label("snapshot_id"),
+        col(PipelineRunSchema.user_id).label("user_id"),
+        col(PipelineRunSchema.start_time).label("start_time"),
+        _duration_seconds_expression(driver).label("duration_seconds"),
+    ]
+    needs_snapshot_join = False
+    if StatisticsGroupingType.SOURCE_SNAPSHOT in grouping_types:
+        needs_snapshot_join = True
+        columns.append(
+            col(PipelineSnapshotSchema.source_snapshot_id).label(
+                "source_snapshot_id"
+            )
+        )
+
+    if StatisticsGroupingType.STACK in grouping_types:
+        needs_snapshot_join = True
+        columns.append(col(PipelineSnapshotSchema.stack_id).label("stack_id"))
+
+    needs_trigger_join = False
+    if StatisticsGroupingType.TRIGGER in grouping_types:
+        needs_trigger_join = True
+        columns.append(
+            col(TriggerExecutionSchema.trigger_id).label("trigger_id")
+        )
+
+    step_aggregates_subquery = _step_aggregates_subquery(metric_sources)
+    if step_aggregates_subquery is not None:
+        if StatisticsMetricSource.STEP_COUNT in metric_sources:
+            columns.append(
+                func.coalesce(step_aggregates_subquery.c.step_count, 0).label(
+                    "step_count"
+                )
+            )
+
+        if StatisticsMetricSource.CACHED_STEP_COUNT in metric_sources:
+            columns.append(
+                func.coalesce(
+                    step_aggregates_subquery.c.cached_step_count, 0
+                ).label("cached_step_count")
+            )
+
+        if StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT in metric_sources:
+            columns.append(
+                func.coalesce(
+                    step_aggregates_subquery.c.output_artifact_count, 0
+                ).label("output_artifact_count")
+            )
+
+    metadata_subqueries: Dict[str, Subquery] = {
+        key: _metadata_subquery(key)
+        for key in dict.fromkeys(
+            [
+                g.metadata_key
+                for g in request.groupings
+                if isinstance(g, MetadataGrouping)
+            ]
+            + [
+                m.metadata_key
+                for m in request.metrics
+                if isinstance(m, MetadataMetric)
+            ]
+        )
+    }
+    for key, metadata_subquery in metadata_subqueries.items():
+        columns.append(metadata_subquery.c.value.label(f"md_value_{key}"))
+        columns.append(
+            _metadata_value_as_float(
+                metadata_subquery=metadata_subquery
+            ).label(f"md_numeric_{key}")
+        )
+
+    # PipelineRunFilter.tags fans rows out per matching tag. Resolve filters
+    # on a distinct id query first so the result stays one row per run.
+    filtered_ids = (
+        request.filter.apply_filter(
+            query=select(col(PipelineRunSchema.id)),
+            table=PipelineRunSchema,
+        )
+        .distinct()
+        .subquery("filtered_run_ids")
+    )
+
+    query = (
+        select(*columns)
+        .select_from(PipelineRunSchema)
+        .where(col(PipelineRunSchema.id).in_(select(filtered_ids.c.id)))
+    )
+    if needs_snapshot_join:
+        query = query.outerjoin(
+            PipelineSnapshotSchema,
+            col(PipelineSnapshotSchema.id)
+            == col(PipelineRunSchema.snapshot_id),
+        )
+
+    if needs_trigger_join:
+        # PK (trigger_id, pipeline_run_id) ensures at most one row per run.
+        query = query.outerjoin(
+            TriggerExecutionSchema,
+            col(TriggerExecutionSchema.pipeline_run_id)
+            == col(PipelineRunSchema.id),
+        )
+
+    if step_aggregates_subquery is not None:
+        query = query.outerjoin(
+            step_aggregates_subquery,
+            step_aggregates_subquery.c.run_id == col(PipelineRunSchema.id),
+        )
+
+    for metadata_subquery in metadata_subqueries.values():
+        query = query.outerjoin(
+            metadata_subquery,
+            metadata_subquery.c.run_id == col(PipelineRunSchema.id),
+        )
+
+    return query.subquery("runs")
+
+
+def _aggregation_query(
+    request: RunStatisticsRequest,
+    runs_subquery: Subquery,
+    driver: Optional[SQLDatabaseDriver],
+) -> Tuple[Any, List[GroupingDecoder], bool]:
+    """Aggregating SELECT over the runs subquery.
+
+    Args:
+        request: Statistics request.
+        runs_subquery: Filtered runs subquery.
+        driver: SQL dialect.
+
+    Returns:
+        Query, one decoder per request grouping, and a flag set when the
+        fetched rows should be reversed for the response.
+    """
+    tag_subquery = (
+        _tag_subquery()
+        if any(g.type == StatisticsGroupingType.TAG for g in request.groupings)
+        else None
+    )
+
+    group_columns: List[ColumnElement[Any]] = []
+    decoders: List[GroupingDecoder] = []
+    for grouping in request.groupings:
+        expression, decoder = _grouping_expression(
+            grouping=grouping,
+            runs=runs_subquery,
+            tag_subquery=tag_subquery,
+            driver=driver,
+        )
+        group_columns.append(expression.label(f"group_{grouping.name}"))
+        decoders.append(decoder)
+
+    metric_columns: List[ColumnElement[Any]] = []
+    for metric in request.metrics:
+        value = _metric_value_expression(metric=metric, runs=runs_subquery)
+        metric_columns.append(
+            _AGGREGATE_FUNCTIONS[metric.aggregation](value).label(
+                f"metric_{metric.name}"
+            )
+        )
+
+    run_count = func.count(distinct(runs_subquery.c.run_id)).label("run_count")
+    select_columns: List[ColumnElement[Any]] = [
+        *group_columns,
+        *metric_columns,
+        run_count,
+    ]
+
+    query = select(*select_columns).select_from(runs_subquery)
+    if tag_subquery is not None:
+        query = query.outerjoin(
+            tag_subquery, tag_subquery.c.run_id == runs_subquery.c.run_id
+        )
+
+    if group_columns:
+        query = query.group_by(*group_columns)
+
+    # Time-grouped queries order everything DESC so the LIMIT keeps the
+    # latest buckets when truncation kicks in. The kept slice is then
+    # reversed by the caller so the response is ascending by time. Non-time
+    # queries order by run count DESC with groupings ASC as tiebreakers.
+    # Request validation guarantees at most one time grouping.
+    time_index = next(
+        (
+            i
+            for i, g in enumerate(request.groupings)
+            if isinstance(g, TimeGrouping)
+        ),
+        None,
+    )
+    if time_index is not None:
+        primary_order: Any = group_columns[time_index].desc()
+        tiebreakers = [
+            c.desc() for i, c in enumerate(group_columns) if i != time_index
+        ]
+        reverse_for_display = True
+    else:
+        primary_order = run_count.desc()
+        tiebreakers = [c.asc() for c in group_columns]
+        reverse_for_display = False
+
+    query = query.order_by(primary_order, *tiebreakers)
+    query = query.limit(request.max_groups + 1)
+
+    return query, decoders, reverse_for_display
+
+
+def _grouping_expression(
+    grouping: Grouping,
+    runs: Subquery,
+    tag_subquery: Optional[Subquery],
+    driver: Optional[SQLDatabaseDriver],
+) -> Tuple[ColumnElement[Any], GroupingDecoder]:
+    """GROUP BY expression and row decoder for one grouping.
+
+    Args:
+        grouping: Request grouping.
+        runs: Filtered runs subquery.
+        tag_subquery: Tag join subquery, present when any grouping is TAG.
+        driver: SQL dialect.
+
+    Returns:
+        GROUP BY expression and decoder for the row value.
+    """
+    if isinstance(grouping, TimeGrouping):
+        return (
+            _time_bucket_expression(
+                column=runs.c.start_time,
+                granularity=grouping.granularity,
+                driver=driver,
+            ),
+            _to_json_scalar,
+        )
+
+    if isinstance(grouping, MetadataGrouping):
+        return (
+            runs.c[f"md_value_{grouping.metadata_key}"],
+            _decode_metadata_value,
+        )
+
+    if grouping.type == StatisticsGroupingType.TAG:
+        assert tag_subquery is not None
+        return tag_subquery.c.name, _to_json_scalar
+
+    return runs.c[_SIMPLE_GROUPING_COLUMNS[grouping.type]], _to_json_scalar
+
+
+def _metric_value_expression(
+    metric: Metric, runs: Subquery
+) -> ColumnElement[Any]:
+    """Per-run scalar the metric aggregates over.
+
+    Args:
+        metric: Request metric.
+        runs: Filtered runs subquery.
+
+    Returns:
+        Column expression.
+    """
+    if isinstance(metric, MetadataMetric):
+        return runs.c[f"md_numeric_{metric.metadata_key}"]
+
+    return runs.c[_SIMPLE_METRIC_COLUMNS[metric.source]]
+
+
+def _row_to_group(
+    row: Row[Any],
+    request: RunStatisticsRequest,
+    decoders: List[GroupingDecoder],
+) -> RunStatisticsGroup:
+    """Convert a result row into a typed response group.
+
+    Args:
+        row: Aggregation result row.
+        request: Statistics request.
+        decoders: One decoder per request grouping.
+
+    Returns:
+        Response group.
+    """
+    mapping = row._mapping
+    group_keys: Dict[str, JsonScalar] = {
+        grouping.name: decoder(mapping[f"group_{grouping.name}"])
+        for grouping, decoder in zip(request.groupings, decoders)
+    }
+    metrics: Dict[str, Optional[float]] = {}
+    for metric in request.metrics:
+        raw = mapping[f"metric_{metric.name}"]
+        metrics[metric.name] = float(raw) if raw is not None else None
+
+    return RunStatisticsGroup(
+        group_keys=group_keys,
+        metrics=metrics,
+        run_count=int(mapping["run_count"] or 0),
+    )
+
+
+def _to_json_scalar(raw: Any) -> JsonScalar:
+    """Coerce a raw DB value to a JSON scalar, stringifying non-scalars.
+
+    Args:
+        raw: Raw DB value.
+
+    Returns:
+        JSON scalar.
+    """
+    if raw is None:
+        return None
+
+    if isinstance(raw, (str, int, float, bool)):
+        return raw
+
+    return str(raw)
+
+
+def _decode_metadata_value(raw: Any) -> JsonScalar:
+    """Decode a JSON-encoded metadata value, returning None if not a scalar.
+
+    Args:
+        raw: Raw DB value.
+
+    Returns:
+        JSON scalar.
+    """
+    if raw is None:
+        return None
+
+    try:
+        decoded = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    if decoded is None or isinstance(decoded, (str, int, float, bool)):
+        return decoded
+
+    return None
+
+
+def _duration_seconds_expression(
+    driver: Optional[SQLDatabaseDriver],
+) -> ColumnElement[float]:
+    """Dialect-appropriate `end_time - start_time` in seconds.
+
+    Args:
+        driver: SQL dialect.
+
+    Returns:
+        Column expression.
+    """
+    start = col(PipelineRunSchema.start_time)
+    end = col(PipelineRunSchema.end_time)
+    if driver == SQLDatabaseDriver.MYSQL:
+        return func.timestampdiff(text("SECOND"), start, end)
+
+    return (func.julianday(end) - func.julianday(start)) * 86400.0
+
+
+def _time_bucket_expression(
+    column: ColumnElement[Any],
+    granularity: StatisticsTimeGranularity,
+    driver: Optional[SQLDatabaseDriver],
+) -> ColumnElement[str]:
+    """Expression for a sortable bucket label for a datetime column.
+
+    WEEK buckets use the Monday of the week as a `YYYY-MM-DD` date.
+
+    Args:
+        column: Datetime column.
+        granularity: Bucket size.
+        driver: SQL dialect.
+
+    Returns:
+        String column expression.
+    """
+    if driver == SQLDatabaseDriver.MYSQL:
+        if granularity == StatisticsTimeGranularity.WEEK:
+            return func.date_format(
+                func.subdate(column, func.weekday(column)), "%Y-%m-%d"
+            )
+
+        mysql_formats = {
+            StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
+            StatisticsTimeGranularity.DAY: "%Y-%m-%d",
+            StatisticsTimeGranularity.MONTH: "%Y-%m-01",
+        }
+        return func.date_format(column, mysql_formats[granularity])
+
+    if granularity == StatisticsTimeGranularity.WEEK:
+        return func.date(column, "-6 days", "weekday 1")
+
+    sqlite_formats = {
+        StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
+        StatisticsTimeGranularity.DAY: "%Y-%m-%d",
+        StatisticsTimeGranularity.MONTH: "%Y-%m-01",
+    }
+    return func.strftime(sqlite_formats[granularity], column)
+
+
+def _metadata_subquery(key: str) -> Subquery:
+    """Subquery that returns metadata entries for a given key.
+
+    If multiple entries exist for the same run, the latest by `created` is
+    returned. This mirrors the behavior of metadata overwriting, which only
+    keeps the latest entry for scalar metadata values.
+    -> See `RunMetadataInterface.fetch_metadata` for more details.
+
+    Args:
+        key: Metadata key.
+
+    Returns:
+        Subquery with `run_id`, `value`, `type` columns.
+    """
+    metadata = aliased(RunMetadataSchema)
+    metadata_resource = aliased(RunMetadataResourceSchema)
+    ranked = (
+        select(
+            col(metadata_resource.resource_id).label("run_id"),
+            col(metadata.value).label("value"),
+            col(metadata.type).label("type"),
+            func.row_number()
+            .over(
+                partition_by=col(metadata_resource.resource_id),
+                order_by=col(metadata.created).desc(),
+            )
+            .label("rn"),
+        )
+        .select_from(metadata)
+        .join(
+            metadata_resource,
+            col(metadata_resource.run_metadata_id) == col(metadata.id),
+        )
+        .where(
+            col(metadata_resource.resource_type)
+            == MetadataResourceTypes.PIPELINE_RUN.value,
+            col(metadata.key) == key,
+        )
+        .subquery()
+    )
+
+    return (
+        select(ranked.c.run_id, ranked.c.value, ranked.c.type)
+        .where(ranked.c.rn == 1)
+        .subquery()
+    )
+
+
+def _metadata_value_as_float(
+    metadata_subquery: Subquery,
+) -> ColumnElement[Any]:
+    """Metadata value cast to FLOAT when stored type is numeric, else NULL.
+
+    Args:
+        metadata_subquery: Subquery with `value` and `type` columns.
+
+    Returns:
+        Column expression.
+    """
+    return case(
+        (
+            metadata_subquery.c.type.in_(
+                (MetadataTypeEnum.INT.value, MetadataTypeEnum.FLOAT.value)
+            ),
+            sql_cast(metadata_subquery.c.value, Numeric),
+        ),
+        else_=None,
+    )
+
+
+def _tag_subquery() -> Subquery:
+    """Tag subquery that joins pipeline runs with their tags.
+
+    Returns:
+        Subquery with `run_id` and `name` columns.
+    """
+    tag_resource = aliased(TagResourceSchema)
+    tag = aliased(TagSchema)
+
+    return (
+        select(
+            col(tag_resource.resource_id).label("run_id"),
+            col(tag.name).label("name"),
+        )
+        .select_from(tag_resource)
+        .join(tag, col(tag.id) == col(tag_resource.tag_id))
+        .where(
+            col(tag_resource.resource_type)
+            == TaggableResourceTypes.PIPELINE_RUN.value
+        )
+        .subquery()
+    )
+
+
+def _step_aggregates_subquery(
+    metric_sources: Set[StatisticsMetricSource],
+) -> Optional[Subquery]:
+    """Step-run aggregates needed by step-derived metrics.
+
+    Args:
+        metric_sources: Metric sources requested.
+
+    Returns:
+        Subquery with `run_id` and the requested aggregate columns, or
+        `None` if no step-derived metric was requested.
+    """
+    need_step_count = StatisticsMetricSource.STEP_COUNT in metric_sources
+    need_cached_step_count = (
+        StatisticsMetricSource.CACHED_STEP_COUNT in metric_sources
+    )
+    need_output_artifact_count = (
+        StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT in metric_sources
+    )
+    if not (
+        need_step_count or need_cached_step_count or need_output_artifact_count
+    ):
+        return None
+
+    columns: List[ColumnElement[Any]] = [
+        col(StepRunSchema.pipeline_run_id).label("run_id"),
+    ]
+    if need_step_count:
+        columns.append(
+            func.count(distinct(col(StepRunSchema.name))).label("step_count")
+        )
+
+    if need_cached_step_count:
+        columns.append(
+            func.count(
+                distinct(
+                    case(
+                        (
+                            col(StepRunSchema.status)
+                            == ExecutionStatus.CACHED.value,
+                            col(StepRunSchema.name),
+                        ),
+                        else_=None,
+                    )
+                )
+            ).label("cached_step_count")
+        )
+
+    if need_output_artifact_count:
+        columns.append(
+            func.count(
+                distinct(col(StepRunOutputArtifactSchema.artifact_id))
+            ).label("output_artifact_count")
+        )
+
+    query = select(*columns).select_from(StepRunSchema)
+    if need_output_artifact_count:
+        query = query.outerjoin(
+            StepRunOutputArtifactSchema,
+            col(StepRunOutputArtifactSchema.step_id) == col(StepRunSchema.id),
+        )
+
+    return query.group_by(col(StepRunSchema.pipeline_run_id)).subquery()

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -58,7 +58,6 @@ from typing import (
     ContextManager,
     Dict,
     ForwardRef,
-    FrozenSet,
     List,
     Literal,
     NoReturn,
@@ -84,16 +83,11 @@ from pydantic import (
     model_validator,
 )
 from sqlalchemy import (
-    Float,
     QueuePool,
-    case,
-    distinct,
     event,
     func,
-    text,
     update,
 )
-from sqlalchemy import cast as sql_cast
 from sqlalchemy.engine import URL, Engine, make_url
 from sqlalchemy.exc import (
     ArgumentError,
@@ -101,13 +95,11 @@ from sqlalchemy.exc import (
 )
 from sqlalchemy.orm import (
     Mapped,
-    aliased,
     load_only,
     noload,
     selectinload,
 )
 from sqlalchemy.sql.base import ExecutableOption
-from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.util import immutabledict
 from sqlmodel import Session as SqlModelSession
 
@@ -252,8 +244,6 @@ from zenml.models import (
     LogsRequest,
     LogsResponse,
     LogsUpdate,
-    MetadataGrouping,
-    MetadataMetric,
     ModelFilter,
     ModelRequest,
     ModelResponse,
@@ -312,7 +302,6 @@ from zenml.models import (
     ResourceRequestResponse,
     RunMetadataRequest,
     RunMetadataResource,
-    RunStatisticsGroup,
     RunStatisticsRequest,
     RunStatisticsResponse,
     RunTemplateFilter,
@@ -354,17 +343,12 @@ from zenml.models import (
     ServiceRequest,
     ServiceResponse,
     ServiceUpdate,
-    SimpleGrouping,
     StackDeploymentConfig,
     StackDeploymentInfo,
     StackFilter,
     StackRequest,
     StackResponse,
     StackUpdate,
-    StatisticsAggregation,
-    StatisticsGroupingType,
-    StatisticsMetricSource,
-    StatisticsTimeGranularity,
     StepRunFilter,
     StepRunRequest,
     StepRunResponse,
@@ -376,7 +360,6 @@ from zenml.models import (
     TagResourceResponse,
     TagResponse,
     TagUpdate,
-    TimeGrouping,
     TriggerDispatchStatusCode,
     TriggerFilter,
     TriggerRequest,
@@ -7371,289 +7354,10 @@ class SqlZenStore(BaseZenStore):
             schema=PipelineRunSchema, filter_model=filter_model
         )
 
-    # -------------------- Run statistics --------------------
-
-    _SIMPLE_GROUPING_COLUMNS: ClassVar[Dict[StatisticsGroupingType, str]] = {
-        StatisticsGroupingType.STATUS: "__status",
-        StatisticsGroupingType.PIPELINE: "__pipeline_id",
-        StatisticsGroupingType.SNAPSHOT: "__snapshot_id",
-        StatisticsGroupingType.SOURCE_SNAPSHOT: "__source_snapshot_id",
-        StatisticsGroupingType.STACK: "__stack_id",
-        StatisticsGroupingType.USER: "__user_id",
-        StatisticsGroupingType.TRIGGER: "__trigger_id",
-    }
-
-    _SIMPLE_METRIC_COLUMNS: ClassVar[Dict[StatisticsMetricSource, str]] = {
-        StatisticsMetricSource.DURATION: "__duration_seconds",
-        StatisticsMetricSource.STEP_COUNT: "__step_count",
-        StatisticsMetricSource.CACHED_STEP_COUNT: "__cached_step_count",
-        StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT: "__output_artifact_count",
-    }
-
-    _UUID_GROUPING_TYPES: ClassVar[FrozenSet[StatisticsGroupingType]] = (
-        frozenset(
-            {
-                StatisticsGroupingType.PIPELINE,
-                StatisticsGroupingType.SNAPSHOT,
-                StatisticsGroupingType.SOURCE_SNAPSHOT,
-                StatisticsGroupingType.STACK,
-                StatisticsGroupingType.TRIGGER,
-                StatisticsGroupingType.USER,
-            }
-        )
-    )
-
-    _AGGREGATE_FUNCTIONS: ClassVar[Dict[StatisticsAggregation, Any]] = {
-        StatisticsAggregation.AVG: func.avg,
-        StatisticsAggregation.SUM: func.sum,
-        StatisticsAggregation.MIN: func.min,
-        StatisticsAggregation.MAX: func.max,
-    }
-
-    def _run_duration_seconds_expr(self) -> ColumnElement[float]:
-        """Dialect-appropriate ``end_time - start_time`` in seconds.
-
-        Returns:
-            Column expression.
-        """
-        start = col(PipelineRunSchema.start_time)
-        end = col(PipelineRunSchema.end_time)
-        if self.config.driver == SQLDatabaseDriver.MYSQL:
-            return func.timestampdiff(text("SECOND"), start, end)
-        return (func.julianday(end) - func.julianday(start)) * 86400.0
-
-    def _time_bucket_expr(
-        self,
-        column: Any,
-        granularity: StatisticsTimeGranularity,
-    ) -> ColumnElement[str]:
-        """Sortable ISO-ish bucket label for a datetime column.
-
-        WEEK buckets use the Monday of the week as a `YYYY-MM-DD` date,
-        matching the DAY and MONTH conventions and avoiding ISO-week vs
-        calendar-week mismatches between dialects.
-
-        Args:
-            column: Datetime column.
-            granularity: Bucket size.
-
-        Returns:
-            Column expression.
-        """
-        if self.config.driver == SQLDatabaseDriver.MYSQL:
-            if granularity == StatisticsTimeGranularity.WEEK:
-                return func.date_format(
-                    func.subdate(column, func.weekday(column)),
-                    "%Y-%m-%d",
-                )
-            mysql_formats = {
-                StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
-                StatisticsTimeGranularity.DAY: "%Y-%m-%d",
-                StatisticsTimeGranularity.MONTH: "%Y-%m-01",
-            }
-            return func.date_format(column, mysql_formats[granularity])
-
-        if granularity == StatisticsTimeGranularity.WEEK:
-            return func.date(column, "-6 days", "weekday 1")
-
-        sqlite_formats = {
-            StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
-            StatisticsTimeGranularity.DAY: "%Y-%m-%d",
-            StatisticsTimeGranularity.MONTH: "%Y-%m-01",
-        }
-        return func.strftime(sqlite_formats[granularity], column)
-
-    @staticmethod
-    def _metadata_group_label(key: str) -> str:
-        """Stage-1 column label for the raw metadata value (grouping use).
-
-        Args:
-            key: Metadata key.
-
-        Returns:
-            Column label.
-        """
-        return f"__md_group__{key}"
-
-    @staticmethod
-    def _metadata_metric_label(key: str) -> str:
-        """Stage-1 column label for the numeric metadata value (metric use).
-
-        Args:
-            key: Metadata key.
-
-        Returns:
-            Column label.
-        """
-        return f"__md_metric__{key}"
-
-    def _latest_metadata_per_run_subquery(self, key: str) -> Any:
-        """Latest metadata row per pipeline run for a key.
-
-        Mirrors `RunMetadataInterface.fetch_metadata` (non-dict path):
-        last entry by `created` wins. Statistics aggregations then see
-        one value per (run, key), matching what every other API surface
-        returns for the same run.
-
-        Args:
-            key: Metadata key.
-
-        Returns:
-            Subquery with `run_id`, `value`, `type` columns.
-        """
-        rm = aliased(RunMetadataSchema)
-        rmr = aliased(RunMetadataResourceSchema)
-        ranked = (
-            select(
-                col(rmr.resource_id).label("run_id"),
-                col(rm.value).label("value"),
-                col(rm.type).label("type"),
-                func.row_number()
-                .over(
-                    partition_by=col(rmr.resource_id),
-                    order_by=col(rm.created).desc(),
-                )
-                .label("rn"),
-            )
-            .select_from(rm)
-            .join(rmr, col(rmr.run_metadata_id) == col(rm.id))
-            .where(
-                col(rmr.resource_type)
-                == MetadataResourceTypes.PIPELINE_RUN.value,
-                col(rm.key) == key,
-            )
-            .subquery()
-        )
-        return (
-            select(
-                ranked.c.run_id,
-                ranked.c.value,
-                ranked.c.type,
-            )
-            .where(ranked.c.rn == 1)
-            .subquery()
-        )
-
-    @staticmethod
-    def _metadata_numeric_expr(latest_sq: Any) -> ColumnElement[Any]:
-        """Numeric-only projection of a latest-per-run metadata subquery.
-
-        Non-numeric types are projected to NULL so outer aggregates skip them.
-
-        Args:
-            latest_sq: Subquery returned by `_latest_metadata_per_run_subquery`.
-
-        Returns:
-            Column expression.
-        """
-        from zenml.metadata.metadata_types import MetadataTypeEnum
-
-        return case(
-            (
-                latest_sq.c.type.in_(
-                    (
-                        MetadataTypeEnum.INT.value,
-                        MetadataTypeEnum.FLOAT.value,
-                    )
-                ),
-                sql_cast(latest_sq.c.value, Float),
-            ),
-            else_=None,
-        )
-
-    def _tag_subquery(self) -> Any:
-        """Pipeline-run-tag association subquery (run_id, name)."""
-        tr = aliased(TagResourceSchema)
-        ts = aliased(TagSchema)
-        return (
-            select(
-                col(tr.resource_id).label("run_id"),
-                col(ts.name).label("name"),
-            )
-            .select_from(tr)
-            .join(ts, col(ts.id) == col(tr.tag_id))
-            .where(
-                col(tr.resource_type)
-                == TaggableResourceTypes.PIPELINE_RUN.value,
-            )
-            .subquery()
-        )
-
-    def _build_step_aggregates_subquery(
-        self,
-        *,
-        need_step_count: bool,
-        need_cached_step_count: bool,
-        need_output_artifact_count: bool,
-    ) -> Optional[Any]:
-        """One-pass step-run aggregates with conditional counts.
-
-        Args:
-            need_step_count: Project distinct step name count.
-            need_cached_step_count: Project distinct cached step name count.
-            need_output_artifact_count: Project distinct output artifact count.
-
-        Returns:
-            Subquery with `run_id` and the requested aggregate columns, or
-            `None` if no step-derived metric was requested.
-        """
-        if not (
-            need_step_count
-            or need_cached_step_count
-            or need_output_artifact_count
-        ):
-            return None
-
-        select_cols: List[ColumnElement[Any]] = [
-            col(StepRunSchema.pipeline_run_id).label("run_id"),
-        ]
-        if need_step_count:
-            select_cols.append(
-                func.count(distinct(col(StepRunSchema.name))).label(
-                    "step_count"
-                )
-            )
-        if need_cached_step_count:
-            select_cols.append(
-                func.count(
-                    distinct(
-                        case(
-                            (
-                                col(StepRunSchema.status)
-                                == ExecutionStatus.CACHED.value,
-                                col(StepRunSchema.name),
-                            ),
-                            else_=None,
-                        )
-                    )
-                ).label("cached_step_count")
-            )
-        if need_output_artifact_count:
-            select_cols.append(
-                func.count(
-                    distinct(col(StepRunOutputArtifactSchema.artifact_id))
-                ).label("output_artifact_count")
-            )
-        query = select(*select_cols).select_from(StepRunSchema)
-        if need_output_artifact_count:
-            query = query.outerjoin(
-                StepRunOutputArtifactSchema,
-                col(StepRunOutputArtifactSchema.step_id)
-                == col(StepRunSchema.id),
-            )
-        return query.group_by(col(StepRunSchema.pipeline_run_id)).subquery()
-
     def get_run_statistics(
         self, request: RunStatisticsRequest
     ) -> RunStatisticsResponse:
         """Compute grouped statistics over pipeline runs.
-
-        Stage 1 produces one row per matching pipeline run with every per-run
-        scalar resolved (status, IDs, duration, step counts, latest metadata
-        value, trigger). Stage 2 optionally LEFT JOINs the tag fan-out source
-        and aggregates over the stage-1 rowset, so a run with N tags
-        contributes once to each tag bucket without inflating AVG/SUM with
-        duplicated rows.
 
         Args:
             request: Statistics request.
@@ -7661,331 +7365,18 @@ class SqlZenStore(BaseZenStore):
         Returns:
             Grouped statistics.
         """
-        filter_model = request.filter
+        from zenml.zen_stores.sql_run_statistics import (
+            compute_run_statistics,
+        )
 
         with Session(self.engine) as session:
             self._set_filter_project_id(
-                filter_model=filter_model,
+                filter_model=request.filter,
                 session=session,
             )
-
-            # ----- Classify the request -----
-            grouping_types = {g.type for g in request.groupings}
-            needs_snapshot_join = bool(
-                grouping_types
-                & {
-                    StatisticsGroupingType.SOURCE_SNAPSHOT,
-                    StatisticsGroupingType.STACK,
-                }
+            return compute_run_statistics(
+                session=session, request=request, driver=self.config.driver
             )
-            needs_trigger_join = (
-                StatisticsGroupingType.TRIGGER in grouping_types
-            )
-            tag_grouping_present = StatisticsGroupingType.TAG in grouping_types
-
-            metric_sources = {m.source for m in request.metrics}
-            need_step_count = (
-                StatisticsMetricSource.STEP_COUNT in metric_sources
-            )
-            need_cached_step_count = (
-                StatisticsMetricSource.CACHED_STEP_COUNT in metric_sources
-            )
-            need_output_artifact_count = (
-                StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT in metric_sources
-            )
-
-            # Metadata keys per use. One subquery per unique key is shared
-            # between grouping and metric projections.
-            metadata_grouping_keys: List[str] = []
-            for grouping in request.groupings:
-                if (
-                    isinstance(grouping, MetadataGrouping)
-                    and grouping.metadata_key not in metadata_grouping_keys
-                ):
-                    metadata_grouping_keys.append(grouping.metadata_key)
-
-            metadata_metric_keys: List[str] = []
-            for metric in request.metrics:
-                if (
-                    isinstance(metric, MetadataMetric)
-                    and metric.metadata_key not in metadata_metric_keys
-                ):
-                    metadata_metric_keys.append(metric.metadata_key)
-
-            metadata_subqueries: Dict[str, Any] = {
-                key: self._latest_metadata_per_run_subquery(key)
-                for key in dict.fromkeys(
-                    [*metadata_grouping_keys, *metadata_metric_keys]
-                )
-            }
-
-            step_aggregates_sq = self._build_step_aggregates_subquery(
-                need_step_count=need_step_count,
-                need_cached_step_count=need_cached_step_count,
-                need_output_artifact_count=need_output_artifact_count,
-            )
-
-            # ----- Stage 1: one row per pipeline run -----
-            stage1_columns: List[ColumnElement[Any]] = [
-                col(PipelineRunSchema.id).label("__run_id"),
-                col(PipelineRunSchema.status).label("__status"),
-                col(PipelineRunSchema.pipeline_id).label("__pipeline_id"),
-                col(PipelineRunSchema.snapshot_id).label("__snapshot_id"),
-                col(PipelineRunSchema.user_id).label("__user_id"),
-                col(PipelineRunSchema.start_time).label("__start_time"),
-                self._run_duration_seconds_expr().label("__duration_seconds"),
-            ]
-            if needs_snapshot_join:
-                stage1_columns.append(
-                    col(PipelineSnapshotSchema.source_snapshot_id).label(
-                        "__source_snapshot_id"
-                    )
-                )
-                stage1_columns.append(
-                    col(PipelineSnapshotSchema.stack_id).label("__stack_id")
-                )
-            if needs_trigger_join:
-                # The (trigger_id, pipeline_run_id) PK on `trigger_execution`
-                # means at most one row per run, so this join does not fan
-                # out the rowset.
-                stage1_columns.append(
-                    col(TriggerExecutionSchema.trigger_id).label(
-                        "__trigger_id"
-                    )
-                )
-            if step_aggregates_sq is not None:
-                if need_step_count:
-                    stage1_columns.append(
-                        func.coalesce(
-                            step_aggregates_sq.c.step_count, 0
-                        ).label("__step_count")
-                    )
-                if need_cached_step_count:
-                    stage1_columns.append(
-                        func.coalesce(
-                            step_aggregates_sq.c.cached_step_count, 0
-                        ).label("__cached_step_count")
-                    )
-                if need_output_artifact_count:
-                    stage1_columns.append(
-                        func.coalesce(
-                            step_aggregates_sq.c.output_artifact_count, 0
-                        ).label("__output_artifact_count")
-                    )
-            for key in metadata_grouping_keys:
-                stage1_columns.append(
-                    metadata_subqueries[key].c.value.label(
-                        self._metadata_group_label(key)
-                    )
-                )
-            for key in metadata_metric_keys:
-                stage1_columns.append(
-                    self._metadata_numeric_expr(
-                        metadata_subqueries[key]
-                    ).label(self._metadata_metric_label(key))
-                )
-
-            stage1_query = select(*stage1_columns).select_from(
-                PipelineRunSchema
-            )
-            if needs_snapshot_join:
-                stage1_query = stage1_query.outerjoin(
-                    PipelineSnapshotSchema,
-                    col(PipelineSnapshotSchema.id)
-                    == col(PipelineRunSchema.snapshot_id),
-                )
-            if needs_trigger_join:
-                stage1_query = stage1_query.outerjoin(
-                    TriggerExecutionSchema,
-                    col(TriggerExecutionSchema.pipeline_run_id)
-                    == col(PipelineRunSchema.id),
-                )
-            if step_aggregates_sq is not None:
-                stage1_query = stage1_query.outerjoin(
-                    step_aggregates_sq,
-                    step_aggregates_sq.c.run_id == col(PipelineRunSchema.id),
-                )
-            for sq in metadata_subqueries.values():
-                stage1_query = stage1_query.outerjoin(
-                    sq, sq.c.run_id == col(PipelineRunSchema.id)
-                )
-
-            # PipelineRunFilter.tags joins tag_resource on every matching
-            # run, fanning rows out per tag. Resolve filters on a flat id
-            # query first and deduplicate so stage 1 keeps one row per run.
-            filtered_ids_subquery = (
-                filter_model.apply_filter(
-                    query=select(col(PipelineRunSchema.id)),
-                    table=PipelineRunSchema,
-                )
-                .distinct()
-                .subquery("filtered_run_ids")
-            )
-            stage1_query = stage1_query.where(
-                col(PipelineRunSchema.id).in_(
-                    select(filtered_ids_subquery.c.id)
-                )
-            )
-            run_stats = stage1_query.subquery("run_stats")
-
-            # ----- Stage 2: tag fan-out (if any), grouping, aggregation -----
-            tag_subquery = (
-                self._tag_subquery() if tag_grouping_present else None
-            )
-
-            group_columns: List[ColumnElement[Any]] = []
-            group_column_labels: List[str] = []
-            for index, grouping in enumerate(request.groupings):
-                label = f"__group_{index}"
-                if isinstance(grouping, TimeGrouping):
-                    expr = self._time_bucket_expr(
-                        run_stats.c["__start_time"], grouping.granularity
-                    )
-                elif isinstance(grouping, MetadataGrouping):
-                    expr = run_stats.c[
-                        self._metadata_group_label(grouping.metadata_key)
-                    ]
-                elif grouping.type == StatisticsGroupingType.TAG:
-                    assert tag_subquery is not None
-                    expr = tag_subquery.c.name
-                else:
-                    expr = run_stats.c[
-                        self._SIMPLE_GROUPING_COLUMNS[grouping.type]
-                    ]
-                group_columns.append(expr.label(label))
-                group_column_labels.append(label)
-
-            metric_columns: List[ColumnElement[Any]] = []
-            metric_column_labels: List[str] = []
-            for index, metric in enumerate(request.metrics):
-                label = f"__metric_{index}"
-                if isinstance(metric, MetadataMetric):
-                    value = run_stats.c[
-                        self._metadata_metric_label(metric.metadata_key)
-                    ]
-                else:
-                    value = run_stats.c[
-                        self._SIMPLE_METRIC_COLUMNS[metric.source]
-                    ]
-                metric_columns.append(
-                    self._AGGREGATE_FUNCTIONS[metric.aggregation](value).label(
-                        label
-                    )
-                )
-                metric_column_labels.append(label)
-
-            run_count_col = func.count(
-                distinct(run_stats.c["__run_id"])
-            ).label("__run_count")
-            select_columns: List[ColumnElement[Any]] = [
-                *group_columns,
-                run_count_col,
-                *metric_columns,
-            ]
-
-            query = select(*select_columns).select_from(run_stats)
-            if tag_subquery is not None:
-                query = query.outerjoin(
-                    tag_subquery,
-                    tag_subquery.c.run_id == run_stats.c["__run_id"],
-                )
-            if group_columns:
-                query = query.group_by(*group_columns)
-
-            # Order: time bucket asc if present, else run_count desc; ties
-            # broken by remaining group columns ascending for determinism.
-            time_group_index = next(
-                (
-                    i
-                    for i, g in enumerate(request.groupings)
-                    if isinstance(g, TimeGrouping)
-                ),
-                None,
-            )
-            primary_order: Any = (
-                group_columns[time_group_index].asc()
-                if time_group_index is not None
-                else desc("__run_count")
-            )
-            tiebreakers = [
-                c.asc()
-                for i, c in enumerate(group_columns)
-                if i != time_group_index
-            ]
-            query = query.order_by(primary_order, *tiebreakers)
-            query = query.limit(request.max_groups + 1)
-
-            rows = session.execute(query).all()
-
-        truncated = len(rows) > request.max_groups
-        if truncated:
-            rows = rows[: request.max_groups]
-
-        groups: List[RunStatisticsGroup] = []
-        for row in rows:
-            row_mapping = row._mapping
-            group_keys: Dict[str, Optional[Union[str, int, float, bool]]] = {
-                grouping.name: self._format_group_value(
-                    grouping, row_mapping[label]
-                )
-                for grouping, label in zip(
-                    request.groupings, group_column_labels
-                )
-            }
-            metrics_out: Dict[str, Optional[float]] = {}
-            for metric, label in zip(request.metrics, metric_column_labels):
-                raw = row_mapping[label]
-                metrics_out[metric.name] = (
-                    float(raw) if raw is not None else None
-                )
-
-            groups.append(
-                RunStatisticsGroup(
-                    group_keys=group_keys,
-                    metrics=metrics_out,
-                    run_count=int(row_mapping["__run_count"] or 0),
-                )
-            )
-
-        return RunStatisticsResponse(groups=groups, truncated=truncated)
-
-    @classmethod
-    def _format_group_value(
-        cls,
-        grouping: Union[SimpleGrouping, TimeGrouping, MetadataGrouping],
-        raw_value: Any,
-    ) -> Optional[Union[str, int, float, bool]]:
-        """Convert a raw SQL group value into the response-shaped value.
-
-        Args:
-            grouping: Grouping the value came from.
-            raw_value: Raw DB value.
-
-        Returns:
-            JSON-shaped value.
-        """
-        if raw_value is None:
-            return None
-
-        if isinstance(grouping, MetadataGrouping):
-            try:
-                decoded = json.loads(raw_value)
-            except (json.JSONDecodeError, TypeError):
-                return str(raw_value)
-            if isinstance(decoded, (str, int, float, bool)):
-                return decoded
-            if decoded is None:
-                return None
-            return str(raw_value)
-
-        if isinstance(grouping, TimeGrouping):
-            return cast(str, raw_value)
-
-        if grouping.type in cls._UUID_GROUPING_TYPES:
-            return str(raw_value)
-
-        # STATUS and TAG yield strings already.
-        return cast(str, raw_value)
 
     def disable_run_heartbeat(self, run_id: UUID) -> None:
         """Disables heartbeat for pipeline and all its running steps.

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -58,6 +58,7 @@ from typing import (
     ContextManager,
     Dict,
     ForwardRef,
+    FrozenSet,
     List,
     Literal,
     NoReturn,
@@ -82,7 +83,17 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from sqlalchemy import QueuePool, event, func, update
+from sqlalchemy import (
+    Float,
+    QueuePool,
+    case,
+    distinct,
+    event,
+    func,
+    text,
+    update,
+)
+from sqlalchemy import cast as sql_cast
 from sqlalchemy.engine import URL, Engine, make_url
 from sqlalchemy.exc import (
     ArgumentError,
@@ -90,11 +101,13 @@ from sqlalchemy.exc import (
 )
 from sqlalchemy.orm import (
     Mapped,
+    aliased,
     load_only,
     noload,
     selectinload,
 )
 from sqlalchemy.sql.base import ExecutableOption
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.util import immutabledict
 from sqlmodel import Session as SqlModelSession
 
@@ -239,6 +252,8 @@ from zenml.models import (
     LogsRequest,
     LogsResponse,
     LogsUpdate,
+    MetadataGrouping,
+    MetadataMetric,
     ModelFilter,
     ModelRequest,
     ModelResponse,
@@ -297,6 +312,9 @@ from zenml.models import (
     ResourceRequestResponse,
     RunMetadataRequest,
     RunMetadataResource,
+    RunStatisticsGroup,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
     RunTemplateFilter,
     RunTemplateRequest,
     RunTemplateResponse,
@@ -336,12 +354,17 @@ from zenml.models import (
     ServiceRequest,
     ServiceResponse,
     ServiceUpdate,
+    SimpleGrouping,
     StackDeploymentConfig,
     StackDeploymentInfo,
     StackFilter,
     StackRequest,
     StackResponse,
     StackUpdate,
+    StatisticsAggregation,
+    StatisticsGroupingType,
+    StatisticsMetricSource,
+    StatisticsTimeGranularity,
     StepRunFilter,
     StepRunRequest,
     StepRunResponse,
@@ -353,6 +376,7 @@ from zenml.models import (
     TagResourceResponse,
     TagResponse,
     TagUpdate,
+    TimeGrouping,
     TriggerDispatchStatusCode,
     TriggerFilter,
     TriggerRequest,
@@ -7346,6 +7370,622 @@ class SqlZenStore(BaseZenStore):
         return self._count_entity(
             schema=PipelineRunSchema, filter_model=filter_model
         )
+
+    # -------------------- Run statistics --------------------
+
+    _SIMPLE_GROUPING_COLUMNS: ClassVar[Dict[StatisticsGroupingType, str]] = {
+        StatisticsGroupingType.STATUS: "__status",
+        StatisticsGroupingType.PIPELINE: "__pipeline_id",
+        StatisticsGroupingType.SNAPSHOT: "__snapshot_id",
+        StatisticsGroupingType.SOURCE_SNAPSHOT: "__source_snapshot_id",
+        StatisticsGroupingType.STACK: "__stack_id",
+        StatisticsGroupingType.USER: "__user_id",
+        StatisticsGroupingType.TRIGGER: "__trigger_id",
+    }
+
+    _SIMPLE_METRIC_COLUMNS: ClassVar[Dict[StatisticsMetricSource, str]] = {
+        StatisticsMetricSource.DURATION: "__duration_seconds",
+        StatisticsMetricSource.STEP_COUNT: "__step_count",
+        StatisticsMetricSource.CACHED_STEP_COUNT: "__cached_step_count",
+        StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT: "__output_artifact_count",
+    }
+
+    _UUID_GROUPING_TYPES: ClassVar[FrozenSet[StatisticsGroupingType]] = (
+        frozenset(
+            {
+                StatisticsGroupingType.PIPELINE,
+                StatisticsGroupingType.SNAPSHOT,
+                StatisticsGroupingType.SOURCE_SNAPSHOT,
+                StatisticsGroupingType.STACK,
+                StatisticsGroupingType.TRIGGER,
+                StatisticsGroupingType.USER,
+            }
+        )
+    )
+
+    _AGGREGATE_FUNCTIONS: ClassVar[Dict[StatisticsAggregation, Any]] = {
+        StatisticsAggregation.AVG: func.avg,
+        StatisticsAggregation.SUM: func.sum,
+        StatisticsAggregation.MIN: func.min,
+        StatisticsAggregation.MAX: func.max,
+    }
+
+    def _run_duration_seconds_expr(self) -> ColumnElement[float]:
+        """Dialect-appropriate ``end_time - start_time`` in seconds.
+
+        Returns:
+            Column expression.
+        """
+        start = col(PipelineRunSchema.start_time)
+        end = col(PipelineRunSchema.end_time)
+        if self.config.driver == SQLDatabaseDriver.MYSQL:
+            return func.timestampdiff(text("SECOND"), start, end)
+        return (func.julianday(end) - func.julianday(start)) * 86400.0
+
+    def _time_bucket_expr(
+        self,
+        column: Any,
+        granularity: StatisticsTimeGranularity,
+    ) -> ColumnElement[str]:
+        """Sortable ISO-ish bucket label for a datetime column.
+
+        WEEK buckets use the Monday of the week as a `YYYY-MM-DD` date,
+        matching the DAY and MONTH conventions and avoiding ISO-week vs
+        calendar-week mismatches between dialects.
+
+        Args:
+            column: Datetime column.
+            granularity: Bucket size.
+
+        Returns:
+            Column expression.
+        """
+        if self.config.driver == SQLDatabaseDriver.MYSQL:
+            if granularity == StatisticsTimeGranularity.WEEK:
+                return func.date_format(
+                    func.subdate(column, func.weekday(column)),
+                    "%Y-%m-%d",
+                )
+            mysql_formats = {
+                StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
+                StatisticsTimeGranularity.DAY: "%Y-%m-%d",
+                StatisticsTimeGranularity.MONTH: "%Y-%m-01",
+            }
+            return func.date_format(column, mysql_formats[granularity])
+
+        if granularity == StatisticsTimeGranularity.WEEK:
+            return func.date(column, "-6 days", "weekday 1")
+
+        sqlite_formats = {
+            StatisticsTimeGranularity.HOUR: "%Y-%m-%d %H:00:00",
+            StatisticsTimeGranularity.DAY: "%Y-%m-%d",
+            StatisticsTimeGranularity.MONTH: "%Y-%m-01",
+        }
+        return func.strftime(sqlite_formats[granularity], column)
+
+    @staticmethod
+    def _metadata_group_label(key: str) -> str:
+        """Stage-1 column label for the raw metadata value (grouping use).
+
+        Args:
+            key: Metadata key.
+
+        Returns:
+            Column label.
+        """
+        return f"__md_group__{key}"
+
+    @staticmethod
+    def _metadata_metric_label(key: str) -> str:
+        """Stage-1 column label for the numeric metadata value (metric use).
+
+        Args:
+            key: Metadata key.
+
+        Returns:
+            Column label.
+        """
+        return f"__md_metric__{key}"
+
+    def _latest_metadata_per_run_subquery(self, key: str) -> Any:
+        """Latest metadata row per pipeline run for a key.
+
+        Mirrors `RunMetadataInterface.fetch_metadata` (non-dict path):
+        last entry by `created` wins. Statistics aggregations then see
+        one value per (run, key), matching what every other API surface
+        returns for the same run.
+
+        Args:
+            key: Metadata key.
+
+        Returns:
+            Subquery with `run_id`, `value`, `type` columns.
+        """
+        rm = aliased(RunMetadataSchema)
+        rmr = aliased(RunMetadataResourceSchema)
+        ranked = (
+            select(
+                col(rmr.resource_id).label("run_id"),
+                col(rm.value).label("value"),
+                col(rm.type).label("type"),
+                func.row_number()
+                .over(
+                    partition_by=col(rmr.resource_id),
+                    order_by=col(rm.created).desc(),
+                )
+                .label("rn"),
+            )
+            .select_from(rm)
+            .join(rmr, col(rmr.run_metadata_id) == col(rm.id))
+            .where(
+                col(rmr.resource_type)
+                == MetadataResourceTypes.PIPELINE_RUN.value,
+                col(rm.key) == key,
+            )
+            .subquery()
+        )
+        return (
+            select(
+                ranked.c.run_id,
+                ranked.c.value,
+                ranked.c.type,
+            )
+            .where(ranked.c.rn == 1)
+            .subquery()
+        )
+
+    @staticmethod
+    def _metadata_numeric_expr(latest_sq: Any) -> ColumnElement[Any]:
+        """Numeric-only projection of a latest-per-run metadata subquery.
+
+        Non-numeric types are projected to NULL so outer aggregates skip them.
+
+        Args:
+            latest_sq: Subquery returned by `_latest_metadata_per_run_subquery`.
+
+        Returns:
+            Column expression.
+        """
+        from zenml.metadata.metadata_types import MetadataTypeEnum
+
+        return case(
+            (
+                latest_sq.c.type.in_(
+                    (
+                        MetadataTypeEnum.INT.value,
+                        MetadataTypeEnum.FLOAT.value,
+                    )
+                ),
+                sql_cast(latest_sq.c.value, Float),
+            ),
+            else_=None,
+        )
+
+    def _tag_subquery(self) -> Any:
+        """Pipeline-run-tag association subquery (run_id, name)."""
+        tr = aliased(TagResourceSchema)
+        ts = aliased(TagSchema)
+        return (
+            select(
+                col(tr.resource_id).label("run_id"),
+                col(ts.name).label("name"),
+            )
+            .select_from(tr)
+            .join(ts, col(ts.id) == col(tr.tag_id))
+            .where(
+                col(tr.resource_type)
+                == TaggableResourceTypes.PIPELINE_RUN.value,
+            )
+            .subquery()
+        )
+
+    def _build_step_aggregates_subquery(
+        self,
+        *,
+        need_step_count: bool,
+        need_cached_step_count: bool,
+        need_output_artifact_count: bool,
+    ) -> Optional[Any]:
+        """One-pass step-run aggregates with conditional counts.
+
+        Args:
+            need_step_count: Project distinct step name count.
+            need_cached_step_count: Project distinct cached step name count.
+            need_output_artifact_count: Project distinct output artifact count.
+
+        Returns:
+            Subquery with `run_id` and the requested aggregate columns, or
+            `None` if no step-derived metric was requested.
+        """
+        if not (
+            need_step_count
+            or need_cached_step_count
+            or need_output_artifact_count
+        ):
+            return None
+
+        select_cols: List[ColumnElement[Any]] = [
+            col(StepRunSchema.pipeline_run_id).label("run_id"),
+        ]
+        if need_step_count:
+            select_cols.append(
+                func.count(distinct(col(StepRunSchema.name))).label(
+                    "step_count"
+                )
+            )
+        if need_cached_step_count:
+            select_cols.append(
+                func.count(
+                    distinct(
+                        case(
+                            (
+                                col(StepRunSchema.status)
+                                == ExecutionStatus.CACHED.value,
+                                col(StepRunSchema.name),
+                            ),
+                            else_=None,
+                        )
+                    )
+                ).label("cached_step_count")
+            )
+        if need_output_artifact_count:
+            select_cols.append(
+                func.count(
+                    distinct(col(StepRunOutputArtifactSchema.artifact_id))
+                ).label("output_artifact_count")
+            )
+        query = select(*select_cols).select_from(StepRunSchema)
+        if need_output_artifact_count:
+            query = query.outerjoin(
+                StepRunOutputArtifactSchema,
+                col(StepRunOutputArtifactSchema.step_id)
+                == col(StepRunSchema.id),
+            )
+        return query.group_by(col(StepRunSchema.pipeline_run_id)).subquery()
+
+    def get_run_statistics(
+        self, request: RunStatisticsRequest
+    ) -> RunStatisticsResponse:
+        """Compute grouped statistics over pipeline runs.
+
+        Stage 1 produces one row per matching pipeline run with every per-run
+        scalar resolved (status, IDs, duration, step counts, latest metadata
+        value, trigger). Stage 2 optionally LEFT JOINs the tag fan-out source
+        and aggregates over the stage-1 rowset, so a run with N tags
+        contributes once to each tag bucket without inflating AVG/SUM with
+        duplicated rows.
+
+        Args:
+            request: Statistics request.
+
+        Returns:
+            Grouped statistics.
+        """
+        filter_model = request.filter
+
+        with Session(self.engine) as session:
+            self._set_filter_project_id(
+                filter_model=filter_model,
+                session=session,
+            )
+
+            # ----- Classify the request -----
+            grouping_types = {g.type for g in request.groupings}
+            needs_snapshot_join = bool(
+                grouping_types
+                & {
+                    StatisticsGroupingType.SOURCE_SNAPSHOT,
+                    StatisticsGroupingType.STACK,
+                }
+            )
+            needs_trigger_join = (
+                StatisticsGroupingType.TRIGGER in grouping_types
+            )
+            tag_grouping_present = StatisticsGroupingType.TAG in grouping_types
+
+            metric_sources = {m.source for m in request.metrics}
+            need_step_count = (
+                StatisticsMetricSource.STEP_COUNT in metric_sources
+            )
+            need_cached_step_count = (
+                StatisticsMetricSource.CACHED_STEP_COUNT in metric_sources
+            )
+            need_output_artifact_count = (
+                StatisticsMetricSource.OUTPUT_ARTIFACT_COUNT in metric_sources
+            )
+
+            # Metadata keys per use. One subquery per unique key is shared
+            # between grouping and metric projections.
+            metadata_grouping_keys: List[str] = []
+            for grouping in request.groupings:
+                if (
+                    isinstance(grouping, MetadataGrouping)
+                    and grouping.metadata_key not in metadata_grouping_keys
+                ):
+                    metadata_grouping_keys.append(grouping.metadata_key)
+
+            metadata_metric_keys: List[str] = []
+            for metric in request.metrics:
+                if (
+                    isinstance(metric, MetadataMetric)
+                    and metric.metadata_key not in metadata_metric_keys
+                ):
+                    metadata_metric_keys.append(metric.metadata_key)
+
+            metadata_subqueries: Dict[str, Any] = {
+                key: self._latest_metadata_per_run_subquery(key)
+                for key in dict.fromkeys(
+                    [*metadata_grouping_keys, *metadata_metric_keys]
+                )
+            }
+
+            step_aggregates_sq = self._build_step_aggregates_subquery(
+                need_step_count=need_step_count,
+                need_cached_step_count=need_cached_step_count,
+                need_output_artifact_count=need_output_artifact_count,
+            )
+
+            # ----- Stage 1: one row per pipeline run -----
+            stage1_columns: List[ColumnElement[Any]] = [
+                col(PipelineRunSchema.id).label("__run_id"),
+                col(PipelineRunSchema.status).label("__status"),
+                col(PipelineRunSchema.pipeline_id).label("__pipeline_id"),
+                col(PipelineRunSchema.snapshot_id).label("__snapshot_id"),
+                col(PipelineRunSchema.user_id).label("__user_id"),
+                col(PipelineRunSchema.start_time).label("__start_time"),
+                self._run_duration_seconds_expr().label("__duration_seconds"),
+            ]
+            if needs_snapshot_join:
+                stage1_columns.append(
+                    col(PipelineSnapshotSchema.source_snapshot_id).label(
+                        "__source_snapshot_id"
+                    )
+                )
+                stage1_columns.append(
+                    col(PipelineSnapshotSchema.stack_id).label("__stack_id")
+                )
+            if needs_trigger_join:
+                # The (trigger_id, pipeline_run_id) PK on `trigger_execution`
+                # means at most one row per run, so this join does not fan
+                # out the rowset.
+                stage1_columns.append(
+                    col(TriggerExecutionSchema.trigger_id).label(
+                        "__trigger_id"
+                    )
+                )
+            if step_aggregates_sq is not None:
+                if need_step_count:
+                    stage1_columns.append(
+                        func.coalesce(
+                            step_aggregates_sq.c.step_count, 0
+                        ).label("__step_count")
+                    )
+                if need_cached_step_count:
+                    stage1_columns.append(
+                        func.coalesce(
+                            step_aggregates_sq.c.cached_step_count, 0
+                        ).label("__cached_step_count")
+                    )
+                if need_output_artifact_count:
+                    stage1_columns.append(
+                        func.coalesce(
+                            step_aggregates_sq.c.output_artifact_count, 0
+                        ).label("__output_artifact_count")
+                    )
+            for key in metadata_grouping_keys:
+                stage1_columns.append(
+                    metadata_subqueries[key].c.value.label(
+                        self._metadata_group_label(key)
+                    )
+                )
+            for key in metadata_metric_keys:
+                stage1_columns.append(
+                    self._metadata_numeric_expr(
+                        metadata_subqueries[key]
+                    ).label(self._metadata_metric_label(key))
+                )
+
+            stage1_query = select(*stage1_columns).select_from(
+                PipelineRunSchema
+            )
+            if needs_snapshot_join:
+                stage1_query = stage1_query.outerjoin(
+                    PipelineSnapshotSchema,
+                    col(PipelineSnapshotSchema.id)
+                    == col(PipelineRunSchema.snapshot_id),
+                )
+            if needs_trigger_join:
+                stage1_query = stage1_query.outerjoin(
+                    TriggerExecutionSchema,
+                    col(TriggerExecutionSchema.pipeline_run_id)
+                    == col(PipelineRunSchema.id),
+                )
+            if step_aggregates_sq is not None:
+                stage1_query = stage1_query.outerjoin(
+                    step_aggregates_sq,
+                    step_aggregates_sq.c.run_id == col(PipelineRunSchema.id),
+                )
+            for sq in metadata_subqueries.values():
+                stage1_query = stage1_query.outerjoin(
+                    sq, sq.c.run_id == col(PipelineRunSchema.id)
+                )
+
+            # PipelineRunFilter.tags joins tag_resource on every matching
+            # run, fanning rows out per tag. Resolve filters on a flat id
+            # query first and deduplicate so stage 1 keeps one row per run.
+            filtered_ids_subquery = (
+                filter_model.apply_filter(
+                    query=select(col(PipelineRunSchema.id)),
+                    table=PipelineRunSchema,
+                )
+                .distinct()
+                .subquery("filtered_run_ids")
+            )
+            stage1_query = stage1_query.where(
+                col(PipelineRunSchema.id).in_(
+                    select(filtered_ids_subquery.c.id)
+                )
+            )
+            run_stats = stage1_query.subquery("run_stats")
+
+            # ----- Stage 2: tag fan-out (if any), grouping, aggregation -----
+            tag_subquery = (
+                self._tag_subquery() if tag_grouping_present else None
+            )
+
+            group_columns: List[ColumnElement[Any]] = []
+            group_column_labels: List[str] = []
+            for index, grouping in enumerate(request.groupings):
+                label = f"__group_{index}"
+                if isinstance(grouping, TimeGrouping):
+                    expr = self._time_bucket_expr(
+                        run_stats.c["__start_time"], grouping.granularity
+                    )
+                elif isinstance(grouping, MetadataGrouping):
+                    expr = run_stats.c[
+                        self._metadata_group_label(grouping.metadata_key)
+                    ]
+                elif grouping.type == StatisticsGroupingType.TAG:
+                    assert tag_subquery is not None
+                    expr = tag_subquery.c.name
+                else:
+                    expr = run_stats.c[
+                        self._SIMPLE_GROUPING_COLUMNS[grouping.type]
+                    ]
+                group_columns.append(expr.label(label))
+                group_column_labels.append(label)
+
+            metric_columns: List[ColumnElement[Any]] = []
+            metric_column_labels: List[str] = []
+            for index, metric in enumerate(request.metrics):
+                label = f"__metric_{index}"
+                if isinstance(metric, MetadataMetric):
+                    value = run_stats.c[
+                        self._metadata_metric_label(metric.metadata_key)
+                    ]
+                else:
+                    value = run_stats.c[
+                        self._SIMPLE_METRIC_COLUMNS[metric.source]
+                    ]
+                metric_columns.append(
+                    self._AGGREGATE_FUNCTIONS[metric.aggregation](value).label(
+                        label
+                    )
+                )
+                metric_column_labels.append(label)
+
+            run_count_col = func.count(
+                distinct(run_stats.c["__run_id"])
+            ).label("__run_count")
+            select_columns: List[ColumnElement[Any]] = [
+                *group_columns,
+                run_count_col,
+                *metric_columns,
+            ]
+
+            query = select(*select_columns).select_from(run_stats)
+            if tag_subquery is not None:
+                query = query.outerjoin(
+                    tag_subquery,
+                    tag_subquery.c.run_id == run_stats.c["__run_id"],
+                )
+            if group_columns:
+                query = query.group_by(*group_columns)
+
+            # Order: time bucket asc if present, else run_count desc; ties
+            # broken by remaining group columns ascending for determinism.
+            time_group_index = next(
+                (
+                    i
+                    for i, g in enumerate(request.groupings)
+                    if isinstance(g, TimeGrouping)
+                ),
+                None,
+            )
+            primary_order: Any = (
+                group_columns[time_group_index].asc()
+                if time_group_index is not None
+                else desc("__run_count")
+            )
+            tiebreakers = [
+                c.asc()
+                for i, c in enumerate(group_columns)
+                if i != time_group_index
+            ]
+            query = query.order_by(primary_order, *tiebreakers)
+            query = query.limit(request.max_groups + 1)
+
+            rows = session.execute(query).all()
+
+        truncated = len(rows) > request.max_groups
+        if truncated:
+            rows = rows[: request.max_groups]
+
+        groups: List[RunStatisticsGroup] = []
+        for row in rows:
+            row_mapping = row._mapping
+            group_keys: Dict[str, Optional[Union[str, int, float, bool]]] = {
+                grouping.name: self._format_group_value(
+                    grouping, row_mapping[label]
+                )
+                for grouping, label in zip(
+                    request.groupings, group_column_labels
+                )
+            }
+            metrics_out: Dict[str, Optional[float]] = {}
+            for metric, label in zip(request.metrics, metric_column_labels):
+                raw = row_mapping[label]
+                metrics_out[metric.name] = (
+                    float(raw) if raw is not None else None
+                )
+
+            groups.append(
+                RunStatisticsGroup(
+                    group_keys=group_keys,
+                    metrics=metrics_out,
+                    run_count=int(row_mapping["__run_count"] or 0),
+                )
+            )
+
+        return RunStatisticsResponse(groups=groups, truncated=truncated)
+
+    @classmethod
+    def _format_group_value(
+        cls,
+        grouping: Union[SimpleGrouping, TimeGrouping, MetadataGrouping],
+        raw_value: Any,
+    ) -> Optional[Union[str, int, float, bool]]:
+        """Convert a raw SQL group value into the response-shaped value.
+
+        Args:
+            grouping: Grouping the value came from.
+            raw_value: Raw DB value.
+
+        Returns:
+            JSON-shaped value.
+        """
+        if raw_value is None:
+            return None
+
+        if isinstance(grouping, MetadataGrouping):
+            try:
+                decoded = json.loads(raw_value)
+            except (json.JSONDecodeError, TypeError):
+                return str(raw_value)
+            if isinstance(decoded, (str, int, float, bool)):
+                return decoded
+            if decoded is None:
+                return None
+            return str(raw_value)
+
+        if isinstance(grouping, TimeGrouping):
+            return cast(str, raw_value)
+
+        if grouping.type in cls._UUID_GROUPING_TYPES:
+            return str(raw_value)
+
+        # STATUS and TAG yield strings already.
+        return cast(str, raw_value)
 
     def disable_run_heartbeat(self, run_id: UUID) -> None:
         """Disables heartbeat for pipeline and all its running steps.

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -102,6 +102,8 @@ from zenml.models import (
     ProjectResponse,
     ProjectUpdate,
     RunMetadataRequest,
+    RunStatisticsRequest,
+    RunStatisticsResponse,
     RunTemplateFilter,
     RunTemplateRequest,
     RunTemplateResponse,
@@ -1640,6 +1642,19 @@ class ZenStoreInterface(ResourcePoolsStoreInterface, ABC):
 
         Returns:
             A list of all pipeline runs matching the filter criteria.
+        """
+
+    @abstractmethod
+    def get_run_statistics(
+        self, request: RunStatisticsRequest
+    ) -> RunStatisticsResponse:
+        """Compute grouped statistics over pipeline runs.
+
+        Args:
+            request: Statistics request.
+
+        Returns:
+            Grouped statistics.
         """
 
     @abstractmethod

--- a/tests/unit/zen_stores/test_run_statistics.py
+++ b/tests/unit/zen_stores/test_run_statistics.py
@@ -1,0 +1,1298 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the run statistics aggregation in SqlZenStore."""
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterator, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from zenml.enums import (
+    ExecutionStatus,
+    MetadataResourceTypes,
+    TaggableResourceTypes,
+)
+from zenml.metadata.metadata_types import MetadataTypeEnum
+from zenml.models import (
+    MetadataGrouping,
+    MetadataMetric,
+    PipelineRunFilter,
+    ProjectFilter,
+    RunStatisticsRequest,
+    SimpleGrouping,
+    SimpleMetric,
+    TimeGrouping,
+    UserFilter,
+)
+from zenml.zen_stores.schemas import (
+    ArtifactSchema,
+    ArtifactVersionSchema,
+    PipelineRunSchema,
+    PipelineSchema,
+    PipelineSnapshotSchema,
+    RunMetadataResourceSchema,
+    RunMetadataSchema,
+    StepRunOutputArtifactSchema,
+    StepRunSchema,
+    TagResourceSchema,
+    TagSchema,
+    TriggerSchema,
+)
+from zenml.zen_stores.schemas.trigger_assoc import TriggerExecutionSchema
+from zenml.zen_stores.sql_zen_store import (
+    Session,
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+
+@pytest.fixture
+def sql_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[SqlZenStore]:
+    """Create a fresh SQLite-backed SqlZenStore for tests."""
+    db_dir = tmp_path / "zenml-cfg"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ZENML_CONFIG_PATH", str(db_dir))
+    db_path = db_dir / "test.db"
+    config = SqlZenStoreConfiguration(url=f"sqlite:///{db_path}")
+    store = SqlZenStore(config=config, skip_default_registrations=False)
+    yield store
+
+
+def _project_id(store: SqlZenStore) -> UUID:
+    return (
+        store.list_projects(project_filter_model=ProjectFilter()).items[0].id
+    )
+
+
+def _default_user_id(store: SqlZenStore) -> UUID:
+    return store.list_users(user_filter_model=UserFilter()).items[0].id
+
+
+def _create_run(
+    sql_store: SqlZenStore,
+    *,
+    project_id: UUID,
+    name: str,
+    status: ExecutionStatus = ExecutionStatus.COMPLETED,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
+    pipeline_id: Optional[UUID] = None,
+    snapshot_id: Optional[UUID] = None,
+    user_id: Optional[UUID] = None,
+    index: int = 1,
+) -> UUID:
+    run = PipelineRunSchema(
+        id=uuid4(),
+        project_id=project_id,
+        name=name,
+        orchestrator_run_id=None,
+        start_time=start_time,
+        end_time=end_time,
+        status=status.value,
+        index=index,
+        in_progress=False,
+        enable_heartbeat=False,
+        pipeline_id=pipeline_id,
+        snapshot_id=snapshot_id,
+        user_id=user_id,
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(run)
+        session.commit()
+    return run.id
+
+
+def _create_run_metadata(
+    sql_store: SqlZenStore,
+    *,
+    project_id: UUID,
+    run_id: UUID,
+    key: str,
+    value: object,
+    type_: MetadataTypeEnum,
+) -> None:
+    rm = RunMetadataSchema(
+        project_id=project_id,
+        key=key,
+        value=json.dumps(value),
+        type=type_.value,
+    )
+    with Session(sql_store.engine) as session:
+        session.add(rm)
+        session.flush()
+        session.add(
+            RunMetadataResourceSchema(
+                resource_id=run_id,
+                resource_type=MetadataResourceTypes.PIPELINE_RUN.value,
+                run_metadata_id=rm.id,
+            )
+        )
+        session.commit()
+
+
+def _create_pipeline(sql_store: SqlZenStore, project_id: UUID) -> UUID:
+    pipeline = PipelineSchema(
+        id=uuid4(),
+        project_id=project_id,
+        name=f"pipeline-{uuid4().hex[:8]}",
+        run_count=0,
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(pipeline)
+        session.commit()
+    return pipeline.id
+
+
+def _create_snapshot(
+    sql_store: SqlZenStore,
+    project_id: UUID,
+    pipeline_id: UUID,
+    source_snapshot_id: Optional[UUID] = None,
+    stack_id: Optional[UUID] = None,
+) -> UUID:
+    snapshot = PipelineSnapshotSchema(
+        id=uuid4(),
+        project_id=project_id,
+        pipeline_id=pipeline_id,
+        pipeline_configuration="{}",
+        client_environment="{}",
+        run_name_template="t",
+        client_version="0.0.0",
+        server_version="0.0.0",
+        source_snapshot_id=source_snapshot_id,
+        stack_id=stack_id,
+        step_count=0,
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(snapshot)
+        session.commit()
+    return snapshot.id
+
+
+def _create_trigger(sql_store: SqlZenStore, project_id: UUID) -> UUID:
+    trigger = TriggerSchema(
+        id=uuid4(),
+        project_id=project_id,
+        name=f"trigger-{uuid4().hex[:8]}",
+        active=True,
+        is_archived=False,
+        type="webhook",
+        flavor="test",
+        configuration="{}",
+        concurrency="SKIP",
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(trigger)
+        session.commit()
+    return trigger.id
+
+
+def _create_tag(sql_store: SqlZenStore, project_id: UUID, name: str) -> UUID:
+    tag = TagSchema(
+        id=uuid4(),
+        name=name,
+        color="gray",
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(tag)
+        session.commit()
+    return tag.id
+
+
+def test_run_count_grouped_by_status(sql_store: SqlZenStore) -> None:
+    """Returns one row per status with the right run counts."""
+    project_id = _project_id(sql_store)
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r1",
+        status=ExecutionStatus.COMPLETED,
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r2",
+        status=ExecutionStatus.COMPLETED,
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r3",
+        status=ExecutionStatus.FAILED,
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="status", name="status")],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_status = {g.group_keys["status"]: g for g in response.groups}
+    assert by_status["completed"].run_count == 2
+    assert by_status["failed"].run_count == 1
+    # ordering: run_count descending
+    assert response.groups[0].run_count >= response.groups[-1].run_count
+
+
+def test_avg_duration_grouped_by_pipeline(sql_store: SqlZenStore) -> None:
+    """Aggregates run duration over the runs joined by pipeline_id."""
+    project_id = _project_id(sql_store)
+    pid_a = _create_pipeline(sql_store, project_id)
+    pid_b = _create_pipeline(sql_store, project_id)
+    base = datetime(2026, 1, 1, 12, 0, 0)
+
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="a1",
+        pipeline_id=pid_a,
+        start_time=base,
+        end_time=base + timedelta(seconds=10),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="a2",
+        pipeline_id=pid_a,
+        start_time=base,
+        end_time=base + timedelta(seconds=20),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="b1",
+        pipeline_id=pid_b,
+        start_time=base,
+        end_time=base + timedelta(seconds=30),
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="pipeline", name="pipeline")],
+        metrics=[
+            SimpleMetric(name="avg_dur", source="duration", aggregation="avg")
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_pipeline = {g.group_keys["pipeline"]: g for g in response.groups}
+    assert by_pipeline[str(pid_a)].run_count == 2
+    assert by_pipeline[str(pid_a)].metrics["avg_dur"] == pytest.approx(15.0)
+    assert by_pipeline[str(pid_b)].metrics["avg_dur"] == pytest.approx(30.0)
+
+
+def test_metadata_aggregation_filters_non_numeric(
+    sql_store: SqlZenStore,
+) -> None:
+    """Average over a metadata key ignores non-numeric stored values."""
+    project_id = _project_id(sql_store)
+    run_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+        for i in range(4)
+    ]
+
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[0],
+        key="accuracy",
+        value=0.5,
+        type_=MetadataTypeEnum.FLOAT,
+    )
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[1],
+        key="accuracy",
+        value=0.9,
+        type_=MetadataTypeEnum.FLOAT,
+    )
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[2],
+        key="accuracy",
+        value=2,
+        type_=MetadataTypeEnum.INT,
+    )
+    # Non-numeric entry must be ignored.
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[3],
+        key="accuracy",
+        value="not-a-number",
+        type_=MetadataTypeEnum.STRING,
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        metrics=[
+            MetadataMetric(
+                name="avg_acc",
+                source="metadata",
+                aggregation="avg",
+                metadata_key="accuracy",
+            )
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    assert response.groups[0].run_count == 4
+    # (0.5 + 0.9 + 2.0) / 3 == 1.13333...
+    assert response.groups[0].metrics["avg_acc"] == pytest.approx(
+        (0.5 + 0.9 + 2.0) / 3
+    )
+
+
+def test_metadata_grouping_decodes_json_values(
+    sql_store: SqlZenStore,
+) -> None:
+    """Grouping by metadata key produces decoded string keys plus null bucket."""
+    project_id = _project_id(sql_store)
+    run_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+        for i in range(3)
+    ]
+
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[0],
+        key="env",
+        value="prod",
+        type_=MetadataTypeEnum.STRING,
+    )
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=run_ids[1],
+        key="env",
+        value="prod",
+        type_=MetadataTypeEnum.STRING,
+    )
+    # run_ids[2] has no `env` metadata -> null bucket
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            MetadataGrouping(type="metadata", name="env", metadata_key="env")
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_env = {g.group_keys["env"]: g.run_count for g in response.groups}
+    assert by_env["prod"] == 2
+    assert by_env[None] == 1
+
+
+def test_metadata_grouping_does_not_double_count_other_keys(
+    sql_store: SqlZenStore,
+) -> None:
+    """Other metadata keys on the same run must not inflate the null bucket.
+
+    Regression test: a run that has both an ``env`` entry and an ``accuracy``
+    entry must end up only in its real ``env`` bucket, not in both the real
+    bucket and the null bucket.
+    """
+    project_id = _project_id(sql_store)
+    run_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+        for i in range(3)
+    ]
+
+    # Each "with-env" run also carries an unrelated `accuracy` entry.
+    for run_id, env in ((run_ids[0], "prod"), (run_ids[1], "staging")):
+        _create_run_metadata(
+            sql_store,
+            project_id=project_id,
+            run_id=run_id,
+            key="env",
+            value=env,
+            type_=MetadataTypeEnum.STRING,
+        )
+        _create_run_metadata(
+            sql_store,
+            project_id=project_id,
+            run_id=run_id,
+            key="accuracy",
+            value=0.5,
+            type_=MetadataTypeEnum.FLOAT,
+        )
+    # run_ids[2] has no metadata at all -> belongs in the null bucket
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            MetadataGrouping(type="metadata", name="env", metadata_key="env")
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_env = {g.group_keys["env"]: g.run_count for g in response.groups}
+    # The two with-env runs must NOT also appear in the null bucket.
+    assert by_env == {"prod": 1, "staging": 1, None: 1}
+    # And the totals must match the actual number of runs in the project.
+    assert sum(g.run_count for g in response.groups) == 3
+
+
+def test_step_count_collapses_retries(sql_store: SqlZenStore) -> None:
+    """COUNT(DISTINCT step_run.name) collapses retries into one step."""
+    project_id = _project_id(sql_store)
+    run_id = _create_run(sql_store, project_id=project_id, name="r-retry")
+
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    with Session(sql_store.engine) as session:
+        # Same step name, two versions = retry attempt
+        session.add(
+            StepRunSchema(
+                id=uuid4(),
+                project_id=project_id,
+                pipeline_run_id=run_id,
+                name="train",
+                version=1,
+                status=ExecutionStatus.FAILED.value,
+                is_retriable=True,
+                start_time=now,
+                end_time=now,
+            )
+        )
+        session.add(
+            StepRunSchema(
+                id=uuid4(),
+                project_id=project_id,
+                pipeline_run_id=run_id,
+                name="train",
+                version=2,
+                status=ExecutionStatus.COMPLETED.value,
+                is_retriable=False,
+                start_time=now,
+                end_time=now,
+            )
+        )
+        session.add(
+            StepRunSchema(
+                id=uuid4(),
+                project_id=project_id,
+                pipeline_run_id=run_id,
+                name="eval",
+                version=1,
+                status=ExecutionStatus.COMPLETED.value,
+                is_retriable=False,
+                start_time=now,
+                end_time=now,
+            )
+        )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        metrics=[
+            SimpleMetric(
+                name="avg_steps", source="step_count", aggregation="avg"
+            )
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    assert response.groups[0].metrics["avg_steps"] == pytest.approx(2.0)
+
+
+def test_cached_step_count(sql_store: SqlZenStore) -> None:
+    """Counts step runs with status='cached', zero for runs with no hits."""
+    project_id = _project_id(sql_store)
+    run_a_id = _create_run(sql_store, project_id=project_id, name="r-cache-a")
+    run_b_id = _create_run(sql_store, project_id=project_id, name="r-cache-b")
+
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    with Session(sql_store.engine) as session:
+        # Run A: 2 cached steps + 1 completed step.
+        session.add_all(
+            [
+                StepRunSchema(
+                    id=uuid4(),
+                    project_id=project_id,
+                    pipeline_run_id=run_a_id,
+                    name="load",
+                    version=1,
+                    status=ExecutionStatus.CACHED.value,
+                    is_retriable=False,
+                    start_time=now,
+                    end_time=now,
+                ),
+                StepRunSchema(
+                    id=uuid4(),
+                    project_id=project_id,
+                    pipeline_run_id=run_a_id,
+                    name="featurize",
+                    version=1,
+                    status=ExecutionStatus.CACHED.value,
+                    is_retriable=False,
+                    start_time=now,
+                    end_time=now,
+                ),
+                StepRunSchema(
+                    id=uuid4(),
+                    project_id=project_id,
+                    pipeline_run_id=run_a_id,
+                    name="train",
+                    version=1,
+                    status=ExecutionStatus.COMPLETED.value,
+                    is_retriable=False,
+                    start_time=now,
+                    end_time=now,
+                ),
+            ]
+        )
+        # Run B: no cached steps.
+        session.add(
+            StepRunSchema(
+                id=uuid4(),
+                project_id=project_id,
+                pipeline_run_id=run_b_id,
+                name="train",
+                version=1,
+                status=ExecutionStatus.COMPLETED.value,
+                is_retriable=False,
+                start_time=now,
+                end_time=now,
+            )
+        )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        metrics=[
+            SimpleMetric(
+                name="total_cached",
+                source="cached_step_count",
+                aggregation="sum",
+            ),
+            SimpleMetric(
+                name="max_cached",
+                source="cached_step_count",
+                aggregation="max",
+            ),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    assert response.groups[0].metrics["total_cached"] == pytest.approx(2.0)
+    assert response.groups[0].metrics["max_cached"] == pytest.approx(2.0)
+
+
+def test_output_artifact_count_dedups_shared_versions(
+    sql_store: SqlZenStore,
+) -> None:
+    """COUNT(DISTINCT artifact_id) counts each version once per run."""
+    project_id = _project_id(sql_store)
+    run_a_id = _create_run(sql_store, project_id=project_id, name="r-a")
+    run_b_id = _create_run(sql_store, project_id=project_id, name="r-b")
+
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    with Session(sql_store.engine) as session:
+        artifact = ArtifactSchema(
+            id=uuid4(),
+            project_id=project_id,
+            name=f"art-{uuid4().hex[:8]}",
+            has_custom_name=False,
+        )
+        session.add(artifact)
+        session.flush()
+
+        # Run A: two step runs that both reference the same artifact version
+        # plus a second step run with its own artifact version. Distinct count
+        # should collapse the shared one to 1 + 1 = 2.
+        shared_version = ArtifactVersionSchema(
+            id=uuid4(),
+            project_id=project_id,
+            artifact_id=artifact.id,
+            version="1",
+            type="DataArtifact",
+            uri="s3://x/1",
+            materializer="m",
+            data_type="d",
+            save_type="step_output",
+        )
+        unique_version = ArtifactVersionSchema(
+            id=uuid4(),
+            project_id=project_id,
+            artifact_id=artifact.id,
+            version="2",
+            type="DataArtifact",
+            uri="s3://x/2",
+            materializer="m",
+            data_type="d",
+            save_type="step_output",
+        )
+        run_b_version = ArtifactVersionSchema(
+            id=uuid4(),
+            project_id=project_id,
+            artifact_id=artifact.id,
+            version="3",
+            type="DataArtifact",
+            uri="s3://x/3",
+            materializer="m",
+            data_type="d",
+            save_type="step_output",
+        )
+        session.add_all([shared_version, unique_version, run_b_version])
+        session.flush()
+
+        step_a1 = StepRunSchema(
+            id=uuid4(),
+            project_id=project_id,
+            pipeline_run_id=run_a_id,
+            name="train",
+            version=1,
+            status=ExecutionStatus.COMPLETED.value,
+            is_retriable=False,
+            start_time=now,
+            end_time=now,
+        )
+        step_a2 = StepRunSchema(
+            id=uuid4(),
+            project_id=project_id,
+            pipeline_run_id=run_a_id,
+            name="eval",
+            version=1,
+            status=ExecutionStatus.COMPLETED.value,
+            is_retriable=False,
+            start_time=now,
+            end_time=now,
+        )
+        step_b1 = StepRunSchema(
+            id=uuid4(),
+            project_id=project_id,
+            pipeline_run_id=run_b_id,
+            name="train",
+            version=1,
+            status=ExecutionStatus.COMPLETED.value,
+            is_retriable=False,
+            start_time=now,
+            end_time=now,
+        )
+        session.add_all([step_a1, step_a2, step_b1])
+        session.flush()
+
+        session.add_all(
+            [
+                StepRunOutputArtifactSchema(
+                    step_id=step_a1.id,
+                    artifact_id=shared_version.id,
+                    name="out",
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=step_a2.id,
+                    artifact_id=shared_version.id,
+                    name="out",
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=step_a2.id,
+                    artifact_id=unique_version.id,
+                    name="extra",
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=step_b1.id,
+                    artifact_id=run_b_version.id,
+                    name="out",
+                ),
+            ]
+        )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        metrics=[
+            SimpleMetric(
+                name="total_outputs",
+                source="output_artifact_count",
+                aggregation="sum",
+            ),
+            SimpleMetric(
+                name="avg_outputs",
+                source="output_artifact_count",
+                aggregation="avg",
+            ),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    # Run A contributes 2 (shared version dedup'd) + Run B contributes 1 = 3.
+    assert response.groups[0].metrics["total_outputs"] == pytest.approx(3.0)
+    assert response.groups[0].metrics["avg_outputs"] == pytest.approx(1.5)
+
+
+def test_multi_dimensional_grouping(sql_store: SqlZenStore) -> None:
+    """Status x time bucket produces one row per combination."""
+    project_id = _project_id(sql_store)
+    day_one = datetime(2026, 1, 1, 12, 0, 0)
+    day_two = datetime(2026, 1, 2, 12, 0, 0)
+
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="d1-c",
+        status=ExecutionStatus.COMPLETED,
+        start_time=day_one,
+        end_time=day_one + timedelta(seconds=1),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="d1-f",
+        status=ExecutionStatus.FAILED,
+        start_time=day_one,
+        end_time=day_one + timedelta(seconds=1),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="d2-c1",
+        status=ExecutionStatus.COMPLETED,
+        start_time=day_two,
+        end_time=day_two + timedelta(seconds=1),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="d2-c2",
+        status=ExecutionStatus.COMPLETED,
+        start_time=day_two,
+        end_time=day_two + timedelta(seconds=1),
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            TimeGrouping(type="time", name="day", granularity="day"),
+            SimpleGrouping(type="status", name="status"),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    combos = {
+        (g.group_keys["day"], g.group_keys["status"]): g.run_count
+        for g in response.groups
+    }
+    assert combos[("2026-01-01", "completed")] == 1
+    assert combos[("2026-01-01", "failed")] == 1
+    assert combos[("2026-01-02", "completed")] == 2
+    # time bucket ordering ascending
+    days = [str(g.group_keys["day"]) for g in response.groups]
+    assert days == sorted(days)
+
+
+def test_duration_metric_unaffected_by_metadata_fan_out(
+    sql_store: SqlZenStore,
+) -> None:
+    """Per-run scalars are not inflated by multi-row metadata metrics.
+
+    R1 has duration 10s and two `score` metadata rows (5, 15); R2 has
+    duration 20s and one `score`=30. SUM(duration) must be 30 (not 40)
+    and AVG(duration) must be 15 (not the fan-out-inflated 13.33).
+    The metadata metric uses the latest value per run (R1=15, R2=30),
+    matching `RunMetadataInterface.fetch_metadata` semantics.
+    """
+    project_id = _project_id(sql_store)
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    r1_id = _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r1",
+        start_time=base,
+        end_time=base + timedelta(seconds=10),
+    )
+    r2_id = _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r2",
+        start_time=base,
+        end_time=base + timedelta(seconds=20),
+    )
+
+    for value in (5, 15):
+        _create_run_metadata(
+            sql_store,
+            project_id=project_id,
+            run_id=r1_id,
+            key="score",
+            value=value,
+            type_=MetadataTypeEnum.INT,
+        )
+    _create_run_metadata(
+        sql_store,
+        project_id=project_id,
+        run_id=r2_id,
+        key="score",
+        value=30,
+        type_=MetadataTypeEnum.INT,
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        metrics=[
+            SimpleMetric(name="sum_dur", source="duration", aggregation="sum"),
+            SimpleMetric(name="avg_dur", source="duration", aggregation="avg"),
+            MetadataMetric(
+                name="sum_score",
+                source="metadata",
+                aggregation="sum",
+                metadata_key="score",
+            ),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    group = response.groups[0]
+    assert group.run_count == 2
+    assert group.metrics["sum_dur"] == pytest.approx(30.0)
+    assert group.metrics["avg_dur"] == pytest.approx(15.0)
+    # Latest-per-run for score: R1=15, R2=30 → SUM = 45.
+    assert group.metrics["sum_score"] == pytest.approx(45.0)
+
+
+def test_week_granularity_buckets_by_monday(sql_store: SqlZenStore) -> None:
+    """WEEK granularity labels each run with the Monday of its week."""
+    project_id = _project_id(sql_store)
+    # 2025-12-29 is the Monday of the week that contains 2025-12-31 and
+    # 2026-01-01, so all three runs must land in the 2025-12-29 bucket.
+    monday = datetime(2025, 12, 29, 10, 0, 0)
+    wednesday = datetime(2025, 12, 31, 10, 0, 0)
+    thursday = datetime(2026, 1, 1, 10, 0, 0)
+    # 2026-01-05 is the next Monday, in a separate bucket.
+    next_monday = datetime(2026, 1, 5, 10, 0, 0)
+
+    for i, ts in enumerate([monday, wednesday, thursday, next_monday]):
+        _create_run(
+            sql_store,
+            project_id=project_id,
+            name=f"r-{i}",
+            start_time=ts,
+            end_time=ts + timedelta(seconds=1),
+        )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            TimeGrouping(type="time", name="week", granularity="week"),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_week = {g.group_keys["week"]: g.run_count for g in response.groups}
+    assert by_week == {"2025-12-29": 3, "2026-01-05": 1}
+    weeks = [str(g.group_keys["week"]) for g in response.groups]
+    assert weeks == sorted(weeks)
+
+
+def test_grouping_by_snapshot_and_user(sql_store: SqlZenStore) -> None:
+    """Snapshot and user grouping return UUID strings."""
+    project_id = _project_id(sql_store)
+    user_a = _default_user_id(sql_store)
+    pipeline_id = _create_pipeline(sql_store, project_id)
+    snap = _create_snapshot(sql_store, project_id, pipeline_id)
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r1",
+        snapshot_id=snap,
+        user_id=user_a,
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r2",
+        snapshot_id=snap,
+        user_id=user_a,
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            SimpleGrouping(type="snapshot", name="snap"),
+            SimpleGrouping(type="user", name="user"),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    group = response.groups[0]
+    assert group.group_keys["snap"] == str(snap)
+    assert group.group_keys["user"] == str(user_a)
+    assert group.run_count == 2
+
+
+def test_grouping_by_source_snapshot(sql_store: SqlZenStore) -> None:
+    """Source snapshot grouping joins through pipeline_snapshot."""
+    project_id = _project_id(sql_store)
+    pipeline_id = _create_pipeline(sql_store, project_id)
+    # source_snapshot_id has no FK; can be any UUID.
+    source_snap = uuid4()
+    snapshot_id = _create_snapshot(
+        sql_store, project_id, pipeline_id, source_snap
+    )
+
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r1",
+        snapshot_id=snapshot_id,
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r2",
+        snapshot_id=snapshot_id,
+    )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            SimpleGrouping(type="source_snapshot", name="src"),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_src = {g.group_keys["src"]: g.run_count for g in response.groups}
+    assert by_src[str(source_snap)] == 2
+
+
+def test_grouping_by_stack(sql_store: SqlZenStore) -> None:
+    """Stack grouping joins through pipeline_snapshot.stack_id."""
+    project_id = _project_id(sql_store)
+    from zenml.models import StackFilter
+
+    stack_id = (
+        sql_store.list_stacks(stack_filter_model=StackFilter()).items[0].id
+    )
+    pipeline_id = _create_pipeline(sql_store, project_id)
+    snapshot_id = _create_snapshot(
+        sql_store, project_id, pipeline_id, stack_id=stack_id
+    )
+
+    for i in range(3):
+        _create_run(
+            sql_store,
+            project_id=project_id,
+            name=f"r{i}",
+            snapshot_id=snapshot_id,
+        )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="stack", name="stack")],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_stack = {g.group_keys["stack"]: g.run_count for g in response.groups}
+    assert by_stack[str(stack_id)] == 3
+
+
+def test_grouping_by_trigger(sql_store: SqlZenStore) -> None:
+    """Trigger grouping joins through trigger_execution to TriggerSchema.id."""
+    project_id = _project_id(sql_store)
+    trigger_id = _create_trigger(sql_store, project_id)
+
+    triggered_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"t{i}")
+        for i in range(2)
+    ]
+    _create_run(sql_store, project_id=project_id, name="manual")
+
+    with Session(sql_store.engine) as session:
+        for run_id in triggered_ids:
+            session.add(
+                TriggerExecutionSchema(
+                    trigger_id=trigger_id, pipeline_run_id=run_id
+                )
+            )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="trigger", name="trigger")],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_trigger = {
+        g.group_keys["trigger"]: g.run_count for g in response.groups
+    }
+    assert by_trigger[str(trigger_id)] == 2
+    assert by_trigger[None] == 1
+
+
+def test_grouping_by_tag_multi_bucket(sql_store: SqlZenStore) -> None:
+    """A run with N tags contributes to N tag buckets.
+
+    Sum across tag buckets can therefore exceed the number of runs.
+    Untagged runs land in the null bucket.
+    """
+    project_id = _project_id(sql_store)
+    run_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+        for i in range(3)
+    ]
+
+    tag_prod = _create_tag(sql_store, project_id, "prod")
+    tag_v1 = _create_tag(sql_store, project_id, "v1")
+
+    with Session(sql_store.engine) as session:
+        # run_ids[0] tagged ["prod", "v1"], run_ids[1] tagged ["prod"],
+        # run_ids[2] none.
+        for tag_id in (tag_prod, tag_v1):
+            session.add(
+                TagResourceSchema(
+                    tag_id=tag_id,
+                    resource_id=run_ids[0],
+                    resource_type=TaggableResourceTypes.PIPELINE_RUN.value,
+                )
+            )
+        session.add(
+            TagResourceSchema(
+                tag_id=tag_prod,
+                resource_id=run_ids[1],
+                resource_type=TaggableResourceTypes.PIPELINE_RUN.value,
+            )
+        )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="tag", name="tag")],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_tag = {g.group_keys["tag"]: g.run_count for g in response.groups}
+    assert by_tag == {"prod": 2, "v1": 1, None: 1}
+    # Sum exceeds total runs (3) because runs[0] is in two buckets.
+    assert sum(by_tag.values()) == 4
+
+
+def test_max_groups_truncation(sql_store: SqlZenStore) -> None:
+    """When more groups exist than max_groups, the response is truncated."""
+    project_id = _project_id(sql_store)
+    pipeline_ids = [_create_pipeline(sql_store, project_id) for _ in range(5)]
+    for i in range(5):
+        _create_run(
+            sql_store,
+            project_id=project_id,
+            name=f"r{i}",
+            status=ExecutionStatus.COMPLETED,
+            pipeline_id=pipeline_ids[i],
+        )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[SimpleGrouping(type="pipeline", name="pipeline")],
+        max_groups=3,
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert response.truncated is True
+    assert len(response.groups) == 3
+
+
+def test_empty_groupings_produce_single_row(sql_store: SqlZenStore) -> None:
+    """No groupings returns one row with the global run_count."""
+    project_id = _project_id(sql_store)
+    for i in range(3):
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    assert response.groups[0].run_count == 3
+    assert response.groups[0].group_keys == {}
+    assert response.groups[0].metrics == {}
+
+
+def test_metadata_key_used_for_both_grouping_and_metric(
+    sql_store: SqlZenStore,
+) -> None:
+    """Same metadata key serves a group bucket and an aggregate together.
+
+    Two runs share env=prod, one has env=staging. The same `env` key drives
+    the grouping (bucket label) and the numeric metric (avg score per
+    bucket, since `env` is non-numeric the metric must be null). A second
+    metric over a different metadata key proves numeric aggregation still
+    works alongside.
+    """
+    project_id = _project_id(sql_store)
+    run_ids = [
+        _create_run(sql_store, project_id=project_id, name=f"r{i}")
+        for i in range(3)
+    ]
+
+    for run_id, env in (
+        (run_ids[0], "prod"),
+        (run_ids[1], "prod"),
+        (run_ids[2], "staging"),
+    ):
+        _create_run_metadata(
+            sql_store,
+            project_id=project_id,
+            run_id=run_id,
+            key="env",
+            value=env,
+            type_=MetadataTypeEnum.STRING,
+        )
+    for run_id, score in (
+        (run_ids[0], 10),
+        (run_ids[1], 20),
+        (run_ids[2], 30),
+    ):
+        _create_run_metadata(
+            sql_store,
+            project_id=project_id,
+            run_id=run_id,
+            key="score",
+            value=score,
+            type_=MetadataTypeEnum.INT,
+        )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            MetadataGrouping(type="metadata", name="env", metadata_key="env"),
+        ],
+        metrics=[
+            # `env` is non-numeric, so the metric must be null in every
+            # bucket; this verifies the per-run latest projection drives
+            # both columns without collision.
+            MetadataMetric(
+                name="avg_env_numeric",
+                source="metadata",
+                aggregation="avg",
+                metadata_key="env",
+            ),
+            MetadataMetric(
+                name="avg_score",
+                source="metadata",
+                aggregation="avg",
+                metadata_key="score",
+            ),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    by_env = {g.group_keys["env"]: g for g in response.groups}
+    assert by_env["prod"].run_count == 2
+    assert by_env["prod"].metrics["avg_env_numeric"] is None
+    assert by_env["prod"].metrics["avg_score"] == pytest.approx(15.0)
+    assert by_env["staging"].run_count == 1
+    assert by_env["staging"].metrics["avg_env_numeric"] is None
+    assert by_env["staging"].metrics["avg_score"] == pytest.approx(30.0)
+
+
+def test_tag_filter_does_not_inflate_metrics(sql_store: SqlZenStore) -> None:
+    """PipelineRunFilter(tags=[...]) must not fan out per-run aggregates.
+
+    A run with N tags is joined N times by `TaggableFilter.apply_filter`.
+    Without deduplication that multiplies SUM/AVG/step_count/etc. The
+    expected sum is 10 + 20 = 30; an inflated query would return 40
+    (the multi-tagged run counted twice).
+    """
+    project_id = _project_id(sql_store)
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    r_multi = _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r-multi",
+        start_time=base,
+        end_time=base + timedelta(seconds=10),
+    )
+    r_single = _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r-single",
+        start_time=base,
+        end_time=base + timedelta(seconds=20),
+    )
+    _create_run(
+        sql_store,
+        project_id=project_id,
+        name="r-other",
+        start_time=base,
+        end_time=base + timedelta(seconds=100),
+    )
+
+    tag_prod = _create_tag(sql_store, project_id, "prod")
+    tag_v1 = _create_tag(sql_store, project_id, "v1")
+
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    with Session(sql_store.engine) as session:
+        for tag_id in (tag_prod, tag_v1):
+            session.add(
+                TagResourceSchema(
+                    tag_id=tag_id,
+                    resource_id=r_multi,
+                    resource_type=TaggableResourceTypes.PIPELINE_RUN.value,
+                )
+            )
+        session.add(
+            TagResourceSchema(
+                tag_id=tag_prod,
+                resource_id=r_single,
+                resource_type=TaggableResourceTypes.PIPELINE_RUN.value,
+            )
+        )
+        # One step per "prod" run to confirm step_count is also not inflated.
+        for run_id in (r_multi, r_single):
+            session.add(
+                StepRunSchema(
+                    id=uuid4(),
+                    project_id=project_id,
+                    pipeline_run_id=run_id,
+                    name="train",
+                    version=1,
+                    status=ExecutionStatus.COMPLETED.value,
+                    is_retriable=False,
+                    start_time=now,
+                    end_time=now,
+                )
+            )
+        session.commit()
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id, tags=["prod"]),
+        metrics=[
+            SimpleMetric(name="sum_dur", source="duration", aggregation="sum"),
+            SimpleMetric(name="avg_dur", source="duration", aggregation="avg"),
+            SimpleMetric(
+                name="sum_steps", source="step_count", aggregation="sum"
+            ),
+        ],
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert len(response.groups) == 1
+    group = response.groups[0]
+    assert group.run_count == 2
+    assert group.metrics["sum_dur"] == pytest.approx(30.0)
+    assert group.metrics["avg_dur"] == pytest.approx(15.0)
+    assert group.metrics["sum_steps"] == pytest.approx(2.0)

--- a/tests/unit/zen_stores/test_run_statistics.py
+++ b/tests/unit/zen_stores/test_run_statistics.py
@@ -35,6 +35,7 @@ from zenml.models import (
     RunStatisticsRequest,
     SimpleGrouping,
     SimpleMetric,
+    StackFilter,
     TimeGrouping,
     UserFilter,
 )
@@ -982,7 +983,6 @@ def test_grouping_by_source_snapshot(sql_store: SqlZenStore) -> None:
 def test_grouping_by_stack(sql_store: SqlZenStore) -> None:
     """Stack grouping joins through pipeline_snapshot.stack_id."""
     project_id = _project_id(sql_store)
-    from zenml.models import StackFilter
 
     stack_id = (
         sql_store.list_stacks(stack_filter_model=StackFilter()).items[0].id
@@ -1112,6 +1112,38 @@ def test_max_groups_truncation(sql_store: SqlZenStore) -> None:
 
     assert response.truncated is True
     assert len(response.groups) == 3
+
+
+def test_time_grouping_truncation_keeps_latest_buckets(
+    sql_store: SqlZenStore,
+) -> None:
+    """Truncation drops the oldest buckets and keeps the latest ones."""
+    project_id = _project_id(sql_store)
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    for i in range(5):
+        _create_run(
+            sql_store,
+            project_id=project_id,
+            name=f"r{i}",
+            start_time=base + timedelta(days=i),
+            end_time=base + timedelta(days=i, seconds=1),
+        )
+
+    request = RunStatisticsRequest(
+        filter=PipelineRunFilter(project=project_id),
+        groupings=[
+            TimeGrouping(type="time", name="day", granularity="day"),
+        ],
+        max_groups=3,
+    )
+    response = sql_store.get_run_statistics(request)
+
+    assert response.truncated is True
+    assert [g.group_keys["day"] for g in response.groups] == [
+        "2026-01-03",
+        "2026-01-04",
+        "2026-01-05",
+    ]
 
 
 def test_empty_groupings_produce_single_row(sql_store: SqlZenStore) -> None:


### PR DESCRIPTION
Add a `POST /api/v1/runs/statistics` endpoint that returns grouped aggregations over pipeline runs.

- **Group by**: status, pipeline, snapshot, source snapshot, stack, trigger, user, time bucket (hour/day/week/month), metadata value, tag. Multiple groupings allowed.
- **Metrics**: `avg`/`sum`/`min`/`max` over `duration`, `step_count` (retries collapsed), `cached_step_count`, `output_artifact_count` or a numeric metadata value. Per-group `run_count` is always returned.
- **Limitation**: metadata metrics only aggregate entries stored as `int` or `float`. Other types are skipped. Tag grouping is multi-bucket: a run with N tags contributes to N buckets, so sum of `run_count` across tag buckets can exceed the number of filtered runs.