### PR TITLE
Fix docs link checker domain policies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ python link_checker.py --dir docs/book --replace-links --url-mapping user-guide=
    - Validates links via HTTP requests
    - Parallel validation for better performance
    - Detailed error reporting
+   - Uses narrow default CI policies for external domains that block automated checks. These policies are status-specific: known bot-hostile documentation domains may accept `403`, and known rate-limited domains may soft-pass `429`, while statuses such as `404`, `410`, and `5xx` still fail.
 
 ### Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,7 @@ python link_checker.py --dir docs/book --replace-links --url-mapping user-guide=
    - Validates links via HTTP requests
    - Parallel validation for better performance
    - Detailed error reporting
-   - Uses narrow default CI policies for external domains that block automated checks. These policies are status-specific: known bot-hostile documentation domains may accept `403`, and known rate-limited domains may soft-pass `429`, while statuses such as `404`, `410`, and `5xx` still fail.
+   - Uses narrow default CI policies for external domains that block automated checks. These policies are status-specific: approved bot-hostile URLs or domains may accept specific statuses such as `403`, `406`, `429`, or `502`, while non-exempt hard failures such as `404` and `410` still fail.
 
 ### Requirements
 

--- a/docs/link_checker.py
+++ b/docs/link_checker.py
@@ -59,7 +59,7 @@ Arguments:
 
 Note:
     Status-specific policies may accept known bot-hostile responses such as 403
-    while still failing 404/410/5xx.
+    while still failing non-exempt hard failures such as 404 and 410.
 
     The 'requests' package is required for link validation. Install it with:
     pip install requests
@@ -98,6 +98,12 @@ except ImportError:
 EXEMPT_URL_STATUS: Dict[str, set] = {
     # Requires authentication; often returns 403 to unauthenticated HEAD/GET.
     "https://huggingface.co/settings/tokens": {403},
+    # Modal and Segment reject automated requests for these approved docs links.
+    "https://modal.com": {403, 406},
+    "https://modal.com/docs/guide/gpu": {403, 406},
+    "https://modal.com/docs/guide/region-selection": {403, 406},
+    "https://modal.com/signup": {403, 406},
+    "https://segment.com": {403},
     # zenml.io/slack and /slack-invite redirect to a zenml.slack.com invite URL.
     # Slack returns 403 to any unauthenticated request to those invite URLs by
     # design, regardless of User-Agent or HEAD/GET. A real takedown would
@@ -113,14 +119,9 @@ EXEMPT_DOMAIN_STATUS: Dict[str, set] = {
     "terraform.io": {429},
     "www.terraform.io": {429},
     # AWS documentation and SDK reference hosts often reject CI traffic.
-    "aws.amazon.com": {403},
     "boto3.amazonaws.com": {403},
     "botocore.amazonaws.com": {403},
     "docs.aws.amazon.com": {403},
-    # Modal docs return 406 Not Acceptable or 403 to automated requests.
-    "modal.com": {403, 406},
-    # Segment can reject automated requests while keeping the public page valid.
-    "segment.com": {403},
     # ghcr.io is a container registry API, not a web page; returns 502 to browsers.
     "ghcr.io": {502},
 }

--- a/docs/link_checker.py
+++ b/docs/link_checker.py
@@ -19,7 +19,7 @@ It provides several key features:
    - Validates links by making HTTP requests
    - Supports parallel validation for better performance
    - Provides detailed error reporting for broken links
-   - Soft-passes HTTP 429 responses for specific domains (e.g., HashiCorp docs) to avoid CI flakiness
+   - Applies narrow status-specific policies for known bot-hostile or rate-limited domains
 
 Usage Examples:
     # Find all links containing 'docs.zenml.io' in a directory
@@ -40,7 +40,7 @@ Usage Examples:
     # Use custom URL path mappings
     python link_checker.py --dir docs --replace-links --url-mapping user-guide=user-guides
 
-    # Soft-pass 429 for HashiCorp docs and skip HEAD for those domains (defaults)
+    # Use default CI policies for known bot-hostile or rate-limited domains
     python link_checker.py --dir docs --substring http --validate-links --ci-mode
 
 Arguments:
@@ -58,6 +58,9 @@ Arguments:
     --user-agent: Custom User-Agent header to use for HTTP requests
 
 Note:
+    Status-specific policies may accept known bot-hostile responses such as 403
+    while still failing 404/410/5xx.
+
     The 'requests' package is required for link validation. Install it with:
     pip install requests
 """
@@ -88,8 +91,8 @@ except ImportError:
 #     EXEMPT_URL_STATUS with the normalized URL (no trailing slash) and a set
 #     of allowed status codes.
 #   - To allow particular statuses for an entire *domain*, add an entry to
-#     EXEMPT_DOMAIN_STATUS with the domain suffix (e.g. "example.com") and a
-#     set of allowed status codes. Matching uses host.endswith(domain).
+#     EXEMPT_DOMAIN_STATUS with the domain (e.g. "example.com") and a set of
+#     allowed status codes. Matching allows only exact hosts or dotted subdomains.
 # ------------------------------------------------------------------------------
 
 EXEMPT_URL_STATUS: Dict[str, set] = {
@@ -109,8 +112,15 @@ EXEMPT_DOMAIN_STATUS: Dict[str, set] = {
     "developer.hashicorp.com": {429},
     "terraform.io": {429},
     "www.terraform.io": {429},
-    # Modal docs return 406 Not Acceptable to automated requests.
-    "modal.com": {406},
+    # AWS documentation and SDK reference hosts often reject CI traffic.
+    "aws.amazon.com": {403},
+    "boto3.amazonaws.com": {403},
+    "botocore.amazonaws.com": {403},
+    "docs.aws.amazon.com": {403},
+    # Modal docs return 406 Not Acceptable or 403 to automated requests.
+    "modal.com": {403, 406},
+    # Segment can reject automated requests while keeping the public page valid.
+    "segment.com": {403},
     # ghcr.io is a container registry API, not a web page; returns 502 to browsers.
     "ghcr.io": {502},
 }
@@ -119,11 +129,13 @@ EXEMPT_DOMAIN_STATUS: Dict[str, set] = {
 # These defaults can be extended via CLI flags.
 DEFAULT_IGNORE_429_DOMAINS = {
     "developer.hashicorp.com",
+    "huggingface.co",
     "terraform.io",
     "www.terraform.io",
 }
 DEFAULT_NO_HEAD_DOMAINS = {
     "developer.hashicorp.com",
+    "huggingface.co",
     "terraform.io",
     "www.terraform.io",
 }
@@ -137,6 +149,11 @@ DEFAULT_USER_AGENT = (
 )
 
 
+def host_matches_domain(host: str, domain: str) -> bool:
+    """Return whether a hostname is the domain itself or a real subdomain."""
+    return host == domain or host.endswith(f".{domain}")
+
+
 def is_exception_status(cleaned_url: str, status_code: int) -> bool:
     """
     Return True if (cleaned_url, status_code) should be treated as valid based
@@ -144,7 +161,7 @@ def is_exception_status(cleaned_url: str, status_code: int) -> bool:
 
     Rules:
       - Exact-URL exemptions: compared after stripping any trailing slash.
-      - Domain exemptions: suffix match against the URL hostname.
+      - Domain exemptions: exact hostname or dotted subdomain match.
     """
     if not cleaned_url.startswith(("http://", "https://")):
         return False
@@ -162,7 +179,7 @@ def is_exception_status(cleaned_url: str, status_code: int) -> bool:
         host = ""
 
     for domain, codes in EXEMPT_DOMAIN_STATUS.items():
-        if host.endswith(domain) and status_code in codes:
+        if host_matches_domain(host, domain) and status_code in codes:
             return True
 
     return False
@@ -409,8 +426,9 @@ def check_link_validity(
                 cleaned_url, timeout=timeout, allow_redirects=True
             )
 
-        # If HEAD fails (>=400), try GET
-        if response.status_code >= 400:
+        # If HEAD fails (>=400), try GET. Domains configured to skip HEAD
+        # already used GET above, so avoid sending the same GET request twice.
+        if not skip_head and response.status_code >= 400:
             response = session.get(
                 cleaned_url, timeout=timeout, allow_redirects=True
             )
@@ -557,6 +575,8 @@ def validate_urls(
                 else:
                     if is_valid and status_code == 429:
                         status = "✅ Valid (429 soft-pass)"
+                    elif is_valid and status_code and status_code >= 400:
+                        status = f"✅ Valid (policy-exempt HTTP {status_code})"
                     else:
                         status = (
                             "✅ Valid" if is_valid else f"❌ {error_message}"
@@ -929,13 +949,13 @@ def main():
         "--ignore-429-domain",
         action="append",
         default=[],
-        help="Domain for which to consider HTTP 429 as a soft pass (can be used multiple times). Defaults include developer.hashicorp.com and terraform.io.",
+        help="Domain for which to consider HTTP 429 as a soft pass (can be used multiple times). Defaults include developer.hashicorp.com, huggingface.co, and terraform.io.",
     )
     parser.add_argument(
         "--no-head-domain",
         action="append",
         default=[],
-        help="Domain for which to skip HEAD and only use GET (can be used multiple times). Defaults include developer.hashicorp.com and terraform.io.",
+        help="Domain for which to skip HEAD and only use GET (can be used multiple times). Defaults include developer.hashicorp.com, huggingface.co, and terraform.io.",
     )
     parser.add_argument(
         "--skip-domain",

--- a/tests/unit/docs/test_link_checker_policies.py
+++ b/tests/unit/docs/test_link_checker_policies.py
@@ -1,0 +1,131 @@
+"""Tests for docs link checker policy exemptions."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def load_link_checker_module() -> ModuleType:
+    """Load the standalone docs link checker script as a module."""
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "docs" / "link_checker.py"
+    spec = importlib.util.spec_from_file_location(
+        "docs_link_checker", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+link_checker = load_link_checker_module()
+
+
+@pytest.mark.parametrize(
+    ("host", "domain", "expected"),
+    [
+        ("modal.com", "modal.com", True),
+        ("docs.modal.com", "modal.com", True),
+        ("a.b.modal.com", "modal.com", True),
+        ("evilmodal.com", "modal.com", False),
+        ("notsegment.com", "segment.com", False),
+        ("modal.com.evil.example", "modal.com", False),
+    ],
+)
+def test_host_matches_domain_only_matches_exact_hosts_or_subdomains(
+    host: str, domain: str, expected: bool
+) -> None:
+    """Check that domain matching excludes unsafe suffix matches."""
+    assert link_checker.host_matches_domain(host, domain) is expected
+
+
+@pytest.mark.parametrize(
+    ("url", "status_code"),
+    [
+        ("https://modal.com", 403),
+        ("https://modal.com", 406),
+        ("https://modal.com/", 403),
+        ("https://modal.com/signup", 403),
+        ("https://modal.com/signup", 406),
+        ("https://modal.com/docs/guide/gpu", 403),
+        ("https://modal.com/docs/guide/gpu", 406),
+        ("https://modal.com/docs/guide/region-selection", 403),
+        ("https://modal.com/docs/guide/region-selection", 406),
+        ("https://segment.com", 403),
+        ("https://segment.com/", 403),
+    ],
+)
+def test_modal_and_segment_approved_urls_are_exempt(
+    url: str, status_code: int
+) -> None:
+    """Check exact approved Modal and Segment URL exemptions."""
+    assert link_checker.is_exception_status(url, status_code) is True
+
+
+@pytest.mark.parametrize(
+    ("url", "status_code"),
+    [
+        ("https://modal.com/unknown", 403),
+        ("https://modal.com/unknown", 406),
+        ("https://docs.modal.com", 403),
+        ("https://segment.com/docs", 403),
+        ("https://api.segment.com", 403),
+        ("https://modal.com", 404),
+        ("https://modal.com", 410),
+        ("https://segment.com", 404),
+        ("https://segment.com", 410),
+        ("https://segment.com", 406),
+    ],
+)
+def test_modal_and_segment_unapproved_urls_or_statuses_are_not_exempt(
+    url: str, status_code: int
+) -> None:
+    """Check broad Modal and Segment domain exemptions are gone."""
+    assert link_checker.is_exception_status(url, status_code) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://docs.aws.amazon.com/general/latest/gr/apprunner.html",
+        "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html",
+        "https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html",
+    ],
+)
+def test_aws_documentation_and_reference_hosts_allow_403(url: str) -> None:
+    """Check focused AWS documentation and reference host exemptions."""
+    assert link_checker.is_exception_status(url, 403) is True
+
+
+@pytest.mark.parametrize(
+    ("url", "status_code"),
+    [
+        ("https://aws.amazon.com/apprunner/", 403),
+        ("https://aws.amazon.com/cli/", 403),
+        ("https://aws.amazon.com/s3/", 403),
+        ("https://docs.aws.amazon.com/general/latest/gr/apprunner.html", 404),
+        ("https://docs.aws.amazon.com/general/latest/gr/apprunner.html", 410),
+        (
+            "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html",
+            404,
+        ),
+        (
+            "https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html",
+            410,
+        ),
+    ],
+)
+def test_aws_product_urls_and_hard_failures_are_not_exempt(
+    url: str, status_code: int
+) -> None:
+    """Check broad AWS product URLs and hard failures still fail."""
+    assert link_checker.is_exception_status(url, status_code) is False
+
+
+def test_ghcr_502_exemption_remains_intentional() -> None:
+    """Check the policy still includes the intentional ghcr.io 502 case."""
+    assert link_checker.is_exception_status("https://ghcr.io", 502) is True


### PR DESCRIPTION
## Summary

- add narrow status-specific link-checker policies for bot-hostile AWS docs/reference hosts
- soft-pass Hugging Face `429` responses and skip `HEAD` for Hugging Face to reduce duplicate rate-limit pressure
- tighten domain policy matching to exact hosts or dotted subdomains only, so arbitrary suffixes like `notsegment.com` do not match
- limit Modal and Segment handling to exact approved docs URLs instead of domain-wide `403` exemptions
- remove the broad `aws.amazon.com` `403` exemption while keeping AWS docs/SDK reference hosts covered
- document the CI policy behavior in `docs/README.md`
- add focused no-network tests for policy boundaries

## Verification

- `python3 -m py_compile docs/link_checker.py`
- focused no-network policy checks for exact/subdomain matching, false-positive hostnames, status-specific exemptions, Hugging Face `429`, and no duplicate `GET` fallback
- `uv run --with pytest pytest --confcutdir=tests/unit/docs tests/unit/docs/test_link_checker_policies.py` (`38 passed`)
- `uv run ruff check tests/unit/docs/test_link_checker_policies.py`
- `uv run ruff format --check docs/link_checker.py tests/unit/docs/test_link_checker_policies.py`
- simplify skill review pass: reuse, quality, and efficiency reviewers found no issues
- Oracle review loop passed after narrowing Modal/Segment/AWS policy scope; final review had no findings
