### PR TITLE
refactor: renamed structlog helper and introduced a new clear contextvar helper

### DIFF
--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -122,8 +122,8 @@ def get_logging_level() -> LoggingLevels:
     return LoggingLevels[verbosity]
 
 
-def bind_request_context(**fields: Any) -> None:
-    """Bind extra context variables to the current logging context.
+def bind_log_context(*, clear: bool = False, **fields: Any) -> None:
+    """Bind fields to the active logging context.
 
     Use it to propagate common context variables to every downstream
     log record. The extra context persists until the current logging
@@ -132,11 +132,22 @@ def bind_request_context(**fields: Any) -> None:
     E.g.: This can be used at request boundaries to propagate context
     like request_id, method, path, etc. to all log records in a request.
 
-    Any previously bound contextvars are cleared first, so this sets a
-    fresh set of context variables to the current logging context.
+    Set ``clear=True`` at request boundaries to avoid leaking context from
+    previous requests.
+
+    Args:
+        clear: Whether to clear the active context before binding fields.
+        **fields: Context fields to bind to the active log context.
     """
-    structlog.contextvars.clear_contextvars()
+    if clear:
+        clear_log_context()
+
     structlog.contextvars.bind_contextvars(**fields)
+
+
+def clear_log_context() -> None:
+    """Clear structured context bound to the active request."""
+    structlog.contextvars.clear_contextvars()
 
 
 @contextmanager
@@ -155,7 +166,7 @@ def logging_scope(**fields: Any) -> Generator[None, None, None]:
             logger.info("transaction attempt succeeded")
 
         This will propagate extra context (on top of the context bound by
-        `bind_request_context`) to the log records emitted within the scope.
+        `bind_log_context`) to the log records emitted within the scope.
     """
     with structlog.contextvars.bound_contextvars(**fields):
         yield
@@ -165,7 +176,7 @@ def get_logging_context() -> dict[str, Any]:
     """Return a snapshot of the currently bound logging context.
 
     Returns a fresh dict (safe to mutate) with all the context
-    variables bound via ``bind_request_context`` or ``logging_scope``.
+    variables bound via ``bind_log_context`` or ``logging_scope``.
 
     Useful at response/error boundaries that need to surface a single field
     (typically ``request_id``) back to the caller.

--- a/src/zenml/logger.py
+++ b/src/zenml/logger.py
@@ -151,7 +151,7 @@ def clear_log_context() -> None:
 
 
 @contextmanager
-def logging_scope(**fields: Any) -> Generator[None, None, None]:
+def logging_context(**fields: Any) -> Generator[None, None, None]:
     """Bind extra context to a specific set of log records.
 
     Use this for narrow scopes inside a request (e.g. a single transaction,
@@ -160,7 +160,7 @@ def logging_scope(**fields: Any) -> Generator[None, None, None]:
 
     E.g.::
 
-        with logging_scope(transaction_id=tx_id, attempt=2):
+        with logging_context(transaction_id=tx_id, attempt=2):
             logger.info("retrying transaction")
             do_something()
             logger.info("transaction attempt succeeded")
@@ -176,7 +176,7 @@ def get_logging_context() -> dict[str, Any]:
     """Return a snapshot of the currently bound logging context.
 
     Returns a fresh dict (safe to mutate) with all the context
-    variables bound via ``bind_log_context`` or ``logging_scope``.
+    variables bound via ``bind_log_context`` or ``logging_context``.
 
     Useful at response/error boundaries that need to surface a single field
     (typically ``request_id``) back to the caller.

--- a/src/zenml/zen_server/middleware.py
+++ b/src/zenml/zen_server/middleware.py
@@ -42,7 +42,7 @@ from zenml.constants import (
 )
 from zenml.enums import SourceContextTypes
 from zenml.logger import (
-    bind_request_context,
+    bind_log_context,
     get_logger,
     get_logging_context,
     logging_scope,
@@ -399,7 +399,7 @@ async def record_requests(request: Request, call_next: Any) -> Any:
 
     # Bind only request_id globally for correlation; method/path/client_ip stay
     # scoped to request lifecycle logs to avoid bloating every downstream line.
-    bind_request_context(request_id=request_context.request_id)
+    bind_log_context(clear=True, request_id=request_context.request_id)
 
     try:
         response = await call_next(request)

--- a/src/zenml/zen_server/middleware.py
+++ b/src/zenml/zen_server/middleware.py
@@ -45,7 +45,7 @@ from zenml.logger import (
     bind_log_context,
     get_logger,
     get_logging_context,
-    logging_scope,
+    logging_context,
 )
 from zenml.utils.time_utils import utc_now
 from zenml.zen_server.request_management import RequestContext
@@ -352,7 +352,7 @@ async def log_requests(request: Request, call_next: Any) -> Any:
     # Log full request metadata on lifecycle events only, i.e. when the
     # request is received and completed; downstream logs get request_id
     # for correlation without repeating method/path/client_ip.
-    with logging_scope(**_request_log_fields(request)):
+    with logging_context(**_request_log_fields(request)):
         logger.debug("request.received", extra=get_system_metrics())
 
     try:
@@ -361,7 +361,7 @@ async def log_requests(request: Request, call_next: Any) -> Any:
         request_context = request_manager().current_request
 
         # Log full request metadata on the request boundary.
-        with logging_scope(**_request_log_fields(request)):
+        with logging_context(**_request_log_fields(request)):
             logger.debug(
                 "request.completed",
                 extra={

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -22,7 +22,6 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-import structlog
 
 import zenml.logger as zenml_logger_module
 from zenml.constants import (
@@ -38,7 +37,8 @@ from zenml.logger import (
     ZenMLConsoleHandler,
     ZenMLJsonFormatter,
     ZenMLLoggingHandler,
-    bind_request_context,
+    bind_log_context,
+    clear_log_context,
     get_logger,
     get_logging_context,
     init_logging,
@@ -98,7 +98,7 @@ def clean_logging_state(
         zenml_logger_module._stderr_wrapped,
     )
 
-    structlog.contextvars.clear_contextvars()
+    clear_log_context()
 
     yield
 
@@ -120,7 +120,7 @@ def clean_logging_state(
 
     # Structured logging context is stored separately from stdlib logging.
     # Clear it so request/scope fields from one test don't appear in another.
-    structlog.contextvars.clear_contextvars()
+    clear_log_context()
 
 
 def _make_log_record(
@@ -892,7 +892,7 @@ def test_logging_context_step_name_prefix_uses_legacy_env_semantics(
 def test_contextvars_filter_copies_bound_context_to_log_record() -> None:
     """Bound logging context is copied onto standard library log records."""
     # Bind the request context.
-    bind_request_context(request_id="request-1", method="GET")
+    bind_log_context(clear=True, request_id="request-1", method="GET")
     record = _make_log_record("request.received")
 
     # Call the contextvars filter to copy the contextvars onto the log record.
@@ -905,7 +905,7 @@ def test_contextvars_filter_copies_bound_context_to_log_record() -> None:
 
 def test_contextvars_filter_preserves_existing_log_record_fields() -> None:
     """Test _ContextVarsFilter copies contextvars onto log record but preserves existing fields."""
-    bind_request_context(request_id="bound-request", method="GET")
+    bind_log_context(clear=True, request_id="bound-request", method="GET")
     # Explicit LogRecord fields should win over bound context. This lets a
     # caller override request-level defaults for a single log line.
     record = _make_log_record("request.received", request_id="record-request")
@@ -948,7 +948,7 @@ def test_step_name_filter_tolerates_step_context_errors(
 
 def test_logging_scope_restores_outer_context() -> None:
     """Scoped logging context is removed after leaving the scope."""
-    bind_request_context(request_id="request-1")
+    bind_log_context(clear=True, request_id="request-1")
 
     with logging_scope(transaction_id="transaction-1"):
         assert get_logging_context() == {

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -42,7 +42,7 @@ from zenml.logger import (
     get_logger,
     get_logging_context,
     init_logging,
-    logging_scope,
+    logging_context,
 )
 
 #####################
@@ -950,7 +950,7 @@ def test_logging_scope_restores_outer_context() -> None:
     """Scoped logging context is removed after leaving the scope."""
     bind_log_context(clear=True, request_id="request-1")
 
-    with logging_scope(transaction_id="transaction-1"):
+    with logging_context(transaction_id="transaction-1"):
         assert get_logging_context() == {
             "request_id": "request-1",
             "transaction_id": "transaction-1",


### PR DESCRIPTION
* Renamed structlog context binding helper to a more generic name `bind_log_context(...)`.
    *  Renamed `logging_scope` to `logging_context`
* Added `clear_log_context()` helper to abstract structlog context cleanup usage.