### PR TITLE
Enable async pipeline and step functions

### DIFF
--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -321,6 +321,62 @@ The `StepRunFuture` object provides several methods:
 When using `step.submit()`, steps with `runtime="isolated"` will execute in separate containers/processes, while steps with `runtime="inline"` will execute in separate threads within the orchestration environment.
 {% endhint %}
 
+### Async Pipelines and Steps
+
+Dynamic pipeline entrypoints and steps can be defined with `async def`. Inside an async pipeline, calling an async step returns an awaitable that dispatches the step when you `await` it, so you can run steps concurrently with `asyncio.gather(...)`:
+
+```python
+import asyncio
+
+from zenml import step, pipeline
+
+@step
+async def fetch(url: str) -> str:
+    ...
+
+@step
+async def summarize(text: str) -> str:
+    ...
+
+@pipeline(dynamic=True)
+async def fan_out_pipeline(urls: list[str]):
+    # Fetch every URL concurrently.
+    pages = await asyncio.gather(*(fetch(url) for url in urls))
+
+    # Await a single step call to get its outputs.
+    summary = await summarize(pages[0])
+```
+
+Awaiting an async step returns the same outputs a regular call would. The pipeline entrypoint and each step can independently be sync or async, but inside an async pipeline how you invoke a step depends on the step:
+
+- **Async step:** `await` it, or `asyncio.gather(...)` several to overlap them. It runs concurrently without blocking the loop.
+- **Sync step:** call `step.submit(...)` and await the returned future. A direct call raises an error. `submit(...)` runs the step on a worker thread.
+
+`step.submit(...)` returns a future immediately without suspending the body, so you can dispatch work and await the futures later or pass them to downstream steps.
+
+{% hint style="warning" %}
+Async entrypoints are only supported for dynamic pipelines. Decorating a non-dynamic pipeline with an `async def` entrypoint is rejected when the pipeline is defined. Use `@pipeline(dynamic=True)` for async pipelines.
+{% endhint %}
+
+{% hint style="info" %}
+Inside an async pipeline, await an async step or the future returned by `submit(...)`. Calling `.result()` or `.wait()` on a step future from the running event loop raises a `RuntimeError`, since blocking the loop would deadlock it.
+{% endhint %}
+
+The table below summarizes how each invocation behaves. A step is **isolated**
+when it has a step operator or resource settings, or `runtime="isolated"`, and
+always runs in a separate container or process. Otherwise it is **inline** and
+runs inside the orchestration environment. The last column shows where inline
+code runs.
+
+| Invocation | Dynamic pipeline | Async dynamic pipeline | Where inline code runs |
+| --- | --- | --- | --- |
+| `sync_step(...)` | Runs and blocks until it returns | Raises an error, use `.submit()` | Calling thread |
+| `async_step(...)` | Runs and blocks until it returns | `await` it, runs concurrently, does not block | Event loop (the shared loop in an async pipeline) |
+| `sync_step.submit(...)` | Returns a future, non-blocking | Returns a future, non-blocking, `await` it | Worker thread |
+| `async_step.submit(...)` | Returns a future, non-blocking | Returns a future, non-blocking, `await` it | Event loop (the shared loop in an async pipeline) |
+
+An async step call that is never awaited or submitted does not run.
+
 ### Child pipelines inside dynamic pipelines
 
 Dynamic pipelines can call other dynamic pipelines from their `@pipeline`

--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Future registry for dynamic pipeline execution."""
 
+import asyncio
 import threading
 import time
 from typing import Dict, List, Union
@@ -265,7 +266,11 @@ class FutureRegistry:
         for future in futures:
             try:
                 future.wait()
-            except Exception:
+            except (Exception, asyncio.CancelledError):
+                # A cancelled step (Ctrl+C) surfaces as a `CancelledError`,
+                # which is a `BaseException`. Swallow it like any other failure
+                # so the drain stays best-effort and the caller can publish the
+                # final run status.
                 pass
 
     def has_in_progress_work(self) -> bool:

--- a/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
+++ b/src/zenml/execution/pipeline/dynamic/interactive_input_utils.py
@@ -4,7 +4,7 @@ import json
 import select
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Tuple
 
 from zenml.client import Client
 from zenml.constants import (
@@ -105,11 +105,17 @@ def maybe_enable_interactive_wait_prompt(
 
 def read_stdin_line_with_timeout(
     timeout: float,
+    interrupt_fd: Optional[int] = None,
 ) -> Tuple[bool, Optional[str]]:
     """Read a line from stdin with a timeout.
 
     Args:
         timeout: Maximum number of seconds to wait.
+        interrupt_fd: Optional file descriptor that aborts the wait when it
+            becomes readable.
+
+    Raises:
+        KeyboardInterrupt: If the interrupt descriptor became readable.
 
     Returns:
         A tuple indicating whether input was received and the entered value.
@@ -118,12 +124,19 @@ def read_stdin_line_with_timeout(
     if timeout <= 0:
         return False, None
 
+    watch: List[Any] = [sys.stdin]
+    if interrupt_fd is not None:
+        watch.append(interrupt_fd)
+
     try:
-        readable, _, _ = select.select([sys.stdin], [], [], timeout)
+        readable, _, _ = select.select(watch, [], [], timeout)
     except (AttributeError, OSError, ValueError):
         return False, None
 
-    if not readable:
+    if interrupt_fd is not None and interrupt_fd in readable:
+        raise KeyboardInterrupt()
+
+    if sys.stdin not in readable:
         return False, None
 
     raw_value = sys.stdin.readline()
@@ -136,15 +149,19 @@ def read_stdin_line_with_timeout(
 def poll_interactive_wait_condition_input(
     condition: "RunWaitConditionResponse",
     poll_interval: int,
+    interrupt_fd: Optional[int] = None,
 ) -> None:
     """Poll interactive input for a wait condition.
 
     Args:
         condition: The wait condition to resolve.
         poll_interval: Maximum number of seconds to wait.
+        interrupt_fd: Optional file descriptor that aborts the wait when it
+            becomes readable.
     """
     has_input, raw_value = read_stdin_line_with_timeout(
         timeout=float(poll_interval),
+        interrupt_fd=interrupt_fd,
     )
     if not has_input:
         return

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -13,12 +13,14 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline execution outputs."""
 
+import asyncio
 import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from contextlib import AbstractContextManager, nullcontext
 from typing import (
     Any,
+    Generator,
     Generic,
     Iterator,
     List,
@@ -117,6 +119,22 @@ PipelineRunOutputs = Union[
 ]
 
 
+def _raise_if_blocking_on_event_loop() -> None:
+    """Raise if a blocking wait is attempted from a running event loop.
+
+    Raises:
+        RuntimeError: If called while an event loop runs on the current thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    raise RuntimeError(
+        "Cannot block on a future inside an async pipeline. Await it "
+        "instead."
+    )
+
+
 class BaseFuture(ABC):
     """Base future."""
 
@@ -167,6 +185,14 @@ class _InlineStepFuture(BaseFuture):
             The result of the step run future.
         """
         return self._wrapped.result()
+
+    async def aresult(self) -> "StepRunResponse":
+        """Await the step run result.
+
+        Returns:
+            The step run response.
+        """
+        return await asyncio.wrap_future(self._wrapped)
 
 
 class _IsolatedStepFuture(BaseFuture):
@@ -263,6 +289,14 @@ class _IsolatedStepFuture(BaseFuture):
 
         return step_run
 
+    async def aresult(self) -> "StepRunResponse":
+        """Await the step run result.
+
+        Returns:
+            The step run response.
+        """
+        return await asyncio.to_thread(self.result)
+
 
 StepExecutionFuture = Union[_InlineStepFuture, _IsolatedStepFuture]
 
@@ -298,6 +332,14 @@ class _StartupResult(Generic[T]):
             The startup result.
         """
         return self._future.result()
+
+    async def aresult(self) -> T:
+        """Await the startup result.
+
+        Returns:
+            The startup result.
+        """
+        return await asyncio.wrap_future(self._future)
 
     def set_result(self, value: T) -> None:
         """Store the startup result if it is still unresolved.
@@ -521,6 +563,28 @@ class StepFuture(BaseStepFuture):
         step_run = self._wait()
         return load_step_run_outputs(step_run.id)
 
+    def __await__(self) -> Generator[Any, None, StepRunOutputs]:
+        """Await the step run outputs.
+
+        Returns:
+            The step run outputs.
+        """
+        return self._aload().__await__()
+
+    async def _aload(self) -> StepRunOutputs:
+        """Await startup and execution, then load the outputs.
+
+        Returns:
+            The step run outputs.
+        """
+        from zenml.execution.pipeline.dynamic.utils import (
+            load_step_run_outputs,
+        )
+
+        execution_future = await self._startup.aresult()
+        step_run = await execution_future.aresult()
+        return await asyncio.to_thread(load_step_run_outputs, step_run.id)
+
     def load(self, disable_cache: bool = False) -> Any:
         """Get the step run output artifact data.
 
@@ -619,6 +683,7 @@ class StepFuture(BaseStepFuture):
         Returns:
             The step run response.
         """
+        _raise_if_blocking_on_event_loop()
         return self._startup.result().result()
 
     def _set_startup_result(
@@ -719,6 +784,7 @@ class PipelineFuture(BaseFuture):
 
     def wait(self) -> None:
         """Wait for the child pipeline to finish."""
+        _raise_if_blocking_on_event_loop()
         with _maybe_release_pipeline_thread():
             self._startup.result().result()
 
@@ -732,9 +798,32 @@ class PipelineFuture(BaseFuture):
             load_pipeline_run_outputs,
         )
 
+        _raise_if_blocking_on_event_loop()
         with _maybe_release_pipeline_thread():
             run = self._startup.result().result()
         return load_pipeline_run_outputs(run=run)
+
+    def __await__(self) -> Generator[Any, None, PipelineRunOutputs]:
+        """Await the child pipeline outputs.
+
+        Returns:
+            The child pipeline outputs.
+        """
+        return self._aload().__await__()
+
+    async def _aload(self) -> PipelineRunOutputs:
+        """Await child pipeline startup and execution, then load the outputs.
+
+        Returns:
+            The child pipeline outputs.
+        """
+        from zenml.execution.pipeline.dynamic.utils import (
+            load_pipeline_run_outputs,
+        )
+
+        execution_future = await self._startup.aresult()
+        run = await asyncio.wrap_future(execution_future)
+        return await asyncio.to_thread(load_pipeline_run_outputs, run)
 
     def artifacts(self) -> PipelineRunOutputs:
         """Get the child pipeline output artifacts.

--- a/src/zenml/execution/pipeline/dynamic/run_context.py
+++ b/src/zenml/execution/pipeline/dynamic/run_context.py
@@ -13,9 +13,10 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline run context."""
 
+import asyncio
 import contextvars
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Self
 
@@ -117,3 +118,14 @@ class DynamicPipelineRunContext(context_utils.BaseContext):
                 "Re-entering the same dynamic pipeline run context is not allowed."
             )
         return super().__enter__()
+
+
+def get_active_pipeline_loop() -> Optional[asyncio.AbstractEventLoop]:
+    """Get the event loop of the active dynamic pipeline run, if any.
+
+    Returns:
+        The event loop of the active dynamic pipeline run, if any.
+    """
+    if run_context := DynamicPipelineRunContext.get():
+        return run_context.runner.event_loop
+    return None

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -13,8 +13,10 @@
 #  permissions and limitations under the License.
 """Dynamic pipeline runner."""
 
+import asyncio
 import contextvars
 import copy
+import inspect
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -24,6 +26,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ContextManager,
+    Coroutine,
     Dict,
     Iterator,
     List,
@@ -372,6 +375,7 @@ class DynamicPipelineRunner:
         self._state = _PipelineThreadState()
 
         self._is_paused = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._pause_coordinator = pause_coordinator or _PauseCoordinator()
         self._pause_coordinator.register(self)
 
@@ -480,6 +484,15 @@ class DynamicPipelineRunner:
             The orchestrator.
         """
         return self._orchestrator
+
+    @property
+    def event_loop(self) -> Optional[asyncio.AbstractEventLoop]:
+        """The event loop running the async pipeline entrypoint, if any.
+
+        Returns:
+            The event loop running the async pipeline entrypoint, if any.
+        """
+        return self._loop
 
     def _monitoring_loop(self) -> None:
         """Monitoring loop.
@@ -861,7 +874,7 @@ class DynamicPipelineRunner:
         return_value: Any = None
         try:
             with self._state.claim():
-                return_value = self.pipeline._call_entrypoint(**params)
+                return_value = self._call_entrypoint(params=params)
         except RunPaused:
             # Either this run or a child run that was awaited on paused.
             self._mark_paused()
@@ -902,6 +915,41 @@ class DynamicPipelineRunner:
             )
             self._publish_run_status(exception=e)
             raise
+
+    def _call_entrypoint(self, params: Dict[str, Any]) -> Any:
+        """Call a pipeline entrypoint.
+
+        Args:
+            params: The pipeline entrypoint parameters.
+
+        Returns:
+            The pipeline entrypoint return value.
+        """
+        call_result = self.pipeline._call_entrypoint(**params)
+        if not inspect.iscoroutine(call_result):
+            return call_result
+        
+        async def _run_entrypoint_on_loop() -> Any:
+            self._loop = asyncio.get_running_loop()
+            try:
+                return await call_result
+            finally:
+                # The pipeline body can spawn step invocations as background
+                # tasks on this loop (e.g. asyncio.create_task(my_step())) and
+                # return without awaiting them. Those tasks might still be
+                # running when the body returns. `asyncio.run(...)`` cancels
+                # any pending tasks when it closes the loop, so we await them
+                # here first to let the tasks finish cleanly.
+                pending = [
+                    task
+                    for task in asyncio.all_tasks(self._loop)
+                    if task is not asyncio.current_task()
+                ]
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+                self._loop = None
+
+        return asyncio.run(_run_entrypoint_on_loop())
 
     def notify_graph_changed(self, nodes_ready: bool) -> None:
         """Wake up the startup loop if new nodes became ready.
@@ -1006,6 +1054,7 @@ class DynamicPipelineRunner:
         ] = None,
         group: Optional["GroupInfo"] = None,
         concurrent: Literal[False] = False,
+        invocation_id: Optional[str] = None,
     ) -> StepRunOutputs: ...
 
     @overload
@@ -1020,6 +1069,7 @@ class DynamicPipelineRunner:
         ] = None,
         group: Optional["GroupInfo"] = None,
         concurrent: Literal[True] = True,
+        invocation_id: Optional[str] = None,
     ) -> "StepFuture": ...
 
     def launch_step(
@@ -1033,6 +1083,7 @@ class DynamicPipelineRunner:
         ] = None,
         group: Optional["GroupInfo"] = None,
         concurrent: bool = False,
+        invocation_id: Optional[str] = None,
     ) -> Union[StepRunOutputs, "StepFuture"]:
         """Launch a step.
 
@@ -1044,6 +1095,8 @@ class DynamicPipelineRunner:
             after: The step run output futures to wait for.
             group: The group information for this step.
             concurrent: Whether to launch the step concurrently.
+            invocation_id: Pre-allocated invocation ID. Allocation is skipped
+                when provided.
 
         Raises:
             BaseException: If the step failed.
@@ -1053,9 +1106,10 @@ class DynamicPipelineRunner:
         """  # noqa: DOC502, DOC503
         step = step.copy()
 
-        invocation_id = self.allocate_invocation_id(
-            base_name=id or step.name, allow_suffix=not id
-        )
+        if invocation_id is None:
+            invocation_id = self.allocate_invocation_id(
+                base_name=id or step.name, allow_suffix=not id
+            )
 
         remaining_retries = None
         if step_run := self._existing_step_runs.get(invocation_id):

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -16,7 +16,9 @@
 import asyncio
 import contextvars
 import copy
+import functools
 import inspect
+import os
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -25,8 +27,8 @@ from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ContextManager,
-    Coroutine,
     Dict,
     Iterator,
     List,
@@ -181,6 +183,51 @@ class _WaitConditionAborted(Exception):
 
 class RunPaused(Exception):
     """Raised when a run (or one of its descendants) entered a paused state."""
+
+
+class _WaitInterrupt:
+    """Cross-thread wake signal for an offloaded wait poll."""
+
+    def __init__(self) -> None:
+        """Initialize the interrupt."""
+        self._event = threading.Event()
+        self._read_fd, self._write_fd = os.pipe()
+
+    @property
+    def fd(self) -> int:
+        """Read end of the wakeup pipe, for use in `select`.
+
+        Returns:
+            The read file descriptor.
+        """
+        return self._read_fd
+
+    def trigger(self) -> None:
+        """Wake the worker poll from its sleep or terminal read."""
+        self._event.set()
+        try:
+            os.write(self._write_fd, b"\x00")
+        except OSError:
+            pass
+
+    def wait(self, timeout: float) -> bool:
+        """Block up to `timeout` seconds or until triggered.
+
+        Args:
+            timeout: Maximum number of seconds to block.
+
+        Returns:
+            Whether the interrupt was triggered.
+        """
+        return self._event.wait(timeout=timeout)
+
+    def close(self) -> None:
+        """Close the wakeup pipe."""
+        for fd in (self._read_fd, self._write_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
 
 
 class _PipelineThreadState:
@@ -373,6 +420,8 @@ class DynamicPipelineRunner:
         self._future_registry = FutureRegistry()
         self._child_runners: Dict[str, "DynamicPipelineRunner"] = {}
         self._state = _PipelineThreadState()
+        self._active_wait = False
+        self._active_wait_lock = threading.Lock()
 
         self._is_paused = False
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -928,7 +977,7 @@ class DynamicPipelineRunner:
         call_result = self.pipeline._call_entrypoint(**params)
         if not inspect.iscoroutine(call_result):
             return call_result
-        
+
         async def _run_entrypoint_on_loop() -> Any:
             self._loop = asyncio.get_running_loop()
             try:
@@ -1432,22 +1481,52 @@ class DynamicPipelineRunner:
             name: Optional deterministic wait condition name.
             after: Optional upstream futures that must finish before waiting.
 
+        Returns:
+            The resolved wait condition value. Inside an async pipeline this is
+            a coroutine that resolves to the value when awaited.
+        """
+        wait_condition_name = self._validate_and_begin_wait(name=name)
+
+        poll = functools.partial(
+            self._run_wait_to_completion,
+            wait_condition_name=wait_condition_name,
+            schema=schema,
+            type=type,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            question=question,
+            metadata=metadata,
+            after=after,
+        )
+
+        if self.event_loop is not None:
+            # Async pipeline: park the body coroutine on the loop and run the
+            # blocking poll on a worker thread so in-flight steps keep draining.
+            return self._await_wait(poll=poll)
+
+        try:
+            return poll()
+        finally:
+            self._end_active_wait()
+
+    def _validate_and_begin_wait(self, name: Optional[str]) -> str:
+        """Validate the wait call and reserve the single active wait slot.
+
+        Args:
+            name: Optional deterministic wait condition name.
+
         Raises:
-            RuntimeError: If called outside the dynamic pipeline function.
-            _WaitConditionAborted: If the wait condition was aborted.
-            RunPaused: If the wait condition polling timed out and the run
-                was transitioned to PAUSED.
-            KeyboardInterrupt: If interrupted while waiting.
-            BaseException: If polling fails after the lease is abandoned.
+            RuntimeError: If called outside the dynamic pipeline function, from
+                inside a step, from a non-pipeline thread, or while another
+                wait is already active.
 
         Returns:
-            The resolved wait condition value.
-        """  # noqa: DOC503
+            The resolved wait condition name.
+        """
         from zenml.execution.pipeline.dynamic.run_context import (
             DynamicPipelineRunContext,
         )
         from zenml.steps.step_context import StepContext
-        from zenml.utils.time_utils import utc_now
 
         context = DynamicPipelineRunContext.get()
         if not context:
@@ -1462,8 +1541,6 @@ class DynamicPipelineRunner:
             )
 
         if threading.get_ident() != self._state.id:
-            # `wait(...)` is currently only allowed as a sync call in the
-            # pipeline function.
             raise RuntimeError(
                 "`zenml.wait(...)` must be called from the pipeline "
                 "thread, not from a worker thread spawned inside the "
@@ -1471,6 +1548,100 @@ class DynamicPipelineRunner:
             )
 
         wait_condition_name = name or context.next_wait_condition_name()
+        self._begin_active_wait()
+        return wait_condition_name
+
+    def _begin_active_wait(self) -> None:
+        """Reserve the single active wait slot for this run.
+
+        Raises:
+            RuntimeError: If a wait is already active on this run.
+        """
+        with self._active_wait_lock:
+            if self._active_wait:
+                raise RuntimeError(
+                    "Only one `zenml.wait(...)` can be active per run. Await "
+                    "the active wait condition before starting another one."
+                )
+            self._active_wait = True
+
+    def _end_active_wait(self) -> None:
+        """Release the single active wait slot for this run."""
+        with self._active_wait_lock:
+            self._active_wait = False
+
+    async def _await_wait(self, poll: Callable[..., Any]) -> Any:
+        """Run the blocking wait poll on a worker thread and await it.
+
+        Args:
+            poll: The wait poll bound with its arguments.
+
+        Returns:
+            The resolved wait condition value.
+        """
+        interrupt = _WaitInterrupt()
+        loop = asyncio.get_running_loop()
+        context = contextvars.copy_context()
+        future = loop.run_in_executor(
+            None, functools.partial(context.run, poll, interrupt=interrupt)
+        )
+        try:
+            try:
+                return await asyncio.shield(future)
+            except asyncio.CancelledError:
+                # Ctrl+C reaches the loop thread as a cancellation here, never
+                # the worker. Forward it so the poll aborts the wait the same
+                # way Ctrl+C does in a sync pipeline.
+                if future.done():
+                    return future.result()
+                interrupt.trigger()
+                return await asyncio.shield(future)
+        finally:
+            interrupt.close()
+            self._end_active_wait()
+
+    def _run_wait_to_completion(
+        self,
+        wait_condition_name: str,
+        schema: Optional[Any] = None,
+        type: RunWaitConditionType = RunWaitConditionType.EXTERNAL_INPUT,
+        timeout: int = 600,
+        poll_interval: int = 5,
+        question: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
+        interrupt: Optional[_WaitInterrupt] = None,
+    ) -> Any:
+        """Create and poll the wait condition until it resolves or pauses.
+
+        Args:
+            wait_condition_name: Resolved wait condition name.
+            schema: Optional expected output type for the resolved result.
+            type: Wait condition type.
+            timeout: Earliest time in seconds at which polling may give up
+                and pause the run. The actual pause is deferred until all
+                active work in this pipeline (or any parent/child pipelines) has
+                finished.
+            poll_interval: Poll interval in seconds.
+            question: Optional question shown to external actors.
+            metadata: Optional metadata attached to the condition.
+            after: Optional upstream futures that must finish before waiting.
+            interrupt: Optional cross-thread interrupt that aborts the poll
+                when triggered from the event loop thread.
+
+        Raises:
+            _WaitConditionAborted: If the wait condition was aborted.
+            RunPaused: If the wait condition polling timed out and the run
+                was transitioned to PAUSED.
+            KeyboardInterrupt: If interrupted while waiting.
+            BaseException: If polling fails after the lease is abandoned.
+
+        Returns:
+            The resolved wait condition value.
+        """  # noqa: DOC503
+        from zenml.utils.time_utils import utc_now
 
         for future in collect_futures(after=after, expand_map_results=True):
             future.wait()
@@ -1553,7 +1724,15 @@ class DynamicPipelineRunner:
                             poll_interactive_wait_condition_input(
                                 condition=condition,
                                 poll_interval=poll_interval,
+                                interrupt_fd=interrupt.fd
+                                if interrupt is not None
+                                else None,
                             )
+                        elif interrupt is not None:
+                            # Async pipeline: wake early if the loop thread
+                            # forwards a Ctrl+C, otherwise sleep the interval.
+                            if interrupt.wait(timeout=poll_interval):
+                                raise KeyboardInterrupt()
                         else:
                             time.sleep(poll_interval)
             except _WaitConditionAborted:

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -19,6 +19,7 @@ import copy
 import functools
 import inspect
 import os
+import signal
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -980,21 +981,34 @@ class DynamicPipelineRunner:
 
         async def _run_entrypoint_on_loop() -> Any:
             self._loop = asyncio.get_running_loop()
+            interrupted = False
             try:
                 return await call_result
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                # Ctrl+C unwinds the body as a cancellation. Cancel in-flight
+                # step tasks instead of waiting for them so the interrupt is as
+                # responsive as it is in a sync pipeline, where the running step
+                # is interrupted immediately. Other failures fall through and
+                # let in-flight steps drain, matching the sync stop-on-failure
+                # behavior.
+                interrupted = True
+                raise
             finally:
                 # The pipeline body can spawn step invocations as background
                 # tasks on this loop (e.g. asyncio.create_task(my_step())) and
                 # return without awaiting them. Those tasks might still be
                 # running when the body returns. `asyncio.run(...)`` cancels
-                # any pending tasks when it closes the loop, so we await them
-                # here first to let the tasks finish cleanly.
+                # any pending tasks when it closes the loop, so on a normal
+                # return we await them here first to let them finish cleanly.
                 pending = [
                     task
                     for task in asyncio.all_tasks(self._loop)
                     if task is not asyncio.current_task()
                 ]
                 if pending:
+                    if interrupted:
+                        for task in pending:
+                            task.cancel()
                     await asyncio.gather(*pending, return_exceptions=True)
                 self._loop = None
 
@@ -1585,18 +1599,47 @@ class DynamicPipelineRunner:
         future = loop.run_in_executor(
             None, functools.partial(context.run, poll, interrupt=interrupt)
         )
+
+        def _remove_sigint_handler() -> None:
+            try:
+                loop.remove_signal_handler(signal.SIGINT)
+            except (NotImplementedError, RuntimeError, ValueError):
+                pass
+
+        def _forward_ctrl_c() -> None:
+            # Restore default handling so a second Ctrl+C force-quits while the
+            # poll aborts the wait, then forward the first one to the poll.
+            _remove_sigint_handler()
+            interrupt.trigger()
+
+        # Route Ctrl+C through the loop so the worker poll aborts the wait the
+        # same way a sync pipeline does, identically across Python versions.
+        # Without this, Python 3.11+ delivers the SIGINT as a task cancellation
+        # while 3.10 raises it as a KeyboardInterrupt during `asyncio.run()`
+        # shutdown, which marks the run failed instead of stopped. The
+        # `CancelledError` branch below stays as the fallback for platforms
+        # without loop signal handlers and child pipelines off the main thread.
+        sigint_forwarded = False
+        try:
+            loop.add_signal_handler(signal.SIGINT, _forward_ctrl_c)
+            sigint_forwarded = True
+        except (NotImplementedError, RuntimeError, ValueError):
+            pass
+
         try:
             try:
                 return await asyncio.shield(future)
             except asyncio.CancelledError:
-                # Ctrl+C reaches the loop thread as a cancellation here, never
-                # the worker. Forward it so the poll aborts the wait the same
-                # way Ctrl+C does in a sync pipeline.
+                # A cancellation reaches the loop thread here, never the
+                # worker. Forward it so the poll aborts the wait the same way
+                # Ctrl+C does in a sync pipeline.
                 if future.done():
                     return future.result()
                 interrupt.trigger()
                 return await asyncio.shield(future)
         finally:
+            if sigint_forwarded:
+                _remove_sigint_handler()
             interrupt.close()
             self._end_active_wait()
 

--- a/src/zenml/execution/pipeline/dynamic/utils.py
+++ b/src/zenml/execution/pipeline/dynamic/utils.py
@@ -136,7 +136,8 @@ def wait(
         RuntimeError: If called outside of dynamic pipeline execution.
 
     Returns:
-        The resolved wait condition value.
+        The resolved wait condition value. Inside an async pipeline this is a
+        coroutine that resolves to the value when awaited.
     """
     from zenml.execution.pipeline.dynamic.run_context import (
         DynamicPipelineRunContext,

--- a/src/zenml/pipelines/dynamic/pipeline_definition.py
+++ b/src/zenml/pipelines/dynamic/pipeline_definition.py
@@ -306,6 +306,13 @@ class DynamicPipeline(Pipeline):
                     "Calling a child pipeline is not allowed within a step function."
                 )
 
+            if run_context.runner.event_loop is not None:
+                raise RuntimeError(
+                    f"Cannot call child pipeline `{self.name}` directly inside "
+                    f"an async pipeline. Use `{self.name}.submit(...)` to run "
+                    f"it."
+                )
+
             return run_context.runner.submit_child_pipeline(
                 pipeline=self,
                 args=args,

--- a/src/zenml/pipelines/pipeline_decorator.py
+++ b/src/zenml/pipelines/pipeline_decorator.py
@@ -29,6 +29,7 @@ from uuid import UUID
 
 from zenml.enums import ExecutionMode
 from zenml.logger import get_logger
+from zenml.utils.async_utils import is_async_callable
 
 if TYPE_CHECKING:
     from zenml.config.base_settings import SettingsOrDict
@@ -214,6 +215,17 @@ def pipeline(
     """
 
     def inner_decorator(func: "F") -> Union["Pipeline", "DynamicPipeline"]:
+        """Create a pipeline instance from the decorated function.
+
+        Args:
+            func: The decorated function.
+
+        Raises:
+            RuntimeError: If a non-dynamic pipeline has an async entrypoint.
+
+        Returns:
+            A pipeline instance.
+        """
         from zenml.pipelines.pipeline_definition import Pipeline
 
         PipelineClass = Pipeline
@@ -233,6 +245,14 @@ def pipeline(
             logger.warning(
                 "The `depends_on` argument is not supported "
                 "for static pipelines and will be ignored."
+            )
+
+        if not dynamic and is_async_callable(func):
+            raise RuntimeError(
+                f"Pipeline `{name or func.__name__}` has an async (`async def`) "
+                "entrypoint but is not a dynamic pipeline. Async pipeline "
+                "entrypoints are only supported for dynamic pipelines. Use "
+                "`@pipeline(dynamic=True)` to define an async pipeline."
             )
 
         p = PipelineClass(

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -69,6 +69,7 @@ from zenml.utils import (
     source_code_utils,
     source_utils,
 )
+from zenml.utils.async_utils import is_async_callable, run_coroutine_blocking
 
 if TYPE_CHECKING:
     from zenml.artifacts.external_artifact import ExternalArtifact
@@ -100,7 +101,9 @@ if TYPE_CHECKING:
         AnyOutputFuture,
         MapResultsFuture,
         StepFuture,
+        StepRunOutputs,
     )
+    from zenml.execution.pipeline.dynamic.runner import DynamicPipelineRunner
     from zenml.pipelines.compilation_context import (
         PipelineCompilationContext,
     )
@@ -612,6 +615,10 @@ class BaseStep:
             after: Upstream steps for the invocation.
             **kwargs: Entrypoint function keyword arguments.
 
+        Raises:
+            RuntimeError: If a sync step is called directly inside an async
+                pipeline.
+
         Returns:
             The outputs of the entrypoint function call.
         """
@@ -671,6 +678,29 @@ class BaseStep:
                 ],
                 after,
             )
+            if run_context.runner.event_loop is not None:
+                # Async dynamic pipeline.
+                if not is_async_callable(self.entrypoint):
+                    raise RuntimeError(
+                        f"Cannot call sync step `{self.name}` directly inside "
+                        f"an async pipeline. Use `{self.name}.submit(...)` to "
+                        f"run it."
+                    )
+                # Return a coroutine so the step is only dispatched once the
+                # body awaits it (or `asyncio.gather`s over it). The invocation
+                # ID is allocated now so IDs follow call order rather than await
+                # order.
+                invocation_id = run_context.runner.allocate_invocation_id(
+                    base_name=id or self.name, allow_suffix=not id
+                )
+                return self._call_async(
+                    runner=run_context.runner,
+                    invocation_id=invocation_id,
+                    args=args,
+                    kwargs=kwargs,
+                    after=after,
+                )
+
             return run_context.runner.launch_step(
                 step=self,
                 id=id,
@@ -693,6 +723,37 @@ class BaseStep:
             return
 
         return run_as_single_step_pipeline(self, None, *args, **kwargs)
+
+    async def _call_async(
+        self,
+        runner: "DynamicPipelineRunner",
+        invocation_id: str,
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        after: Union["AnyOutputFuture", Sequence["AnyOutputFuture"], None],
+    ) -> "StepRunOutputs":
+        """Dispatch the step and await its outputs.
+
+        Args:
+            runner: The dynamic pipeline runner.
+            invocation_id: The pre-allocated invocation ID.
+            args: Entrypoint function arguments.
+            kwargs: Entrypoint function keyword arguments.
+            after: Upstream futures to wait for before executing the step.
+
+        Returns:
+            The step run outputs.
+        """
+        future = runner.launch_step(
+            step=self,
+            id=None,
+            args=args,
+            kwargs=kwargs,
+            after=after,
+            concurrent=True,
+            invocation_id=invocation_id,
+        )
+        return await future
 
     def call_entrypoint(self, *args: Any, **kwargs: Any) -> Any:
         """Calls the entrypoint function of the step.
@@ -720,6 +781,16 @@ class BaseStep:
                 "Invalid step function entrypoint arguments. Check out the "
                 "pydantic error above for more details."
             ) from e
+
+        if is_async_callable(self.entrypoint):
+            from zenml.execution.pipeline.dynamic.run_context import (
+                get_active_pipeline_loop,
+            )
+
+            return run_coroutine_blocking(
+                self.entrypoint(**validated_args),
+                loop=get_active_pipeline_loop(),
+            )
 
         return self.entrypoint(**validated_args)
 

--- a/src/zenml/utils/async_utils.py
+++ b/src/zenml/utils/async_utils.py
@@ -1,0 +1,128 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Helpers for running async user code from synchronous code."""
+
+import asyncio
+import contextvars
+import functools
+import inspect
+from concurrent.futures import Future
+from typing import Any, Coroutine, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+def is_async_callable(fn: Any) -> bool:
+    """Check whether a callable is a coroutine function.
+
+    Unwraps `functools.partial` and `functools.wraps`-style wrappers.
+
+    Args:
+        fn: The callable to check.
+
+    Returns:
+        Whether calling `fn` returns a coroutine.
+    """
+    while isinstance(fn, functools.partial):
+        fn = fn.func
+
+    if inspect.iscoroutinefunction(fn):
+        return True
+
+    unwrapped = inspect.unwrap(fn) if callable(fn) else fn
+    return inspect.iscoroutinefunction(unwrapped)
+
+
+def run_coroutine_blocking(
+    coro: "Coroutine[Any, Any, T]",
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+) -> T:
+    """Run a coroutine to completion from synchronous code.
+
+    If `loop` is given and running, the coroutine is dispatched onto it under
+    the caller's `contextvars` context and this call blocks until it finishes.
+    Otherwise the coroutine runs on a new event loop on the current thread.
+
+    Args:
+        coro: The coroutine to run.
+        loop: The shared event loop to dispatch onto, if any.
+
+    Raises:
+        RuntimeError: If `loop` is the event loop already running on the
+            current thread.
+
+    Returns:
+        The coroutine result.
+    """
+    if loop is not None and loop.is_running():
+        try:
+            running_loop: Optional[asyncio.AbstractEventLoop] = (
+                asyncio.get_running_loop()
+            )
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            raise RuntimeError(
+                "Cannot run a coroutine to completion from within the event "
+                "loop it should run on."
+            )
+
+        context = contextvars.copy_context()
+        return run_coroutine_threadsafe_in_context(
+            coro=coro, loop=loop, context=context
+        ).result()
+
+    return asyncio.run(coro)
+
+
+def run_coroutine_threadsafe_in_context(
+    coro: "Coroutine[Any, Any, T]",
+    loop: asyncio.AbstractEventLoop,
+    context: contextvars.Context,
+) -> "Future[T]":
+    """Schedule a coroutine on another loop under a captured context.
+
+    The coroutine task is created from within `context.run(...)` so the task
+    copies and runs under the captured context.
+
+    Args:
+        coro: The coroutine to run.
+        loop: The target event loop.
+        context: The context to run the coroutine under.
+
+    Returns:
+        A future resolved with the coroutine result.
+    """
+    result_future: "Future[T]" = Future()
+
+    def _schedule() -> None:
+        try:
+            task = context.run(loop.create_task, coro)
+        except BaseException as exc:
+            result_future.set_exception(exc)
+            return
+
+        def _chain(completed: "asyncio.Task[T]") -> None:
+            if completed.cancelled():
+                result_future.set_exception(asyncio.CancelledError())
+            elif (exc := completed.exception()) is not None:
+                result_future.set_exception(exc)
+            else:
+                result_future.set_result(completed.result())
+
+        task.add_done_callback(_chain)
+
+    loop.call_soon_threadsafe(_schedule)
+    return result_future

--- a/tests/unit/execution/pipeline/dynamic/test_async_pipelines.py
+++ b/tests/unit/execution/pipeline/dynamic/test_async_pipelines.py
@@ -1,0 +1,265 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""End-to-end tests for async dynamic pipelines."""
+
+import asyncio
+import threading
+
+import pytest
+
+from zenml import pipeline, step
+
+# ---------------------------------------------------------------------------
+# Shared state across step bodies running in-process on the local orchestrator.
+# Any asyncio primitive stored here is loop-bound, so it must be created lazily
+# inside a step body and the dict reset at the start of each run.
+# ---------------------------------------------------------------------------
+
+_shared: dict = {}
+
+
+@step
+async def barrier_worker(name: str) -> str:
+    _shared["entered"] = _shared.get("entered", 0) + 1
+    _shared["max"] = max(_shared.get("max", 0), _shared["entered"])
+    barrier = _shared.setdefault("barrier", asyncio.Event())
+    if _shared["entered"] >= 2:
+        barrier.set()
+    # If the two bodies were on different loops, this Event would never be set
+    # by the other body and this would time out.
+    await asyncio.wait_for(barrier.wait(), timeout=10.0)
+    _shared["entered"] -= 1
+    return name
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_gather_pipeline() -> None:
+    _shared.clear()
+    results = await asyncio.gather(barrier_worker("a"), barrier_worker("b"))
+    names = sorted(r.load() for r in results)
+    assert names == ["a", "b"], names
+    assert _shared["max"] == 2, _shared
+
+
+def test_async_gather_overlaps_on_shared_loop() -> None:
+    run = async_gather_pipeline()
+    assert run.status.is_successful
+
+
+@step
+async def async_plus_one(x: int) -> int:
+    await asyncio.sleep(0.01)
+    return x + 1
+
+
+@step
+def sync_times_ten(x: int) -> int:
+    return x * 10
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_mixed_pipeline() -> None:
+    a = await async_plus_one(10)
+    # A sync step cannot be called directly in an async pipeline, it has to be
+    # submitted to run on a worker thread.
+    b = await sync_times_ten.submit(5)
+    assert a.load() == 11, a.load()
+    assert b.load() == 50, b.load()
+
+
+def test_async_dynamic_mixed_steps() -> None:
+    run = async_mixed_pipeline()
+    assert run.status.is_successful
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_calls_sync_step_directly() -> None:
+    await sync_times_ten(5)
+
+
+def test_sync_step_direct_call_rejected_in_async_pipeline() -> None:
+    with pytest.raises(RuntimeError, match="submit"):
+        async_pipeline_calls_sync_step_directly()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def sync_mixed_pipeline() -> None:
+    a = async_plus_one(10)
+    b = sync_times_ten(5)
+    assert a.load() == 11, a.load()
+    assert b.load() == 50, b.load()
+
+
+def test_sync_dynamic_mixed_steps() -> None:
+    run = sync_mixed_pipeline()
+    assert run.status.is_successful
+
+
+@step
+async def async_reads_context() -> str:
+    from zenml import get_step_context
+
+    await asyncio.sleep(0.01)
+    return get_step_context().step_run.name
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_context_pipeline() -> None:
+    out = await async_reads_context()
+    assert out.load() == "async_reads_context", out.load()
+
+
+def test_async_body_has_step_context() -> None:
+    run = async_context_pipeline()
+    assert run.status.is_successful
+
+
+# ---------------------------------------------------------------------------
+# `submit()` on async steps runs them concurrently in both sync and async
+# dynamic pipelines. In an async pipeline the resulting future must be awaited.
+# A blocking `.result()` / `.wait()` on the shared loop is rejected because it
+# would deadlock the loop.
+# ---------------------------------------------------------------------------
+
+_submit_state: dict = {}
+
+
+@step
+async def submit_concurrent_worker(name: str) -> str:
+    barrier: threading.Barrier = _submit_state["barrier"]
+    await asyncio.sleep(0.01)
+    # Each submitted async step runs on its own loop on its own worker thread.
+    # The barrier releases only once both workers arrive, proving concurrency.
+    barrier.wait(timeout=10.0)
+    return name
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def sync_pipeline_submits_async() -> None:
+    _submit_state["barrier"] = threading.Barrier(2)
+    future_a = submit_concurrent_worker.submit("a", id="worker_a")
+    future_b = submit_concurrent_worker.submit("b", id="worker_b")
+    results = sorted([future_a.result().load(), future_b.result().load()])
+    assert results == ["a", "b"], results
+
+
+def test_submit_async_steps_run_concurrently_in_sync_pipeline() -> None:
+    run = sync_pipeline_submits_async()
+    assert run.status.is_successful
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_submits_and_awaits() -> None:
+    future = async_plus_one.submit(10)
+    out = await future
+    assert out.load() == 11, out.load()
+
+
+def test_submit_async_step_in_async_pipeline_is_awaitable() -> None:
+    run = async_pipeline_submits_and_awaits()
+    assert run.status.is_successful
+
+
+@step
+async def async_double(x: int) -> int:
+    await asyncio.sleep(0.01)
+    return x * 2
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_wires_submit_future() -> None:
+    future = async_plus_one.submit(10)
+    out = await async_double(future)
+    assert out.load() == 22, out.load()
+
+
+def test_submit_future_wires_into_bare_call() -> None:
+    run = async_pipeline_wires_submit_future()
+    assert run.status.is_successful
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_blocking_result() -> None:
+    future = async_plus_one.submit(10)
+    future.result()
+
+
+def test_blocking_result_rejected_in_async_pipeline() -> None:
+    with pytest.raises(RuntimeError, match="async pipeline"):
+        async_pipeline_blocking_result()
+
+
+# ---------------------------------------------------------------------------
+# A bare step call in an async pipeline returns a coroutine. The step is only
+# dispatched once it is awaited, not at call time.
+# ---------------------------------------------------------------------------
+
+_lazy_state: dict = {}
+
+
+@step
+async def records_execution() -> int:
+    _lazy_state["ran"] = True
+    return 1
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_lazy_call() -> None:
+    _lazy_state.clear()
+    coro = records_execution()
+    # Yield to the loop. An eagerly dispatched step would run here.
+    await asyncio.sleep(0.05)
+    assert _lazy_state.get("ran") is None, "step ran before being awaited"
+    out = await coro
+    assert _lazy_state.get("ran") is True
+    assert out.load() == 1, out.load()
+
+
+def test_bare_call_is_lazy() -> None:
+    run = async_pipeline_lazy_call()
+    assert run.status.is_successful
+
+
+# ---------------------------------------------------------------------------
+# Invocation IDs are allocated at call time, so they follow call order even
+# when the steps are awaited in a different order.
+# ---------------------------------------------------------------------------
+
+_id_order: dict = {}
+
+
+@step
+async def async_records_id(x: int) -> int:
+    from zenml import get_step_context
+
+    _id_order[x] = get_step_context().step_run.name
+    await asyncio.sleep(0.01)
+    return x
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_id_order() -> None:
+    _id_order.clear()
+    first = async_records_id(1)
+    second = async_records_id(2)
+    # Await in reverse order. The first call still owns the unsuffixed ID.
+    await second
+    await first
+
+
+def test_invocation_ids_follow_call_order() -> None:
+    run = async_pipeline_id_order()
+    assert run.status.is_successful
+    assert _id_order[1] == "async_records_id", _id_order
+    assert _id_order[2] == "async_records_id_2", _id_order

--- a/tests/unit/execution/pipeline/dynamic/test_async_wait.py
+++ b/tests/unit/execution/pipeline/dynamic/test_async_wait.py
@@ -1,0 +1,231 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""End-to-end tests for `zenml.wait()` in async dynamic pipelines."""
+
+import asyncio
+import os
+import sys
+import time
+
+import pytest
+from tests.unit.execution.pipeline.dynamic.test_child_pipelines import (
+    _latest_run_id,
+    _refresh,
+    _resolve_pending_wait,
+    _run_in_thread,
+    _wait_for_thread,
+)
+
+from zenml import pipeline, step, wait
+from zenml.client import Client
+from zenml.enums import ExecutionStatus
+from zenml.execution.pipeline.dynamic.interactive_input_utils import (
+    read_stdin_line_with_timeout,
+)
+from zenml.execution.pipeline.dynamic.runner import _WaitInterrupt
+
+# Shared flag set by a step body that runs on the pipeline loop while a wait is
+# pending. Reset at the start of each run that uses it.
+_drain_state: dict = {}
+
+
+@step
+async def async_wait_double(value: int) -> int:
+    await asyncio.sleep(0.01)
+    return value * 2
+
+
+@step
+async def async_wait_marker(value: int = 1) -> int:
+    await asyncio.sleep(0.05)
+    _drain_state["done"] = True
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Awaiting `zenml.wait(...)` resolves to the typed value.
+# ---------------------------------------------------------------------------
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_waiting_returns_value() -> int:
+    answer: int = await wait(schema=int, timeout=20, poll_interval=1)
+    return await async_wait_double(answer)
+
+
+def test_async_wait_continue_returns_typed_value() -> None:
+    thread, holder, started_at = _run_in_thread(async_waiting_returns_value)
+    run_id = _latest_run_id("async_waiting_returns_value", after=started_at)
+    _resolve_pending_wait(run_id, result=21)
+    _wait_for_thread(thread)
+    assert "exc" not in holder, holder.get("exc")
+    run = holder["run"]
+    assert run.status.is_successful
+    refreshed = _refresh(run.id)
+    assert len(refreshed.outputs) == 1
+    only_output = next(iter(refreshed.outputs.values()))
+    assert only_output.load() == 42
+
+
+# ---------------------------------------------------------------------------
+# The await frees the loop, so work scheduled on it keeps draining while the
+# wait is pending. A blocking wait on the loop would freeze this.
+# ---------------------------------------------------------------------------
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_wait_with_concurrent_loop_task() -> None:
+    _drain_state.clear()
+    # The bare step call runs on the pipeline loop once scheduled as a task.
+    task = asyncio.create_task(async_wait_marker())
+    answer: int = await wait(schema=int, timeout=30, poll_interval=1)
+    assert answer == 5, answer
+    out = await task
+    assert out.load() == 1, out.load()
+
+
+def test_async_wait_does_not_freeze_loop() -> None:
+    thread, holder, started_at = _run_in_thread(
+        async_wait_with_concurrent_loop_task
+    )
+    run_id = _latest_run_id(
+        "async_wait_with_concurrent_loop_task", after=started_at
+    )
+    # The task scheduled on the loop must complete while the wait is pending.
+    # If the wait froze the loop, the task could not run.
+    deadline = time.time() + 15.0
+    while time.time() < deadline and not _drain_state.get("done"):
+        time.sleep(0.05)
+    assert _drain_state.get("done") is True, (
+        "concurrent loop task did not run while the wait was pending"
+    )
+    pending = Client().list_run_wait_conditions(
+        pipeline_run=run_id, status="pending"
+    )
+    assert pending.items, "wait resolved before the concurrent task finished"
+    _resolve_pending_wait(run_id, result=5)
+    _wait_for_thread(thread)
+    assert "exc" not in holder, holder.get("exc")
+    assert holder["run"].status.is_successful
+
+
+# ---------------------------------------------------------------------------
+# Only one wait can be active per run. Gathering two waits rejects the second.
+# ---------------------------------------------------------------------------
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_double_wait() -> None:
+    await asyncio.gather(
+        wait(schema=int, timeout=20, poll_interval=1),
+        wait(schema=int, timeout=20, poll_interval=1),
+    )
+
+
+@pytest.mark.filterwarnings(
+    "ignore:coroutine.*was never awaited:RuntimeWarning"
+)
+def test_async_second_concurrent_wait_rejected() -> None:
+    # The second `wait(...)` raises synchronously while `gather`'s arguments
+    # are evaluated, so the first wait's coroutine is never awaited.
+    with pytest.raises(RuntimeError, match="Only one"):
+        async_double_wait()
+
+
+# ---------------------------------------------------------------------------
+# `zenml.wait(...)` is rejected from inside a step and from a worker thread.
+# ---------------------------------------------------------------------------
+
+
+@step
+async def async_step_calls_wait() -> None:
+    await wait(schema=int, timeout=20, poll_interval=1)
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_wait_in_step() -> None:
+    await async_step_calls_wait()
+
+
+def test_async_wait_inside_step_rejected() -> None:
+    with pytest.raises(RuntimeError, match="cannot be called inside a step"):
+        async_pipeline_wait_in_step()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_pipeline_wait_from_worker_thread() -> None:
+    # `asyncio.to_thread` copies the run context to a worker thread, so the
+    # context guard passes and the pipeline-thread guard fires.
+    await asyncio.to_thread(wait, schema=int, timeout=20, poll_interval=1)
+
+
+def test_async_wait_from_worker_thread_rejected() -> None:
+    with pytest.raises(RuntimeError, match="pipeline thread"):
+        async_pipeline_wait_from_worker_thread()
+
+
+# ---------------------------------------------------------------------------
+# A wait that never resolves pauses the run after in-flight work drains.
+# ---------------------------------------------------------------------------
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def async_waiting_short_timeout() -> None:
+    await wait(timeout=2, poll_interval=1)
+    await async_wait_double(1)  # Must not run.
+
+
+def test_async_wait_timeout_pauses_run() -> None:
+    run = async_waiting_short_timeout()
+    assert run is not None
+    final = _refresh(run.id)
+    assert final.status == ExecutionStatus.PAUSED
+    assert "async_wait_double" not in final.steps
+
+
+# ---------------------------------------------------------------------------
+# Ctrl+C on an async pipeline reaches the loop thread as a cancellation. The
+# wait poll runs on a worker thread, so the cancellation is forwarded to it via
+# `_WaitInterrupt` to abort the wait the same way a sync Ctrl+C does. These
+# cover the forwarding primitives; the end-to-end signal path is verified
+# manually since unit tests cannot deliver SIGINT deterministically.
+# ---------------------------------------------------------------------------
+
+
+def test_wait_interrupt_blocks_then_wakes() -> None:
+    interrupt = _WaitInterrupt()
+    try:
+        assert interrupt.wait(timeout=0.01) is False
+        interrupt.trigger()
+        assert interrupt.wait(timeout=1.0) is True
+    finally:
+        interrupt.close()
+
+
+def test_read_stdin_aborts_on_interrupt_fd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stdin_read_fd, stdin_write_fd = os.pipe()
+    interrupt = _WaitInterrupt()
+    try:
+        interrupt.trigger()
+        with os.fdopen(stdin_read_fd) as fake_stdin:
+            monkeypatch.setattr(sys, "stdin", fake_stdin)
+            with pytest.raises(KeyboardInterrupt):
+                read_stdin_line_with_timeout(
+                    timeout=1.0, interrupt_fd=interrupt.fd
+                )
+    finally:
+        os.close(stdin_write_fd)
+        interrupt.close()

--- a/tests/unit/execution/pipeline/dynamic/test_child_pipelines.py
+++ b/tests/unit/execution/pipeline/dynamic/test_child_pipelines.py
@@ -221,6 +221,43 @@ def test_inline_child_does_not_create_child_run() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Child pipelines inside an async parent
+# ---------------------------------------------------------------------------
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def parent_async_awaits_child_submit() -> None:
+    out = await child_emit_int_pipeline.submit()
+    assert out.load() == 11, out.load()
+
+
+def test_async_parent_awaits_child_submit() -> None:
+    run = parent_async_awaits_child_submit()
+    assert run.status.is_successful
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def parent_async_calls_child_directly() -> None:
+    child_emit_int_pipeline()
+
+
+def test_direct_child_call_rejected_in_async_pipeline() -> None:
+    with pytest.raises(RuntimeError, match="submit"):
+        parent_async_calls_child_directly()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+async def parent_async_blocks_on_child_result() -> None:
+    future = child_emit_int_pipeline.submit()
+    future.result()
+
+
+def test_blocking_on_child_result_rejected_in_async_pipeline() -> None:
+    with pytest.raises(RuntimeError, match="async pipeline"):
+        parent_async_blocks_on_child_result()
+
+
+# ---------------------------------------------------------------------------
 # B. I/O between parent and child
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/pipelines/test_async_pipeline_validation.py
+++ b/tests/unit/pipelines/test_async_pipeline_validation.py
@@ -1,0 +1,61 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for async pipeline validation."""
+
+import pytest
+
+from zenml import pipeline
+
+
+def test_async_bare_pipeline_decorator_raises() -> None:
+    """Tests that a bare `@pipeline` rejects an async entrypoint."""
+    with pytest.raises(RuntimeError, match="dynamic=True"):
+
+        @pipeline
+        async def p() -> None: ...
+
+
+def test_async_non_dynamic_pipeline_decorator_raises() -> None:
+    """Tests that `@pipeline(dynamic=False)` rejects an async entrypoint."""
+    with pytest.raises(RuntimeError, match="dynamic=True"):
+
+        @pipeline(dynamic=False)
+        async def p() -> None: ...
+
+
+def test_async_dynamic_pipeline_decorator_succeeds() -> None:
+    """Tests that `@pipeline(dynamic=True)` accepts an async entrypoint."""
+
+    @pipeline(dynamic=True)
+    async def p() -> None: ...
+
+    assert p
+
+
+def test_sync_bare_pipeline_decorator_succeeds() -> None:
+    """Tests that a bare `@pipeline` accepts a sync entrypoint."""
+
+    @pipeline
+    def p() -> None: ...
+
+    assert p
+
+
+def test_sync_dynamic_pipeline_decorator_succeeds() -> None:
+    """Tests that `@pipeline(dynamic=True)` accepts a sync entrypoint."""
+
+    @pipeline(dynamic=True)
+    def p() -> None: ...
+
+    assert p

--- a/tests/unit/steps/test_async_entrypoint.py
+++ b/tests/unit/steps/test_async_entrypoint.py
@@ -1,0 +1,69 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for async step entrypoints."""
+
+import asyncio
+
+from zenml import pipeline, step
+
+
+@step
+async def async_add_one(x: int) -> int:
+    await asyncio.sleep(0.01)
+    return x + 1
+
+
+@step
+def sync_add_one(x: int) -> int:
+    return x + 1
+
+
+@step
+def assert_equals(value: int, expected: int) -> None:
+    assert value == expected, f"{value} != {expected}"
+
+
+@pipeline(enable_cache=False)
+def static_pipeline_with_async_step() -> None:
+    result = async_add_one(41)
+    assert_equals(result, 42)
+
+
+def test_async_step_runs_in_static_pipeline() -> None:
+    """An async step inside a static pipeline runs and materializes output."""
+    run = static_pipeline_with_async_step()
+    assert run.status.is_successful
+    output = run.steps["async_add_one"].output.load()
+    assert output == 42
+
+
+@pipeline(enable_cache=False)
+def static_pipeline_with_mixed_steps() -> None:
+    sync_result = sync_add_one(10)
+    async_result = async_add_one(sync_result)
+    assert_equals(async_result, 12)
+
+
+def test_async_and_sync_steps_run_together() -> None:
+    """A static pipeline mixing a sync and an async step both succeed."""
+    run = static_pipeline_with_mixed_steps()
+    assert run.status.is_successful
+    assert run.steps["sync_add_one"].output.load() == 11
+    assert run.steps["async_add_one"].output.load() == 12
+
+
+def test_async_step_called_directly() -> None:
+    """Calling an async step with no active pipeline returns the right value."""
+    result = async_add_one(5)
+    assert result == 6

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -1,0 +1,137 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for async utils."""
+
+import asyncio
+import contextvars
+import functools
+import threading
+from typing import Optional
+
+import pytest
+
+from zenml.utils.async_utils import (
+    is_async_callable,
+    run_coroutine_blocking,
+)
+
+
+async def _async_fn() -> int:
+    return 1
+
+
+def _sync_fn() -> int:
+    return 1
+
+
+def test_is_async_callable_true_for_async_def() -> None:
+    """An `async def` function is detected as async."""
+    assert is_async_callable(_async_fn) is True
+
+
+def test_is_async_callable_false_for_sync_def_and_lambda() -> None:
+    """A plain function and a lambda are not detected as async."""
+    assert is_async_callable(_sync_fn) is False
+    assert is_async_callable(lambda: 1) is False
+
+
+def test_is_async_callable_true_for_partial_wrapping_async() -> None:
+    """A partial wrapping an `async def` is detected as async."""
+    partial = functools.partial(_async_fn)
+    assert is_async_callable(partial) is True
+
+
+def test_is_async_callable_false_for_partial_wrapping_sync() -> None:
+    """A partial wrapping a sync function is not detected as async."""
+    partial = functools.partial(_sync_fn)
+    assert is_async_callable(partial) is False
+
+
+def test_run_coroutine_blocking_no_loop_returns_value() -> None:
+    """Running without a loop returns the coroutine result."""
+
+    async def coro() -> int:
+        return 42
+
+    assert run_coroutine_blocking(coro()) == 42
+
+
+def test_run_coroutine_blocking_no_loop_propagates_exception() -> None:
+    """Running without a loop propagates an exception from the coroutine."""
+
+    async def coro() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_coroutine_blocking(coro())
+
+
+def test_run_coroutine_blocking_dispatches_to_loop_with_context() -> None:
+    """Dispatching onto a running loop preserves context and switches thread."""
+    test_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "_test_var", default="default"
+    )
+
+    loop = asyncio.new_event_loop()
+    loop_thread_id: Optional[int] = None
+    ready = threading.Event()
+
+    def _run_loop() -> None:
+        nonlocal loop_thread_id
+        loop_thread_id = threading.get_ident()
+        asyncio.set_event_loop(loop)
+        loop.call_soon(ready.set)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run_loop)
+    thread.start()
+    try:
+        ready.wait()
+        assert loop.is_running()
+
+        main_thread_id = threading.get_ident()
+        test_var.set("propagated")
+
+        async def read_var() -> tuple[str, int]:
+            return test_var.get(), threading.get_ident()
+
+        value, executed_thread_id = run_coroutine_blocking(
+            read_var(), loop=loop
+        )
+
+        assert value == "propagated"
+        assert executed_thread_id == loop_thread_id
+        assert executed_thread_id != main_thread_id
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join()
+        loop.close()
+
+
+def test_run_coroutine_blocking_raises_on_same_thread_loop() -> None:
+    """Dispatching onto the loop running on the current thread raises."""
+
+    async def inner() -> int:
+        return 1
+
+    async def main() -> None:
+        loop = asyncio.get_running_loop()
+        coro = inner()
+        try:
+            with pytest.raises(RuntimeError):
+                run_coroutine_blocking(coro, loop=loop)
+        finally:
+            coro.close()
+
+    asyncio.run(main())


### PR DESCRIPTION
This PR lets you define dynamic pipeline entrypoints and steps with `async def`. Inside an async dynamic pipeline, calling an async step returns an awaitable that dispatches the step when you `await` it, so you can run steps concurrently with `asyncio.gather(...)`.

```python
@step
async def fetch(url: str) -> str: ...

@pipeline(dynamic=True)
async def my_pipeline(urls: list[str]):
    results = await asyncio.gather(*(fetch(url) for url in urls))
```

**Limitations:**
- Async entrypoints are only supported for dynamic pipelines. A non-dynamic pipeline with an `async def` entrypoint is rejected at definition time.
- Inside an async pipeline, await a step instead of blocking on it. Calling `.result()` on a step future from the running event loop raises.


**TODO**:
- Once #4875 is merged, add support for async hook functions