### PR TITLE
Add missing authorization checks to stack deployment endpoint

### DIFF
--- a/src/zenml/zen_server/routers/stack_deployment_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_deployment_endpoints.py
@@ -40,6 +40,7 @@ from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import (
     batch_verify_permissions_for_models,
+    dehydrate_response_model,
     verify_permission,
 )
 from zenml.zen_server.utils import (
@@ -182,5 +183,6 @@ def get_deployed_stack(
         batch_verify_permissions_for_models(
             models=rbac_read_checks, action=Action.READ
         )
+        deployed_stack = dehydrate_response_model(deployed_stack)
 
     return deployed_stack

--- a/src/zenml/zen_server/routers/stack_deployment_endpoints.py
+++ b/src/zenml/zen_server/routers/stack_deployment_endpoints.py
@@ -14,9 +14,10 @@
 """Endpoint definitions for stack deployments."""
 
 import datetime
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Request, Security
+from pydantic import BaseModel
 
 from zenml.constants import (
     API,
@@ -37,7 +38,10 @@ from zenml.stack_deployments.utils import get_stack_deployment_class
 from zenml.zen_server.auth import AuthContext, authorize, generate_access_token
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.models import Action, ResourceType
-from zenml.zen_server.rbac.utils import verify_permission
+from zenml.zen_server.rbac.utils import (
+    batch_verify_permissions_for_models,
+    verify_permission,
+)
 from zenml.zen_server.utils import (
     async_fastapi_endpoint_wrapper,
     server_config,
@@ -162,7 +166,7 @@ def get_deployed_stack(
         was not found.
     """
     stack_deployment_class = get_stack_deployment_class(provider)
-    return stack_deployment_class(
+    deployed_stack = stack_deployment_class(
         terraform=terraform,
         stack_name=stack_name,
         location=location,
@@ -170,3 +174,13 @@ def get_deployed_stack(
         zenml_server_url="",
         zenml_server_api_token="",
     ).get_stack(date_start=date_start)
+
+    if deployed_stack:
+        rbac_read_checks: List[BaseModel] = [deployed_stack.stack]
+        if deployed_stack.service_connector:
+            rbac_read_checks.append(deployed_stack.service_connector)
+        batch_verify_permissions_for_models(
+            models=rbac_read_checks, action=Action.READ
+        )
+
+    return deployed_stack


### PR DESCRIPTION
## Summary

Fixes an authorization gap in the stack deployment lookup endpoint. `GET /api/v1/stack-deployment/stack` now verifies that the authenticated user has READ permissions for the returned stack and its associated service connector before returning deployment metadata.

## Details

Previously, `get_deployed_stack` authenticated the caller but returned the matching deployed stack without checking RBAC permissions on the resolved resources. This could allow an authenticated user to receive metadata for a stack or service connector they could not normally read through the standard RBAC-protected endpoints.

The fix keeps the existing lookup behavior but adds a batched RBAC read check before returning the response:

* verifies READ permission for the resolved `StackResponse`
* verifies READ permission for the resolved `ServiceConnectorResponse`, when present
* uses `batch_verify_permissions_for_models` so both checks happen through one RBAC call

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

