### PR TITLE
Show more info on recoverable pending pods

### DIFF
--- a/src/zenml/integrations/kubernetes/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/kube_utils.py
@@ -37,6 +37,7 @@ import json
 import re
 import time
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -957,9 +958,7 @@ def get_pod_pending_details(
     """
     try:
         details: list[str] = []
-
-        if pod.metadata and pod.metadata.name:
-            details.append(f"pod `{pod.metadata.name}`")
+        pod_name = pod.metadata.name if pod.metadata else None
 
         if pod.status:
             for condition in pod.status.conditions or []:
@@ -993,7 +992,8 @@ def get_pod_pending_details(
             )
 
         if details:
-            return "; ".join(details)
+            prefix = f"pod `{pod_name}`" if pod_name else "pod"
+            return f"{prefix}: " + "; ".join(details)
     except Exception:
         logger.debug("Failed to extract pod pending details.", exc_info=True)
 
@@ -1173,7 +1173,9 @@ def check_job_status(
         api_request_timeout: The request timeout in seconds.
 
     Returns:
-        The status of the job and an error message if the job failed.
+        The status of the job and an optional status message. For failed jobs,
+        this is the error message; for running jobs, this can contain pending
+        pod diagnostics.
     """
     job: k8s_client.V1Job = retry_on_api_exception(
         batch_api.read_namespaced_job, api_request_timeout=api_request_timeout
@@ -1217,6 +1219,14 @@ def check_job_status(
             label_selector=f"job-name={job_name}",
             field_selector="status.phase=Pending",
         )
+        pod_list.items.sort(
+            key=lambda pod: (
+                pod.metadata.creation_timestamp
+                if pod.metadata and pod.metadata.creation_timestamp
+                else datetime.min.replace(tzinfo=timezone.utc)
+            ),
+            reverse=True,
+        )
         for pod in pod_list.items:
             container_state = get_container_status(
                 pod, container_name or "main"
@@ -1241,6 +1251,8 @@ def check_job_status(
                 error_message = (
                     f"Detected container in state `{waiting_state.reason}`"
                 )
+                if pending_message:
+                    error_message += f" ({pending_message})"
                 return JobStatus.FAILED, error_message
 
     return JobStatus.RUNNING, pending_message

--- a/src/zenml/integrations/kubernetes/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/kube_utils.py
@@ -943,6 +943,63 @@ def get_pod_failure_details(
     return None
 
 
+def get_pod_pending_details(
+    pod: k8s_client.V1Pod, container_name: str
+) -> Optional[str]:
+    """Get best-effort pod pending details.
+
+    Args:
+        pod: The pod to get pending details for.
+        container_name: The container name.
+
+    Returns:
+        Pending details for the pod, if available.
+    """
+    try:
+        details: list[str] = []
+
+        if pod.metadata and pod.metadata.name:
+            details.append(f"pod `{pod.metadata.name}`")
+
+        if pod.status:
+            for condition in pod.status.conditions or []:
+                if condition.status == "False" and (
+                    condition.reason or condition.message
+                ):
+                    condition_details = [condition.type or "Unknown"]
+                    if condition.reason:
+                        condition_details.append(condition.reason)
+                    if condition.message:
+                        condition_details.append(
+                            f"message={condition.message}"
+                        )
+                    details.append(
+                        "pod condition: " + ", ".join(condition_details)
+                    )
+
+            if pod.status.reason:
+                details.append(f"pod reason: {pod.status.reason}")
+            if pod.status.message:
+                details.append(f"pod message: {pod.status.message}")
+
+        container_state = get_container_status(pod, container_name)
+        if container_state and container_state.waiting:
+            waiting = container_state.waiting
+            container_details = [waiting.reason or "Unknown"]
+            if waiting.message:
+                container_details.append(f"message={waiting.message}")
+            details.append(
+                f"container waiting reason: {', '.join(container_details)}"
+            )
+
+        if details:
+            return "; ".join(details)
+    except Exception:
+        logger.debug("Failed to extract pod pending details.", exc_info=True)
+
+    return None
+
+
 def wait_for_job_to_finish(
     get_client: Callable[[], k8s_client.ApiClient],
     namespace: str,
@@ -1150,6 +1207,7 @@ def check_job_status(
 
                 return JobStatus.FAILED, error_message
 
+    pending_message = None
     if fail_on_container_waiting_reasons:
         pod_list: k8s_client.V1PodList = retry_on_api_exception(
             core_api.list_namespaced_pod,
@@ -1161,6 +1219,9 @@ def check_job_status(
         )
         for pod in pod_list.items:
             container_state = get_container_status(
+                pod, container_name or "main"
+            )
+            pending_message = pending_message or get_pod_pending_details(
                 pod, container_name or "main"
             )
 
@@ -1182,7 +1243,7 @@ def check_job_status(
                 )
                 return JobStatus.FAILED, error_message
 
-    return JobStatus.RUNNING, None
+    return JobStatus.RUNNING, pending_message
 
 
 def create_config_map(

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator_entrypoint.py
@@ -746,7 +746,7 @@ def main() -> None:
                     snapshot.step_configurations[step_name]
                 ),
             )
-            status, error_message = kube_utils.check_job_status(
+            status, status_message = kube_utils.check_job_status(
                 batch_api=batch_api,
                 core_api=core_api,
                 namespace=namespace,
@@ -760,7 +760,7 @@ def main() -> None:
                 logger.error(
                     "Job for step `%s` failed: %s",
                     step_name,
-                    error_message,
+                    status_message,
                 )
                 return _handle_failed_job(step_name)
             elif (
@@ -774,6 +774,19 @@ def main() -> None:
                 stop_step(node=node)
                 return NodeStatus.FAILED
             else:
+                if status_message:
+                    last_pending_message = node.metadata.get(
+                        "last_pending_status_message"
+                    )
+                    if last_pending_message != status_message:
+                        logger.info(
+                            "Job for step `%s` is pending: %s",
+                            step_name,
+                            status_message,
+                        )
+                        node.metadata["last_pending_status_message"] = (
+                            status_message
+                        )
                 return NodeStatus.RUNNING
 
         def should_interrupt_execution() -> Optional[InterruptMode]:

--- a/tests/unit/integrations/kubernetes/test_kube_utils.py
+++ b/tests/unit/integrations/kubernetes/test_kube_utils.py
@@ -1,10 +1,84 @@
 """Tests for Kubernetes utility functions."""
 
+from datetime import datetime, timezone
 from typing import Any
 
 from kubernetes import client as k8s_client
 
 from zenml.integrations.kubernetes import kube_utils
+
+
+def _pending_pod(
+    name: str = "step-job-pod",
+    creation_timestamp: datetime | None = None,
+    condition_message: str | None = None,
+    waiting_reason: str | None = None,
+    waiting_message: str | None = None,
+) -> k8s_client.V1Pod:
+    conditions = []
+    if condition_message:
+        conditions.append(
+            k8s_client.V1PodCondition(
+                type="PodScheduled",
+                status="False",
+                reason="Unschedulable",
+                message=condition_message,
+            )
+        )
+
+    container_statuses = []
+    if waiting_reason:
+        container_statuses.append(
+            k8s_client.V1ContainerStatus(
+                name="main",
+                image="step-image",
+                image_id="",
+                ready=False,
+                restart_count=0,
+                state=k8s_client.V1ContainerState(
+                    waiting=k8s_client.V1ContainerStateWaiting(
+                        reason=waiting_reason,
+                        message=waiting_message,
+                    )
+                ),
+            )
+        )
+
+    return k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            creation_timestamp=creation_timestamp,
+        ),
+        status=k8s_client.V1PodStatus(
+            conditions=conditions,
+            container_statuses=container_statuses,
+        ),
+    )
+
+
+def _check_job_status_for_pods(
+    pods: list[k8s_client.V1Pod],
+) -> tuple[kube_utils.JobStatus, str | None]:
+    class BatchApi:
+        def read_namespaced_job(self, **_: Any) -> k8s_client.V1Job:
+            return k8s_client.V1Job(
+                status=k8s_client.V1JobStatus(conditions=[])
+            )
+
+        def delete_namespaced_job(self, **_: Any) -> None:
+            return None
+
+    class CoreApi:
+        def list_namespaced_pod(self, **_: Any) -> k8s_client.V1PodList:
+            return k8s_client.V1PodList(items=pods)
+
+    return kube_utils.check_job_status(
+        batch_api=BatchApi(),  # type: ignore[arg-type]
+        core_api=CoreApi(),  # type: ignore[arg-type]
+        namespace="default",
+        job_name="step-job",
+        fail_on_container_waiting_reasons=["ImagePullBackOff"],
+    )
 
 
 def test_get_pod_failure_details_includes_container_and_pod_details() -> None:
@@ -46,40 +120,22 @@ def test_get_pod_pending_details_includes_scheduler_and_container_details() -> (
     None
 ):
     """Test that pending details include pod conditions and container state."""
-    pod = k8s_client.V1Pod(
-        metadata=k8s_client.V1ObjectMeta(name="step-job-pod"),
-        status=k8s_client.V1PodStatus(
-            conditions=[
-                k8s_client.V1PodCondition(
-                    type="PodScheduled",
-                    status="False",
-                    reason="Unschedulable",
-                    message="0/2 nodes are available: 2 Insufficient cpu.",
-                )
-            ],
-            container_statuses=[
-                k8s_client.V1ContainerStatus(
-                    name="main",
-                    image="step-image",
-                    image_id="",
-                    ready=False,
-                    restart_count=0,
-                    state=k8s_client.V1ContainerState(
-                        waiting=k8s_client.V1ContainerStateWaiting(
-                            reason="ContainerCreating"
-                        )
-                    ),
-                )
-            ],
-        ),
+    pod = _pending_pod(
+        condition_message="0/2 nodes are available: 2 Insufficient cpu.",
+        waiting_reason="ContainerCreating",
     )
 
     assert kube_utils.get_pod_pending_details(pod, "main") == (
-        "pod `step-job-pod`; "
+        "pod `step-job-pod`: "
         "pod condition: PodScheduled, Unschedulable, "
         "message=0/2 nodes are available: 2 Insufficient cpu.; "
         "container waiting reason: ContainerCreating"
     )
+
+
+def test_get_pod_pending_details_ignores_metadata_only_pods() -> None:
+    """Test that pending details require an actual diagnostic."""
+    assert kube_utils.get_pod_pending_details(_pending_pod(), "main") is None
 
 
 def test_get_pod_pending_details_returns_none_on_unexpected_data() -> None:
@@ -89,41 +145,97 @@ def test_get_pod_pending_details_returns_none_on_unexpected_data() -> None:
 
 def test_check_job_status_returns_pending_details_without_failing() -> None:
     """Test that non-fatal pending pod details are returned for visibility."""
-    pod = k8s_client.V1Pod(
-        metadata=k8s_client.V1ObjectMeta(name="step-job-pod"),
-        status=k8s_client.V1PodStatus(
-            conditions=[
-                k8s_client.V1PodCondition(
-                    type="PodScheduled",
-                    status="False",
-                    reason="Unschedulable",
-                    message="0/2 nodes are available: 2 Insufficient memory.",
+    status, message = _check_job_status_for_pods(
+        [
+            _pending_pod(
+                condition_message=(
+                    "0/2 nodes are available: 2 Insufficient memory."
                 )
-            ]
-        ),
-    )
-
-    class BatchApi:
-        def read_namespaced_job(self, **_: Any) -> k8s_client.V1Job:
-            return k8s_client.V1Job(
-                status=k8s_client.V1JobStatus(conditions=[])
             )
-
-    class CoreApi:
-        def list_namespaced_pod(self, **_: Any) -> k8s_client.V1PodList:
-            return k8s_client.V1PodList(items=[pod])
-
-    status, message = kube_utils.check_job_status(
-        batch_api=BatchApi(),  # type: ignore[arg-type]
-        core_api=CoreApi(),  # type: ignore[arg-type]
-        namespace="default",
-        job_name="step-job",
-        fail_on_container_waiting_reasons=["ImagePullBackOff"],
+        ]
     )
 
     assert status == kube_utils.JobStatus.RUNNING
     assert message == (
-        "pod `step-job-pod`; "
+        "pod `step-job-pod`: "
         "pod condition: PodScheduled, Unschedulable, "
         "message=0/2 nodes are available: 2 Insufficient memory."
+    )
+
+
+def test_check_job_status_uses_later_pending_pod_with_diagnostics() -> None:
+    """Test that metadata-only pods do not mask useful diagnostics."""
+    status, message = _check_job_status_for_pods(
+        [
+            _pending_pod(
+                name="metadata-only-pod",
+            ),
+            _pending_pod(
+                name="metadata-only-pod",
+                creation_timestamp=None,
+            ),
+            _pending_pod(
+                name="diagnostic-pod",
+                creation_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                condition_message=(
+                    "0/2 nodes are available: 2 Insufficient cpu."
+                ),
+            ),
+        ]
+    )
+
+    assert status == kube_utils.JobStatus.RUNNING
+    assert message == (
+        "pod `diagnostic-pod`: "
+        "pod condition: PodScheduled, Unschedulable, "
+        "message=0/2 nodes are available: 2 Insufficient cpu."
+    )
+
+
+def test_check_job_status_prefers_latest_pending_pod_diagnostics() -> None:
+    """Test that pending details come from the latest diagnostic pod."""
+    status, message = _check_job_status_for_pods(
+        [
+            _pending_pod(
+                name="older-pod",
+                creation_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                condition_message=(
+                    "0/2 nodes are available: 2 Insufficient cpu."
+                ),
+            ),
+            _pending_pod(
+                name="newer-pod",
+                creation_timestamp=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                condition_message=(
+                    "0/2 nodes are available: 2 Insufficient memory."
+                ),
+            ),
+        ]
+    )
+
+    assert status == kube_utils.JobStatus.RUNNING
+    assert message == (
+        "pod `newer-pod`: "
+        "pod condition: PodScheduled, Unschedulable, "
+        "message=0/2 nodes are available: 2 Insufficient memory."
+    )
+
+
+def test_check_job_status_includes_pending_details_on_fail_fast() -> None:
+    """Test that fail-fast waiting states include Kubernetes diagnostics."""
+    status, message = _check_job_status_for_pods(
+        [
+            _pending_pod(
+                creation_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                waiting_reason="ImagePullBackOff",
+                waiting_message="Back-off pulling image missing-image.",
+            )
+        ]
+    )
+
+    assert status == kube_utils.JobStatus.FAILED
+    assert message == (
+        "Detected container in state `ImagePullBackOff` "
+        "(pod `step-job-pod`: container waiting reason: ImagePullBackOff, "
+        "message=Back-off pulling image missing-image.)"
     )

--- a/tests/unit/integrations/kubernetes/test_kube_utils.py
+++ b/tests/unit/integrations/kubernetes/test_kube_utils.py
@@ -1,5 +1,7 @@
 """Tests for Kubernetes utility functions."""
 
+from typing import Any
+
 from kubernetes import client as k8s_client
 
 from zenml.integrations.kubernetes import kube_utils
@@ -38,3 +40,90 @@ def test_get_pod_failure_details_includes_container_and_pod_details() -> None:
 def test_get_pod_failure_details_returns_none_on_unexpected_data() -> None:
     """Test that failure detail extraction is best-effort."""
     assert kube_utils.get_pod_failure_details(object(), "main") is None  # type: ignore[arg-type]
+
+
+def test_get_pod_pending_details_includes_scheduler_and_container_details() -> (
+    None
+):
+    """Test that pending details include pod conditions and container state."""
+    pod = k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(name="step-job-pod"),
+        status=k8s_client.V1PodStatus(
+            conditions=[
+                k8s_client.V1PodCondition(
+                    type="PodScheduled",
+                    status="False",
+                    reason="Unschedulable",
+                    message="0/2 nodes are available: 2 Insufficient cpu.",
+                )
+            ],
+            container_statuses=[
+                k8s_client.V1ContainerStatus(
+                    name="main",
+                    image="step-image",
+                    image_id="",
+                    ready=False,
+                    restart_count=0,
+                    state=k8s_client.V1ContainerState(
+                        waiting=k8s_client.V1ContainerStateWaiting(
+                            reason="ContainerCreating"
+                        )
+                    ),
+                )
+            ],
+        ),
+    )
+
+    assert kube_utils.get_pod_pending_details(pod, "main") == (
+        "pod `step-job-pod`; "
+        "pod condition: PodScheduled, Unschedulable, "
+        "message=0/2 nodes are available: 2 Insufficient cpu.; "
+        "container waiting reason: ContainerCreating"
+    )
+
+
+def test_get_pod_pending_details_returns_none_on_unexpected_data() -> None:
+    """Test that pending detail extraction is best-effort."""
+    assert kube_utils.get_pod_pending_details(object(), "main") is None  # type: ignore[arg-type]
+
+
+def test_check_job_status_returns_pending_details_without_failing() -> None:
+    """Test that non-fatal pending pod details are returned for visibility."""
+    pod = k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(name="step-job-pod"),
+        status=k8s_client.V1PodStatus(
+            conditions=[
+                k8s_client.V1PodCondition(
+                    type="PodScheduled",
+                    status="False",
+                    reason="Unschedulable",
+                    message="0/2 nodes are available: 2 Insufficient memory.",
+                )
+            ]
+        ),
+    )
+
+    class BatchApi:
+        def read_namespaced_job(self, **_: Any) -> k8s_client.V1Job:
+            return k8s_client.V1Job(
+                status=k8s_client.V1JobStatus(conditions=[])
+            )
+
+    class CoreApi:
+        def list_namespaced_pod(self, **_: Any) -> k8s_client.V1PodList:
+            return k8s_client.V1PodList(items=[pod])
+
+    status, message = kube_utils.check_job_status(
+        batch_api=BatchApi(),  # type: ignore[arg-type]
+        core_api=CoreApi(),  # type: ignore[arg-type]
+        namespace="default",
+        job_name="step-job",
+        fail_on_container_waiting_reasons=["ImagePullBackOff"],
+    )
+
+    assert status == kube_utils.JobStatus.RUNNING
+    assert message == (
+        "pod `step-job-pod`; "
+        "pod condition: PodScheduled, Unschedulable, "
+        "message=0/2 nodes are available: 2 Insufficient memory."
+    )


### PR DESCRIPTION
## Describe changes

Enhances kubernetes workflow visibility by logging helpful info on pending pods (e.g a step is pending because the cluster has insufficient resources).

Example log:

```
Job for step generate_people is pending: pod fb789029-generate-people-io-pipeline-xpv68: pod condition: PodScheduled, Unschedulable, message=0/3 nodes are available: 1 node(s) had untolerated taint {pool: workspaces}, 2 Insufficient memory. preemption: 0/3 nodes are available: 1 Preemption is not helpful for scheduling, 2 No preemption victims found for incoming pod.
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

