### PR TITLE
Enable async steps and hooks

### DIFF
--- a/docs/book/how-to/steps-pipelines/advanced_features.md
+++ b/docs/book/how-to/steps-pipelines/advanced_features.md
@@ -116,6 +116,26 @@ settings:
 
 You can also configure the orchestrator to always run asynchronously by setting `synchronous=False` in its configuration.
 
+### Async Steps
+
+Step functions can be defined with `async def`. ZenML runs the coroutine to completion when the step executes, so whether a step body is async is invisible at the call site:
+
+```python
+from zenml import step
+
+@step
+async def fetch_data(url: str) -> bytes:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        return response.content
+```
+
+An async step behaves like any other step: call it inside a pipeline, pass its outputs downstream, or run several concurrently with [`.submit()`](dynamic_pipelines.md#parallel-step-execution). Submitted async steps run on separate threads, so their `await` points overlap and IO-bound work proceeds in parallel.
+
+{% hint style="warning" %}
+A blocking call inside an async body (`time.sleep`, a synchronous HTTP request, heavy CPU work) stalls that step's event loop and erases the concurrency. Use the async equivalents (`asyncio.sleep`, an async HTTP client) inside async steps.
+{% endhint %}
+
 ### Step Execution Order
 
 By default, ZenML determines step execution order based on data dependencies. When a step requires output from another step, it automatically creates a dependency.

--- a/docs/book/how-to/steps-pipelines/hooks.md
+++ b/docs/book/how-to/steps-pipelines/hooks.md
@@ -140,6 +140,8 @@ def my_step():
 * **Hook failures are swallowed.** When a lifecycle hook raises, the run or step is
   not aborted. The exception is captured into the `HookInvocation` record with
   `status=FAILED` and execution proceeds.
+* **Async hooks.** Hook functions can be defined with `async def`. When the hook
+  fires, ZenML runs the coroutine to completion and blocks until it finishes.
 * **Return values are discarded.** Set `ZENML_TRACK_LIFECYCLE_HOOK_OUTPUTS=true`
   in the execution environment to instead materialize lifecycle hook return
   values as output artifacts of the invocation, following the same rules as

--- a/src/zenml/hooks/execution.py
+++ b/src/zenml/hooks/execution.py
@@ -36,7 +36,7 @@ from zenml.hooks.validation import bind_optional_hook_args
 from zenml.logger import get_logger
 from zenml.models import ExceptionInfo
 from zenml.models.v2.core.hook_invocation import HOOK_NAME_PATTERN
-from zenml.utils import source_utils
+from zenml.utils import async_utils, source_utils
 from zenml.utils.exception_utils import collect_exception_information
 from zenml.utils.time_utils import utc_now
 
@@ -239,7 +239,12 @@ def run_hook(
     with logs_context or nullcontext():
         try:
             try:
-                result = loaded_func(*args, **(kwargs or {}))
+                if async_utils.is_async_callable(loaded_func):
+                    result = async_utils.run_coroutine_isolated(
+                        loaded_func(*args, **(kwargs or {}))
+                    )
+                else:
+                    result = loaded_func(*args, **(kwargs or {}))
             except BaseException as e:
                 status = ExecutionStatus.FAILED
                 exception_info = collect_exception_information(

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -61,6 +61,7 @@ from zenml.steps.utils import (
     run_as_single_step_pipeline,
 )
 from zenml.utils import (
+    async_utils,
     dict_utils,
     materializer_utils,
     notebook_utils,
@@ -726,6 +727,11 @@ class BaseStep:
                 "Invalid step function entrypoint arguments. Check out the "
                 "pydantic error above for more details."
             ) from e
+
+        if async_utils.is_async_callable(self.entrypoint):
+            return async_utils.run_coroutine_isolated(
+                self.entrypoint(**validated_args)
+            )
 
         return self.entrypoint(**validated_args)
 

--- a/src/zenml/utils/async_utils.py
+++ b/src/zenml/utils/async_utils.py
@@ -1,0 +1,64 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Asyncio utilities."""
+
+import asyncio
+import contextvars
+import functools
+import inspect
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+def is_async_callable(fn: Any) -> bool:
+    """Check whether a callable is a coroutine function.
+
+    Args:
+        fn: The callable to check.
+
+    Returns:
+        Whether the callable is a coroutine function.
+    """
+    while isinstance(fn, functools.partial):
+        fn = fn.func
+
+    if inspect.iscoroutinefunction(fn):
+        return True
+
+    unwrapped = inspect.unwrap(fn) if callable(fn) else fn
+    return inspect.iscoroutinefunction(unwrapped)
+
+
+def run_coroutine_isolated(coro: Coroutine[Any, Any, T]) -> T:
+    """Run a coroutine to completion on its own event loop.
+
+    Uses the current thread when it has no running loop, otherwise runs on a
+    fresh thread so an already-running loop is never reused or blocked.
+
+    Args:
+        coro: The coroutine to run.
+
+    Returns:
+        The result of the coroutine.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    ctx = contextvars.copy_context()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(ctx.run, asyncio.run, coro).result()

--- a/tests/unit/hooks/test_run_hook.py
+++ b/tests/unit/hooks/test_run_hook.py
@@ -37,6 +37,14 @@ def _boom_hook() -> None:
     raise RuntimeError("boom")
 
 
+async def _async_hook() -> int:
+    return 7
+
+
+async def _async_boom_hook() -> None:
+    raise RuntimeError("async boom")
+
+
 def test_run_hook_output_parse_error_keeps_status_completed():
     """An output parse error does not mark a successful hook as FAILED."""
     with mock.patch.object(
@@ -60,6 +68,23 @@ def test_run_hook_failure_records_failed_with_exception_info():
     with mock.patch.object(hook_execution, "record_hook_invocation") as record:
         with pytest.raises(RuntimeError, match="boom"):
             run_hook(_boom_hook)
+
+    record.assert_called_once()
+    assert record.call_args.kwargs["status"] == ExecutionStatus.FAILED
+    assert record.call_args.kwargs["exception_info"] is not None
+
+
+def test_run_hook_async_function_runs_coroutine_to_completion():
+    """An async hook runs to completion and returns its result."""
+    with mock.patch.object(hook_execution, "record_hook_invocation"):
+        assert run_hook(_async_hook) == 7
+
+
+def test_run_hook_async_failure_records_failed_with_exception_info():
+    """A failing async hook records FAILED with exception info and re-raises."""
+    with mock.patch.object(hook_execution, "record_hook_invocation") as record:
+        with pytest.raises(RuntimeError, match="async boom"):
+            run_hook(_async_boom_hook)
 
     record.assert_called_once()
     assert record.call_args.kwargs["status"] == ExecutionStatus.FAILED

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -11,9 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-import asyncio
 import os
-import time
 from contextlib import ExitStack as does_not_raise
 from typing import Tuple
 
@@ -148,32 +146,3 @@ def test_pipeline_run_with_nested_pipeline_definition() -> None:
     )
     with does_not_raise():
         nested_pipeline()
-
-
-ASYNC_STEP_SLEEP_SECONDS = 0.5
-ASYNC_STEP_COUNT = 4
-
-
-@step
-async def async_sleep_step() -> None:
-    await asyncio.sleep(ASYNC_STEP_SLEEP_SECONDS)
-
-
-@pipeline(dynamic=True, enable_cache=False)
-def concurrent_async_steps_pipeline() -> None:
-    futures = [async_sleep_step.submit() for _ in range(ASYNC_STEP_COUNT)]
-    for future in futures:
-        future.result()
-
-
-def test_submitted_async_steps_run_concurrently() -> None:
-    """Tests that submitted async steps overlap instead of running sequentially."""
-    start = time.monotonic()
-    concurrent_async_steps_pipeline()
-    duration = time.monotonic() - start
-
-    # Sequential execution would take at least
-    # `ASYNC_STEP_COUNT * ASYNC_STEP_SLEEP_SECONDS`. The submitted steps run on
-    # separate threads, so their sleeps overlap and the total stays below that
-    # lower bound.
-    assert duration < ASYNC_STEP_COUNT * ASYNC_STEP_SLEEP_SECONDS

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -11,7 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import asyncio
 import os
+import time
 from contextlib import ExitStack as does_not_raise
 from typing import Tuple
 
@@ -146,3 +148,32 @@ def test_pipeline_run_with_nested_pipeline_definition() -> None:
     )
     with does_not_raise():
         nested_pipeline()
+
+
+ASYNC_STEP_SLEEP_SECONDS = 0.5
+ASYNC_STEP_COUNT = 4
+
+
+@step
+async def async_sleep_step() -> None:
+    await asyncio.sleep(ASYNC_STEP_SLEEP_SECONDS)
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def concurrent_async_steps_pipeline() -> None:
+    futures = [async_sleep_step.submit() for _ in range(ASYNC_STEP_COUNT)]
+    for future in futures:
+        future.result()
+
+
+def test_submitted_async_steps_run_concurrently() -> None:
+    """Tests that submitted async steps overlap instead of running sequentially."""
+    start = time.monotonic()
+    concurrent_async_steps_pipeline()
+    duration = time.monotonic() - start
+
+    # Sequential execution would take at least
+    # `ASYNC_STEP_COUNT * ASYNC_STEP_SLEEP_SECONDS`. The submitted steps run on
+    # separate threads, so their sleeps overlap and the total stays below that
+    # lower bound.
+    assert duration < ASYNC_STEP_COUNT * ASYNC_STEP_SLEEP_SECONDS

--- a/tests/unit/pipelines/test_base_pipeline.py
+++ b/tests/unit/pipelines/test_base_pipeline.py
@@ -195,6 +195,27 @@ def test_step_can_receive_the_same_input_artifact_multiple_times():
         test_pipeline.with_options(unlisted=True)()
 
 
+@step
+async def async_int_producer() -> int:
+    return 7
+
+
+@step
+def assert_input_is_seven(value: int) -> None:
+    assert value == 7
+
+
+def test_async_step_runs_in_static_pipeline():
+    """Tests that an async step runs to completion inside a static pipeline."""
+
+    @pipeline
+    def async_pipeline():
+        assert_input_is_seven(async_int_producer())
+
+    with does_not_raise():
+        async_pipeline.with_options(unlisted=True)()
+
+
 @step(step_operator="azureml")
 def step_that_requires_step_operator() -> None:
     pass

--- a/tests/unit/steps/test_base_step.py
+++ b/tests/unit/steps/test_base_step.py
@@ -224,6 +224,16 @@ def test_calling_a_step_works():
         step_instance.call_entrypoint()
 
 
+def test_async_step_call_entrypoint_runs_coroutine_to_completion():
+    """Tests that calling an async step entrypoint returns the coroutine result."""
+
+    @step
+    async def async_step(value: int) -> int:
+        return value + 1
+
+    assert async_step.call_entrypoint(value=1) == 2
+
+
 @step
 def wrong_int_output_step_1() -> int:
     return "not_an_int"

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -1,0 +1,111 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+import asyncio
+import functools
+
+import pytest
+
+from zenml.utils.async_utils import is_async_callable, run_coroutine_isolated
+
+
+def _sync_fn() -> int:
+    return 1
+
+
+async def _async_fn() -> int:
+    return 1
+
+
+def test_is_async_callable_with_plain_function():
+    """Tests that a plain function is not detected as async."""
+    assert is_async_callable(_sync_fn) is False
+
+
+def test_is_async_callable_with_coroutine_function():
+    """Tests that a coroutine function is detected as async."""
+    assert is_async_callable(_async_fn) is True
+
+
+def test_is_async_callable_with_partial_of_plain_function():
+    """Tests that a partial of a plain function is not detected as async."""
+    assert is_async_callable(functools.partial(_sync_fn)) is False
+
+
+def test_is_async_callable_with_partial_of_coroutine_function():
+    """Tests that a partial of a coroutine function is detected as async."""
+    assert is_async_callable(functools.partial(_async_fn)) is True
+
+
+def test_is_async_callable_with_wrapped_plain_function():
+    """Tests that a wrapper around a plain function is not detected as async."""
+
+    @functools.wraps(_sync_fn)
+    def wrapper():
+        return _sync_fn()
+
+    assert is_async_callable(wrapper) is False
+
+
+def test_is_async_callable_with_wrapped_coroutine_function():
+    """Tests that a wrapper around a coroutine function is detected as async."""
+
+    @functools.wraps(_async_fn)
+    def wrapper():
+        return _async_fn()
+
+    assert is_async_callable(wrapper) is True
+
+
+def test_run_coroutine_isolated_returns_value():
+    """Tests that the coroutine result is returned."""
+
+    async def coro():
+        return 42
+
+    assert run_coroutine_isolated(coro()) == 42
+
+
+def test_run_coroutine_isolated_propagates_exception():
+    """Tests that an exception raised inside the coroutine propagates."""
+
+    async def coro():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_coroutine_isolated(coro())
+
+
+def test_run_coroutine_isolated_returns_value_from_running_loop():
+    """Tests that the result is returned when called from a running loop."""
+
+    async def coro():
+        return 42
+
+    async def driver():
+        return run_coroutine_isolated(coro())
+
+    assert asyncio.run(driver()) == 42
+
+
+def test_run_coroutine_isolated_propagates_exception_from_running_loop():
+    """Tests that an exception propagates when called from a running loop."""
+
+    async def coro():
+        raise ValueError("boom")
+
+    async def driver():
+        return run_coroutine_isolated(coro())
+
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(driver())


### PR DESCRIPTION
This PR lets users define steps and hooks with `async def`. ZenML makes sure async functions are executed on a fresh event loop.

```python
@step
async def fetch(urls: list[str]) -> list[bytes]:
  async with httpx.AsyncClient() as client:
    responses = await asyncio.gather(*(client.get(url) for url in urls))

  return [response.content for response in responses]

@pipeline(dynamic=True)
def my_pipeline(urls: list[str]):
  fetch(urls)
  # or `fetch.submit(urls)` to run non-blocking 
```