### PR TITLE
Harden server middleware against Host-header path poisoning

### DIFF
--- a/src/zenml/zen_server/middleware.py
+++ b/src/zenml/zen_server/middleware.py
@@ -53,6 +53,7 @@ from zenml.zen_server.secure_headers import (
     secure_headers,
 )
 from zenml.zen_server.utils import (
+    get_request_path,
     get_system_metrics,
     is_user_request,
     request_manager,
@@ -175,7 +176,7 @@ class RestrictFileUploadsMiddleware(BaseHTTPMiddleware):
             content_type = request.headers.get("content-type", "")
             if (
                 "multipart/form-data" in content_type
-                and request.url.path not in self.allowed_paths
+                and get_request_path(request) not in self.allowed_paths
             ):
                 return JSONResponse(
                     status_code=403,
@@ -321,9 +322,8 @@ async def set_secure_headers(request: Request, call_next: Any) -> Any:
         response = _error_response()
 
     # If the request is for the openAPI docs, don't set secure headers
-    if request.url.path.startswith("/docs") or request.url.path.startswith(
-        "/redoc"
-    ):
+    request_path = get_request_path(request)
+    if request_path.startswith("/docs") or request_path.startswith("/redoc"):
         return response
 
     await secure_headers().set_headers_async(response)
@@ -420,7 +420,7 @@ async def skip_health_middleware(request: Request, call_next: Any) -> Any:
     Returns:
         The response to the request.
     """
-    if request.url.path in [HEALTH, READY]:
+    if get_request_path(request) in [HEALTH, READY]:
         # Skip expensive processing
         return PlainTextResponse("ok")
 

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -724,6 +724,25 @@ def verify_admin_status_if_no_rbac(
     return
 
 
+def get_request_path(request: "Request") -> str:
+    """Return the routed request path, immune to Host-header poisoning.
+
+    Security checks must not use ``request.url.path``. Starlette rebuilds
+    ``request.url`` from the (unvalidated) ``Host`` header, so a crafted Host
+    header can make ``request.url.path`` differ from the path the router
+    actually dispatched to (CVE-2026-48710 / GHSA-86qp-5c8j-p5mr). The raw ASGI
+    ``scope["path"]`` is the value routing uses and the Host header cannot
+    influence it, so it is the only safe basis for a path-based decision.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The raw ASGI path that routing dispatched to.
+    """
+    return str(request.scope["path"])
+
+
 def is_user_request(request: "Request") -> bool:
     """Determine if the incoming request is a user request.
 
@@ -749,18 +768,17 @@ def is_user_request(request: "Request") -> bool:
 
     user_prefix = f"{API}{VERSION_1}"
     excluded_user_apis = [INFO]
+    path = get_request_path(request)
     # Check if this is not an excluded endpoint
-    if request.url.path in [
-        user_prefix + suffix for suffix in excluded_user_apis
-    ]:
+    if path in [user_prefix + suffix for suffix in excluded_user_apis]:
         return False
 
     # Check if this is other user request
-    if request.url.path.startswith(user_prefix):
+    if path.startswith(user_prefix):
         return True
 
     # Exclude system paths
-    if any(request.url.path.startswith(path) for path in system_paths):
+    if any(path.startswith(system_path) for system_path in system_paths):
         return False
 
     # Exclude requests with specific headers

--- a/tests/unit/zen_server/test_middleware.py
+++ b/tests/unit/zen_server/test_middleware.py
@@ -1,0 +1,87 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for path-based security decisions in the ZenML server middleware."""
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from zenml.zen_server.middleware import RestrictFileUploadsMiddleware
+
+MULTIPART_HEADERS = {"content-type": "multipart/form-data; boundary=x"}
+
+
+def _build_upload_app() -> Starlette:
+    """Build a minimal app guarded by the upload-restriction middleware.
+
+    Returns:
+        A Starlette app that only allows multipart uploads on ``/allowed``.
+    """
+
+    async def upload(_request: Request) -> PlainTextResponse:
+        return PlainTextResponse("reached upload handler")
+
+    app = Starlette(
+        routes=[
+            Route("/allowed", upload, methods=["POST"]),
+            Route("/blocked", upload, methods=["POST"]),
+        ]
+    )
+    app.add_middleware(
+        RestrictFileUploadsMiddleware, allowed_paths={"/allowed"}
+    )
+    return app
+
+
+def test_upload_allowed_on_allowlisted_path():
+    """Multipart uploads are permitted on an allowlisted path."""
+    client = TestClient(_build_upload_app())
+
+    response = client.post("/allowed", headers=MULTIPART_HEADERS)
+
+    assert response.status_code == 200
+
+
+def test_upload_blocked_on_non_allowlisted_path():
+    """Multipart uploads are rejected on a path outside the allowlist."""
+    client = TestClient(_build_upload_app())
+
+    response = client.post("/blocked", headers=MULTIPART_HEADERS)
+
+    assert response.status_code == 403
+
+
+def test_upload_block_survives_host_header_poisoning():
+    """Regression test for CVE-2026-48710 / GHSA-86qp-5c8j-p5mr.
+
+    A malformed ``Host`` header makes Starlette reconstruct ``request.url.path``
+    so that it differs from the path the router actually dispatched to. Here the
+    header is crafted so ``request.url.path`` reconstructs to the allowlisted
+    ``/allowed`` while routing still serves ``/blocked``. The upload restriction
+    must hold, because it now keys off the raw ASGI scope path rather than the
+    poisonable reconstructed URL.
+    """
+    client = TestClient(_build_upload_app())
+
+    response = client.post(
+        "/blocked",
+        headers={**MULTIPART_HEADERS, "host": "evil.example.com/allowed?x="},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == (
+        "File uploads are not allowed on this endpoint."
+    )


### PR DESCRIPTION
## What this does

Routes every **path-based security decision** in the ZenML server through a new `get_request_path()` helper that reads the raw ASGI `scope["path"]` instead of `request.url.path`.

## Why (the story for reviewers)

The dependency audit flags `starlette` (CVE-2026-48710 / GHSA-86qp-5c8j-p5mr, medium). The bug: Starlette rebuilds `request.url` from the **unvalidated HTTP `Host` header**, while the router dispatches on the raw path. A crafted Host header makes the two disagree. Concretely, an attacker sends:

```http
POST /blocked HTTP/1.1
Host: evil.example.com/allowed?x=
```

Starlette reconstructs the URL to `http://evil.example.com/allowed?x=/blocked`, so `request.url.path` parses to `/allowed` — **but routing still serves `/blocked`.** Any middleware that reads `request.url.path` sees a different path than the endpoint that actually runs.

ZenML's server made four such decisions on `request.url.path`. The one that matters most is the **upload restriction** (`RestrictFileUploadsMiddleware`): it blocks multipart uploads unless the path is allowlisted. With the poisoned Host header above, the middleware sees the allowlisted `/allowed` and lets a multipart upload through to `/blocked`, which was never meant to accept one. (The other three — the `/docs` secure-headers skip, the `/health`,`/ready` short-circuit, and `is_user_request` activity tracking — are lower impact but share the same flaw.)

## The fix, and why it's in code rather than a dependency bump

The patched `starlette==1.0.1` only becomes installable once we move to `fastapi>=0.133.0` (where FastAPI dropped its `starlette<1.0.0` ceiling) — a 13-minor jump from the currently pinned `0.120.x`, which is a much larger, riskier change than the audit remediation intends.

The advisory itself says the bypass only hits code that reads `request.url` "rather than the raw scope path." So the surgical mitigation is to read `request.scope["path"]` — the value routing uses, which the Host header cannot influence. This closes the actual exploitable mismatch **on any Starlette version**, independent of when we can bump FastAPI/Starlette. The audit finding stays tracked as non-blocking until that upgrade happens, but the real hole is closed here.

## What changed / what was deliberately left

**Changed** (path-based security decisions, now via `get_request_path`):

- `RestrictFileUploadsMiddleware` upload allowlist
- `set_secure_headers` `/docs`,`/redoc` skip
- `skip_health_middleware` `/health`,`/ready` short-circuit
- `is_user_request` path classification

**Left unchanged on purpose** (not security decisions): request-log strings (`middleware.py`, `request_management.py`) and the cookie-domain host lookup in `auth.py` (reads `request.url.netloc`, prefers `x-forwarded-host`, and validates via `is_same_or_subdomain`).

## Tests

`tests/unit/zen_server/test_middleware.py` adds a regression test that sends the poisoned `Host` header to a non-allowlisted path and asserts the upload restriction still returns `403`. The repo's pinned Starlette (0.45.3) is vulnerable, so this test genuinely fails on the old `request.url.path` code (it would return `200`) and passes on the fix.

## Reviewer attention

- Confirm `request.scope["path"]` is the right immune field for our routing (it is what Starlette's router matches on; the Host header can't reach it).
- Sanity-check the "left unchanged" list — happy to extend coverage to the log reads if you'd prefer logs to always show the routed path during an attack.

## Stacking

Based on `feature/dependency-audit-ci` (PR #4805) since it grew out of that audit work; retargets to `develop` cleanly once the base merges.
