### PR TITLE
Fix broken hooks docs link failing the absolute-links check

### DIFF
--- a/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
+++ b/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
@@ -281,7 +281,7 @@ for run in runs.items:
 
 #### Monitoring with Alerters
 
-For critical pipelines, [add alerting](https://docs.zenml.io/stacks/alerters) to notify you of failures via a [failure hook](https://docs.zenml.io/how-to/steps-pipelines/hooks):
+For critical pipelines, [add alerting](https://docs.zenml.io/stacks/alerters) to notify you of failures via a [failure hook](https://docs.zenml.io/concepts/steps_and_pipelines/advanced_features#hooks):
 
 ```python
 from zenml.hooks import alerter_failure_hook


### PR DESCRIPTION
The docs site moved the hooks page — `https://docs.zenml.io/how-to/steps-pipelines/hooks` now 404s, which fails `check-absolute-links` on every open PR. Points the link at the live location (`concepts/steps_and_pipelines/advanced_features#hooks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)