### PR TITLE
Run arbitrary (non-)python commands as steps

### DIFF
--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -23,6 +23,29 @@ if __name__ == "__main__":
 
 The command is whatever you would type in a shell, split into a list. The image just needs to contain the binary you invoke. Shell features like pipes and `&&` need an explicit shell, for example `["bash", "-c", "a | b"]`.
 
+## Running a Python function
+
+Instead of a command, you can pass a Python function. ZenML extracts the source code of the function and runs it with `python -c`:
+
+```python
+from zenml import CommandStep
+
+def train() -> None:
+    import json
+
+    print(json.dumps({"status": "training"}))
+
+train_step = CommandStep(command=train)
+```
+
+The extracted source code is the entire program, nothing around the function travels with it. This means the function must be self-contained:
+
+- All imports must happen inside the function body. Module-level imports are not available.
+- The function must not reference module-level variables, constants, or other functions.
+- The function must not take any parameters, be decorated, or be defined inside another function.
+
+ZenML rejects parameters, decorators, and references to enclosing functions when the step is created. The execution environment only needs a `python` binary on the `PATH`, ZenML does not have to be installed.
+
 ## Running without ZenML in the image
 
 A regular step runs your Python function inside the container, so the image has to contain `zenml`, your step code, and all of its dependencies. A command step does not. ZenML treats the command as a black box and never imports anything inside the container, so you can run an image that does not have `zenml` installed.
@@ -74,3 +97,4 @@ Environment variables and secrets are passed to the command as environment varia
 - Logs of command steps are not tracked by ZenML. They stay in the backend's native logging (for example CloudWatch or pod logs).
 - Step hooks are not allowed.
 - Steps in static pipelines without a step operator are not supported.
+- Functions passed as commands must be self-contained (see [Running a Python function](#running-a-python-function)).

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -46,7 +46,7 @@ The extracted source code is the entire program, nothing around the function tra
 
 ZenML rejects parameters, decorators, and references to enclosing functions when the step is created. The execution environment only needs a `python` binary on the `PATH`, ZenML does not have to be installed.
 
-## Running without ZenML in the image
+## Running without ZenML in the image (dynamic pipelines only)
 
 A regular step runs your Python function inside the container, so the image has to contain `zenml`, your step code, and all of its dependencies. A command step does not. ZenML treats the command as a black box and never imports anything inside the container, so you can run an image that does not have `zenml` installed.
 
@@ -65,14 +65,15 @@ train = CommandStep(
 )
 ```
 
-The image must be pullable by the backend and already carry your code and libraries. The container owns its own credentials for anything it accesses.
+The image must be pullable by the execution backend and already carry your code and libraries.
 
 ## Where command steps run
 
 A command step follows the same execution routing as any other step. It can run:
 
 - On a **step operator**, in both static and dynamic pipelines.
-- **Locally as a subprocess** in dynamic pipelines, without a step operator.
+- As an **isolated step** (dynamic pipelines only)
+- **Locally as a subprocess** as an inline step (dynamic pipelines only)
 
 A static pipeline without a step operator is rejected at compile time. Attach a step operator, or use a dynamic pipeline.
 

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -93,6 +93,7 @@ Environment variables and secrets are passed to the command as environment varia
 ## Limitations
 
 - Command steps do not support inputs and outputs.
+- Your code is not downloaded into the execution environment.
 - `get_step_context()`, metadata, visualizations, and tags are not available inside the command.
 - Logs of command steps are not tracked by ZenML. They stay in the backend's native logging (for example CloudWatch or pod logs).
 - Step hooks are not allowed.

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -1,0 +1,76 @@
+---
+description: Run arbitrary commands as pipeline steps
+---
+
+# Command Steps
+
+A command step runs an arbitrary command as a step in your pipeline instead of a Python function. Use the `CommandStep` class to wrap any command, and add it to a pipeline like any other step:
+
+```python
+from zenml import CommandStep, pipeline
+
+train = CommandStep(command=["python", "train.py"])
+report = CommandStep(command=["bash", "-c", "echo 'done'"])
+
+@pipeline(dynamic=True, enable_cache=False)
+def my_pipeline() -> None:
+    train()
+    report()
+
+if __name__ == "__main__":
+    my_pipeline()
+```
+
+The command is whatever you would type in a shell, split into a list. The image just needs to contain the binary you invoke. Shell features like pipes and `&&` need an explicit shell, for example `["bash", "-c", "a | b"]`.
+
+## Running without ZenML in the image
+
+A regular step runs your Python function inside the container, so the image has to contain `zenml`, your step code, and all of its dependencies. A command step does not. ZenML treats the command as a black box and never imports anything inside the container, so you can run an image that does not have `zenml` installed.
+
+Point a command step at such an image with the existing Docker settings:
+
+```python
+from zenml import CommandStep
+from zenml.config import DockerSettings
+
+train = CommandStep(
+    command=["python", "train.py"],
+    step_operator="sagemaker",
+    settings={
+        "docker": DockerSettings(skip_build=True, parent_image="my-registry/train:latest")
+    },
+)
+```
+
+The image must be pullable by the backend and already carry your code and libraries. The container owns its own credentials for anything it accesses.
+
+## Where command steps run
+
+A command step follows the same execution routing as any other step. It can run:
+
+- On a **step operator**, in both static and dynamic pipelines.
+- **Locally as a subprocess** in dynamic pipelines, without a step operator.
+
+A static pipeline without a step operator is rejected at compile time. Attach a step operator, or use a dynamic pipeline.
+
+## Configuring a command step
+
+A command step is a regular step. It takes the same options as any other step (step operator, settings, resources, retry, environment, secrets, and so on), either in the constructor or through `.with_options()` and `.configure()`:
+
+```python
+train = CommandStep(command=["python", "train.py"], step_operator="sagemaker")
+
+@pipeline(dynamic=True)
+def my_pipeline() -> None:
+    train.with_options(environment={"EPOCHS": "10"}, secrets=["my_api_key"])()
+```
+
+Environment variables and secrets are passed to the command as environment variables. The step succeeds when the command exits with status `0` and fails on any non-zero exit. See [Configuration](configuration.md) for the full set of options and the difference between `.with_options()` and `.configure()`.
+
+## Limitations
+
+- Command steps do not support inputs and outputs.
+- `get_step_context()`, metadata, visualizations, and tags are not available inside the command.
+- Logs of command steps are not tracked by ZenML. They stay in the backend's native logging (for example CloudWatch or pod logs).
+- Step hooks are not allowed.
+- Steps in static pipelines without a step operator are not supported.

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -47,6 +47,7 @@
   * [Advanced Features](how-to/steps-pipelines/advanced_features.md)
   * [Hooks](how-to/steps-pipelines/hooks.md)
   * [Dynamic Pipelines](how-to/steps-pipelines/dynamic_pipelines.md)
+  * [Command Steps](how-to/steps-pipelines/command_steps.md)
   * [Streaming Events](how-to/steps-pipelines/streaming_events.md)
 * [Artifacts](how-to/artifacts/artifacts.md)
   * [Materializers](how-to/artifacts/materializers.md)

--- a/src/zenml/__init__.py
+++ b/src/zenml/__init__.py
@@ -60,7 +60,7 @@ from zenml.artifacts.artifact_config import ArtifactConfig
 from zenml.artifacts.external_artifact import ExternalArtifact
 from zenml.model.model import Model
 from zenml.pipelines import get_pipeline_context, pipeline
-from zenml.steps import step, get_step_context
+from zenml.steps import step, get_step_context, CommandStep
 from zenml.steps.utils import log_step_metadata
 from zenml.utils.metadata_utils import log_metadata, bulk_log_metadata
 from zenml.utils.tag_utils import Tag, add_tags, remove_tags
@@ -72,6 +72,7 @@ __all__ = [
     "remove_tags",
     "Tag",
     "ArtifactConfig",
+    "CommandStep",
     "ExternalArtifact",
     "get_pipeline_context",
     "get_step_context",

--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -532,6 +532,10 @@ class Compiler:
             pipeline: Configuration for the pipeline.
             skip_input_validation: If True, will skip the input validation.
 
+        Raises:
+            StepInterfaceError: If a command step defines success or failure
+                hooks.
+
         Returns:
             The compiled step.
         """

--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -41,7 +41,7 @@ from zenml.config.step_configurations import (
 )
 from zenml.enums import StepRuntime
 from zenml.environment import get_run_environment_dict
-from zenml.exceptions import StackValidationError
+from zenml.exceptions import StackValidationError, StepInterfaceError
 from zenml.models import PipelineSnapshotBase
 from zenml.pipelines.run_utils import get_default_run_name
 from zenml.utils import pydantic_utils, secret_utils, settings_utils
@@ -150,6 +150,7 @@ class Compiler:
         }
 
         self._ensure_required_stack_components_exist(stack=stack, steps=steps)
+        self._validate_command_steps(pipeline=pipeline, steps=steps)
 
         run_name = run_configuration.run_name or get_default_run_name(
             pipeline_name=pipeline.name
@@ -574,6 +575,20 @@ class Compiler:
                 parameters_to_ignore=parameters_to_ignore,
                 skip_input_validation=skip_input_validation,
             )
+
+        if step_configuration_overrides.command:
+            # Do not allow explicit hooks on a command step. In case they get
+            # applied from the pipeline level, we do not fail but just ignore
+            # them. Otherwise, the hook defaults from the pipeline would be
+            # unusable if the pipeline contains a command step.
+            if (
+                step_configuration_overrides.failure_hook_source
+                or step_configuration_overrides.success_hook_source
+            ):
+                raise StepInterfaceError(
+                    "Command steps do not support success or failure hooks."
+                )
+
         full_step_config = (
             step_configuration_overrides.apply_pipeline_configuration(
                 pipeline_configuration=pipeline.configuration,
@@ -639,6 +654,34 @@ class Compiler:
             for name_in_pipeline in sorted_step_names
         ]
         return sorted_invocations
+
+    @staticmethod
+    def _validate_command_steps(
+        pipeline: "Pipeline", steps: Mapping[str, "Step"]
+    ) -> None:
+        """Validates the command steps of a pipeline.
+
+        Args:
+            pipeline: The pipeline to validate.
+            steps: The steps of the pipeline.
+
+        Raises:
+            StackValidationError: If a command step in a static pipeline has no
+                step operator.
+        """
+        if pipeline.is_dynamic:
+            return
+
+        for name, step in steps.items():
+            if (
+                step.config.command is not None
+                and not step.config.step_operator
+            ):
+                raise StackValidationError(
+                    f"Command step `{name}` in a static pipeline requires a "
+                    "step operator. Configure a step operator for the step, or "
+                    "use a dynamic pipeline."
+                )
 
     @staticmethod
     def _ensure_required_stack_components_exist(

--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -588,10 +588,10 @@ class Compiler:
             if (
                 step_configuration_overrides.failure_hook_source
                 or step_configuration_overrides.success_hook_source
+                or step_configuration_overrides.end_hook_source
+                or step_configuration_overrides.start_hook_source
             ):
-                raise StepInterfaceError(
-                    "Command steps do not support success or failure hooks."
-                )
+                raise StepInterfaceError("Command steps do not support hooks.")
 
         full_step_config = (
             step_configuration_overrides.apply_pipeline_configuration(

--- a/src/zenml/config/step_configurations.py
+++ b/src/zenml/config/step_configurations.py
@@ -254,7 +254,6 @@ class StepConfigurationUpdate(FrozenBaseModel):
         default=None,
         description="The group information for the step.",
     )
-
     outputs: Mapping[str, PartialArtifactConfiguration] = {}
 
     def uses_step_operator(self, name: str) -> bool:
@@ -309,6 +308,7 @@ class PartialStepConfiguration(StepConfigurationUpdate):
     client_lazy_loaders: Mapping[str, ClientLazyLoader] = {}
     outputs: Mapping[str, PartialArtifactConfiguration] = {}
     cache_policy: CachePolicyWithValidator = CachePolicy.default()
+    command: Optional[List[str]] = None
 
     # TODO: In Pydantic v2, the `model_` is a protected namespaces for all
     #  fields defined under base models. If not handled, this raises a warning.

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -488,10 +488,6 @@ class DynamicPipelineRunner:
         """Monitoring loop.
 
         This should run in a separate thread and monitors the running steps.
-
-        Raises:
-            RuntimeError: If a regular (=non-command) step completed on the
-                infrastructure side but its status was not updated in the DB.
         """
         from zenml.config.step_configurations import Step
 

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -138,6 +138,7 @@ from zenml.orchestrators.publish_utils import (
     publish_failed_step_run,
     publish_pipeline_run_status_update,
     publish_stopped_step_run,
+    publish_successful_step_run,
 )
 from zenml.pipelines.dynamic.pipeline_definition import DynamicPipeline
 from zenml.pipelines.run_utils import create_placeholder_run
@@ -487,6 +488,10 @@ class DynamicPipelineRunner:
         """Monitoring loop.
 
         This should run in a separate thread and monitors the running steps.
+
+        Raises:
+            RuntimeError: If a regular (=non-command) step completed on the
+                infrastructure side but its status was not updated in the DB.
         """
         from zenml.config.step_configurations import Step
 
@@ -569,6 +574,31 @@ class DynamicPipelineRunner:
                     # Step failed/stopped on the infra side, but the
                     # code failed before it could report the status back to us.
                     step_run = publish_failed_step_run(step_run.id)
+                elif (
+                    infra_status == ExecutionStatus.COMPLETED
+                    and db_status == ExecutionStatus.RUNNING
+                ):
+                    if step_run.config.command is not None:
+                        # For isolated command steps, no zenml code is running
+                        # and therefore nothing publishes the status. We assume
+                        # the command finished successfully because of the
+                        # infra status.
+                        step_run = publish_successful_step_run(
+                            step_run_id=step_run.id,
+                            output_artifact_ids={},
+                        )
+                    else:
+                        # This should never happen, handle it just in case. If
+                        # this happens, the node would stay in `RUNNING` status
+                        # forever and keep the pipeline from finishing. We
+                        # record a failure but don't raise to keep the
+                        # monitoring loop alive during the shutdown phase.
+                        exc = RuntimeError(
+                            f"Step `{invocation_id}` completed on the "
+                            "infrastructure side but its status was not "
+                            "updated."
+                        )
+                        self.record_failure(exc)
 
                 # Get the updated status that we might have just published
                 db_status = step_run.status

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -85,7 +85,10 @@ from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType, Uri
 from zenml.orchestrators import ContainerizedOrchestrator, SubmissionResult
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
-from zenml.orchestrators.utils import get_orchestrator_run_name
+from zenml.orchestrators.utils import (
+    get_orchestrator_run_name,
+    get_step_entrypoint_command,
+)
 from zenml.stack import StackValidator
 from zenml.utils.env_utils import split_environment_variables
 from zenml.utils.time_utils import to_utc_timezone, utc_now_tz_aware
@@ -1086,9 +1089,14 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             SagemakerOrchestratorSettings, self.get_settings(step_run_info)
         )
 
-        command = SagemakerStepOperatorEntrypointConfiguration.get_entrypoint_command()
-        arguments = SagemakerStepOperatorEntrypointConfiguration.get_entrypoint_arguments(
-            step_name=step_run_info.pipeline_step_name,
+        step = step_run_info.snapshot.step_configurations[
+            step_run_info.pipeline_step_name
+        ]
+        command, arguments = get_step_entrypoint_command(
+            step=step,
+            entrypoint_config_class=(
+                SagemakerStepOperatorEntrypointConfiguration
+            ),
             snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),
         )

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -1089,11 +1089,9 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             SagemakerOrchestratorSettings, self.get_settings(step_run_info)
         )
 
-        step = step_run_info.snapshot.step_configurations[
-            step_run_info.pipeline_step_name
-        ]
         command, arguments = get_step_entrypoint_command(
-            step=step,
+            invocation_id=step_run_info.pipeline_step_name,
+            config=step_run_info.config,
             entrypoint_config_class=(
                 SagemakerStepOperatorEntrypointConfiguration
             ),

--- a/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
+++ b/src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py
@@ -75,11 +75,13 @@ from zenml.integrations.aws.orchestrators.sagemaker_orchestrator_entrypoint_conf
     SagemakerEntrypointConfiguration,
 )
 from zenml.integrations.aws.step_operators.sagemaker_step_operator_entrypoint_config import (
+    SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT,
     SagemakerStepOperatorEntrypointConfiguration,
 )
 from zenml.integrations.aws.utils import (
     convert_processing_job_status,
     convert_training_job_status,
+    validate_command_step_environment,
 )
 from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType, Uri
@@ -387,6 +389,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
         step_name: Optional[str] = None,
         upstream_steps: Optional[List[str]] = None,
         wait: bool = True,
+        is_command_step: bool = False,
     ) -> Tuple[
         Union[Estimator, Processor, Step],
         Optional[str],
@@ -409,6 +412,8 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             step_name: The name of the pipeline step.
             upstream_steps: The upstream steps of the pipeline step.
             wait: Whether to wait for the job to complete.
+            is_command_step: Whether the job runs an opaque command step rather
+                than the ZenML entrypoint.
 
         Returns:
             The estimator or processor object or pipeline step object and the
@@ -418,16 +423,6 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             TypeError: If the network_config passed is not compatible with the
                 AWS SageMaker NetworkConfig class.
         """
-        # Sagemaker does not allow environment variables longer than 256
-        # characters to be passed to Processor steps. If an environment variable
-        # is longer than 256 characters, we split it into multiple environment
-        # variables (chunks) and re-construct it on the other side using the
-        # custom entrypoint configuration.
-        split_environment_variables(
-            size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT,
-            env=environment,
-        )
-
         # Sagemaker requires the base job name to use alphanum and hyphens only
         base_job_name = re.sub(r"[^a-zA-Z0-9\-]", "-", base_job_name)
 
@@ -440,6 +435,28 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
                 else True
             )
         )
+
+        # Sagemaker does not allow environment variables longer than 256
+        # characters for Processor steps (512 for Estimator steps). Normally we
+        # split oversized variables into chunks and reconstruct them on the
+        # other side using the custom entrypoint configuration. Command steps
+        # run an opaque command instead of that entrypoint, so the
+        # reconstruction never runs. We therefore validate the sizes against the
+        # real per-job-type limit and fail if a variable exceeds it.
+        if is_command_step:
+            validate_command_step_environment(
+                environment=environment,
+                size_limit=(
+                    SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT
+                    if use_training_step
+                    else SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT
+                ),
+            )
+        else:
+            split_environment_variables(
+                size_limit=SAGEMAKER_PROCESSOR_STEP_ENV_VAR_SIZE_LIMIT,
+                env=environment,
+            )
 
         if use_training_step:
             job_args = settings.estimator_args.copy() or {}
@@ -1108,6 +1125,7 @@ class SagemakerOrchestrator(ContainerizedOrchestrator):
             command=command,
             arguments=arguments,
             wait=False,
+            is_command_step=step_run_info.config.command is not None,
         )
         assert job_name
         job_type = "training" if isinstance(job, Estimator) else "processing"

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -45,6 +45,7 @@ from zenml.integrations.aws.utils import (
 )
 from zenml.logger import get_logger
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
+from zenml.orchestrators.utils import shell_join
 from zenml.stack import Stack, StackValidator
 from zenml.step_operators import BaseStepOperator
 from zenml.step_operators.step_operator_entrypoint_configuration import (
@@ -248,7 +249,7 @@ class SagemakerStepOperator(BaseStepOperator):
         )
 
         image_name = info.get_image(key=SAGEMAKER_DOCKER_IMAGE_KEY)
-        environment[_ENTRYPOINT_ENV_VARIABLE] = " ".join(entrypoint_command)
+        environment[_ENTRYPOINT_ENV_VARIABLE] = shell_join(entrypoint_command)
 
         # Get and default fill SageMaker estimator arguments for full ZenML support
         estimator_args = settings.estimator_args

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -42,6 +42,7 @@ from zenml.integrations.aws.step_operators.sagemaker_step_operator_entrypoint_co
 )
 from zenml.integrations.aws.utils import (
     convert_training_job_status,
+    validate_command_step_environment,
 )
 from zenml.logger import get_logger
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
@@ -242,11 +243,20 @@ class SagemakerStepOperator(BaseStepOperator):
         # characters to be passed to Estimator steps. If an environment variable
         # is longer than 512 characters, we split it into multiple environment
         # variables (chunks) and re-construct it on the other side using the
-        # custom entrypoint configuration.
-        split_environment_variables(
-            env=environment,
-            size_limit=SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT,
-        )
+        # custom entrypoint configuration. Command steps run an opaque command
+        # instead of that entrypoint, so the reconstruction never runs. We
+        # therefore validate the sizes instead of splitting and fail if a
+        # variable exceeds the limit.
+        if info.config.command is not None:
+            validate_command_step_environment(
+                environment=environment,
+                size_limit=SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT,
+            )
+        else:
+            split_environment_variables(
+                env=environment,
+                size_limit=SAGEMAKER_ESTIMATOR_STEP_ENV_VAR_SIZE_LIMIT,
+            )
 
         image_name = info.get_image(key=SAGEMAKER_DOCKER_IMAGE_KEY)
         environment[_ENTRYPOINT_ENV_VARIABLE] = shell_join(entrypoint_command)

--- a/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
+++ b/src/zenml/integrations/aws/step_operators/sagemaker_step_operator.py
@@ -46,7 +46,6 @@ from zenml.integrations.aws.utils import (
 )
 from zenml.logger import get_logger
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
-from zenml.orchestrators.utils import shell_join
 from zenml.stack import Stack, StackValidator
 from zenml.step_operators import BaseStepOperator
 from zenml.step_operators.step_operator_entrypoint_configuration import (
@@ -63,7 +62,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 SAGEMAKER_DOCKER_IMAGE_KEY = "sagemaker_step_operator"
-_ENTRYPOINT_ENV_VARIABLE = "__ZENML_ENTRYPOINT"
 STEP_JOB_NAME_METADATA_KEY = "job_name"
 
 
@@ -164,7 +162,6 @@ class SagemakerStepOperator(BaseStepOperator):
                     key=SAGEMAKER_DOCKER_IMAGE_KEY,
                     settings=step.config.docker_settings,
                     step_name=step_name,
-                    entrypoint=f"${_ENTRYPOINT_ENV_VARIABLE}",
                 )
                 builds.append(build)
 
@@ -259,7 +256,6 @@ class SagemakerStepOperator(BaseStepOperator):
             )
 
         image_name = info.get_image(key=SAGEMAKER_DOCKER_IMAGE_KEY)
-        environment[_ENTRYPOINT_ENV_VARIABLE] = shell_join(entrypoint_command)
 
         # Get and default fill SageMaker estimator arguments for full ZenML support
         estimator_args = settings.estimator_args
@@ -273,6 +269,10 @@ class SagemakerStepOperator(BaseStepOperator):
         estimator_args["environment"] = environment
         estimator_args["instance_count"] = 1
         estimator_args["sagemaker_session"] = self.sagemaker_session
+        # The max length of the container entry point is 256 characters. Not
+        # really anything we can do about that, it will just fail with a
+        # SageMaker error for command steps that exceed the limit.
+        estimator_args["container_entry_point"] = entrypoint_command
 
         # Create Estimator
         estimator = Estimator(image_name, self.config.role, **estimator_args)

--- a/src/zenml/integrations/aws/utils.py
+++ b/src/zenml/integrations/aws/utils.py
@@ -13,7 +13,40 @@
 #  permissions and limitations under the License.
 """Utility functions for the AWS integration."""
 
+from typing import Dict
+
 from zenml.enums import ExecutionStatus
+
+
+def validate_command_step_environment(
+    environment: Dict[str, str],
+    size_limit: int,
+) -> None:
+    """Validate environment variable sizes for a SageMaker command step.
+
+    Args:
+        environment: The environment variables to validate.
+        size_limit: The maximum allowed length of an environment variable
+            value.
+
+    Raises:
+        RuntimeError: If an environment variable value exceeds the size limit.
+    """
+    oversized = {
+        key: len(value)
+        for key, value in environment.items()
+        if len(value) > size_limit
+    }
+    if oversized:
+        details = ", ".join(
+            f"`{key}` ({length} characters)"
+            for key, length in sorted(oversized.items())
+        )
+        raise RuntimeError(
+            "Unable to run command step. The following environment variables "
+            f"exceed the maximum length of {size_limit} characters allowed by "
+            f"SageMaker: {details}."
+        )
 
 
 def convert_training_job_status(status: str) -> ExecutionStatus:

--- a/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
+++ b/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
@@ -623,11 +623,9 @@ class AzureMLOrchestrator(ContainerizedOrchestrator):
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
         env = Environment(name=f"zenml-{step_run_info.run_name}", image=image)
 
-        step = step_run_info.snapshot.step_configurations[
-            step_run_info.pipeline_step_name
-        ]
         entrypoint_command, entrypoint_args = get_step_entrypoint_command(
-            step=step,
+            invocation_id=step_run_info.pipeline_step_name,
+            config=step_run_info.config,
             entrypoint_config_class=StepOperatorEntrypointConfiguration,
             snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),

--- a/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
+++ b/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
@@ -69,7 +69,10 @@ from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType, Uri
 from zenml.orchestrators import ContainerizedOrchestrator, SubmissionResult
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
-from zenml.orchestrators.utils import get_orchestrator_run_name
+from zenml.orchestrators.utils import (
+    get_orchestrator_run_name,
+    get_step_entrypoint_command,
+)
 from zenml.pipelines.dynamic.entrypoint_configuration import (
     DynamicPipelineEntrypointConfiguration,
 )
@@ -620,15 +623,14 @@ class AzureMLOrchestrator(ContainerizedOrchestrator):
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
         env = Environment(name=f"zenml-{step_run_info.run_name}", image=image)
 
-        entrypoint_command = (
-            StepOperatorEntrypointConfiguration.get_entrypoint_command()
-        )
-        entrypoint_args = (
-            StepOperatorEntrypointConfiguration.get_entrypoint_arguments(
-                step_name=step_run_info.pipeline_step_name,
-                snapshot_id=(step_run_info.snapshot.id),
-                step_run_id=str(step_run_info.step_run_id),
-            )
+        step = step_run_info.snapshot.step_configurations[
+            step_run_info.pipeline_step_name
+        ]
+        entrypoint_command, entrypoint_args = get_step_entrypoint_command(
+            step=step,
+            entrypoint_config_class=StepOperatorEntrypointConfiguration,
+            snapshot_id=step_run_info.snapshot.id,
+            step_run_id=str(step_run_info.step_run_id),
         )
 
         compute_target = create_or_get_compute(

--- a/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
+++ b/src/zenml/integrations/azure/orchestrators/azureml_orchestrator.py
@@ -72,6 +72,7 @@ from zenml.orchestrators.publish_utils import publish_step_run_metadata
 from zenml.orchestrators.utils import (
     get_orchestrator_run_name,
     get_step_entrypoint_command,
+    shell_join,
 )
 from zenml.pipelines.dynamic.entrypoint_configuration import (
     DynamicPipelineEntrypointConfiguration,
@@ -641,7 +642,7 @@ class AzureMLOrchestrator(ContainerizedOrchestrator):
         command_job = command(
             name=job_name,
             display_name=job_name,
-            command=" ".join(entrypoint_command + entrypoint_args),
+            command=shell_join(entrypoint_command + entrypoint_args),
             environment=env,
             environment_variables=environment,
             compute=compute_target,

--- a/src/zenml/integrations/azure/step_operators/azureml_step_operator.py
+++ b/src/zenml/integrations/azure/step_operators/azureml_step_operator.py
@@ -227,8 +227,13 @@ class AzureMLStepOperator(BaseStepOperator):
             azureml_client, settings, default_compute_name=f"zenml_{self.id}"
         )
 
+        job_name_prefix = str(info.step_run_id)[:8]
+        job_name = (
+            f"{job_name_prefix}-{info.run_name}-{info.pipeline_step_name}"
+        )
+
         command_job = command(
-            name=info.run_name,
+            name=job_name,
             command=shell_join(entrypoint_command),
             environment=env,
             environment_variables=environment,

--- a/src/zenml/integrations/azure/step_operators/azureml_step_operator.py
+++ b/src/zenml/integrations/azure/step_operators/azureml_step_operator.py
@@ -32,6 +32,7 @@ from zenml.integrations.azure.flavors.azureml_step_operator_flavor import (
 )
 from zenml.logger import get_logger
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
+from zenml.orchestrators.utils import shell_join
 from zenml.stack import Stack, StackValidator
 from zenml.step_operators import BaseStepOperator
 
@@ -228,7 +229,7 @@ class AzureMLStepOperator(BaseStepOperator):
 
         command_job = command(
             name=info.run_name,
-            command=" ".join(entrypoint_command),
+            command=shell_join(entrypoint_command),
             environment=env,
             environment_variables=environment,
             compute=compute_target,

--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -99,7 +99,10 @@ from zenml.logger import get_logger
 from zenml.metadata.metadata_types import MetadataType, Uri
 from zenml.orchestrators import ContainerizedOrchestrator, SubmissionResult
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
-from zenml.orchestrators.utils import get_orchestrator_run_name
+from zenml.orchestrators.utils import (
+    get_orchestrator_run_name,
+    get_step_entrypoint_command,
+)
 from zenml.pipelines.dynamic.entrypoint_configuration import (
     DynamicPipelineEntrypointConfiguration,
 )
@@ -767,10 +770,13 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
         )
 
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
-        command = StepOperatorEntrypointConfiguration.get_entrypoint_command()
-        args = StepOperatorEntrypointConfiguration.get_entrypoint_arguments(
-            step_name=step_run_info.pipeline_step_name,
-            snapshot_id=(step_run_info.snapshot.id),
+        step = step_run_info.snapshot.step_configurations[
+            step_run_info.pipeline_step_name
+        ]
+        command, args = get_step_entrypoint_command(
+            step=step,
+            entrypoint_config_class=StepOperatorEntrypointConfiguration,
+            snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),
         )
 

--- a/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
+++ b/src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py
@@ -770,11 +770,9 @@ class VertexOrchestrator(ContainerizedOrchestrator, GoogleCredentialsMixin):
         )
 
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
-        step = step_run_info.snapshot.step_configurations[
-            step_run_info.pipeline_step_name
-        ]
         command, args = get_step_entrypoint_command(
-            step=step,
+            invocation_id=step_run_info.pipeline_step_name,
+            config=step_run_info.config,
             entrypoint_config_class=StepOperatorEntrypointConfiguration,
             snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -95,7 +95,11 @@ from zenml.orchestrators import (
     PipelineSubmissionError,
     SubmissionResult,
 )
+from zenml.orchestrators import utils as orchestrator_utils
 from zenml.stack import StackValidator
+from zenml.step_operators.step_operator_entrypoint_configuration import (
+    StepOperatorEntrypointConfiguration,
+)
 
 if TYPE_CHECKING:
     from zenml.config.step_run_info import StepRunInfo
@@ -884,10 +888,6 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
             environment: The environment variables to set in the execution
                 environment.
         """
-        from zenml.step_operators.step_operator_entrypoint_configuration import (
-            StepOperatorEntrypointConfiguration,
-        )
-
         logger.info(
             "Launching job for step `%s`.",
             step_run_info.pipeline_step_name,
@@ -897,10 +897,13 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
             KubernetesOrchestratorSettings, self.get_settings(step_run_info)
         )
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
-        command = StepOperatorEntrypointConfiguration.get_entrypoint_command()
-        args = StepOperatorEntrypointConfiguration.get_entrypoint_arguments(
-            step_name=step_run_info.pipeline_step_name,
-            snapshot_id=(step_run_info.snapshot.id),
+        step = step_run_info.snapshot.step_configurations[
+            step_run_info.pipeline_step_name
+        ]
+        command, args = orchestrator_utils.get_step_entrypoint_command(
+            step=step,
+            entrypoint_config_class=StepOperatorEntrypointConfiguration,
+            snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),
         )
 

--- a/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
+++ b/src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py
@@ -897,11 +897,9 @@ class KubernetesOrchestrator(ContainerizedOrchestrator):
             KubernetesOrchestratorSettings, self.get_settings(step_run_info)
         )
         image = step_run_info.get_image(key=ORCHESTRATOR_DOCKER_IMAGE_KEY)
-        step = step_run_info.snapshot.step_configurations[
-            step_run_info.pipeline_step_name
-        ]
         command, args = orchestrator_utils.get_step_entrypoint_command(
-            step=step,
+            invocation_id=step_run_info.pipeline_step_name,
+            config=step_run_info.config,
             entrypoint_config_class=StepOperatorEntrypointConfiguration,
             snapshot_id=step_run_info.snapshot.id,
             step_run_id=str(step_run_info.step_run_id),

--- a/src/zenml/integrations/runai/step_operators/runai_step_operator.py
+++ b/src/zenml/integrations/runai/step_operators/runai_step_operator.py
@@ -527,19 +527,15 @@ class RunAIStepOperator(BaseStepOperator):
         Returns:
             Tuple of (command, args) as strings. The args value is None when
             there are no extra tokens.
-
-        Raises:
-            ValueError: If entrypoint_command format is invalid.
         """
-        if len(entrypoint_command) < 3:
-            raise ValueError(
-                f"Expected entrypoint command with at least 3 elements "
-                f"(e.g., ['python', '-m', 'module_name']), but got "
-                f"{len(entrypoint_command)} elements: {entrypoint_command}"
-            )
-
-        command_tokens = entrypoint_command[:3]
-        args_tokens = entrypoint_command[3:]
+        if len(entrypoint_command) > 3:
+            command_tokens = entrypoint_command[:3]
+            args_tokens = entrypoint_command[3:]
+        else:
+            # For command steps, the entrypoint command can be of arbitrary
+            # length. We treat it as a single command with no arguments.
+            command_tokens = entrypoint_command
+            args_tokens = []
 
         command = shell_join(command_tokens)
         args = shell_join(args_tokens) if args_tokens else None

--- a/src/zenml/integrations/runai/step_operators/runai_step_operator.py
+++ b/src/zenml/integrations/runai/step_operators/runai_step_operator.py
@@ -73,6 +73,7 @@ from zenml.integrations.runai.flavors.runai_step_operator_flavor import (
 )
 from zenml.logger import get_logger
 from zenml.orchestrators.publish_utils import publish_step_run_metadata
+from zenml.orchestrators.utils import shell_join
 from zenml.stack import Stack, StackValidator
 from zenml.step_operators import BaseStepOperator
 
@@ -540,8 +541,8 @@ class RunAIStepOperator(BaseStepOperator):
         command_tokens = entrypoint_command[:3]
         args_tokens = entrypoint_command[3:]
 
-        command = " ".join(command_tokens)
-        args = " ".join(args_tokens) if args_tokens else None
+        command = shell_join(command_tokens)
+        args = shell_join(args_tokens) if args_tokens else None
         return command, args
 
     def _build_environment_variables(

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -564,6 +564,10 @@ class BaseOrchestrator(StackComponent, ABC):
     ) -> None:
         """Submit an isolated step.
 
+        Implementations should use
+        `zenml.orchestrators.utils.get_step_entrypoint_command(...)` to get
+        the command and arguments to run the step.
+
         Args:
             step_run_info: The step run information.
             environment: The environment variables to set in the execution

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -366,7 +366,7 @@ class BaseOrchestrator(StackComponent, ABC):
                                 )
                         except Exception as e:
                             logger.debug(
-                                "Something went went wrong trying to publish the"
+                                "Something went wrong trying to publish the "
                                 f"run metadata: {e}"
                             )
             else:

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Class to launch (run directly or using a step operator) steps."""
 
+import subprocess
 import time
 from contextlib import nullcontext
 from typing import (
@@ -477,15 +478,13 @@ class StepLauncher:
             step_operator_name=step_operator_name,
         )
 
-        entrypoint_cfg_class = step_operator.entrypoint_config_class
-        entrypoint_command = (
-            entrypoint_cfg_class.get_entrypoint_command()
-            + entrypoint_cfg_class.get_entrypoint_arguments(
-                step_name=self._invocation_id,
-                snapshot_id=self._snapshot.id,
-                step_run_id=str(step_run_info.step_run_id),
-            )
+        command, args = orchestrator_utils.get_step_entrypoint_command(
+            step=self._step,
+            entrypoint_config_class=step_operator.entrypoint_config_class,
+            snapshot_id=self._snapshot.id,
+            step_run_id=str(step_run_info.step_run_id),
         )
+        entrypoint_command = command + args
         environment, secrets = orchestrator_utils.get_config_environment_vars(
             pipeline_run_id=step_run_info.run_id,
         )
@@ -553,7 +552,19 @@ class StepLauncher:
                 status = step_operator.wait(
                     step_run=step_run_info.step_run,
                 )
-                if not status.is_successful:
+                if status.is_successful:
+                    if self._is_command_step:
+                        # No in-container `StepRunner` publishes the status for
+                        # a command step, so the parent does it here.
+                        publish_utils.publish_successful_step_run(
+                            step_run_id=step_run_info.step_run_id,
+                            output_artifact_ids={},
+                        )
+                else:
+                    if self._is_command_step:
+                        publish_utils.publish_failed_step_run(
+                            step_run_info.step_run_id
+                        )
                     step_run = Client().get_run_step(step_run_info.step_run_id)
                     raise exception_utils.reconstruct_exception(
                         exception_info=step_run.exception_info,
@@ -595,7 +606,19 @@ class StepLauncher:
             status = self._stack.orchestrator.wait_for_isolated_step(
                 step_run_info.step_run
             )
-            if not status.is_successful:
+            if status.is_successful:
+                if self._is_command_step:
+                    # No in-container `StepRunner` publishes the status for
+                    # a command step, so the parent does it here.
+                    publish_utils.publish_successful_step_run(
+                        step_run_id=step_run_info.step_run_id,
+                        output_artifact_ids={},
+                    )
+            else:
+                if self._is_command_step:
+                    publish_utils.publish_failed_step_run(
+                        step_run_info.step_run_id
+                    )
                 step_run = Client().get_run_step(step_run_info.step_run_id)
                 raise exception_utils.reconstruct_exception(
                     exception_info=step_run.exception_info,
@@ -622,6 +645,10 @@ class StepLauncher:
             input_artifacts: The input artifact versions of the current step.
             output_artifact_uris: The output artifact URIs of the current step.
         """
+        if self._is_command_step:
+            self._run_command_step_locally(step_run=step_run)
+            return
+
         runner = StepRunner(step=self._step, stack=self._stack)
         runner.run(
             pipeline_run=pipeline_run,
@@ -630,6 +657,46 @@ class StepLauncher:
             output_artifact_uris=output_artifact_uris,
             step_run_info=step_run_info,
         )
+
+    @property
+    def _is_command_step(self) -> bool:
+        """Whether the step is a command step.
+
+        Returns:
+            Whether the step is a command step.
+        """
+        return self._step.config.command is not None
+
+    def _run_command_step_locally(self, step_run: StepRunResponse) -> None:
+        """Runs a command step as a subprocess in the current environment.
+
+        Args:
+            step_run: The model of the current step run.
+
+        Raises:
+            RuntimeError: If the command exits with a non-zero status.
+        """
+        command = self._step.config.command
+        assert command is not None
+
+        logger.info(
+            "Running command step `%s` locally: %s",
+            self._invocation_id,
+            command,
+        )
+        # TODO: env etc
+        result = subprocess.run(command)
+        if result.returncode == 0:
+            publish_utils.publish_successful_step_run(
+                step_run_id=step_run.id,
+                output_artifact_ids={},
+            )
+        else:
+            publish_utils.publish_failed_step_run(step_run.id)
+            raise RuntimeError(
+                f"Command step `{self._invocation_id}` failed with exit code "
+                f"{result.returncode}."
+            )
 
     def _should_register_signal_handler(self) -> bool:
         """Whether the signal handler should be registered.

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -13,7 +13,6 @@
 #  permissions and limitations under the License.
 """Class to launch (run directly or using a step operator) steps."""
 
-import subprocess
 import time
 from contextlib import nullcontext
 from typing import (
@@ -479,7 +478,8 @@ class StepLauncher:
         )
 
         command, args = orchestrator_utils.get_step_entrypoint_command(
-            step=self._step,
+            invocation_id=self._invocation_id,
+            config=self._step.config,
             entrypoint_config_class=step_operator.entrypoint_config_class,
             snapshot_id=self._snapshot.id,
             step_run_id=str(step_run_info.step_run_id),
@@ -552,27 +552,9 @@ class StepLauncher:
                 status = step_operator.wait(
                     step_run=step_run_info.step_run,
                 )
-                if status.is_successful:
-                    if self._is_command_step:
-                        # No in-container `StepRunner` publishes the status for
-                        # a command step, so the parent does it here.
-                        publish_utils.publish_successful_step_run(
-                            step_run_id=step_run_info.step_run_id,
-                            output_artifact_ids={},
-                        )
-                else:
-                    if self._is_command_step:
-                        publish_utils.publish_failed_step_run(
-                            step_run_info.step_run_id
-                        )
-                    step_run = Client().get_run_step(step_run_info.step_run_id)
-                    raise exception_utils.reconstruct_exception(
-                        exception_info=step_run.exception_info,
-                        fallback_message=(
-                            f"Step `{step_run_info.pipeline_step_name}` failed "
-                            f"with status `{status}`."
-                        ),
-                    )
+                self._finalize_remote_step(
+                    status=status, step_run_info=step_run_info
+                )
 
     def _run_step_with_dynamic_orchestrator(
         self,
@@ -606,27 +588,39 @@ class StepLauncher:
             status = self._stack.orchestrator.wait_for_isolated_step(
                 step_run_info.step_run
             )
-            if status.is_successful:
-                if self._is_command_step:
-                    # No in-container `StepRunner` publishes the status for
-                    # a command step, so the parent does it here.
-                    publish_utils.publish_successful_step_run(
-                        step_run_id=step_run_info.step_run_id,
-                        output_artifact_ids={},
-                    )
-            else:
-                if self._is_command_step:
-                    publish_utils.publish_failed_step_run(
-                        step_run_info.step_run_id
-                    )
-                step_run = Client().get_run_step(step_run_info.step_run_id)
-                raise exception_utils.reconstruct_exception(
-                    exception_info=step_run.exception_info,
-                    fallback_message=(
-                        f"Step `{step_run_info.pipeline_step_name}` failed "
-                        f"with status `{status}`."
-                    ),
-                )
+            self._finalize_remote_step(
+                status=status, step_run_info=step_run_info
+            )
+
+    def _finalize_remote_step(
+        self, status: ExecutionStatus, step_run_info: StepRunInfo
+    ) -> None:
+        """Finalizes a step that was executed in a remote environment.
+
+        Args:
+            status: The status reported by the remote environment.
+            step_run_info: Additional information needed to run the step.
+
+        Raises:
+            BaseException: If the step run failed.
+        """  # noqa: DOC502, DOC503
+        if not status.is_successful:
+            step_run = Client().get_run_step(step_run_info.step_run_id)
+            raise exception_utils.reconstruct_exception(
+                exception_info=step_run.exception_info,
+                fallback_message=(
+                    f"Step `{step_run_info.pipeline_step_name}` failed "
+                    f"with status `{status}`."
+                ),
+            )
+
+        if self._step.config.command is not None:
+            # Nothing in the execution environment publishes the status for
+            # a command step, so we do it here.
+            publish_utils.publish_successful_step_run(
+                step_run_id=step_run_info.step_run_id,
+                output_artifact_ids={},
+            )
 
     def _run_step_in_current_thread(
         self,
@@ -645,10 +639,6 @@ class StepLauncher:
             input_artifacts: The input artifact versions of the current step.
             output_artifact_uris: The output artifact URIs of the current step.
         """
-        if self._is_command_step:
-            self._run_command_step_locally(step_run=step_run)
-            return
-
         runner = StepRunner(step=self._step, stack=self._stack)
         runner.run(
             pipeline_run=pipeline_run,
@@ -657,46 +647,6 @@ class StepLauncher:
             output_artifact_uris=output_artifact_uris,
             step_run_info=step_run_info,
         )
-
-    @property
-    def _is_command_step(self) -> bool:
-        """Whether the step is a command step.
-
-        Returns:
-            Whether the step is a command step.
-        """
-        return self._step.config.command is not None
-
-    def _run_command_step_locally(self, step_run: StepRunResponse) -> None:
-        """Runs a command step as a subprocess in the current environment.
-
-        Args:
-            step_run: The model of the current step run.
-
-        Raises:
-            RuntimeError: If the command exits with a non-zero status.
-        """
-        command = self._step.config.command
-        assert command is not None
-
-        logger.info(
-            "Running command step `%s` locally: %s",
-            self._invocation_id,
-            command,
-        )
-        # TODO: env etc
-        result = subprocess.run(command)
-        if result.returncode == 0:
-            publish_utils.publish_successful_step_run(
-                step_run_id=step_run.id,
-                output_artifact_ids={},
-            )
-        else:
-            publish_utils.publish_failed_step_run(step_run.id)
-            raise RuntimeError(
-                f"Command step `{self._invocation_id}` failed with exit code "
-                f"{result.returncode}."
-            )
 
     def _should_register_signal_handler(self) -> bool:
         """Whether the signal handler should be registered.
@@ -732,6 +682,14 @@ class StepLauncher:
             from zenml.execution.pipeline.dynamic.compilation import (
                 get_step_runtime,
             )
+
+            if self._step.config.command is not None:
+                # Command steps can't report themselves as running once the
+                # container started, so we start them in a running state.
+                # Once we extend all orchestrator/step operator implementations
+                # to distinguish between the provisioning and running states,
+                # we can remove this special case.
+                return ExecutionStatus.RUNNING
 
             step_runtime = get_step_runtime(
                 step_config=self._step.config,

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -15,7 +15,7 @@
 
 import os
 import random
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 from uuid import UUID
 
 from zenml.client import Client
@@ -39,6 +39,10 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from zenml.artifact_stores.base_artifact_store import BaseArtifactStore
+    from zenml.config.step_configurations import Step
+    from zenml.entrypoints.step_entrypoint_configuration import (
+        StepEntrypointConfiguration,
+    )
 
 
 def get_orchestrator_run_name(
@@ -226,6 +230,39 @@ def get_config_environment_vars(
     )
 
     return environment_vars, secrets
+
+
+def get_step_entrypoint_command(
+    step: "Step",
+    entrypoint_config_class: Type["StepEntrypointConfiguration"],
+    snapshot_id: UUID,
+    **entrypoint_config_kwargs: Any,
+) -> Tuple[List[str], List[str]]:
+    """Gets the entrypoint command to run a step.
+
+    Args:
+        step: The step to run.
+        entrypoint_config_class: The entrypoint configuration class used to
+            build the ZenML step entrypoint command.
+        snapshot_id: The snapshot ID to pass to the entrypoint configuration
+            class.
+        **entrypoint_config_kwargs: Additional keyword arguments to pass to the
+            entrypoint configuration class.
+
+    Returns:
+        A tuple containing command and args.
+    """
+    if step.config.command is not None:
+        return step.config.command, []
+
+    return (
+        entrypoint_config_class.get_entrypoint_command(),
+        entrypoint_config_class.get_entrypoint_arguments(
+            step_name=step.spec.invocation_id,
+            snapshot_id=snapshot_id,
+            **entrypoint_config_kwargs,
+        ),
+    )
 
 
 class register_artifact_store_filesystem:

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -39,7 +39,7 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from zenml.artifact_stores.base_artifact_store import BaseArtifactStore
-    from zenml.config.step_configurations import Step
+    from zenml.config.step_configurations import StepConfiguration
     from zenml.entrypoints.step_entrypoint_configuration import (
         StepEntrypointConfiguration,
     )
@@ -233,7 +233,8 @@ def get_config_environment_vars(
 
 
 def get_step_entrypoint_command(
-    step: "Step",
+    invocation_id: str,
+    config: "StepConfiguration",
     entrypoint_config_class: Type["StepEntrypointConfiguration"],
     snapshot_id: UUID,
     **entrypoint_config_kwargs: Any,
@@ -241,7 +242,8 @@ def get_step_entrypoint_command(
     """Gets the entrypoint command to run a step.
 
     Args:
-        step: The step to run.
+        invocation_id: The invocation ID of the step to run.
+        config: The configuration of the step to run.
         entrypoint_config_class: The entrypoint configuration class used to
             build the ZenML step entrypoint command.
         snapshot_id: The snapshot ID to pass to the entrypoint configuration
@@ -252,13 +254,13 @@ def get_step_entrypoint_command(
     Returns:
         A tuple containing command and args.
     """
-    if step.config.command is not None:
-        return step.config.command, []
+    if config.command is not None:
+        return config.command, []
 
     return (
         entrypoint_config_class.get_entrypoint_command(),
         entrypoint_config_class.get_entrypoint_arguments(
-            step_name=step.spec.invocation_id,
+            step_name=invocation_id,
             snapshot_id=snapshot_id,
             **entrypoint_config_kwargs,
         ),

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -15,6 +15,7 @@
 
 import os
 import random
+import shlex
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 from uuid import UUID
 
@@ -265,6 +266,22 @@ def get_step_entrypoint_command(
             **entrypoint_config_kwargs,
         ),
     )
+
+
+def shell_join(command: List[str]) -> str:
+    """Joins command tokens into a single shell-escaped string.
+
+    Use this when a backend flattens an entrypoint command into a string that
+    a shell later re-splits. Command step commands can contain spaces, quotes
+    and newlines that a plain space join would corrupt.
+
+    Args:
+        command: The command tokens to join.
+
+    Returns:
+        The command tokens joined into a single shell-escaped string.
+    """
+    return shlex.join(command)
 
 
 class register_artifact_store_filesystem:

--- a/src/zenml/steps/__init__.py
+++ b/src/zenml/steps/__init__.py
@@ -28,12 +28,14 @@ decorator.
 
 from zenml.steps.base_step import BaseStep
 from zenml.config.resource_settings import ResourceSettings
+from zenml.steps.command_step import CommandStep
 from zenml.steps.heartbeat import StepHeartbeatWorker, StepHeartBeatTerminationException
 from zenml.steps.step_context import StepContext, get_step_context
 from zenml.steps.step_decorator import step
 
 __all__ = [
     "BaseStep",
+    "CommandStep",
     "ResourceSettings",
     "StepContext",
     "step",

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -296,7 +296,7 @@ class BaseStep:
         if isinstance(obj, BaseStep):
             return obj
         elif isinstance(obj, type) and issubclass(obj, BaseStep):
-            return obj()
+            return obj._load_from_source()
         elif inspect.isfunction(obj):
             from zenml.steps.step_decorator import step
 
@@ -310,6 +310,15 @@ class BaseStep:
                 f"resolve to a `BaseStep` instance/subclass or a function, "
                 f"got `{type(obj).__name__}`."
             )
+
+    @classmethod
+    def _load_from_source(cls) -> "BaseStep":
+        """Creates a step instance from a source class.
+
+        Returns:
+            A step instance.
+        """
+        return cls()
 
     def resolve(self) -> Source:
         """Resolves the step.

--- a/src/zenml/steps/command_step.py
+++ b/src/zenml/steps/command_step.py
@@ -13,7 +13,9 @@
 #  permissions and limitations under the License.
 """Step that runs an opaque container command."""
 
-from typing import TYPE_CHECKING, Any, Dict, List
+import inspect
+import textwrap
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
 
 from zenml.exceptions import StepInterfaceError
 from zenml.steps.base_step import BaseStep
@@ -22,14 +24,86 @@ if TYPE_CHECKING:
     from zenml.config.step_configurations import StepConfigurationUpdate
 
 
+def _build_function_command(func: Callable[[], Any]) -> List[str]:
+    """Builds a command that runs a function using `python -c`.
+
+    Args:
+        func: The function to run.
+
+    Raises:
+        StepInterfaceError: If the function is not a plain undecorated
+            function without parameters, or if its source code cannot be
+            extracted.
+
+    Returns:
+        The command.
+    """
+    if not inspect.isfunction(func):
+        raise StepInterfaceError(
+            "The object passed as command step function is not a function: "
+            f"`{func}`."
+        )
+
+    if func.__name__ == "<lambda>":
+        raise StepInterfaceError(
+            "Lambdas cannot be used as command step functions."
+        )
+
+    if hasattr(func, "__wrapped__"):
+        raise StepInterfaceError(
+            f"The command step function `{func.__name__}` is decorated."
+        )
+
+    if func.__closure__ is not None:
+        raise StepInterfaceError(
+            f"The command step function `{func.__name__}` references "
+            "variables from an enclosing function."
+        )
+
+    if inspect.signature(func).parameters:
+        raise StepInterfaceError(
+            f"The command step function `{func.__name__}` has parameters."
+        )
+
+    try:
+        source = textwrap.dedent(inspect.getsource(func))
+    except (OSError, TypeError):
+        raise StepInterfaceError(
+            "Failed to get the source code of the command step function "
+            f"`{func.__name__}`."
+        )
+
+    if source.lstrip().startswith("@"):
+        raise StepInterfaceError(
+            f"The command step function `{func.__name__}` is decorated."
+        )
+
+    code = f"{source}\n{func.__name__}()\n"
+
+    try:
+        compile(code, "<command-step>", "exec")
+    except SyntaxError as e:
+        raise StepInterfaceError(
+            "Failed to compile the source code of the command step function "
+            f"`{func.__name__}`: {e}"
+        )
+
+    return ["python", "-c", code]
+
+
 class CommandStep(BaseStep):
     """Step that runs an opaque container command."""
 
-    def __init__(self, command: List[str], **kwargs: Any) -> None:
+    def __init__(
+        self,
+        command: Union[List[str], Callable[[], Any]],
+        **kwargs: Any,
+    ) -> None:
         """Initializes a command step.
 
         Args:
-            command: The command to run for the step.
+            command: The command to run for the step, or a self-contained
+                function to run with `python -c`.
             **kwargs: Keyword arguments to configure the step. Forwarded to
                 the `BaseStep` constructor.
 
@@ -37,6 +111,9 @@ class CommandStep(BaseStep):
             StepInterfaceError: If the command is empty, or if a subclass
                 overrides the entrypoint to declare inputs or outputs.
         """
+        if callable(command):
+            command = _build_function_command(command)
+
         if not command:
             raise StepInterfaceError(
                 "The command of a command step must not be empty."

--- a/src/zenml/steps/command_step.py
+++ b/src/zenml/steps/command_step.py
@@ -52,18 +52,19 @@ def _build_function_command(func: Callable[[], Any]) -> List[str]:
 
     if hasattr(func, "__wrapped__"):
         raise StepInterfaceError(
-            f"The command step function `{func.__name__}` is decorated."
+            f"The command step function `{func.__name__}` cannot be decorated."
         )
 
     if func.__closure__ is not None:
         raise StepInterfaceError(
-            f"The command step function `{func.__name__}` references "
+            f"The command step function `{func.__name__}` cannot reference "
             "variables from an enclosing function."
         )
 
     if inspect.signature(func).parameters:
         raise StepInterfaceError(
-            f"The command step function `{func.__name__}` has parameters."
+            f"The command step function `{func.__name__}` cannot have "
+            "parameters."
         )
 
     try:
@@ -76,7 +77,7 @@ def _build_function_command(func: Callable[[], Any]) -> List[str]:
 
     if source.lstrip().startswith("@"):
         raise StepInterfaceError(
-            f"The command step function `{func.__name__}` is decorated."
+            f"The command step function `{func.__name__}` cannot be decorated."
         )
 
     code = f"{source}\n{func.__name__}()\n"
@@ -184,7 +185,10 @@ class CommandStep(BaseStep):
             config=config, runtime_parameters=runtime_parameters
         )
 
-        if config.failure_hook_source or config.success_hook_source:
-            raise StepInterfaceError(
-                "Command steps do not support success or failure hooks."
-            )
+        if (
+            config.failure_hook_source
+            or config.success_hook_source
+            or config.end_hook_source
+            or config.start_hook_source
+        ):
+            raise StepInterfaceError("Command steps do not support hooks.")

--- a/src/zenml/steps/command_step.py
+++ b/src/zenml/steps/command_step.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 """Step that runs an opaque container command."""
 
 import inspect
+import subprocess
 import textwrap
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
 
@@ -146,7 +147,10 @@ class CommandStep(BaseStep):
         return cls(command=["zenml-command-step-from-source"])
 
     def entrypoint(self) -> None:
-        """No-op entrypoint. A command step has no Python body to run."""
+        """Runs the configured command as a subprocess."""
+        command = self.configuration.command
+        assert command is not None
+        subprocess.run(command, check=True)
 
     def _validate_configuration(
         self,

--- a/src/zenml/steps/command_step.py
+++ b/src/zenml/steps/command_step.py
@@ -146,6 +146,20 @@ class CommandStep(BaseStep):
         # configuration. So we just return a step with a dummy command.
         return cls(command=["zenml-command-step-from-source"])
 
+    @property
+    def source_code_cache_value(self) -> str:
+        """The source code cache value of this step.
+
+        Returns:
+            The source code cache value of this step.
+        """
+        # This value is captured at compile time on the original step
+        # instance, so the dummy command of instances loaded from source
+        # never ends up in it.
+        command = self.configuration.command
+        assert command is not None
+        return self.source_code + str(command)
+
     def entrypoint(self) -> None:
         """Runs the configured command as a subprocess."""
         command = self.configuration.command

--- a/src/zenml/steps/command_step.py
+++ b/src/zenml/steps/command_step.py
@@ -1,0 +1,95 @@
+#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Step that runs an opaque container command."""
+
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from zenml.exceptions import StepInterfaceError
+from zenml.steps.base_step import BaseStep
+
+if TYPE_CHECKING:
+    from zenml.config.step_configurations import StepConfigurationUpdate
+
+
+class CommandStep(BaseStep):
+    """Step that runs an opaque container command."""
+
+    def __init__(self, command: List[str], **kwargs: Any) -> None:
+        """Initializes a command step.
+
+        Args:
+            command: The command to run for the step.
+            **kwargs: Keyword arguments to configure the step. Forwarded to
+                the `BaseStep` constructor.
+
+        Raises:
+            StepInterfaceError: If the command is empty, or if a subclass
+                overrides the entrypoint to declare inputs or outputs.
+        """
+        if not command:
+            raise StepInterfaceError(
+                "The command of a command step must not be empty."
+            )
+
+        super().__init__(**kwargs)
+
+        if (
+            self.entrypoint_definition.inputs
+            or self.entrypoint_definition.outputs
+        ):
+            raise StepInterfaceError(
+                "A command step cannot have inputs or outputs. Do not override "
+                "the `entrypoint` method with parameters or a return annotation."
+            )
+
+        self._configuration = self._configuration.model_copy(
+            update={"command": command, "enable_cache": False}
+        )
+
+    @classmethod
+    def _load_from_source(cls) -> "BaseStep":
+        """Creates a command step instance from a source class.
+
+        Returns:
+            A command step instance.
+        """
+        # When being loaded from source, we do not yet have access to the
+        # configuration. So we just return a step with a dummy command.
+        return cls(command=["zenml-command-step-from-source"])
+
+    def entrypoint(self) -> None:
+        """No-op entrypoint. A command step has no Python body to run."""
+
+    def _validate_configuration(
+        self,
+        config: "StepConfigurationUpdate",
+        runtime_parameters: Dict[str, Any],
+    ) -> None:
+        """Validates command step configuration updates.
+
+        Args:
+            config: The configuration update to validate.
+            runtime_parameters: Runtime parameters passed to the step.
+
+        Raises:
+            StepInterfaceError: If success or failure hooks are configured.
+        """
+        super()._validate_configuration(
+            config=config, runtime_parameters=runtime_parameters
+        )
+
+        if config.failure_hook_source or config.success_hook_source:
+            raise StepInterfaceError(
+                "Command steps do not support success or failure hooks."
+            )

--- a/tests/unit/orchestrators/test_step_launcher.py
+++ b/tests/unit/orchestrators/test_step_launcher.py
@@ -17,8 +17,7 @@ from uuid import uuid4
 
 import pytest
 
-from zenml.enums import ExecutionStatus
-from zenml.enums import StackComponentType
+from zenml.enums import ExecutionStatus, StackComponentType
 from zenml.orchestrators.step_launcher import (
     StepLauncher,
     _get_step_operator,
@@ -92,7 +91,7 @@ def test_dynamic_command_step_success_publishes_status(mocker):
     publish_failed.assert_not_called()
 
 
-def test_dynamic_command_step_failure_publishes_status(mocker):
+def test_dynamic_command_step_failure_raises(mocker):
     launcher = object.__new__(StepLauncher)
     launcher._stack = mocker.Mock()
     launcher._stack.orchestrator.wait_for_isolated_step.return_value = (
@@ -134,4 +133,6 @@ def test_dynamic_command_step_failure_publishes_status(mocker):
         )
 
     publish_success.assert_not_called()
-    publish_failed.assert_called_once_with(step_run_info.step_run_id)
+    # Publishing the failed status is the responsibility of the generic
+    # exception handling in `StepLauncher.launch(...)`.
+    publish_failed.assert_not_called()

--- a/tests/unit/orchestrators/test_step_launcher.py
+++ b/tests/unit/orchestrators/test_step_launcher.py
@@ -17,8 +17,10 @@ from uuid import uuid4
 
 import pytest
 
+from zenml.enums import ExecutionStatus
 from zenml.enums import StackComponentType
 from zenml.orchestrators.step_launcher import (
+    StepLauncher,
     _get_step_operator,
 )
 from zenml.stack import Stack
@@ -49,3 +51,87 @@ def test_step_operator_validation(local_stack, sample_step_operator):
             stack=stack_with_step_operator,
             step_operator_name=sample_step_operator.name,
         )
+
+
+def test_dynamic_command_step_success_publishes_status(mocker):
+    launcher = object.__new__(StepLauncher)
+    launcher._stack = mocker.Mock()
+    launcher._stack.orchestrator.wait_for_isolated_step.return_value = (
+        ExecutionStatus.COMPLETED
+    )
+    launcher._wait = True
+    launcher._step = mocker.Mock()
+    launcher._step.config.command = ["echo", "hi"]
+
+    step_run_info = mocker.Mock()
+    step_run_info.step_run = mocker.Mock()
+    step_run_info.step_run_id = uuid4()
+
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.orchestrator_utils.get_config_environment_vars",
+        return_value=({}, {}),
+    )
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.env_utils.get_runtime_environment",
+        return_value={},
+    )
+
+    publish_success = mocker.patch(
+        "zenml.orchestrators.step_launcher.publish_utils.publish_successful_step_run"
+    )
+    publish_failed = mocker.patch(
+        "zenml.orchestrators.step_launcher.publish_utils.publish_failed_step_run"
+    )
+
+    launcher._run_step_with_dynamic_orchestrator(step_run_info=step_run_info)
+
+    publish_success.assert_called_once_with(
+        step_run_id=step_run_info.step_run_id,
+        output_artifact_ids={},
+    )
+    publish_failed.assert_not_called()
+
+
+def test_dynamic_command_step_failure_publishes_status(mocker):
+    launcher = object.__new__(StepLauncher)
+    launcher._stack = mocker.Mock()
+    launcher._stack.orchestrator.wait_for_isolated_step.return_value = (
+        ExecutionStatus.FAILED
+    )
+    launcher._wait = True
+    launcher._step = mocker.Mock()
+    launcher._step.config.command = ["echo", "hi"]
+
+    step_run_info = mocker.Mock()
+    step_run_info.step_run = mocker.Mock()
+    step_run_info.step_run_id = uuid4()
+    step_run_info.pipeline_step_name = "step_name"
+
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.orchestrator_utils.get_config_environment_vars",
+        return_value=({}, {}),
+    )
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.env_utils.get_runtime_environment",
+        return_value={},
+    )
+
+    publish_success = mocker.patch(
+        "zenml.orchestrators.step_launcher.publish_utils.publish_successful_step_run"
+    )
+    publish_failed = mocker.patch(
+        "zenml.orchestrators.step_launcher.publish_utils.publish_failed_step_run"
+    )
+    mocker.patch("zenml.orchestrators.step_launcher.Client.get_run_step")
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.exception_utils.reconstruct_exception",
+        return_value=RuntimeError("step failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="step failed"):
+        launcher._run_step_with_dynamic_orchestrator(
+            step_run_info=step_run_info
+        )
+
+    publish_success.assert_not_called()
+    publish_failed.assert_called_once_with(step_run_info.step_run_id)

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -40,28 +40,24 @@ class _FakeEntrypointConfig:
 
 def test_get_step_entrypoint_command_for_command_step():
     """Tests that the helper returns the custom command for a command step."""
-    step = SimpleNamespace(
-        config=SimpleNamespace(command=["python", "train.py"]),
-        spec=SimpleNamespace(invocation_id="train"),
-    )
+    config = SimpleNamespace(command=["python", "train.py"])
     command, args = get_step_entrypoint_command(
-        step=step,
+        invocation_id="train",
+        config=config,
         entrypoint_config_class=_FakeEntrypointConfig,
         snapshot_id=uuid4(),
         step_run_id=uuid4(),
     )
-    assert command == ["python"]
-    assert args == ["train.py"]
+    assert command == ["python", "train.py"]
+    assert args == []
 
 
 def test_get_step_entrypoint_command_for_regular_step():
     """Tests that the helper returns the ZenML entrypoint for a regular step."""
-    step = SimpleNamespace(
-        config=SimpleNamespace(command=None),
-        spec=SimpleNamespace(invocation_id="train"),
-    )
+    config = SimpleNamespace(command=None)
     command, args = get_step_entrypoint_command(
-        step=step,
+        invocation_id="train",
+        config=config,
         entrypoint_config_class=_FakeEntrypointConfig,
         snapshot_id=uuid4(),
         step_run_id=uuid4(),

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -11,16 +11,63 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+from types import SimpleNamespace
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 
 from zenml.enums import StackComponentType
 from zenml.orchestrators.utils import (
     get_orchestrator_run_name,
+    get_step_entrypoint_command,
     is_setting_enabled,
     register_artifact_store_filesystem,
 )
+
+
+class _FakeEntrypointConfig:
+    """Fake entrypoint configuration class for testing."""
+
+    @classmethod
+    def get_entrypoint_command(cls):
+        return ["python", "-m", "zenml.entrypoint"]
+
+    @classmethod
+    def get_entrypoint_arguments(cls, step_name, snapshot_id, step_run_id):
+        return ["--step", step_name]
+
+
+def test_get_step_entrypoint_command_for_command_step():
+    """Tests that the helper returns the custom command for a command step."""
+    step = SimpleNamespace(
+        config=SimpleNamespace(command=["python", "train.py"]),
+        spec=SimpleNamespace(invocation_id="train"),
+    )
+    command, args = get_step_entrypoint_command(
+        step=step,
+        entrypoint_config_class=_FakeEntrypointConfig,
+        snapshot_id=uuid4(),
+        step_run_id=uuid4(),
+    )
+    assert command == ["python"]
+    assert args == ["train.py"]
+
+
+def test_get_step_entrypoint_command_for_regular_step():
+    """Tests that the helper returns the ZenML entrypoint for a regular step."""
+    step = SimpleNamespace(
+        config=SimpleNamespace(command=None),
+        spec=SimpleNamespace(invocation_id="train"),
+    )
+    command, args = get_step_entrypoint_command(
+        step=step,
+        entrypoint_config_class=_FakeEntrypointConfig,
+        snapshot_id=uuid4(),
+        step_run_id=uuid4(),
+    )
+    assert command == ["python", "-m", "zenml.entrypoint"]
+    assert args == ["--step", "train"]
 
 
 def test_is_setting_enabled():

--- a/tests/unit/steps/test_command_step.py
+++ b/tests/unit/steps/test_command_step.py
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import functools
+import subprocess
+
 import pytest
 
 from zenml.config.compiler import Compiler
@@ -45,6 +48,82 @@ def test_command_step_with_empty_command_fails():
     """Tests that constructing a command step with an empty command fails."""
     with pytest.raises(StepInterfaceError):
         CommandStep(command=[])
+
+
+def _self_contained_function() -> None:
+    import json
+
+    print(json.dumps({"status": "done"}))
+
+
+def test_command_step_with_function():
+    """Tests that a command step can be constructed from a function."""
+    step = CommandStep(command=_self_contained_function)
+
+    command = step.configuration.command
+    assert command is not None
+    assert command[:2] == ["python", "-c"]
+    assert "_self_contained_function()" in command[2]
+
+    result = subprocess.run(command, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.strip() == '{"status": "done"}'
+
+
+def test_command_step_with_lambda_fails():
+    """Tests that lambdas are rejected as command step functions."""
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=lambda: None)
+
+
+def test_command_step_with_function_with_parameters_fails():
+    """Tests that functions with parameters are rejected."""
+
+    def _with_parameter(x: int = 1) -> None:
+        pass
+
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=_with_parameter)
+
+
+def test_command_step_with_closure_fails():
+    """Tests that closures are rejected as command step functions."""
+    captured = "value"
+
+    def _closure() -> None:
+        print(captured)
+
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=_closure)
+
+
+def test_command_step_with_decorated_function_fails():
+    """Tests that decorated functions are rejected."""
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper() -> None:
+            func()
+
+        return _wrapper
+
+    @_decorator
+    def _decorated() -> None:
+        pass
+
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=_decorated)
+
+
+def test_command_step_with_method_fails():
+    """Tests that methods are rejected as command step functions."""
+
+    class _WithMethod:
+        def method(self) -> None:
+            pass
+
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=_WithMethod().method)
 
 
 def test_command_step_can_be_loaded_from_source():

--- a/tests/unit/steps/test_command_step.py
+++ b/tests/unit/steps/test_command_step.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 import functools
 import subprocess
+import sys
 
 import pytest
 
@@ -48,6 +49,26 @@ def test_command_step_with_empty_command_fails():
     """Tests that constructing a command step with an empty command fails."""
     with pytest.raises(StepInterfaceError):
         CommandStep(command=[])
+
+
+def test_command_step_entrypoint_runs_command(tmp_path):
+    """Tests that the step entrypoint runs the configured command."""
+    output_file = tmp_path / "output.txt"
+    step = CommandStep(
+        command=[sys.executable, "-c", f"open(r'{output_file}', 'w').close()"]
+    )
+
+    step.entrypoint()
+
+    assert output_file.exists()
+
+
+def test_command_step_entrypoint_raises_on_failure():
+    """Tests that the step entrypoint raises if the command fails."""
+    step = CommandStep(command=[sys.executable, "-c", "raise SystemExit(1)"])
+
+    with pytest.raises(subprocess.CalledProcessError):
+        step.entrypoint()
 
 
 def _self_contained_function() -> None:

--- a/tests/unit/steps/test_command_step.py
+++ b/tests/unit/steps/test_command_step.py
@@ -1,0 +1,125 @@
+#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+import pytest
+
+from zenml.config.compiler import Compiler
+from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
+from zenml.exceptions import StackValidationError, StepInterfaceError
+from zenml.pipelines.pipeline_decorator import pipeline
+from zenml.steps.base_step import BaseStep
+from zenml.steps.command_step import CommandStep
+
+
+def _success_hook() -> None:
+    pass
+
+
+def test_command_step_has_no_inputs_or_outputs():
+    """Tests that a command step has no inputs and no outputs."""
+    step = CommandStep(command=["echo", "hi"])
+
+    assert step.entrypoint_definition.inputs == {}
+    assert step.entrypoint_definition.outputs == {}
+    assert step.configuration.command == ["echo", "hi"]
+
+
+def test_command_step_disables_caching():
+    """Tests that caching is forced off for a command step."""
+    step = CommandStep(command=["echo", "hi"], enable_cache=True)
+
+    assert step.configuration.enable_cache is False
+
+
+def test_command_step_with_empty_command_fails():
+    """Tests that constructing a command step with an empty command fails."""
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=[])
+
+
+def test_command_step_can_be_loaded_from_source():
+    """Tests that command step source loading returns a valid instance."""
+    step = BaseStep.load_from_source("zenml.steps.command_step.CommandStep")
+
+    assert isinstance(step, CommandStep)
+    assert step.configuration.command == ["zenml-command-step-from-source"]
+
+
+def test_command_step_subclass_with_inputs_fails():
+    """Tests that a command step subclass declaring inputs fails."""
+
+    class _WithInput(CommandStep):
+        def entrypoint(self, x: int) -> None:  # type: ignore[override]
+            pass
+
+    with pytest.raises(StepInterfaceError):
+        _WithInput(command=["echo", "hi"])
+
+
+def test_command_step_subclass_with_outputs_fails():
+    """Tests that a command step subclass declaring outputs fails."""
+
+    class _WithOutput(CommandStep):
+        def entrypoint(self) -> int:  # type: ignore[override]
+            return 1
+
+    with pytest.raises(StepInterfaceError):
+        _WithOutput(command=["echo", "hi"])
+
+
+def test_command_step_with_hooks_fails():
+    """Tests that command steps reject hook configuration."""
+    with pytest.raises(StepInterfaceError):
+        CommandStep(command=["echo", "hi"], on_success=_success_hook)
+
+
+def test_command_step_configure_with_hooks_fails():
+    """Tests that command steps reject hooks in `configure`."""
+    step = CommandStep(command=["echo", "hi"])
+
+    with pytest.raises(StepInterfaceError):
+        step.configure(on_success=_success_hook)
+
+
+def test_pipeline_hooks_on_command_step_fail_compilation(local_stack):
+    """Tests that pipeline-level hooks cannot be applied to command steps."""
+
+    @pipeline(dynamic=True, on_success=_success_hook)
+    def _pipeline() -> None:
+        CommandStep(command=["echo", "hi"])()
+
+    pipeline_instance = _pipeline()
+    pipeline_instance.prepare()
+
+    with pytest.raises(StepInterfaceError):
+        Compiler().compile(
+            pipeline=pipeline_instance,
+            stack=local_stack,
+            run_configuration=PipelineRunConfiguration(),
+        )
+
+
+def test_command_step_in_static_pipeline_without_step_operator_fails(
+    one_step_pipeline, local_stack
+):
+    """Tests that a command step in a static pipeline without a step operator
+    fails to compile."""
+    pipeline_instance = one_step_pipeline(CommandStep(command=["echo", "hi"]))
+    pipeline_instance.prepare()
+
+    with pytest.raises(StackValidationError):
+        Compiler().compile(
+            pipeline=pipeline_instance,
+            stack=local_stack,
+            run_configuration=PipelineRunConfiguration(),
+        )

--- a/tests/unit/steps/test_command_step.py
+++ b/tests/unit/steps/test_command_step.py
@@ -19,6 +19,7 @@ import pytest
 
 from zenml.config.compiler import Compiler
 from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
+from zenml.constants import CODE_HASH_PARAMETER_NAME
 from zenml.exceptions import StackValidationError, StepInterfaceError
 from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.steps.base_step import BaseStep
@@ -43,6 +44,17 @@ def test_command_step_disables_caching():
     step = CommandStep(command=["echo", "hi"], enable_cache=True)
 
     assert step.configuration.enable_cache is False
+
+
+def test_command_step_command_affects_code_hash():
+    """Tests that the command is part of the code hash caching parameter."""
+    step_1 = CommandStep(command=["echo", "hi"])
+    step_2 = CommandStep(command=["echo", "bye"])
+
+    assert (
+        step_1.caching_parameters[CODE_HASH_PARAMETER_NAME]
+        != step_2.caching_parameters[CODE_HASH_PARAMETER_NAME]
+    )
 
 
 def test_command_step_with_empty_command_fails():


### PR DESCRIPTION
This PR adds code to run arbitrary commands as steps in a pipeline using the `CommandStep(...)` class.
Command steps do **not** require ZenML in the execution environment.

**Example:**
```python
from zenml import CommandStep, pipeline

def some_func():
  print("hello from python function")

bash_command_step = CommandStep(command=["bash", "-c", "echo 'hello from bash"])
function_command_step = CommandStep(some_func)

@pipeline(dynamic=True, enable_cache=False)
def command_step_pipeline() -> None:
    bash_command_step()
    function_command_step.submit()

if __name__ == "__main__":
    command_step_pipeline()
```

**Limitations**:
- Command steps do not support inputs and outputs
- Your code is not downloaded into the execution environment
- Logs of command steps are not tracked
- Steps in static pipelines without step operator are not supported