### PR TITLE
Don't require container engine when specifying skip_build

### DIFF
--- a/src/zenml/config/build_configuration.py
+++ b/src/zenml/config/build_configuration.py
@@ -111,10 +111,15 @@ class BuildConfiguration(BaseModel):
                 hash_.update(f.read())
 
         if self.settings.parent_image and stack.container_registry:
-            digest = get_container_engine().get_image_repo_digest(
-                self.settings.parent_image,
-                container_registry=stack.container_registry,
-            )
+            try:
+                digest = get_container_engine().get_image_repo_digest(
+                    image_name=self.settings.parent_image,
+                    container_registry=stack.container_registry,
+                )
+            except RuntimeError:
+                # No container engine available, we can't fetch the digest.
+                digest = None
+
             if digest:
                 hash_.update(digest.encode())
             elif self.settings.skip_build:


### PR DESCRIPTION
## Describe changes
Even if users specified `skip_build=True` in their DockerSettings, we would fail trying to compute the build checksum if no container engine was available.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

