### PR TITLE
Fix time format in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-      time: 07:00
+      time: "07:00"
       timezone: Europe/Amsterdam
     reviewers: [strickvl]
     labels: [dependencies, internal, no-release-notes]


### PR DESCRIPTION
Change time format to string in dependabot configuration. https://github.com/zenml-io/zenml/commit/8092e24b94aa0bd7d63656de5c5a00d4075955a3 this commit broke it, it seems. See https://github.com/zenml-io/zenml/pull/4607/checks?check_run_id=79682507429 for an e.g. of it failing