### PR TITLE
Fix the rate-limiting

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -20,7 +20,20 @@ An enrollment key has been auto-generated for your server. Please use the follow
 {{- end }}
 
 {{- else }}
-{{- if $server.ingress.enabled }}
+{{- if $server.gateway.enabled }}
+{{- if $server.gateway.host }}
+{{- $gatewayScheme := "http" }}
+{{- if eq $server.gateway.sectionName "https" }}
+{{- $gatewayScheme = "https" }}
+{{- end }}
+
+Please access the ZenML server at the following URL {{- if .Release.IsInstall }} to activate the server and create an initial admin user account {{- end }}:
+
+  {{ $gatewayScheme }}://{{ $server.gateway.host }}{{ $server.gateway.path }}
+
+{{- else }}
+{{- end }}
+{{- else if $server.ingress.enabled }}
 {{- if $server.ingress.host }}
 
 Please access the ZenML server at the following URL {{- if .Release.IsInstall }} to activate the server and create an initial admin user account {{- end }}:

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -129,6 +129,8 @@ spec:
             - --proxy-headers
             - --forwarded-allow-ips
             - {{ $server.proxyHeaders.forwardedAllowIPs | quote }}
+            {{ else }}
+            - --no-proxy-headers
             {{ end }}
             - --port
             - "8080"

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -121,6 +121,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ $server.image.repository }}:{{ $server.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ $server.image.pullPolicy }}
+          args:
+            - uvicorn
+            - zenml.zen_server.zen_server_api:app
+            - --no-server-header
+            {{ if $server.proxyHeaders.enabled }}
+            - --proxy-headers
+            - --forwarded-allow-ips
+            - {{ $server.proxyHeaders.forwardedAllowIPs | quote }}
+            {{ end }}
+            - --port
+            - "8080"
+            - --host
+            - "0.0.0.0"
           volumeMounts:
             - name: zenml-config
               mountPath: /zenml/.zenconfig

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1192,13 +1192,21 @@ server:
 
   # Uvicorn proxy header handling.
   #
-  # These defaults match the ZenML server image CMD:
-  #   --proxy-headers --forwarded-allow-ips "*"
+  # SECURITY WARNING: Only enable this if ZenML is behind trusted proxies that
+  # control the X-Forwarded-* headers. Client-supplied X-Forwarded-For values
+  # can be forged and may bypass IP-based protections such as login rate
+  # limiting if they are trusted blindly.
   #
-  # Disable proxyHeaders.enabled to make Uvicorn ignore X-Forwarded-* headers,
-  # or set forwardedAllowIPs to a comma-separated list of trusted proxy IPs.
+  # Safe configurations are either:
+  #   1. Set forwardedAllowIPs to a strict comma-separated list of trusted
+  #      proxy IPs/CIDRs; or
+  #   2. Ensure your ingress/gateway sanitizes or overwrites incoming
+  #      X-Forwarded-* headers before forwarding requests to ZenML.
+  #
+  # When disabled, Uvicorn ignores X-Forwarded-* headers and ZenML sees the
+  # direct peer address, which is usually the ingress/gateway IP in Kubernetes.
   proxyHeaders:
-    enabled: true
+    enabled: false
     forwardedAllowIPs: "*"
 
   ingress:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1190,6 +1190,17 @@ server:
     port: 80
     annotations: {}
 
+  # Uvicorn proxy header handling.
+  #
+  # These defaults match the ZenML server image CMD:
+  #   --proxy-headers --forwarded-allow-ips "*"
+  #
+  # Disable proxyHeaders.enabled to make Uvicorn ignore X-Forwarded-* headers,
+  # or set forwardedAllowIPs to a comma-separated list of trusted proxy IPs.
+  proxyHeaders:
+    enabled: true
+    forwardedAllowIPs: "*"
+
   ingress:
     enabled: true
     className: "nginx"

--- a/src/zenml/zen_server/rate_limit.py
+++ b/src/zenml/zen_server/rate_limit.py
@@ -135,7 +135,7 @@ class RequestLimiter:
     def _get_ipaddr(self, request: Request) -> str:
         """Returns the IP address for the current request.
 
-        Based on the X-Forwarded-For headers or client information.
+        Based on the client information provided by the ASGI server.
 
         Args:
             request: The request object.
@@ -143,11 +143,6 @@ class RequestLimiter:
         Returns:
             The ip address for the current request (or 127.0.0.1 if none found).
         """
-        forwarded_for = request.headers.get("X-Forwarded-For")
-
-        if forwarded_for:
-            return forwarded_for.split(",")[-1].strip()
-
         if not request.client or not request.client.host:
             return "127.0.0.1"
 

--- a/src/zenml/zen_server/rate_limit.py
+++ b/src/zenml/zen_server/rate_limit.py
@@ -143,13 +143,15 @@ class RequestLimiter:
         Returns:
             The ip address for the current request (or 127.0.0.1 if none found).
         """
-        if "X_FORWARDED_FOR" in request.headers:
-            return request.headers["X_FORWARDED_FOR"]
-        else:
-            if not request.client or not request.client.host:
-                return "127.0.0.1"
+        forwarded_for = request.headers.get("X-Forwarded-For")
 
-            return request.client.host
+        if forwarded_for:
+            return forwarded_for.split(",")[-1].strip()
+
+        if not request.client or not request.client.host:
+            return "127.0.0.1"
+
+        return request.client.host
 
     @contextmanager
     def limit_failed_requests(

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -397,7 +397,7 @@ def device_authorization(
     forwarded = request.headers.get("X-Forwarded-For")
 
     if forwarded:
-        ip_address = forwarded.split(",")[0].strip()
+        ip_address = forwarded.split(",")[-1].strip()
     elif request.client and request.client.host:
         ip_address = request.client.host
 

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -44,7 +44,7 @@ from zenml.enums import (
     OAuthDeviceStatus,
     OAuthGrantTypes,
 )
-from zenml.exceptions import AuthorizationException
+from zenml.exceptions import AuthorizationException, CredentialsNotValid
 from zenml.logger import get_logger
 from zenml.models import (
     OAuthDeviceAuthorizationResponse,
@@ -243,6 +243,7 @@ def token(
         An access token or a redirect response.
 
     Raises:
+        CredentialsNotValid: If the credentials are invalid.
         ValueError: If the grant type is invalid.
     """
     config = server_config()
@@ -279,6 +280,7 @@ def token(
         # Try to get the external session token or authorization token from the
         # authorization header
         authorization_header = request.headers.get("Authorization")
+        external_access_token: Optional[str] = None
         if authorization_header:
             scheme, _, token = authorization_header.partition(" ")
             if token and scheme.lower() == "bearer":
@@ -292,6 +294,12 @@ def token(
 
             # Redirect the user to the external authentication login endpoint
             return OAuthRedirectResponse(authorization_url=authorization_url)
+
+        if not external_access_token:
+            logger.info("Request with invalid external authorization header")
+            raise CredentialsNotValid(
+                "Invalid request: invalid authorization header."
+            )
 
         auth_context = authenticate_external_user(
             external_access_token=external_access_token,

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -402,11 +402,7 @@ def device_authorization(
     # Fetch the IP address of the client
     ip_address: str = ""
     city, region, country = "", "", ""
-    forwarded = request.headers.get("X-Forwarded-For")
-
-    if forwarded:
-        ip_address = forwarded.split(",")[-1].strip()
-    elif request.client and request.client.host:
+    if request.client and request.client.host:
         ip_address = request.client.host
 
     if ip_address:

--- a/tests/unit/zen_server/test_rate_limit.py
+++ b/tests/unit/zen_server/test_rate_limit.py
@@ -34,13 +34,13 @@ def _request(
     )
 
 
-def test_get_ipaddr_uses_proxy_appended_x_forwarded_for_header() -> None:
-    """The limiter uses the proxy-appended X-Forwarded-For value."""
+def test_get_ipaddr_ignores_raw_x_forwarded_for_header() -> None:
+    """The limiter uses the ASGI client host, not raw forwarded headers."""
     limiter = RequestLimiter(day_limit=10)
 
     request = _request([(b"x-forwarded-for", b"203.0.113.5, 10.0.0.1")])
 
-    assert limiter._get_ipaddr(request) == "10.0.0.1"
+    assert limiter._get_ipaddr(request) == "10.0.0.10"
 
 
 def test_get_ipaddr_falls_back_to_client_host() -> None:

--- a/tests/unit/zen_server/test_rate_limit.py
+++ b/tests/unit/zen_server/test_rate_limit.py
@@ -1,0 +1,52 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for ZenML server rate limiting."""
+
+from starlette.requests import Request
+
+from zenml.zen_server.rate_limit import RequestLimiter
+
+
+def _request(
+    headers: list[tuple[bytes, bytes]],
+    client: str = "10.0.0.10",
+) -> Request:
+    """Create a minimal Starlette request for rate limiter tests."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": headers,
+            "client": (client, 1234),
+        }
+    )
+
+
+def test_get_ipaddr_uses_proxy_appended_x_forwarded_for_header() -> None:
+    """The limiter uses the proxy-appended X-Forwarded-For value."""
+    limiter = RequestLimiter(day_limit=10)
+
+    request = _request([(b"x-forwarded-for", b"203.0.113.5, 10.0.0.1")])
+
+    assert limiter._get_ipaddr(request) == "10.0.0.1"
+
+
+def test_get_ipaddr_falls_back_to_client_host() -> None:
+    """The limiter falls back to the direct client host."""
+    limiter = RequestLimiter(day_limit=10)
+
+    request = _request(headers=[], client="10.0.0.10")
+
+    assert limiter._get_ipaddr(request) == "10.0.0.10"


### PR DESCRIPTION
## Summary

Fixes ZenML server login rate limiting behind reverse proxies by removing direct trust in raw `X-Forwarded-For` headers and making Uvicorn proxy-header handling explicit in the Helm chart.

The limiter keys failed login attempts by client IP. In Kubernetes/Ingress deployments, ZenML usually receives traffic from an ingress controller, gateway, or other proxy rather than directly from the client. Proxies may add an `X-Forwarded-For` header to preserve client IP information:

```text
X-Forwarded-For: <client-ip>, <proxy-hop-1>, <proxy-hop-2>
```

However, clients can also send this header themselves. If an ingress/gateway appends to an existing value instead of sanitizing or replacing it, part of the chain can be attacker-controlled:

```text
X-Forwarded-For: <spoofed-ip>, <real-client-ip>
```

Parsing this header in ZenML application code is unsafe. The correct source of truth is `request.client.host`, after Uvicorn has applied its configured proxy-header trust policy. If proxy headers are disabled, Uvicorn ignores `X-Forwarded-*`; if enabled, Uvicorn resolves the client host according to `--forwarded-allow-ips`.

This PR updates rate limiting and device authorization to use the ASGI/Uvicorn-resolved client host instead of reading raw forwarded headers directly. It also makes proxy-header behavior configurable in Helm and disables proxy-header trust by default for safer Kubernetes deployments.

## Changes

- Updated the login rate limiter to use `request.client.host` as resolved by Uvicorn/FastAPI.
- Removed direct `X-Forwarded-For` parsing from the rate limiter.
- Removed direct `X-Forwarded-For` parsing from device authorization IP/geolocation handling.
- Added regression coverage that verifies raw `X-Forwarded-For` does not override the ASGI client host.
- Made Uvicorn proxy-header behavior configurable in the Helm chart:
  - `server.proxyHeaders.enabled`
  - `server.proxyHeaders.forwardedAllowIPs`
- Changed the Helm default to disable proxy-header trust:
  - `server.proxyHeaders.enabled: false`
- Render `--no-proxy-headers` explicitly when proxy headers are disabled.
- Render `--proxy-headers --forwarded-allow-ips <value>` when proxy headers are enabled.
- Added a Helm warning explaining that proxy headers should only be enabled when:
  - `forwardedAllowIPs` is set to a strict trusted proxy IP/CIDR list, or
  - the ingress/gateway sanitizes or overwrites incoming `X-Forwarded-*` headers before forwarding to ZenML.

Side changes:
- Updated Helm notes to report Gateway API URLs correctly.
- Fixed a potential `500 Internal Server Error` in the token endpoint.

## Breaking Changes

This changes the default behavior for Helm deployments. The chart now renders `--no-proxy-headers` by default, so Uvicorn will ignore `X-Forwarded-*` headers unless the operator explicitly enables them.

Previously, the server image started Uvicorn with `--proxy-headers --forwarded-allow-ips "*"`, which trusted forwarded headers from any peer. That made deployments more likely to see the original client IP automatically, but it was unsafe unless the ingress/gateway sanitized client-supplied `X-Forwarded-For` headers first.

With the new default:

```yaml
server:
  proxyHeaders:
    enabled: false
```

ZenML will see the direct peer address, usually the ingress/gateway IP in Kubernetes. This is safer against forged `X-Forwarded-For` values, but it may group many users into the same IP-based rate-limit bucket.

Deployments that need ZenML to see real client IPs must opt in explicitly:

```yaml
server:
  proxyHeaders:
    enabled: true
    forwardedAllowIPs: "<trusted proxy IPs or CIDRs>"
```

Only use `forwardedAllowIPs: "*"` if the ingress/gateway reliably strips, overwrites, or sanitizes incoming `X-Forwarded-*` headers before forwarding to ZenML.

For ingress-nginx, align this with its forwarded-header settings. If nginx is the public edge, avoid trusting arbitrary upstream forwarded headers; if it is behind another trusted load balancer, configure `use-forwarded-headers`, `enable-real-ip`, and `proxy-real-ip-cidr` so only trusted upstream ranges can supply client IP headers. ingress-nginx documents these settings in its ConfigMap options. Source: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/

For Envoy / Envoy Gateway, configure trusted client IP detection at the gateway/proxy layer, for example via trusted hops or trusted CIDRs, so Envoy determines the client address from a trusted chain rather than accepting arbitrary client-provided XFF. Envoy’s XFF handling is based on trusted proxy configuration; the app should consume the resolved downstream/client address, not parse raw XFF itself. Source: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html#x-forwarded-for

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

