### PR TITLE
Prevent referencing private and internal secrets internally.

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -9106,6 +9106,39 @@ class SqlZenStore(BaseZenStore):
         if self.backup_secrets_store:
             self.backup_secrets_store.delete_secret_values(secret_id=secret_id)
 
+    def _get_visible_secret_schema(
+        self,
+        secret_name_or_id: Union[str, UUID],
+        session: Session,
+    ) -> SecretSchema:
+        """Get a non-internal secret schema visible to the active user.
+
+        Args:
+            secret_name_or_id: The name or ID of the secret to fetch.
+            session: The database session to use.
+
+        Returns:
+            The secret schema.
+
+        Raises:
+            KeyError: If the secret does not exist, is internal, or is private
+                and not owned by the current user.
+        """
+        secret_schema = self._get_schema_by_name_or_id(
+            secret_name_or_id, schema_class=SecretSchema, session=session
+        )
+        if (
+            secret_schema.internal
+            or secret_schema.private
+            and secret_schema.user.id != self._get_active_user(session).id
+        ):
+            raise KeyError(
+                f"Secret with name or ID {secret_name_or_id} not found "
+                "or is private and not owned by the current user."
+            )
+
+        return secret_schema
+
     def _link_secrets_to_resource(
         self,
         secrets: Optional[Sequence[Union[str, UUID]]],
@@ -9135,8 +9168,8 @@ class SqlZenStore(BaseZenStore):
                     # Not a valid UUID string, proceed normally
                     pass
 
-            secret_schema = self._get_schema_by_name_or_id(
-                secret, schema_class=SecretSchema, session=session
+            secret_schema = self._get_visible_secret_schema(
+                secret, session=session
             )
             resource_type = resource_types[type(resource)]
             secret_resource = SecretResourceSchema(
@@ -9183,8 +9216,8 @@ class SqlZenStore(BaseZenStore):
                     # Not a valid UUID string, proceed normally
                     pass
 
-            secret_schema = self._get_schema_by_name_or_id(
-                secret, schema_class=SecretSchema, session=session
+            secret_schema = self._get_visible_secret_schema(
+                secret, session=session
             )
             resource_type = resource_types[type(resource)]
 
@@ -9289,27 +9322,13 @@ class SqlZenStore(BaseZenStore):
             The secret.
 
         Raises:
-            KeyError: if the secret doesn't exist.
-        """
+            KeyError: If the secret does not exist, is internal, or is private
+                and not owned by the current user.
+        """  # noqa: DOC502
         with Session(self.engine) as session:
-            secret_in_db = session.exec(
-                select(SecretSchema).where(
-                    SecretSchema.id == secret_id,
-                    # Don't return internal secrets
-                    col(SecretSchema.internal).is_(False),
-                )
-            ).first()
-            if (
-                secret_in_db is None
-                # Private secrets are only accessible to their owner
-                or secret_in_db.private
-                and secret_in_db.user.id != self._get_active_user(session).id
-            ):
-                raise KeyError(
-                    f"Secret with ID {secret_id} not found or is private and "
-                    "not owned by the current user."
-                )
-
+            secret_in_db = self._get_visible_secret_schema(
+                secret_id, session=session
+            )
             secret_model = secret_in_db.to_model(
                 include_metadata=hydrate, include_resources=True
             )
@@ -9323,7 +9342,10 @@ class SqlZenStore(BaseZenStore):
         secret_name_or_id: Union[str, UUID],
         include_secret_values: bool = False,
     ) -> SecretResponse:
-        """Get a secret by name or ID.
+        """Get a non-internal secret by name or ID.
+
+        Private secrets are only accessible to their owner. Internal secrets
+        are not returned by this method.
 
         Args:
             secret_name_or_id: The name or ID of the secret to fetch.
@@ -9332,18 +9354,23 @@ class SqlZenStore(BaseZenStore):
 
         Returns:
             The secret.
-        """
+
+        Raises:
+            KeyError: If the secret does not exist, is internal, or is private
+                and not owned by the current user.
+        """  # noqa: DOC502
         with Session(self.engine) as session:
-            secret_in_db = self._get_schema_by_name_or_id(
-                secret_name_or_id, schema_class=SecretSchema, session=session
+            secret_in_db = self._get_visible_secret_schema(
+                secret_name_or_id, session=session
             )
             secret_model = secret_in_db.to_model(
                 include_metadata=True, include_resources=True
             )
+            secret_id = secret_in_db.id
 
         if include_secret_values:
             secret_model.set_secrets(
-                self._get_secret_values(secret_id=secret_in_db.id)
+                self._get_secret_values(secret_id=secret_id)
             )
 
         return secret_model
@@ -9412,32 +9439,18 @@ class SqlZenStore(BaseZenStore):
             The updated secret.
 
         Raises:
-            KeyError: if the secret doesn't exist.
+            KeyError: If the secret does not exist, is internal, or is private
+                and not owned by the current user.
             EntityExistsError: If a secret with the same name already exists in
                 the same scope.
             IllegalOperationError: if the secret is private and the current user
                 is not the owner of the secret.
-        """
+        """  # noqa: DOC503
         with Session(self.engine) as session:
-            existing_secret = session.exec(
-                select(SecretSchema).where(
-                    SecretSchema.id == secret_id,
-                    # Don't update internal secrets
-                    col(SecretSchema.internal).is_(False),
-                )
-            ).first()
-
+            existing_secret = self._get_visible_secret_schema(
+                secret_id, session=session
+            )
             active_user = self._get_active_user(session)
-
-            if not existing_secret or (
-                # Private secrets are only accessible to their owner
-                existing_secret.private
-                and existing_secret.user.id != active_user.id
-            ):
-                raise KeyError(
-                    f"Secret with ID {secret_id} not found or is private and "
-                    "not owned by the current user."
-                )
 
             if (
                 secret_update.private is not None
@@ -9520,28 +9533,11 @@ class SqlZenStore(BaseZenStore):
             secret_id: The id of the secret to delete.
 
         Raises:
-            KeyError: if the secret doesn't exist.
-        """
+            KeyError: If the secret does not exist, is internal, or is private
+                and not owned by the current user.
+        """  # noqa: DOC502
         with Session(self.engine) as session:
-            existing_secret = session.exec(
-                select(SecretSchema).where(
-                    SecretSchema.id == secret_id,
-                    # Don't delete internal secrets
-                    col(SecretSchema.internal).is_(False),
-                )
-            ).first()
-
-            if not existing_secret or (
-                # Private secrets are only accessible to their owner
-                existing_secret.private
-                and existing_secret.user.id
-                != self._get_active_user(session).id
-            ):
-                raise KeyError(
-                    f"Secret with ID {secret_id} not found or is private and "
-                    "not owned by the current user."
-                )
-
+            self._get_visible_secret_schema(secret_id, session=session)
             self._delete_secret_schema(secret_id=secret_id, session=session)
 
     def backup_secrets(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -9320,11 +9320,7 @@ class SqlZenStore(BaseZenStore):
 
         Returns:
             The secret.
-
-        Raises:
-            KeyError: If the secret does not exist, is internal, or is private
-                and not owned by the current user.
-        """  # noqa: DOC502
+        """
         with Session(self.engine) as session:
             secret_in_db = self._get_visible_secret_schema(
                 secret_id, session=session
@@ -9354,11 +9350,7 @@ class SqlZenStore(BaseZenStore):
 
         Returns:
             The secret.
-
-        Raises:
-            KeyError: If the secret does not exist, is internal, or is private
-                and not owned by the current user.
-        """  # noqa: DOC502
+        """
         with Session(self.engine) as session:
             secret_in_db = self._get_visible_secret_schema(
                 secret_name_or_id, session=session
@@ -9439,13 +9431,11 @@ class SqlZenStore(BaseZenStore):
             The updated secret.
 
         Raises:
-            KeyError: If the secret does not exist, is internal, or is private
-                and not owned by the current user.
             EntityExistsError: If a secret with the same name already exists in
                 the same scope.
             IllegalOperationError: if the secret is private and the current user
                 is not the owner of the secret.
-        """  # noqa: DOC503
+        """
         with Session(self.engine) as session:
             existing_secret = self._get_visible_secret_schema(
                 secret_id, session=session
@@ -9531,11 +9521,7 @@ class SqlZenStore(BaseZenStore):
 
         Args:
             secret_id: The id of the secret to delete.
-
-        Raises:
-            KeyError: If the secret does not exist, is internal, or is private
-                and not owned by the current user.
-        """  # noqa: DOC502
+        """
         with Session(self.engine) as session:
             self._get_visible_secret_schema(secret_id, session=session)
             self._delete_secret_schema(secret_id=secret_id, session=session)

--- a/tests/integration/functional/zen_stores/test_secrets_store.py
+++ b/tests/integration/functional/zen_stores/test_secrets_store.py
@@ -25,10 +25,17 @@ from tests.integration.functional.zen_stores.utils import (
     UserContext,
 )
 from zenml.client import Client
-from zenml.enums import SecretsStoreType, StoreType
+from zenml.constants import ENV_ZENML_SERVER
+from zenml.enums import SecretsStoreType, StackComponentType, StoreType
 from zenml.exceptions import EntityExistsError, IllegalOperationError
-from zenml.models import SecretFilter, SecretUpdate
+from zenml.models import (
+    ComponentRequest,
+    SecretFilter,
+    SecretUpdate,
+    UserRequest,
+)
 from zenml.utils.string_utils import random_str
+from zenml.zen_server.auth import AuthContext
 
 
 def _get_secrets_store_type() -> SecretsStoreType:
@@ -781,6 +788,112 @@ def test_public_secret_is_visible_to_other_users():
                 ),
             ).items
             assert len(private_secrets) == 0
+
+
+def test_get_secret_by_name_or_id_respects_private_scope_for_sql_store(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Tests that the SQL store does not resolve other users' private secrets."""
+    client = Client()
+    store = client.zen_store
+    if store.type != StoreType.SQL:
+        pytest.skip("This test only applies to direct SQL Zen Stores.")
+
+    with SecretContext() as public_secret:
+        with SecretContext(private=True) as private_secret:
+            other_user = store.create_user(
+                UserRequest(
+                    name=sample_name("private_secret_resolver_user"),
+                    password=random_str(32),
+                    active=True,
+                    is_admin=True,
+                )
+            )
+            try:
+                with monkeypatch.context() as m:
+                    from zenml.zen_server import utils as server_utils
+
+                    m.setenv(ENV_ZENML_SERVER, "true")
+                    m.setattr(
+                        server_utils,
+                        "get_auth_context",
+                        lambda: AuthContext(user=other_user),
+                    )
+
+                    resolved_public_secret = store.get_secret_by_name_or_id(
+                        public_secret.name
+                    )
+                    assert resolved_public_secret.id == public_secret.id
+
+                    with pytest.raises(KeyError):
+                        store.get_secret_by_name_or_id(private_secret.name)
+
+                    with pytest.raises(KeyError):
+                        store.get_secret_by_name_or_id(private_secret.id)
+
+                    component = store.create_stack_component(
+                        ComponentRequest(
+                            name=sample_name("component_with_public_secret"),
+                            flavor="local",
+                            type=StackComponentType.ARTIFACT_STORE,
+                            configuration={},
+                            secrets=[public_secret.name],
+                        )
+                    )
+                    store.delete_stack_component(component.id)
+
+                    with pytest.raises(KeyError):
+                        store.create_stack_component(
+                            ComponentRequest(
+                                name=sample_name(
+                                    "component_with_private_secret"
+                                ),
+                                flavor="local",
+                                type=StackComponentType.ARTIFACT_STORE,
+                                configuration={},
+                                secrets=[private_secret.name],
+                            )
+                        )
+            finally:
+                store.delete_user(other_user.id)
+
+
+def test_private_secret_cannot_be_referenced_by_other_users():
+    """Tests that private secrets cannot be referenced by other users."""
+    if Client().zen_store.type == StoreType.SQL:
+        pytest.skip("SQL Zen Stores do not support user switching.")
+
+    with SecretContext() as public_secret:
+        with SecretContext(private=True) as private_secret:
+            with UserContext(login=True):
+                other_client = Client()
+
+                component = other_client.create_stack_component(
+                    name=sample_name("component_with_public_secret"),
+                    flavor="local",
+                    component_type=StackComponentType.ARTIFACT_STORE,
+                    configuration={},
+                    secrets=[public_secret.name],
+                )
+                other_client.delete_stack_component(component.id)
+
+                with pytest.raises(KeyError):
+                    other_client.create_stack_component(
+                        name=sample_name("component_with_private_secret"),
+                        flavor="local",
+                        component_type=StackComponentType.ARTIFACT_STORE,
+                        configuration={},
+                        secrets=[private_secret.name],
+                    )
+
+                with pytest.raises(KeyError):
+                    other_client.create_stack_component(
+                        name=sample_name("component_with_private_secret_id"),
+                        flavor="local",
+                        component_type=StackComponentType.ARTIFACT_STORE,
+                        configuration={},
+                        secrets=[private_secret.id],
+                    )
 
 
 def test_private_secret_is_not_visible_to_other_users():


### PR DESCRIPTION
## Summary

This PR fixes a secret reference-resolution issue that allowed users to attach secrets they should not be able to access to their own ZenML resources.

Before this change, a user who knew or guessed the name or UUID of a private secret owned by another user, or an internal ZenML-managed secret, could reference that secret from places such as stacks or stack components. This did not expose the secret values and did not allow the user to actually use those secret values at runtime, because the later value-resolution paths still enforce the proper access checks.

However, allowing these secrets to be referenced at all was still incorrect. It could disclose that a private/internal secret exists and could store unauthorized secret references in user-controlled resource metadata.

This PR closes that gap by making secret reference resolution follow the same visibility rules as normal secret access:

- private secrets can only be resolved by their owner
- internal secrets cannot be resolved through user-facing reference paths
- public secrets remain referenceable as before

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

