### PR TITLE
Support snapshots are source types for platform triggers

### DIFF
--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -434,11 +434,13 @@ Supported target events depend on the source type:
 |-------------|---------|---------------|
 | `pipeline` | React to runs of a pipeline | `run_completed`, `run_failed` |
 | `pipeline_run` | React to one specific pipeline run | `completed`, `failed` |
+| `pipeline_snapshot` | React to runs of a pipeline snapshot | `run_completed`, `run_failed` |
 
 That distinction is easy to miss. If the source is a pipeline, the event name
 includes the word `run` because the pipeline itself is not what completes; one
-of its runs does. If the source is already a pipeline run, the event is simply
-`completed` or `failed`.
+of its runs does. Pipeline snapshot events follow the same naming pattern. If
+the source is already a pipeline run, the event is simply `completed` or
+`failed`.
 
 
 ### Create Platform Event Trigger

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -700,6 +700,7 @@ class SourceType(StrEnum):
 
     PIPELINE = "pipeline"
     PIPELINE_RUN = "pipeline_run"
+    PIPELINE_SNAPSHOT = "pipeline_snapshot"
 
 
 class PipelineEvent(DescribedValuesEnum):
@@ -740,7 +741,27 @@ class PipelineRunEvent(DescribedValuesEnum):
         }
 
 
+class PipelineSnapshotEvent(DescribedValuesEnum):
+    """Enum representing platform target events for pipeline snapshots."""
+
+    RUN_COMPLETED = "run_completed"
+    RUN_FAILED = "run_failed"
+
+    @classmethod
+    def value_description_index(cls) -> dict[str, str]:
+        """Helper utility to describe enum values.
+
+        Returns:
+            A dictionary with descriptions for each value.
+        """
+        return {
+            cls.RUN_COMPLETED: "A pipeline run of the source snapshot has completed successfully.",
+            cls.RUN_FAILED: "A pipeline run of the source snapshot has failed.",
+        }
+
+
 PLATFORM_EVENT_REGISTRY: dict[SourceType, type[DescribedValuesEnum]] = {
     SourceType.PIPELINE: PipelineEvent,
     SourceType.PIPELINE_RUN: PipelineRunEvent,
+    SourceType.PIPELINE_SNAPSHOT: PipelineSnapshotEvent,
 }

--- a/src/zenml/utils/trigger_utils.py
+++ b/src/zenml/utils/trigger_utils.py
@@ -24,6 +24,7 @@ from zenml.enums import (
     PLATFORM_EVENT_REGISTRY,
     PipelineEvent,
     PipelineRunEvent,
+    PipelineSnapshotEvent,
     SourceType,
     TriggerRunConcurrency,
 )
@@ -58,11 +59,29 @@ def create_platform_event_trigger(
     pass
 
 
+# create pipeline snapshot trigger overload
+@overload
+def create_platform_event_trigger(
+    *,
+    name: str,
+    source_pipeline_snapshot_id: UUID,
+    target_events: list[PipelineSnapshotEvent],
+    active: bool = True,
+    concurrency: TriggerRunConcurrency = TriggerRunConcurrency.SKIP,
+) -> PlatformEventTriggerResponse:
+    pass
+
+
 def create_platform_event_trigger(
     name: str,
-    target_events: list[PipelineEvent] | list[PipelineRunEvent],
+    target_events: (
+        list[PipelineEvent]
+        | list[PipelineRunEvent]
+        | list[PipelineSnapshotEvent]
+    ),
     source_pipeline_id: UUID | None = None,
     source_pipeline_run_id: UUID | None = None,
+    source_pipeline_snapshot_id: UUID | None = None,
     active: bool = True,
     concurrency: TriggerRunConcurrency = TriggerRunConcurrency.SKIP,
 ) -> PlatformEventTriggerResponse:
@@ -73,6 +92,7 @@ def create_platform_event_trigger(
         target_events: A list of target events (events that will cause trigger execution).
         source_pipeline_id: A Pipeline ID (one of the source options).
         source_pipeline_run_id: A Pipeline Run ID (one of the source options).
+        source_pipeline_snapshot_id: A Pipeline Snapshot ID (one of the source options).
         active: Flag - whether to activate the trigger on creation.
         concurrency: How to handle concurrent executions (SKIP/SUBMIT etc.).
 
@@ -87,6 +107,7 @@ def create_platform_event_trigger(
     options = [
         source_pipeline_id,
         source_pipeline_run_id,
+        source_pipeline_snapshot_id,
     ]
 
     if sum(1 if option is not None else 0 for option in options) > 1:
@@ -97,6 +118,9 @@ def create_platform_event_trigger(
     elif source_pipeline_run_id is not None:
         source_type = SourceType.PIPELINE_RUN
         source_id = source_pipeline_run_id
+    elif source_pipeline_snapshot_id is not None:
+        source_type = SourceType.PIPELINE_SNAPSHOT
+        source_id = source_pipeline_snapshot_id
     else:
         raise ValueError("You must specify at least one source option")
 
@@ -141,7 +165,25 @@ def update_platform_event_trigger(
     *,
     trigger_name_id_or_prefix: str | UUID,
     name: str | None = None,
-    target_events: list[PipelineEvent] | list[PipelineRunEvent] | None = None,
+    source_pipeline_snapshot_id: UUID | None = None,
+    target_events: list[PipelineSnapshotEvent] | None = None,
+    active: bool | None = None,
+    concurrency: TriggerRunConcurrency | None = None,
+) -> PlatformEventTriggerResponse:
+    pass
+
+
+@overload
+def update_platform_event_trigger(
+    *,
+    trigger_name_id_or_prefix: str | UUID,
+    name: str | None = None,
+    target_events: (
+        list[PipelineEvent]
+        | list[PipelineRunEvent]
+        | list[PipelineSnapshotEvent]
+        | None
+    ) = None,
     active: bool | None = None,
     concurrency: TriggerRunConcurrency | None = None,
 ) -> PlatformEventTriggerResponse:
@@ -151,9 +193,15 @@ def update_platform_event_trigger(
 def update_platform_event_trigger(
     trigger_name_id_or_prefix: str | UUID,
     name: str | None = None,
-    target_events: list[PipelineEvent] | list[PipelineRunEvent] | None = None,
+    target_events: (
+        list[PipelineEvent]
+        | list[PipelineRunEvent]
+        | list[PipelineSnapshotEvent]
+        | None
+    ) = None,
     source_pipeline_id: UUID | None = None,
     source_pipeline_run_id: UUID | None = None,
+    source_pipeline_snapshot_id: UUID | None = None,
     active: bool | None = None,
     concurrency: TriggerRunConcurrency | None = None,
 ) -> PlatformEventTriggerResponse:
@@ -165,6 +213,7 @@ def update_platform_event_trigger(
         target_events: A list of target events (events that will cause trigger execution).
         source_pipeline_id: A Pipeline ID (one of the source options).
         source_pipeline_run_id: A Pipeline Run ID (one of the source options).
+        source_pipeline_snapshot_id: A Pipeline Snapshot ID (one of the source options).
         active: Flag - whether to activate the trigger on creation.
         concurrency: How to handle concurrent executions (SKIP/SUBMIT etc.).
 
@@ -179,6 +228,7 @@ def update_platform_event_trigger(
     options = [
         source_pipeline_id,
         source_pipeline_run_id,
+        source_pipeline_snapshot_id,
     ]
 
     if sum(1 if option is not None else 0 for option in options) > 1:
@@ -189,6 +239,9 @@ def update_platform_event_trigger(
     elif source_pipeline_run_id is not None:
         source_id = source_pipeline_run_id
         source_type = SourceType.PIPELINE_RUN
+    elif source_pipeline_snapshot_id is not None:
+        source_id = source_pipeline_snapshot_id
+        source_type = SourceType.PIPELINE_SNAPSHOT
     else:
         source_id = None
         source_type = None

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -93,6 +93,11 @@ def verify_permissions_for_source_entity(
             model=zen_store().get_run(run_id=source_id),
             action=Action.UPDATE,
         )
+    elif source_type == SourceType.PIPELINE_SNAPSHOT:
+        verify_permission_for_model(
+            model=zen_store().get_snapshot(snapshot_id=source_id),
+            action=Action.UPDATE,
+        )
     else:
         raise ValueError(f"Unexpected source type: {format(source_type)}")
 

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -222,6 +222,20 @@ def test_platform_event_valid_and_inheritance():
     assert body.source_entity.type == SourceType.PIPELINE_RUN
 
 
+def test_platform_event_snapshot_source_valid():
+    req = PlatformEventTriggerRequest(
+        project=uuid4(),
+        name="evt",
+        active=True,
+        type=TriggerType.PLATFORM_EVENT,
+        flavor=TriggerFlavor.PLATFORM_EVENT,
+        source_entity={"type": SourceType.PIPELINE_SNAPSHOT, "id": uuid4()},
+        target_events=["run_completed"],
+    )
+
+    assert req.source_entity.type == SourceType.PIPELINE_SNAPSHOT
+
+
 def test_platform_event_invalid_combinations():
     # invalid: pipeline + COMPLETED
     with pytest.raises(ValidationError):
@@ -245,4 +259,19 @@ def test_platform_event_invalid_combinations():
             flavor=TriggerFlavor.PLATFORM_EVENT,
             source_entity={"type": SourceType.PIPELINE_RUN, "id": uuid4()},
             target_events=["run_completed"],
+        )
+
+    # invalid: pipeline_snapshot + COMPLETED
+    with pytest.raises(ValidationError):
+        PlatformEventTriggerRequest(
+            project=uuid4(),
+            name="evt",
+            active=True,
+            type=TriggerType.PLATFORM_EVENT,
+            flavor=TriggerFlavor.PLATFORM_EVENT,
+            source_entity={
+                "type": SourceType.PIPELINE_SNAPSHOT,
+                "id": uuid4(),
+            },
+            target_events=["completed"],
         )

--- a/tests/unit/utils/test_trigger_utils.py
+++ b/tests/unit/utils/test_trigger_utils.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from zenml.enums import (
     PipelineEvent,
     PipelineRunEvent,
+    PipelineSnapshotEvent,
     SourceType,
     TriggerRunConcurrency,
 )
@@ -27,6 +28,13 @@ def test_list_supported_events():
 
     assert len(pipeline_events) > 1
     assert "run_completed" in pipeline_events
+
+    snapshot_events = trigger_utils.list_supported_events(
+        source_type=SourceType.PIPELINE_SNAPSHOT
+    )
+
+    assert len(snapshot_events) > 1
+    assert "run_completed" in snapshot_events
 
     with pytest.raises(ValidationError):
         trigger_utils.list_supported_events(source_type="snapshot")
@@ -59,6 +67,33 @@ def test_create_platform_event_trigger_happy_path():
     )
 
 
+def test_create_platform_event_trigger_with_snapshot_source():
+    source_pipeline_snapshot_id = uuid4()
+    expected_response = Mock()
+
+    mock_client = Mock()
+    mock_client.create_platform_event_trigger.return_value = expected_response
+
+    with patch.object(trigger_utils, "Client", return_value=mock_client):
+        result = trigger_utils.create_platform_event_trigger(
+            name="my-snapshot-trigger",
+            source_pipeline_snapshot_id=source_pipeline_snapshot_id,
+            target_events=[PipelineSnapshotEvent.RUN_COMPLETED],
+            active=False,
+            concurrency=TriggerRunConcurrency.SUBMIT,
+        )
+
+    assert result is expected_response
+    mock_client.create_platform_event_trigger.assert_called_once_with(
+        name="my-snapshot-trigger",
+        source_type=SourceType.PIPELINE_SNAPSHOT,
+        source_id=source_pipeline_snapshot_id,
+        target_events=[str(PipelineSnapshotEvent.RUN_COMPLETED.value)],
+        active=False,
+        concurrency=TriggerRunConcurrency.SUBMIT,
+    )
+
+
 @pytest.mark.parametrize(
     "kwargs, expected_message",
     [
@@ -66,6 +101,7 @@ def test_create_platform_event_trigger_happy_path():
             {
                 "source_pipeline_id": uuid4(),
                 "source_pipeline_run_id": uuid4(),
+                "source_pipeline_snapshot_id": uuid4(),
             },
             "You can not provide more than 1 source option",
         ),
@@ -136,5 +172,32 @@ def test_update_platform_event_trigger_allows_single_source_pipeline_id():
         source_id=source_pipeline_id,
         source_type=SourceType.PIPELINE,
         target_events=[str(PipelineEvent.RUN_COMPLETED.value)],
+        concurrency=None,
+    )
+
+
+def test_update_platform_event_trigger_allows_single_source_snapshot_id():
+    trigger_id = uuid4()
+    source_pipeline_snapshot_id = uuid4()
+    expected_response = Mock()
+
+    mock_client = Mock()
+    mock_client.update_platform_event_trigger.return_value = expected_response
+
+    with patch.object(trigger_utils, "Client", return_value=mock_client):
+        result = trigger_utils.update_platform_event_trigger(
+            trigger_name_id_or_prefix=trigger_id,
+            source_pipeline_snapshot_id=source_pipeline_snapshot_id,
+            target_events=[PipelineSnapshotEvent.RUN_COMPLETED],
+        )
+
+    assert result is expected_response
+    mock_client.update_platform_event_trigger.assert_called_once_with(
+        trigger_name_id_or_prefix=trigger_id,
+        name=None,
+        active=None,
+        source_id=source_pipeline_snapshot_id,
+        source_type=SourceType.PIPELINE_SNAPSHOT,
+        target_events=[str(PipelineSnapshotEvent.RUN_COMPLETED.value)],
         concurrency=None,
     )


### PR DESCRIPTION
## Describe changes

This is an extension to the Platform Event triggers PRO feature. Users can now specify snapshots as a source type for a platform event trigger.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

