### PR TITLE
Include hook sources as string in snapshot config template

### DIFF
--- a/src/zenml/config/pipeline_configurations.py
+++ b/src/zenml/config/pipeline_configurations.py
@@ -35,7 +35,7 @@ from zenml.config.constants import (
 )
 from zenml.config.frozen_base_model import FrozenBaseModel
 from zenml.config.retry_config import StepRetryConfig
-from zenml.config.source import SourceWithValidator
+from zenml.config.source import StringSerializableSource
 from zenml.enums import ExecutionMode
 from zenml.model.model import Model
 from zenml.utils.tag_utils import Tag
@@ -66,11 +66,11 @@ class PipelineConfigurationUpdate(FrozenBaseModel):
     settings: Dict[str, SerializeAsAny[BaseSettings]] = {}
     tags: Optional[List[Union[str, "Tag"]]] = None
     extra: Dict[str, Any] = {}
-    failure_hook_source: Optional[SourceWithValidator] = None
-    success_hook_source: Optional[SourceWithValidator] = None
-    init_hook_source: Optional[SourceWithValidator] = None
+    failure_hook_source: Optional[StringSerializableSource] = None
+    success_hook_source: Optional[StringSerializableSource] = None
+    init_hook_source: Optional[StringSerializableSource] = None
     init_hook_kwargs: Optional[Dict[str, Any]] = None
-    cleanup_hook_source: Optional[SourceWithValidator] = None
+    cleanup_hook_source: Optional[StringSerializableSource] = None
     model: Optional[Model] = None
     parameters: Optional[Dict[str, Any]] = None
     retry: Optional[StepRetryConfig] = None

--- a/src/zenml/config/pipeline_run_configuration.py
+++ b/src/zenml/config/pipeline_run_configuration.py
@@ -23,7 +23,7 @@ from zenml.config.cache_policy import CachePolicyWithValidator
 from zenml.config.frozen_base_model import FrozenBaseModel
 from zenml.config.retry_config import StepRetryConfig
 from zenml.config.schedule import Schedule
-from zenml.config.source import SourceWithValidator
+from zenml.config.source import StringSerializableSource
 from zenml.config.step_configurations import StepConfigurationUpdate
 from zenml.enums import ExecutionMode
 from zenml.model.model import Model
@@ -106,11 +106,11 @@ class PipelineRunConfiguration(
         default=None,
         description="The retry configuration for all steps of the pipeline run.",
     )
-    failure_hook_source: Optional[SourceWithValidator] = Field(
+    failure_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The failure hook source for all steps of the pipeline run.",
     )
-    init_hook_source: Optional[SourceWithValidator] = Field(
+    init_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The init hook source for the pipeline run.",
     )
@@ -118,11 +118,11 @@ class PipelineRunConfiguration(
         default=None,
         description="The init hook args for the pipeline run.",
     )
-    cleanup_hook_source: Optional[SourceWithValidator] = Field(
+    cleanup_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The cleanup hook source for the pipeline run.",
     )
-    success_hook_source: Optional[SourceWithValidator] = Field(
+    success_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The success hook source for all steps of the pipeline run.",
     )

--- a/src/zenml/config/source.py
+++ b/src/zenml/config/source.py
@@ -24,6 +24,7 @@ from pydantic import (
     ConfigDict,
     PlainSerializer,
     SerializeAsAny,
+    WrapSerializer,
     field_validator,
 )
 from typing_extensions import Annotated
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
     AnyClassMethod = classmethod[Any]  # type: ignore[type-arg]
 
 logger = get_logger(__name__)
+
+SERIALIZE_AS_STRING_CONTEXT_KEY = "serialize_as_string"
 
 
 class SourceType(Enum):
@@ -483,6 +486,35 @@ class NotebookSource(Source):
 SourceWithValidator = Annotated[
     SerializeAsAny[Source],
     BeforeValidator(Source.convert_source),
+]
+
+
+def _serialize_source_optionally_as_string(
+    value: Any, handler: Any, info: Any
+) -> Any:
+    """Optionally serialize a source as an import path string.
+
+    This serializer keeps the default source serialization unless the
+    serialization context explicitly enables string output.
+
+    Args:
+        value: The source value.
+        handler: The default serializer handler.
+        info: Serialization info containing the context.
+
+    Returns:
+        The serialized source value.
+    """
+    context = info.context
+    if context and context.get(SERIALIZE_AS_STRING_CONTEXT_KEY):
+        return value.import_path
+
+    return handler(value, info)
+
+
+StringSerializableSource = Annotated[
+    SourceWithValidator,
+    WrapSerializer(_serialize_source_optionally_as_string),
 ]
 
 if TYPE_CHECKING:

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -44,7 +44,11 @@ from zenml.config.cache_policy import CachePolicy, CachePolicyWithValidator
 from zenml.config.constants import DOCKER_SETTINGS_KEY, RESOURCE_SETTINGS_KEY
 from zenml.config.frozen_base_model import FrozenBaseModel
 from zenml.config.retry_config import StepRetryConfig
-from zenml.config.source import Source, SourceWithValidator
+from zenml.config.source import (
+    Source,
+    SourceWithValidator,
+    StringSerializableSource,
+)
 from zenml.enums import GroupType, StepRuntime, StepType
 from zenml.logger import get_logger
 from zenml.model.lazy_load import ModelVersionDataLazyLoader
@@ -200,11 +204,11 @@ class StepConfigurationUpdate(FrozenBaseModel):
         default=None,
         description="Extra configurations for the step.",
     )
-    failure_hook_source: Optional[SourceWithValidator] = Field(
+    failure_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The failure hook source for the step.",
     )
-    success_hook_source: Optional[SourceWithValidator] = Field(
+    success_hook_source: Optional[StringSerializableSource] = Field(
         default=None,
         description="The success hook source for the step.",
     )

--- a/src/zenml/zen_stores/template_utils.py
+++ b/src/zenml/zen_stores/template_utils.py
@@ -23,7 +23,10 @@ from pydantic.fields import FieldInfo
 from zenml.config import ResourceSettings
 from zenml.config.base_settings import BaseSettings
 from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
-from zenml.config.source import SourceWithValidator
+from zenml.config.source import (
+    SERIALIZE_AS_STRING_CONTEXT_KEY,
+    StringSerializableSource,
+)
 from zenml.config.step_configurations import StepConfigurationUpdate
 from zenml.enums import StackComponentType
 from zenml.logger import get_logger
@@ -110,6 +113,7 @@ def generate_config_template(
             exclude={"name", "outputs"},
             exclude_none=True,
             exclude_defaults=True,
+            context={SERIALIZE_AS_STRING_CONTEXT_KEY: True},
         )
         for name, step in step_configurations.items()
     }
@@ -126,6 +130,7 @@ def generate_config_template(
         exclude=pipeline_config_exclude,
         exclude_none=True,
         exclude_defaults=True,
+        context={SERIALIZE_AS_STRING_CONTEXT_KEY: True},
     )
 
     pipeline_config.get("settings", {}).pop("docker", None)
@@ -210,7 +215,7 @@ def generate_config_schema(
         if key in step_config_exclude:
             continue
 
-        if field_info.annotation == Optional[SourceWithValidator]:  # type: ignore[comparison-overlap]
+        if field_info.annotation == Optional[StringSerializableSource]:  # type: ignore[comparison-overlap]
             generic_step_fields[key] = (Optional[str], field_info)
         else:
             generic_step_fields[key] = (field_info.annotation, field_info)
@@ -314,7 +319,7 @@ def generate_config_schema(
         if key in ["schedule", "build", "steps", "settings", "parameters"]:
             continue
 
-        if field_info.annotation == Optional[SourceWithValidator]:  # type: ignore[comparison-overlap]
+        if field_info.annotation == Optional[StringSerializableSource]:  # type: ignore[comparison-overlap]
             top_level_fields[key] = (Optional[str], field_info)
         else:
             top_level_fields[key] = (field_info.annotation, field_info)

--- a/tests/unit/zen_stores/test_template_utils.py
+++ b/tests/unit/zen_stores/test_template_utils.py
@@ -3,7 +3,10 @@ from typing import Any, Dict
 
 from zenml.config.pipeline_configurations import PipelineConfiguration
 from zenml.config.step_configurations import Step, StepConfiguration, StepSpec
-from zenml.zen_stores.template_utils import generate_config_schema
+from zenml.zen_stores.template_utils import (
+    generate_config_schema,
+    generate_config_template,
+)
 
 
 def _create_step(name: str, parameter_spec: Dict[str, Any]) -> Step:
@@ -133,4 +136,47 @@ def test_generate_config_schema_reuses_and_renames_step_defs():
             "properties"
         ]["config"]["$ref"]
         == "#/$defs/conflicting_step__NestedConfig"
+    )
+
+
+def test_generate_config_template_serializes_hook_sources_as_import_paths():
+    """Tests that hook sources are stringified in generated templates."""
+    step = Step(
+        spec=StepSpec(
+            source="module.step",
+            upstream_steps=[],
+            invocation_id="my_step",
+        ),
+        config=StepConfiguration(name="my_step"),
+        step_config_overrides=StepConfiguration(
+            name="my_step",
+            failure_hook_source="hooks.step_failure",
+            success_hook_source="hooks.step_success",
+        ),
+    )
+    snapshot = SimpleNamespace(is_dynamic=True, run_name_template="my_run")
+
+    template = generate_config_template(
+        snapshot=snapshot,
+        pipeline_configuration=PipelineConfiguration(
+            name="pipeline",
+            failure_hook_source="hooks.pipeline_failure",
+            success_hook_source="hooks.pipeline_success",
+            init_hook_source="hooks.pipeline_init",
+            cleanup_hook_source="hooks.pipeline_cleanup",
+        ),
+        step_configurations={"my_step": step},
+    )
+
+    assert template["failure_hook_source"] == "hooks.pipeline_failure"
+    assert template["success_hook_source"] == "hooks.pipeline_success"
+    assert template["init_hook_source"] == "hooks.pipeline_init"
+    assert template["cleanup_hook_source"] == "hooks.pipeline_cleanup"
+    assert (
+        template["steps"]["my_step"]["failure_hook_source"]
+        == "hooks.step_failure"
+    )
+    assert (
+        template["steps"]["my_step"]["success_hook_source"]
+        == "hooks.step_success"
     )


### PR DESCRIPTION
## Describe changes
The config schema specified a string instead of the full source object in the config schema, but the config template returned the full source object. This PR fixes that by also passing only the string representation of a source object in the template.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

