### PR TITLE
Improve tiebreaker sort direction in list calls

### DIFF
--- a/src/zenml/models/v2/base/filter.py
+++ b/src/zenml/models/v2/base/filter.py
@@ -1023,13 +1023,16 @@ class BaseFilter(BaseModel):
 
         if operand == SorterOps.DESCENDING:
             sort_clause = desc(getattr(table, column))
+            tiebreaker = desc(table.id)
         else:
             sort_clause = asc(getattr(table, column))
+            tiebreaker = asc(table.id)
 
         # We always add the `id` column as a tiebreaker to ensure a stable,
         # repeatable order of items, otherwise subsequent pages might contain
-        # the same items.
-        query = query.order_by(sort_clause, asc(table.id))  # type: ignore[arg-type]
+        # the same items. The tiebreaker follows the primary sort direction so
+        # the order matches an index and avoids a filesort on descending sorts.
+        query = query.order_by(sort_clause, tiebreaker)  # type: ignore[arg-type]
 
         return query
 

--- a/src/zenml/models/v2/base/filter.py
+++ b/src/zenml/models/v2/base/filter.py
@@ -1018,21 +1018,22 @@ class BaseFilter(BaseModel):
             The query with sorting applied.
         """
         from sqlalchemy import asc, desc
+        from sqlmodel import col
 
         column, operand = self.sorting_params
 
         if operand == SorterOps.DESCENDING:
             sort_clause = desc(getattr(table, column))
-            tiebreaker = desc(table.id)
+            tiebreaker = desc(col(table.id))
         else:
             sort_clause = asc(getattr(table, column))
-            tiebreaker = asc(table.id)
+            tiebreaker = asc(col(table.id))
 
         # We always add the `id` column as a tiebreaker to ensure a stable,
         # repeatable order of items, otherwise subsequent pages might contain
         # the same items. The tiebreaker follows the primary sort direction so
         # the order matches an index and avoids a filesort on descending sorts.
-        query = query.order_by(sort_clause, tiebreaker)  # type: ignore[arg-type]
+        query = query.order_by(sort_clause, tiebreaker)
 
         return query
 

--- a/src/zenml/zen_stores/migrations/versions/41b28cae31ce_make_artifacts_workspace_scoped.py
+++ b/src/zenml/zen_stores/migrations/versions/41b28cae31ce_make_artifacts_workspace_scoped.py
@@ -7,6 +7,7 @@ Create Date: 2025-02-19 23:23:08.133826
 """
 
 import os
+from uuid import UUID
 
 import sqlalchemy as sa
 from alembic import op
@@ -66,7 +67,7 @@ def upgrade() -> None:
 
     # Update existing records with the default workspace
     op.execute(
-        artifact_table.update().values(workspace_id=default_workspace_id)
+        artifact_table.update().values(workspace_id=UUID(default_workspace_id))
     )
 
     bind = op.get_bind()


### PR DESCRIPTION
## Describe changes

Our list endpoints always appended `id ASC` as the tiebreaker for the `ORDER_BY` clause. When sorting by `DESC:...`, this produced a mixed-direction `ORDER BY`
  like `created DESC, id ASC`. Our indexes could not cover this and therefore forced the DB to run a filesort over every matched row. The tiebreaker now follows the primary sort direction, so descending sorts are served by a backward index scan instead.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

