### PR TITLE
Misc dynamic pipeline fixes

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -184,6 +184,19 @@ class FutureRegistry:
             step_future = self.get_step_future(invocation_id=invocation_id)
             step_future._set_startup_result(future)
 
+    def rebind_step_execution_future(
+        self, invocation_id: str, future: StepExecutionFuture
+    ) -> None:
+        """Rebind the step execution future to a new attempt of the step.
+
+        Args:
+            invocation_id: The step invocation ID.
+            future: The future that represents the new step execution attempt.
+        """
+        with self._lock:
+            step_future = self.get_step_future(invocation_id=invocation_id)
+            step_future._rebind_execution_future(future)
+
     def bind_map_child_futures(
         self, map_id: str, child_futures: List[StepFuture]
     ) -> None:

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -14,6 +14,7 @@
 """Dynamic pipeline execution outputs."""
 
 import threading
+import time
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from contextlib import AbstractContextManager, nullcontext
@@ -231,22 +232,10 @@ class _IsolatedStepFuture(BaseFuture):
         Returns:
             The result of the step future.
         """  # noqa: DOC503
-        from zenml.execution.pipeline.dynamic.utils import (
-            wait_for_step_to_finish,
-        )
-
         if self._finished_step_run is not None:
             step_run = self._finished_step_run
         else:
-            if self._wrapped:
-                # We first wait until the step run is submitted and only then
-                # start monitoring the actual step.
-                self._wrapped.result()
-
-            step_run = wait_for_step_to_finish(
-                pipeline_run_id=self.pipeline_run_id,
-                step_name=self.invocation_id,
-            )
+            step_run = self._wait_for_step_to_finish()
             self._finished_step_run = step_run
 
         if (
@@ -262,6 +251,43 @@ class _IsolatedStepFuture(BaseFuture):
             )
 
         return step_run
+
+    def _wait_for_step_to_finish(self) -> "StepRunResponse":
+        """Wait until the step is finished.
+
+        Returns:
+            The finished step run.
+        """
+        from zenml.execution.pipeline.dynamic.utils import get_latest_step_run
+
+        sleep_interval = 1
+        max_sleep_interval = 64
+
+        while True:
+            # Re-check the wrapped future in case it got replaced.
+            if wrapped := self._wrapped:
+                wrapped.result()
+
+            step_run = get_latest_step_run(
+                self.pipeline_run_id, self.invocation_id, hydrate=False
+            )
+            # If a step is in `retrying` status, another step run will be
+            # created and we will try to pick it up in the next iteration.
+            if step_run.status not in {
+                ExecutionStatus.RUNNING,
+                ExecutionStatus.RETRYING,
+            }:
+                return step_run
+
+            logger.debug(
+                "Waiting for step `%s` to finish (current status: %s)",
+                self.invocation_id,
+                step_run.status,
+            )
+
+            time.sleep(sleep_interval)
+            if sleep_interval < max_sleep_interval:
+                sleep_interval *= 2
 
 
 StepExecutionFuture = Union[_InlineStepFuture, _IsolatedStepFuture]
@@ -621,15 +647,25 @@ class StepFuture(BaseStepFuture):
         """
         return self._startup.result().result()
 
-    def _set_startup_result(
-        self, wrapped: Union[_InlineStepFuture, _IsolatedStepFuture]
-    ) -> None:
+    def _set_startup_result(self, wrapped: StepExecutionFuture) -> None:
         """Store the future that represents the started step.
 
         Args:
             wrapped: The future that represents the started step.
         """
         self._startup.set_result(wrapped)
+
+    def _rebind_execution_future(self, future: StepExecutionFuture) -> None:
+        """Rebind the execution future to a new attempt of the step.
+
+        Args:
+            future: The future that represents the new step execution attempt.
+        """
+        existing_future = self._startup.result()
+        assert isinstance(future, _IsolatedStepFuture)
+        assert isinstance(existing_future, _IsolatedStepFuture)
+
+        existing_future._wrapped = future._wrapped
 
     def _set_startup_failed(self, exception: BaseException) -> None:
         """Store a startup exception for the step.

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -274,6 +274,7 @@ class _IsolatedStepFuture(BaseFuture):
             # If a step is in `retrying` status, another step run will be
             # created and we will try to pick it up in the next iteration.
             if step_run.status not in {
+                ExecutionStatus.PROVISIONING,
                 ExecutionStatus.RUNNING,
                 ExecutionStatus.RETRYING,
             }:

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -557,11 +557,13 @@ class DynamicPipelineRunner:
                     # Resource preemption sets the status to CANCELLING. We now
                     # update the status to CANCELLED.
                     step_run = publish_cancelled_step_run(step_run.id)
-                elif (
-                    infra_status
-                    in [ExecutionStatus.FAILED, ExecutionStatus.STOPPED]
-                    and db_status == ExecutionStatus.RUNNING
-                ):
+                elif infra_status in [
+                    ExecutionStatus.FAILED,
+                    ExecutionStatus.STOPPED,
+                ] and db_status in [
+                    ExecutionStatus.PROVISIONING,
+                    ExecutionStatus.RUNNING,
+                ]:
                     # Step failed/stopped on the infra side, but the
                     # code failed before it could report the status back to us.
                     step_run = publish_failed_step_run(step_run.id)
@@ -1140,7 +1142,10 @@ class DynamicPipelineRunner:
 
             remaining_retries = get_remaining_retries(step_run=step_run)
 
-            if step_run.status == ExecutionStatus.RUNNING:
+            if step_run.status in {
+                ExecutionStatus.PROVISIONING,
+                ExecutionStatus.RUNNING,
+            }:
                 logger.info(
                     "Restarting the monitoring of existing step `%s` "
                     "(ID: %s). Remaining retries: %d",

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -645,7 +645,17 @@ class DynamicPipelineRunner:
                                 config=step_run.config,
                                 step_config_overrides=step_run.config,
                             )
-                            self._queue_concurrent_isolated_step(step=step)
+                            execution_future = (
+                                self._queue_concurrent_isolated_step(step=step)
+                            )
+                            # Replace the execution future of the registered
+                            # step future. This is done so a failed submission
+                            # resolves the future instead of leaving it polling
+                            # the step run that is stuck in `RETRYING` status.
+                            self._future_registry.rebind_step_execution_future(
+                                invocation_id=invocation_id,
+                                future=execution_future,
+                            )
 
                 time.sleep(monitoring_delay)
 

--- a/src/zenml/execution/pipeline/dynamic/utils.py
+++ b/src/zenml/execution/pipeline/dynamic/utils.py
@@ -221,44 +221,6 @@ def get_latest_step_run(
     return step_runs.items[0]
 
 
-def wait_for_step_to_finish(
-    pipeline_run_id: UUID, step_name: str
-) -> "StepRunResponse":
-    """Wait until a step is finished.
-
-    Args:
-        pipeline_run_id: The ID of the pipeline run.
-        step_name: The name of the step.
-
-    Returns:
-        The finished step run.
-    """
-    sleep_interval = 1
-    max_sleep_interval = 64
-
-    while True:
-        step_run = get_latest_step_run(
-            pipeline_run_id, step_name, hydrate=False
-        )
-        # If a step is in `retrying` status, another step run will be
-        # created and we will try to pick it up in the next iteration.
-        if step_run.status not in {
-            ExecutionStatus.RUNNING,
-            ExecutionStatus.RETRYING,
-        }:
-            return step_run
-
-        logger.debug(
-            "Waiting for step `%s` to finish (current status: %s)",
-            step_name,
-            step_run.status,
-        )
-
-        time.sleep(sleep_interval)
-        if sleep_interval < max_sleep_interval:
-            sleep_interval *= 2
-
-
 def load_step_run_outputs(step_run_id: UUID) -> "StepRunOutputs":
     """Load the outputs of a step run.
 

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -273,6 +273,7 @@ class StepLauncher:
                                 e,
                             )
                             if step_run.status in {
+                                ExecutionStatus.PROVISIONING,
                                 ExecutionStatus.RUNNING,
                                 ExecutionStatus.QUEUED,
                             }:

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -202,6 +202,7 @@ class StepLauncher:
                 invocation_id=self._invocation_id,
                 dynamic_config=dynamic_config,
             )
+            step_run_request.status = self._get_initial_step_run_status()
             if isinstance(logs_context, LoggingContext):
                 step_run_request.logs = logs_context.log_model.id
 
@@ -652,6 +653,27 @@ class StepLauncher:
             orchestrator=self._stack.orchestrator,
         )
         return step_runtime == StepRuntime.INLINE
+
+    def _get_initial_step_run_status(self) -> ExecutionStatus:
+        """Gets the initial status of the step run.
+
+        Returns:
+            The initial status of the step run.
+        """
+        if self._snapshot.is_dynamic:
+            from zenml.execution.pipeline.dynamic.compilation import (
+                get_step_runtime,
+            )
+
+            step_runtime = get_step_runtime(
+                step_config=self._step.config,
+                pipeline_docker_settings=self._snapshot.pipeline_configuration.docker_settings,
+                orchestrator=self._stack.orchestrator,
+            )
+            if step_runtime == StepRuntime.ISOLATED:
+                return ExecutionStatus.PROVISIONING
+
+        return ExecutionStatus.RUNNING
 
     def _wait_until_resources_acquired(
         self, step_run_info: StepRunInfo

--- a/src/zenml/step_operators/step_operator_entrypoint_configuration.py
+++ b/src/zenml/step_operators/step_operator_entrypoint_configuration.py
@@ -23,6 +23,8 @@ from zenml.entrypoints.step_entrypoint_configuration import (
     STEP_NAME_OPTION,
     StepEntrypointConfiguration,
 )
+from zenml.enums import ExecutionStatus
+from zenml.models import StepRunUpdate
 from zenml.orchestrators import input_utils, output_utils
 from zenml.orchestrators.step_runner import StepRunner
 
@@ -83,7 +85,18 @@ class StepOperatorEntrypointConfiguration(StepEntrypointConfiguration):
         """
         if self._step_run is None:
             step_run_id = UUID(self.entrypoint_args[STEP_RUN_ID_OPTION])
-            self._step_run = Client().zen_store.get_run_step(step_run_id)
+            if self.snapshot.is_dynamic:
+                # Isolated steps in dynamic pipelines are created in
+                # provisioning status. Update the status to signal that the
+                # execution environment started.
+                self._step_run = Client().zen_store.update_run_step(
+                    step_run_id=step_run_id,
+                    step_run_update=StepRunUpdate(
+                        status=ExecutionStatus.RUNNING
+                    ),
+                )
+            else:
+                self._step_run = Client().zen_store.get_run_step(step_run_id)
         return self._step_run
 
     @property

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -950,6 +950,14 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 return False
 
             new_status = requested_status or current_status
+
+            # If the run is stopping and fails, we set its status to stopped.
+            if (
+                current_status
+                in {ExecutionStatus.STOPPING, ExecutionStatus.STOPPED}
+                and new_status == ExecutionStatus.FAILED
+            ):
+                new_status = ExecutionStatus.STOPPED
         else:
             # For static pipelines we compute the run status based on the step
             # statuses.

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -11980,13 +11980,32 @@ class SqlZenStore(BaseZenStore):
                     new_status=step_run_update.status,
                 )
 
-            if existing_step_run.is_retriable and step_run_update.status in {
+            if step_run_update.status in {
                 ExecutionStatus.FAILED,
                 ExecutionStatus.CANCELLED,
             }:
-                # This step will be retried by the orchestrator, so we
-                # set its status accordingly.
-                step_run_update.status = ExecutionStatus.RETRYING
+                can_retry = existing_step_run.is_retriable
+
+                if can_retry:
+                    run_status = ExecutionStatus(
+                        session.exec(
+                            select(PipelineRunSchema.status).where(
+                                PipelineRunSchema.id
+                                == existing_step_run.pipeline_run_id
+                            )
+                        ).one()
+                    )
+                    if run_status in {
+                        ExecutionStatus.STOPPING,
+                        ExecutionStatus.STOPPED,
+                    }:
+                        # The run is stopping, which prevents any step retries.
+                        can_retry = False
+
+                if can_retry:
+                    # This step will be retried by the orchestrator, so we
+                    # set its status accordingly.
+                    step_run_update.status = ExecutionStatus.RETRYING
 
             # If the step is stopping and fails, we need to set its status to stopped.
             if (


### PR DESCRIPTION
## Describe changes
- Detect failures of steps that happen while launching a retry
- If a step fails while the run is in `STOPPING`/`STOPPED` state, the server now does not set the `RETRYING` step status anymore
- If a run fails while in `STOPPING` state, it will be transitioned to `STOPPED` state instead of failed. This mirrors the behaviour we already had for steps.
- Use `PROVISIONING` status for isolated steps while they're getting launched

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

