### PR TITLE
Tighten API key validity checks

### DIFF
--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -154,7 +154,7 @@ def _fetch_and_verify_api_key(
         logger.error(error)
         raise CredentialsNotValid(error)
 
-    if key_to_verify and not api_key.verify_key(key_to_verify):
+    if key_to_verify is not None and not api_key.verify_key(key_to_verify):
         error = (
             f"Authentication error: could not verify key value for API key "
             f"{api_key.name}"

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -87,6 +87,7 @@ from zenml.exceptions import (
 )
 from zenml.metadata.metadata_types import MetadataTypeEnum
 from zenml.models import (
+    APIKey,
     APIKeyFilter,
     APIKeyRequest,
     APIKeyRotateRequest,
@@ -2121,6 +2122,11 @@ def test_login_api_key():
             new_zen_store = Client().zen_store
             active_user = new_zen_store.get_user()
             assert active_user.id == service_account.id
+
+        forged_api_key = APIKey(id=api_key.id, key="").encode()
+        with pytest.raises(AuthorizationException):
+            with LoginContext(api_key=forged_api_key):
+                Client().zen_store.get_user()
 
         api_key = zen_store.get_api_key(
             service_account_id=service_account.id,

--- a/tests/unit/zen_server/test_auth.py
+++ b/tests/unit/zen_server/test_auth.py
@@ -1,0 +1,73 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for ZenML server authentication helpers."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from zenml.exceptions import CredentialsNotValid
+from zenml.zen_server import auth
+
+
+class _ApiKey:
+    def __init__(self):
+        self.id = uuid4()
+        self.name = "test-key"
+        self.active = True
+        self.service_account = SimpleNamespace(
+            active=True, external_user_id=None, name="test-service-account"
+        )
+        self.verified_keys = []
+
+    def verify_key(self, key: str) -> bool:
+        self.verified_keys.append(key)
+        return key == "valid"
+
+
+class _ZenStore:
+    def __init__(self, api_key: _ApiKey):
+        self.api_key = api_key
+        self.updated_api_key_ids = []
+
+    def get_internal_api_key(self, api_key_id):
+        assert api_key_id == self.api_key.id
+        return self.api_key
+
+    def update_internal_api_key(self, api_key_id, _):
+        self.updated_api_key_ids.append(api_key_id)
+
+
+def test_fetch_and_verify_api_key_rejects_empty_key(monkeypatch):
+    """Ensure empty client-supplied API key secrets are still verified."""
+    api_key = _ApiKey()
+    monkeypatch.setattr(auth, "zen_store", lambda: _ZenStore(api_key))
+
+    with pytest.raises(CredentialsNotValid):
+        auth._fetch_and_verify_api_key(api_key_id=api_key.id, key_to_verify="")
+
+    assert api_key.verified_keys == [""]
+
+
+def test_fetch_and_verify_api_key_allows_internal_skip(monkeypatch):
+    """Ensure the internal JWT re-auth path can still skip key verification."""
+    api_key = _ApiKey()
+    store = _ZenStore(api_key)
+    monkeypatch.setattr(auth, "zen_store", lambda: store)
+
+    auth._fetch_and_verify_api_key(api_key_id=api_key.id, key_to_verify=None)
+
+    assert api_key.verified_keys == []
+    assert store.updated_api_key_ids == [api_key.id]


### PR DESCRIPTION
## Summary

Tightens service-account API key validation to ensure all client-provided key values are handled consistently.

## Changes

- Updated API key verification logic to distinguish omitted internal verification input from explicitly provided client input.
- Added regression coverage for API key validation edge cases.
- Preserved the existing internal re-authentication behavior.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

