### PR TITLE
Validate artifact content hash when loading pickled artifacts

### DIFF
--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -582,6 +582,7 @@ def load_artifact_from_response(artifact: "ArtifactVersionResponse") -> Any:
         data_type=artifact.data_type,
         uri=artifact.uri,
         artifact_store=artifact_store,
+        expected_content_hash=artifact.content_hash,
     )
 
 
@@ -765,6 +766,7 @@ def _load_artifact_from_uri(
     data_type: Union["Source", str],
     uri: str,
     artifact_store: Optional["BaseArtifactStore"] = None,
+    expected_content_hash: Optional[str] = None,
 ) -> Any:
     """Load an artifact using the given materializer.
 
@@ -773,6 +775,8 @@ def _load_artifact_from_uri(
         data_type: The source of the artifact data type.
         uri: The uri of the artifact.
         artifact_store: The artifact store used to store this artifact.
+        expected_content_hash: Content hash recorded for this artifact version,
+            forwarded to the materializer to validate the stored file on load.
 
     Returns:
         The artifact loaded into memory.
@@ -821,6 +825,7 @@ def _load_artifact_from_uri(
     materializer_object: BaseMaterializer = materializer_class(
         uri, artifact_store
     )
+    materializer_object.expected_content_hash = expected_content_hash
     artifact = materializer_object.load(artifact_class)
     logger.debug("Artifact loaded successfully.")
 
@@ -1039,12 +1044,14 @@ def load_model_from_metadata(model_uri: str) -> Any:
     """
     # Load the model from its metadata
     artifact_versions_by_uri = Client().list_artifact_versions(uri=model_uri)
+    expected_content_hash: Optional[str] = None
     if artifact_versions_by_uri.total == 1:
         artifact_store = (
             _get_artifact_store_from_response_or_from_active_stack(
                 artifact_versions_by_uri.items[0]
             )
         )
+        expected_content_hash = artifact_versions_by_uri.items[0].content_hash
     else:
         artifact_store = Client().active_stack.artifact_store
 
@@ -1059,6 +1066,7 @@ def load_model_from_metadata(model_uri: str) -> Any:
         data_type=data_type,
         uri=model_uri,
         artifact_store=artifact_store,
+        expected_content_hash=expected_content_hash,
     )
 
     # Switch to eval mode if the model is a torch model

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -122,6 +122,11 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
 
     _DOCS_BUILDING_MODE: ClassVar[bool] = False
 
+    # Content hash recorded for this artifact version, if known. Set by the
+    # loading machinery before `load` so materializers can validate the stored
+    # file against it. `None` means no hash is available.
+    expected_content_hash: Optional[str] = None
+
     def __init__(
         self, uri: str, artifact_store: Optional[BaseArtifactStore] = None
     ):

--- a/src/zenml/materializers/cloudpickle_materializer.py
+++ b/src/zenml/materializers/cloudpickle_materializer.py
@@ -13,8 +13,10 @@
 #  permissions and limitations under the License.
 """Implementation of ZenML's cloudpickle materializer."""
 
+import hashlib
+import hmac
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import Any, ClassVar, Optional, Tuple, Type
 
 import cloudpickle
 
@@ -31,6 +33,9 @@ logger = get_logger(__name__)
 
 DEFAULT_FILENAME = "artifact.pkl"
 DEFAULT_PYTHON_VERSION_FILENAME = "python_version.txt"
+
+# Chunk size used when streaming the stored artifact to compute its hash.
+_HASH_CHUNK_SIZE = 65536
 
 
 class CloudpickleMaterializer(BaseMaterializer):
@@ -51,11 +56,18 @@ class CloudpickleMaterializer(BaseMaterializer):
     def load(self, data_type: Type[Any]) -> Any:
         """Reads an artifact from a cloudpickle file.
 
+        When a content hash was recorded for this artifact version, the stored
+        file is checked against it before it is read back.
+
         Args:
             data_type: The data type of the artifact.
 
         Returns:
             The loaded artifact data.
+
+        Raises:
+            RuntimeError: If the stored file does not match the recorded content
+                hash.
         """
         # validate python version
         source_python_version = self._load_python_version()
@@ -69,11 +81,22 @@ class CloudpickleMaterializer(BaseMaterializer):
                 "versions. Attempting to load anyway..."
             )
 
-        # load data
         filepath = os.path.join(self.uri, DEFAULT_FILENAME)
         with self.artifact_store.open(filepath, "rb") as fid:
-            data = cloudpickle.load(fid)
-        return data
+            serialized_data = fid.read()
+
+        expected_content_hash = self.expected_content_hash
+        if expected_content_hash is not None:
+            actual_content_hash = hashlib.sha256(serialized_data).hexdigest()
+            if not hmac.compare_digest(
+                actual_content_hash, expected_content_hash
+            ):
+                raise RuntimeError(
+                    f"The artifact at '{self.uri}' does not match the content "
+                    f"hash recorded for it and was not loaded."
+                )
+
+        return cloudpickle.loads(serialized_data)
 
     def _load_python_version(self) -> str:
         """Loads the Python version that was used to materialize the artifact.
@@ -118,3 +141,32 @@ class CloudpickleMaterializer(BaseMaterializer):
         filepath = os.path.join(self.uri, DEFAULT_PYTHON_VERSION_FILENAME)
         current_python_version = Environment().python_version()
         write_file_contents_as_string(filepath, current_python_version)
+
+    def compute_content_hash(self, data: Any) -> Optional[str]:
+        """Compute a hash of the stored artifact file.
+
+        The hash is taken over the bytes written to the store (not over `data`)
+        so it can be recomputed on load without reading the object back.
+
+        Args:
+            data: The saved data. Unused; the hash is taken over the stored file.
+
+        Returns:
+            The hex-encoded SHA-256 of the stored file, or `None` if it cannot
+            be read.
+        """
+        filepath = os.path.join(self.uri, DEFAULT_FILENAME)
+        try:
+            digest = hashlib.sha256()
+            with self.artifact_store.open(filepath, "rb") as fid:
+                for chunk in iter(lambda: fid.read(_HASH_CHUNK_SIZE), b""):
+                    digest.update(chunk)
+            return digest.hexdigest()
+        except Exception as e:
+            logger.warning(
+                "Could not compute the content hash for the artifact at "
+                "'%s'. (%s)",
+                self.uri,
+                e,
+            )
+            return None

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -562,6 +562,7 @@ class StepRunner:
             materializer: BaseMaterializer = materializer_class(
                 uri=artifact.uri, artifact_store=artifact_store
             )
+            materializer.expected_content_hash = artifact.content_hash
 
             if artifact.chunk_index is not None:
                 # We need to skip the type compatibility check here because

--- a/tests/unit/materializers/test_cloudpickle_materializer.py
+++ b/tests/unit/materializers/test_cloudpickle_materializer.py
@@ -17,6 +17,9 @@ import os
 import pickle
 from tempfile import TemporaryDirectory
 
+import cloudpickle
+import pytest
+
 from tests.unit.test_general import _test_materializer
 from zenml.environment import Environment
 from zenml.materializers.cloudpickle_materializer import (
@@ -69,3 +72,61 @@ def test_cloudpickle_materializer_can_load_pickle(clean_client):
         materializer = CloudpickleMaterializer(uri=artifact_uri)
         loaded_object = materializer.load(data_type=Unmaterializable)
         assert loaded_object.cat == "aria"
+
+
+def test_load_without_recorded_hash_is_not_checked(clean_client):
+    """With no recorded hash there is nothing to check, so the file loads.
+
+    This keeps nested element loads (e.g. items of a `List[CustomObj]`, which
+    have no per-element recorded hash) and artifacts written by older versions
+    working unchanged.
+    """
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        with open(os.path.join(artifact_uri, DEFAULT_FILENAME), "wb") as f:
+            pickle.dump(Unmaterializable(), f)
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        assert materializer.expected_content_hash is None
+        loaded = materializer.load(data_type=Unmaterializable)
+        assert loaded.cat == "aria"
+
+
+def test_load_with_matching_hash_succeeds(clean_client):
+    """A stored file whose bytes match the recorded hash loads without opt-in."""
+    original = Unmaterializable()
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        materializer.save(original)
+        recorded_hash = materializer.compute_content_hash(original)
+        assert recorded_hash is not None
+
+        loader = CloudpickleMaterializer(uri=artifact_uri)
+        loader.expected_content_hash = recorded_hash
+        loaded = loader.load(data_type=Unmaterializable)
+        assert loaded.cat == "aria"
+
+
+def test_content_hash_mismatch_is_rejected(clean_client):
+    """A stored file that does not match the recorded hash is not loaded."""
+    original = Unmaterializable()
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        materializer.save(original)
+        recorded_hash = materializer.compute_content_hash(original)
+        assert recorded_hash is not None
+
+        # Replace the stored file with different bytes.
+        with open(os.path.join(artifact_uri, DEFAULT_FILENAME), "wb") as f:
+            cloudpickle.dump({"other": "object"}, f)
+
+        loader = CloudpickleMaterializer(uri=artifact_uri)
+        loader.expected_content_hash = recorded_hash
+        with pytest.raises(
+            RuntimeError, match="does not match the content hash"
+        ):
+            loader.load(data_type=Unmaterializable)

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -108,6 +108,12 @@ def _test_materializer(
             assert isinstance(key, str)
             assert isinstance(value, MetadataTypeTuple)
 
+        # Mirror the loading machinery, which feeds the recorded content hash
+        # back to the materializer before load.
+        materializer.expected_content_hash = materializer.compute_content_hash(
+            step_output
+        )
+
         # Assert that materializer loads the data with the correct type
         loaded_data = materializer.load(step_output_type)
         if assert_data_type:


### PR DESCRIPTION
The cloudpickle fallback materializer records the SHA-256 of the stored file (compute_content_hash) and, when a content hash was recorded for the artifact version, checks the stored bytes against it before reading them back. Artifacts with no recorded hash load unchanged.

The recorded hash reaches the materializer through a new BaseMaterializer.expected_content_hash field, set in _load_artifact_from_uri, the model-metadata loader, and step-input loading.

Adds unit tests for matching-hash loads, content-hash mismatches, and the no-hash path.

## Describe changes
I implemented/fixed _ to achieve _.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

