### PR TITLE
Kubernetes sandbox

### DIFF
--- a/docs/book/component-guide/sandboxes/README.md
+++ b/docs/book/component-guide/sandboxes/README.md
@@ -108,6 +108,7 @@ Every value you put in a Session's environment (`sandbox_environment`) is **read
 ## Available flavors
 
 - **[Local](local.md)** — subprocess-based; **no isolation**; built-in. Intended for examples, unit tests, and development against the abstraction.
+- **[Kubernetes](kubernetes.md)** — pod-backed sessions executed through Kubernetes exec.
 
 ## Develop a custom Sandbox
 

--- a/docs/book/component-guide/sandboxes/kubernetes.md
+++ b/docs/book/component-guide/sandboxes/kubernetes.md
@@ -33,7 +33,7 @@ Some configuration options for the Kubernetes sandbox can only be set through th
 The following configuration options can be set either through the sandbox config or overridden using `KubernetesSandboxSettings`:
 
 - **`sandbox_environment`**: Environment variables to set in session pods and command executions.
-- **`image`** (default: "python:3.11-slim"): The container image used for session pods. The image must provide `/bin/sh`, so distroless images are not supported.
+- **`image`** (default: "python:3.11-slim"): The container image used for session pods. The image must provide `/bin/sh` and `base64`, so distroless images are not supported.
 - **`pod_settings`**: Node selectors, labels, affinity, tolerations, secrets, environment variables, image pull secrets, the scheduler name and additional arguments to apply to the session pods. These can be either specified using the Kubernetes model objects or as dictionaries.
 - **`service_account_name`**: The name of a Kubernetes service account to use for session pods. If not configured, pods use the namespace default service account.
 - **`automount_service_account_token`** (default: False): If `True`, a Kubernetes API token is mounted into session pods, allowing code running in the sandbox to call the Kubernetes API with the service account's RBAC permissions.
@@ -76,7 +76,7 @@ Without these controls, sandbox pods may still reach internal services or extern
 | `destroy()` | ✅ | Deletes the backing pod. |
 | `attach(session_id)` | ✅ | Re-attaches to a running session pod. |
 | `snapshot()` / `restore()` | ❌ | Not implemented. |
-| `upload_file` / `download_file` | ❌ | Not implemented. |
+| `upload_file` / `download_file` | ✅ | Transfers file content through Kubernetes exec. |
 
 ## Attaching to a running session
 

--- a/docs/book/component-guide/sandboxes/kubernetes.md
+++ b/docs/book/component-guide/sandboxes/kubernetes.md
@@ -76,7 +76,7 @@ Without these controls, sandbox pods may still reach internal services or extern
 | `destroy()` | ✅ | Deletes the backing pod. |
 | `attach(session_id)` | ✅ | Re-attaches to a running session pod. |
 | `snapshot()` / `restore()` | ❌ | Not implemented. |
-| `upload_file` / `download_file` | ✅ | Transfers file content through Kubernetes exec. |
+| `upload_file` / `download_file` | ✅ | Transfers file content through Kubernetes exec. Uploads are limited to 256 MiB per file. |
 
 ## Attaching to a running session
 

--- a/docs/book/component-guide/sandboxes/kubernetes.md
+++ b/docs/book/component-guide/sandboxes/kubernetes.md
@@ -1,0 +1,94 @@
+---
+description: Pod-backed sandbox sessions for isolated command execution on Kubernetes.
+---
+
+# Kubernetes Sandbox
+
+The Kubernetes sandbox flavor creates one Kubernetes pod per sandbox session and executes each `session.exec(...)` command inside that pod using Kubernetes `exec`.
+
+## How to register
+
+```bash
+zenml integration install kubernetes
+zenml sandbox register k8s-sb --flavor=kubernetes --connector=<CONNECTOR_NAME>
+zenml stack update --sandbox k8s-sb
+```
+
+The [Service Connector](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/service-connectors-guide) must provide access to a Kubernetes cluster. Alternatively, you can register the sandbox without a connector:
+
+```bash
+zenml sandbox register k8s-sb --flavor=kubernetes --kubernetes_context=<CONTEXT_NAME>
+```
+
+In this case, the sandbox uses your local kubeconfig credentials. `kubernetes_context` selects the kubeconfig context to use and defaults to the active one.
+
+## Additional configuration
+
+Some configuration options for the Kubernetes sandbox can only be set through the sandbox config when you register it (and cannot be changed per-session through the settings):
+
+- **`incluster`** (default: False): If `True`, the sandbox will load the in-cluster Kubernetes configuration and create session pods in the same cluster it is running in, ignoring the `kubernetes_context`.
+- **`kubernetes_context`**: The name of the Kubernetes context to use for creating session pods (ignored if using a service connector or `incluster`).
+- **`kubernetes_namespace`** (default: "zenml"): The Kubernetes namespace in which session pods are created. The namespace must already exist in the Kubernetes cluster.
+
+The following configuration options can be set either through the sandbox config or overridden using `KubernetesSandboxSettings`:
+
+- **`sandbox_environment`**: Environment variables to set in session pods and command executions.
+- **`image`** (default: "python:3.11-slim"): The container image used for session pods. The image must provide `/bin/sh`, so distroless images are not supported.
+- **`pod_settings`**: Node selectors, labels, affinity, tolerations, secrets, environment variables, image pull secrets, the scheduler name and additional arguments to apply to the session pods. These can be either specified using the Kubernetes model objects or as dictionaries.
+- **`service_account_name`**: The name of a Kubernetes service account to use for session pods. If not configured, pods use the namespace default service account.
+- **`automount_service_account_token`** (default: False): If `True`, a Kubernetes API token is mounted into session pods, allowing code running in the sandbox to call the Kubernetes API with the service account's RBAC permissions.
+- **`privileged`** (default: False): If the container should be run in privileged mode.
+- **`pod_startup_timeout`** (default: 120): The maximum time (in seconds) to wait for a session pod to become running.
+- **`api_request_timeout`**: Timeout (in seconds) for Kubernetes API requests. If not set, client defaults are used.
+
+## Security model
+
+This flavor is designed to make safer defaults possible, but cluster policy remains the primary security boundary.
+
+### ZenML-side safeguards (default behavior)
+
+- Service account token is not mounted in sandbox pods (`automount_service_account_token=False`).
+- `sandbox_environment` values are visible to executed code. Do not inject secrets you do not want sandbox code to read.
+
+For untrusted code, set `service_account_name` to a dedicated least-privilege service account instead of relying on the namespace default.
+
+### Required cluster-admin controls
+
+For untrusted LLM code, configure at least:
+
+- **Least-privilege RBAC** for sandbox service accounts.
+- **Pod Security Admission** (or equivalent policy engine) to forbid privileged containers and host namespace escapes.
+- **Runtime hardening policy** (e.g. Kyverno/Gatekeeper) to enforce non-root, read-only root filesystem, seccomp, and no privilege escalation where required.
+- **Network policies** with explicit egress/ingress rules (default-deny plus allow-list).
+- **ResourceQuota / LimitRange** to constrain runaway compute and memory usage.
+- **Image policy controls** (trusted registry, signature/provenance checks if available).
+
+Without these controls, sandbox pods may still reach internal services or external networks based on cluster defaults.
+
+## Feature set
+
+| Feature | Kubernetes | Notes |
+|---|---|---|
+| `create_session()` | ✅ | Creates a pod and waits until it is running. |
+| `exec()` | ✅ | Uses Kubernetes exec websocket streaming. |
+| Streaming output | ✅ | Stdout/stderr stream line-by-line through `SandboxProcess`. |
+| Sandbox log forwarding | ✅ | Output is forwarded into `sandbox:<session_id>` step logs. |
+| `destroy()` | ✅ | Deletes the backing pod. |
+| `attach(session_id)` | ✅ | Re-attaches to a running session pod. |
+| `snapshot()` / `restore()` | ❌ | Not implemented. |
+| `upload_file` / `download_file` | ❌ | Not implemented. |
+
+## Attaching to a running session
+
+`attach(session_id)` re-creates a session handle for an existing session pod. Attaching fails if the pod does not exist, is not running, or was created by a different sandbox component.
+
+{% hint style="warning" %}
+An attached session shares the pod with the original session handle. Calling `destroy()` on either handle deletes the pod, after which `exec()` calls on the other handle fail.
+{% endhint %}
+
+## Lifecycle behavior
+
+- `close()` closes only the local session handle. It does not delete the pod.
+- `destroy()` deletes the backing pod and then closes the handle.
+- `kill()` only stops streaming output. Kubernetes exec does not propagate signals on disconnect, so the command keeps running inside the pod until the pod is deleted.
+

--- a/docs/book/component-guide/toc.md
+++ b/docs/book/component-guide/toc.md
@@ -50,6 +50,7 @@
   * [Develop a Custom Log Store](log-stores/custom.md)
 * [Sandboxes](sandboxes/README.md)
   * [Local](sandboxes/local.md)
+  * [Kubernetes](sandboxes/kubernetes.md)
 * [Step Operators](step-operators/README.md)
   * [Amazon SageMaker](step-operators/sagemaker.md)
   * [AzureML](step-operators/azureml.md)

--- a/src/zenml/integrations/kubernetes/__init__.py
+++ b/src/zenml/integrations/kubernetes/__init__.py
@@ -26,6 +26,7 @@ from zenml.stack import Flavor
 KUBERNETES_ORCHESTRATOR_FLAVOR = "kubernetes"
 KUBERNETES_STEP_OPERATOR_FLAVOR = "kubernetes"
 KUBERNETES_DEPLOYER_FLAVOR = "kubernetes"
+KUBERNETES_SANDBOX_FLAVOR = "kubernetes"
 
 
 class KubernetesIntegration(Integration):
@@ -46,12 +47,14 @@ class KubernetesIntegration(Integration):
         from zenml.integrations.kubernetes.flavors import (
             KubernetesDeployerFlavor,
             KubernetesOrchestratorFlavor,
+            KubernetesSandboxFlavor,
             KubernetesStepOperatorFlavor,
         )
 
         return [
             KubernetesDeployerFlavor,
             KubernetesOrchestratorFlavor,
+            KubernetesSandboxFlavor,
             KubernetesStepOperatorFlavor,
         ]
 

--- a/src/zenml/integrations/kubernetes/flavors/__init__.py
+++ b/src/zenml/integrations/kubernetes/flavors/__init__.py
@@ -23,6 +23,11 @@ from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import
     KubernetesOrchestratorFlavor,
     KubernetesOrchestratorSettings,
 )
+from zenml.integrations.kubernetes.flavors.kubernetes_sandbox_flavor import (
+    KubernetesSandboxConfig,
+    KubernetesSandboxFlavor,
+    KubernetesSandboxSettings,
+)
 from zenml.integrations.kubernetes.flavors.kubernetes_step_operator_flavor import (
     KubernetesStepOperatorConfig,
     KubernetesStepOperatorFlavor,
@@ -36,6 +41,9 @@ __all__ = [
     "KubernetesOrchestratorFlavor",
     "KubernetesOrchestratorConfig",
     "KubernetesOrchestratorSettings",
+    "KubernetesSandboxConfig",
+    "KubernetesSandboxFlavor",
+    "KubernetesSandboxSettings",
     "KubernetesStepOperatorConfig",
     "KubernetesStepOperatorFlavor",
     "KubernetesStepOperatorSettings",

--- a/src/zenml/integrations/kubernetes/flavors/kubernetes_sandbox_flavor.py
+++ b/src/zenml/integrations/kubernetes/flavors/kubernetes_sandbox_flavor.py
@@ -1,0 +1,174 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Kubernetes sandbox flavor."""
+
+from typing import TYPE_CHECKING, Optional, Type
+
+from pydantic import Field, PositiveInt
+
+from zenml.constants import KUBERNETES_CLUSTER_RESOURCE_TYPE
+from zenml.integrations.kubernetes import KUBERNETES_SANDBOX_FLAVOR
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+from zenml.models import ServiceConnectorRequirements
+from zenml.sandboxes.base import (
+    BaseSandboxConfig,
+    BaseSandboxFlavor,
+    BaseSandboxSettings,
+)
+
+if TYPE_CHECKING:
+    from zenml.integrations.kubernetes.sandboxes import KubernetesSandbox
+
+
+class KubernetesSandboxSettings(BaseSandboxSettings):
+    """Settings for the Kubernetes sandbox."""
+
+    image: str = Field(
+        default="python:3.11-slim",
+        description="Container image used for sandbox session pods.",
+    )
+    pod_settings: Optional[KubernetesPodSettings] = Field(
+        default=None,
+        description="Pod configuration overrides for sandbox session pods.",
+    )
+    service_account_name: Optional[str] = Field(
+        default=None,
+        description="Service account assigned to sandbox session pods.",
+    )
+    automount_service_account_token: bool = Field(
+        default=False,
+        description="Whether to mount a Kubernetes API token into sandbox "
+        "pods, which grants in-pod cluster API access.",
+    )
+    privileged: bool = Field(
+        default=False,
+        description="Whether sandbox session containers run in privileged mode.",
+    )
+    pod_startup_timeout: PositiveInt = Field(
+        default=120,
+        description="Maximum number of seconds to wait for a sandbox pod to "
+        "reach the running phase.",
+    )
+    api_request_timeout: Optional[PositiveInt] = Field(
+        default=None,
+        description="Timeout for Kubernetes API requests in seconds.",
+    )
+
+
+class KubernetesSandboxConfig(BaseSandboxConfig, KubernetesSandboxSettings):
+    """Configuration for the Kubernetes sandbox."""
+
+    kubernetes_namespace: str = Field(
+        default="zenml",
+        description="Kubernetes namespace where sandbox pods are created.",
+    )
+    incluster: bool = Field(
+        default=False,
+        description="Whether to load in-cluster Kubernetes credentials.",
+    )
+    kubernetes_context: Optional[str] = Field(
+        default=None,
+        description="Kubernetes context to use when running out-of-cluster.",
+    )
+
+    @property
+    def is_remote(self) -> bool:
+        """Whether this stack component runs remotely.
+
+        Returns:
+            `True`, because sandbox execution happens in Kubernetes pods.
+        """
+        return True
+
+    @property
+    def is_local(self) -> bool:
+        """Whether this stack component runs locally.
+
+        Returns:
+            `False`.
+        """
+        return False
+
+
+class KubernetesSandboxFlavor(BaseSandboxFlavor):
+    """Kubernetes sandbox flavor."""
+
+    @property
+    def name(self) -> str:
+        """Name of the flavor.
+
+        Returns:
+            The flavor name.
+        """
+        return KUBERNETES_SANDBOX_FLAVOR
+
+    @property
+    def service_connector_requirements(
+        self,
+    ) -> Optional[ServiceConnectorRequirements]:
+        """Service connector requirements for this flavor.
+
+        Returns:
+            Requirements for compatible service connectors.
+        """
+        return ServiceConnectorRequirements(
+            resource_type=KUBERNETES_CLUSTER_RESOURCE_TYPE,
+        )
+
+    @property
+    def docs_url(self) -> Optional[str]:
+        """A URL to docs for this flavor.
+
+        Returns:
+            Flavor docs URL.
+        """
+        return self.generate_default_docs_url()
+
+    @property
+    def sdk_docs_url(self) -> Optional[str]:
+        """A URL to SDK docs for this flavor.
+
+        Returns:
+            Flavor SDK docs URL.
+        """
+        return self.generate_default_sdk_docs_url()
+
+    @property
+    def logo_url(self) -> str:
+        """A URL to represent this flavor in the dashboard.
+
+        Returns:
+            Flavor logo URL.
+        """
+        return "https://public-flavor-logos.s3.eu-central-1.amazonaws.com/sandbox/kubernetes.png"
+
+    @property
+    def config_class(self) -> Type[KubernetesSandboxConfig]:
+        """Configuration class for this flavor.
+
+        Returns:
+            `KubernetesSandboxConfig`.
+        """
+        return KubernetesSandboxConfig
+
+    @property
+    def implementation_class(self) -> Type["KubernetesSandbox"]:
+        """Implementation class for this flavor.
+
+        Returns:
+            The implementation class.
+        """
+        from zenml.integrations.kubernetes.sandboxes import KubernetesSandbox
+
+        return KubernetesSandbox

--- a/src/zenml/integrations/kubernetes/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/kube_utils.py
@@ -280,6 +280,57 @@ def get_pod(
         raise RuntimeError from e
 
 
+def create_pod(
+    core_api: k8s_client.CoreV1Api,
+    namespace: str,
+    pod_manifest: k8s_client.V1Pod,
+    api_request_timeout: Optional[int] = None,
+) -> None:
+    """Create a Kubernetes pod.
+
+    Args:
+        core_api: Client of `CoreV1Api` of Kubernetes API.
+        namespace: The namespace in which to create the pod.
+        pod_manifest: The manifest of the pod to create.
+        api_request_timeout: The request timeout in seconds.
+    """
+    retry_on_api_exception(
+        core_api.create_namespaced_pod,
+        api_request_timeout=api_request_timeout,
+    )(
+        namespace=namespace,
+        body=pod_manifest,
+    )
+
+
+def delete_pod(
+    core_api: k8s_client.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    api_request_timeout: Optional[int] = None,
+) -> None:
+    """Delete a Kubernetes pod.
+
+    Args:
+        core_api: Client of `CoreV1Api` of Kubernetes API.
+        pod_name: The name of the pod to delete.
+        namespace: The namespace of the pod.
+        api_request_timeout: The request timeout in seconds.
+    """
+    try:
+        retry_on_api_exception(
+            core_api.delete_namespaced_pod,
+            api_request_timeout=api_request_timeout,
+        )(
+            name=pod_name,
+            namespace=namespace,
+            propagation_policy="Foreground",
+        )
+    except k8s_client.rest.ApiException as e:
+        if e.status != 404:
+            raise
+
+
 def wait_pod(
     kube_client_fn: Callable[[], k8s_client.ApiClient],
     pod_name: str,

--- a/src/zenml/integrations/kubernetes/kube_utils.py
+++ b/src/zenml/integrations/kubernetes/kube_utils.py
@@ -316,6 +316,10 @@ def delete_pod(
         pod_name: The name of the pod to delete.
         namespace: The namespace of the pod.
         api_request_timeout: The request timeout in seconds.
+
+    Raises:
+        k8s_client.rest.ApiException: If the pod deletion failed for any
+            reason other than the pod not being found.
     """
     try:
         retry_on_api_exception(

--- a/src/zenml/integrations/kubernetes/sandboxes/__init__.py
+++ b/src/zenml/integrations/kubernetes/sandboxes/__init__.py
@@ -1,0 +1,22 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Kubernetes sandbox implementations."""
+
+from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+    KubernetesSandbox,
+)
+
+__all__ = [
+    "KubernetesSandbox",
+]

--- a/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
+++ b/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
@@ -1,0 +1,595 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Kubernetes sandbox implementation."""
+
+import logging
+import queue
+import re
+import shlex
+import threading
+import time
+import uuid
+from typing import Dict, Iterator, List, Optional, Tuple, Type, Union, cast
+
+from kubernetes import client as k8s_client
+from kubernetes.stream import stream as k8s_stream
+
+from zenml.config.base_settings import BaseSettings
+from zenml.integrations.kubernetes import kube_utils
+from zenml.integrations.kubernetes.flavors import (
+    KubernetesSandboxConfig,
+    KubernetesSandboxSettings,
+)
+from zenml.integrations.kubernetes.manifest_utils import build_pod_manifest
+from zenml.logger import get_logger
+from zenml.sandboxes.base import BaseSandbox, BaseSandboxSettings
+from zenml.sandboxes.process import SandboxExecError, SandboxProcess
+from zenml.sandboxes.session import SandboxSession
+
+logger = get_logger(__name__)
+
+_STREAM_END = object()
+
+# Env var keys are interpolated unquoted into `export <key>=...`, so only
+# shell-identifier keys are safe there.
+_ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Per-stream line cap for the websocket drain queues. A caller that only
+# wait()s on a noisy command would otherwise grow these queues without
+# bound. Past the cap the oldest lines are dropped (logged once).
+_STREAM_BUFFER_MAX_LINES = 100_000
+
+
+def _split_lines_with_buffer(chunk: str, buffer: str) -> Tuple[List[str], str]:
+    """Split a chunk into lines and remaining buffer.
+
+    Args:
+        chunk: A chunk from a stream.
+        buffer: The remaining buffer from previous chunks.
+
+    Returns:
+        A tuple of lines and remaining buffer.
+    """
+    combined = f"{buffer}{chunk}"
+    lines = combined.splitlines(keepends=True)
+    if lines and not lines[-1].endswith("\n"):
+        return lines[:-1], lines[-1]
+    return lines, ""
+
+
+class KubernetesSandboxProcess(SandboxProcess):
+    """Handle to a command running in a Kubernetes sandbox session."""
+
+    def __init__(
+        self,
+        session: "KubernetesSandboxSession",
+        websocket_client: "k8s_stream.ws_client.WSClient",
+        started_at: float,
+    ) -> None:
+        """Initialize the Kubernetes sandbox process.
+
+        Args:
+            session: The owning sandbox session.
+            websocket_client: Kubernetes websocket client for pod exec.
+            started_at: The wall-clock time the process started.
+        """
+        super().__init__(session=session, started_at=started_at)
+        self._websocket_client = websocket_client
+        self._stdout_queue: "queue.Queue[object]" = queue.Queue()
+        self._stderr_queue: "queue.Queue[object]" = queue.Queue()
+        self._exit_code: Optional[int] = None
+        self._overflow_warned = False
+        self._done = threading.Event()
+        self._drain_thread = threading.Thread(
+            target=self._drain_streams,
+            name=f"k8s-sandbox-process-{session.id}",
+            daemon=True,
+        )
+        self._drain_thread.start()
+
+    def _enqueue_line(self, q: "queue.Queue[object]", line: str) -> None:
+        """Enqueue a stream line, dropping the oldest lines past the cap.
+
+        Args:
+            q: Target stream queue.
+            line: Stream line to enqueue.
+        """
+        while q.qsize() >= _STREAM_BUFFER_MAX_LINES:
+            try:
+                q.get_nowait()
+            except queue.Empty:
+                break
+
+            if not self._overflow_warned:
+                self._overflow_warned = True
+                logger.warning(
+                    "Kubernetes sandbox exec output exceeded the %d-line "
+                    "buffer, oldest undrained lines are being dropped. "
+                    "Drain process.stdout()/stderr() (or use collect()) to "
+                    "keep full output.",
+                    _STREAM_BUFFER_MAX_LINES,
+                )
+
+        q.put(line)
+
+    def _drain_streams(self) -> None:
+        """Read stdout/stderr from websocket and feed line queues."""
+        stdout_buffer = ""
+        stderr_buffer = ""
+        try:
+            while self._websocket_client.is_open():
+                self._websocket_client.update(timeout=1)
+                if self._websocket_client.peek_stdout():
+                    stdout_chunk = self._websocket_client.read_stdout()
+                    lines, stdout_buffer = _split_lines_with_buffer(
+                        chunk=stdout_chunk, buffer=stdout_buffer
+                    )
+                    for line in lines:
+                        self._enqueue_line(self._stdout_queue, line)
+                if self._websocket_client.peek_stderr():
+                    stderr_chunk = self._websocket_client.read_stderr()
+                    lines, stderr_buffer = _split_lines_with_buffer(
+                        chunk=stderr_chunk, buffer=stderr_buffer
+                    )
+                    for line in lines:
+                        self._enqueue_line(self._stderr_queue, line)
+        except Exception as e:
+            logger.debug(
+                "Error while draining Kubernetes sandbox streams: %s", e
+            )
+            if self._exit_code is None:
+                self._exit_code = 1
+            self._stderr_queue.put(f"Kubernetes sandbox stream failed: {e}\n")
+        finally:
+            if stdout_buffer:
+                self._enqueue_line(self._stdout_queue, stdout_buffer)
+            if stderr_buffer:
+                self._enqueue_line(self._stderr_queue, stderr_buffer)
+            if self._exit_code is None:
+                try:
+                    self._exit_code = self._websocket_client.returncode
+                except Exception:
+                    logger.debug(
+                        "Failed to read Kubernetes sandbox exec exit code.",
+                        exc_info=True,
+                    )
+            if self._exit_code is None:
+                self._exit_code = 1
+            self._stdout_queue.put(_STREAM_END)
+            self._stderr_queue.put(_STREAM_END)
+            self._done.set()
+
+    @staticmethod
+    def _iter_queue(q: "queue.Queue[object]") -> Iterator[str]:
+        """Iterate queue items until sentinel is reached.
+
+        Args:
+            q: Queue of stream line items.
+
+        Yields:
+            Stream lines.
+        """
+        while True:
+            item = q.get()
+            if item is _STREAM_END:
+                break
+            yield cast(str, item)
+
+    def stdout(self) -> Iterator[str]:
+        """Stdout line iterator.
+
+        Returns:
+            Stdout line iterator.
+        """
+        return self._session._wrap_stream(
+            self._iter_queue(self._stdout_queue), log_level=logging.INFO
+        )
+
+    def stderr(self) -> Iterator[str]:
+        """Stderr line iterator.
+
+        Returns:
+            Stderr line iterator.
+        """
+        return self._session._wrap_stream(
+            self._iter_queue(self._stderr_queue), log_level=logging.ERROR
+        )
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        """Wait for command completion.
+
+        Args:
+            timeout: Timeout in seconds to wait.
+
+        Raises:
+            TimeoutError: If the command did not finish in time.
+
+        Returns:
+            The exit code.
+        """
+        if not self._done.wait(timeout):
+            raise TimeoutError(
+                "Timed out waiting for sandbox command to finish."
+            )
+        assert self._exit_code is not None
+        return self._exit_code
+
+    def kill(self) -> None:
+        """Terminate the running command stream."""
+        if not self._done.is_set():
+            try:
+                self._websocket_client.close()
+            except Exception as e:
+                logger.warning(
+                    "KubernetesSandbox kill() failed: %s. Command stream may "
+                    "still be active.",
+                    e,
+                    exc_info=True,
+                )
+
+    @property
+    def exit_code(self) -> Optional[int]:
+        """Exit code or `None` if still running.
+
+        Returns:
+            Exit code or `None`.
+        """
+        return self._exit_code
+
+
+class KubernetesSandboxSession(SandboxSession):
+    """Session for a Kubernetes-backed sandbox pod."""
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        pod_name: str,
+        namespace: str,
+        parent: "BaseSandbox",
+    ) -> None:
+        """Initialize a Kubernetes sandbox session.
+
+        Args:
+            id: Session identifier.
+            pod_name: Name of the backing Kubernetes pod.
+            namespace: Kubernetes namespace of the pod.
+            parent: The sandbox component that created this session.
+        """
+        self._pod_name = pod_name
+        self._namespace = namespace
+        super().__init__(id=id, parent=parent)
+
+    @property
+    def _core_api(self) -> k8s_client.CoreV1Api:
+        """Return Kubernetes Core API client.
+
+        Returns:
+            The CoreV1Api client.
+        """
+        sandbox = cast(KubernetesSandbox, self._parent)
+        return sandbox.core_api
+
+    @staticmethod
+    def _build_shell_command(
+        command: Union[str, List[str]],
+        cwd: Optional[str],
+        env: Optional[Dict[str, str]],
+    ) -> List[str]:
+        """Build shell command for pod exec with cwd/env handling.
+
+        Args:
+            command: Command to execute.
+            cwd: Optional working directory.
+            env: Optional environment variables.
+
+        Raises:
+            ValueError: If an `env` key is not a valid shell identifier.
+
+        Returns:
+            A shell command list suitable for Kubernetes pod exec.
+        """
+        if isinstance(command, list):
+            command_str = " ".join(shlex.quote(part) for part in command)
+        else:
+            command_str = command
+
+        if env:
+            for key in env:
+                if not _ENV_KEY_PATTERN.fullmatch(key):
+                    raise ValueError(
+                        f"Invalid environment variable name {key!r}: must "
+                        "match [A-Za-z_][A-Za-z0-9_]*."
+                    )
+            exports = "".join(
+                f"export {key}={shlex.quote(value)}; "
+                for key, value in env.items()
+            )
+            command_str = f"{exports}{command_str}"
+
+        if cwd:
+            # The group is terminated with a newline rather than `; }`: a
+            # raw string command ending in `#comment`, `;` or `&` would
+            # swallow or clash with `; }`, while a newline ends comments
+            # and is a valid command terminator in all cases.
+            command_str = f"cd {shlex.quote(cwd)} && {{ {command_str}\n}}"
+
+        return ["/bin/sh", "-c", command_str]
+
+    def _exec(
+        self,
+        command: Union[str, List[str]],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> SandboxProcess:
+        """Execute a command in the sandbox pod.
+
+        Args:
+            command: The command to execute.
+            cwd: Optional working directory override.
+            env: Optional environment variables to set in the command process.
+
+        Raises:
+            SandboxExecError: If command execution cannot be started.
+
+        Returns:
+            Process handle.
+        """
+        self._log_command(command)
+
+        exec_command = self._build_shell_command(
+            command=command, cwd=cwd, env=env
+        )
+        started_at = time.time()
+        try:
+            websocket_client = k8s_stream(
+                self._core_api.connect_get_namespaced_pod_exec,
+                self._pod_name,
+                self._namespace,
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+                _preload_content=False,
+            )
+        except Exception as e:
+            raise SandboxExecError(
+                f"Kubernetes sandbox execution failed to launch: {e}"
+            ) from e
+
+        return KubernetesSandboxProcess(
+            session=self,
+            websocket_client=websocket_client,
+            started_at=started_at,
+        )
+
+    def _close(self) -> None:
+        """Close session handle without terminating the pod."""
+
+    def _destroy(self) -> None:
+        """Delete the backing sandbox pod from Kubernetes."""
+        sandbox = cast(KubernetesSandbox, self._parent)
+        kube_utils.delete_pod(
+            core_api=self._core_api,
+            pod_name=self._pod_name,
+            namespace=self._namespace,
+            api_request_timeout=sandbox.config.api_request_timeout,
+        )
+
+
+class KubernetesSandbox(BaseSandbox):
+    """Kubernetes pod-backed sandbox."""
+
+    _k8s_client: Optional[k8s_client.ApiClient] = None
+
+    @property
+    def config(self) -> KubernetesSandboxConfig:
+        """Kubernetes sandbox configuration.
+
+        Returns:
+            The Kubernetes sandbox configuration.
+        """
+        return cast(KubernetesSandboxConfig, self._config)
+
+    @property
+    def settings_class(self) -> Optional[Type["BaseSettings"]]:
+        """Settings class.
+
+        Returns:
+            `KubernetesSandboxSettings`.
+        """
+        return KubernetesSandboxSettings
+
+    def get_kube_client(self) -> k8s_client.ApiClient:
+        """Get the Kubernetes API client.
+
+        Returns:
+            The Kubernetes API client.
+
+        Raises:
+            RuntimeError: If the service connector returns an unexpected client.
+        """
+        if self.config.incluster:
+            kube_utils.load_kube_config(incluster=True)
+            self._k8s_client = k8s_client.ApiClient()
+            return self._k8s_client
+
+        if self._k8s_client and not self.connector_has_expired():
+            return self._k8s_client
+
+        connector = self.get_connector()
+        if connector:
+            client = connector.connect()
+            if not isinstance(client, k8s_client.ApiClient):
+                raise RuntimeError(
+                    f"Expected a k8s_client.ApiClient while trying to use "
+                    f"the linked connector, but got {type(client)}."
+                )
+            self._k8s_client = client
+        else:
+            kube_utils.load_kube_config(
+                context=self.config.kubernetes_context,
+            )
+            self._k8s_client = k8s_client.ApiClient()
+
+        return self._k8s_client
+
+    @property
+    def core_api(self) -> k8s_client.CoreV1Api:
+        """Get the Kubernetes Core API client.
+
+        Returns:
+            The CoreV1Api client.
+        """
+        return k8s_client.CoreV1Api(self.get_kube_client())
+
+    def create_session(
+        self, settings: Optional[BaseSandboxSettings] = None
+    ) -> SandboxSession:
+        """Create a sandbox session backed by a Kubernetes pod.
+
+        Args:
+            settings: Optional settings overrides.
+
+        Raises:
+            Exception: If the sandbox pod fails to start.
+
+        Returns:
+            A Kubernetes sandbox session.
+        """
+        resolved_settings = cast(
+            KubernetesSandboxSettings, self.resolve_settings(settings)
+        )
+        session_id = f"k8s-{uuid.uuid4().hex[:12]}"
+        pod_name = kube_utils.sanitize_label(f"zenml-sandbox-{session_id}")
+        labels = {
+            "zenml-sandbox-id": kube_utils.sanitize_label_value(session_id),
+            "zenml-sandbox-component-id": kube_utils.sanitize_label_value(
+                str(self.id)
+            ),
+        }
+        env = self._resolve_session_environment(resolved_settings)
+        pod_manifest = build_pod_manifest(
+            pod_name=pod_name,
+            image_name=resolved_settings.image,
+            command=["/bin/sh", "-c"],
+            args=["while true; do sleep 30; done"],
+            privileged=resolved_settings.privileged,
+            pod_settings=resolved_settings.pod_settings,
+            service_account_name=resolved_settings.service_account_name,
+            env=env,
+            labels=labels,
+        )
+        if pod_manifest.spec is not None:
+            pod_manifest.spec.automount_service_account_token = (
+                resolved_settings.automount_service_account_token
+            )
+
+        kube_utils.create_pod(
+            core_api=self.core_api,
+            namespace=self.config.kubernetes_namespace,
+            pod_manifest=pod_manifest,
+            api_request_timeout=resolved_settings.api_request_timeout,
+        )
+
+        try:
+            kube_utils.wait_pod(
+                kube_client_fn=self.get_kube_client,
+                pod_name=pod_name,
+                namespace=self.config.kubernetes_namespace,
+                exit_condition_lambda=lambda pod: (
+                    pod.status is not None
+                    and pod.status.phase == kube_utils.PodPhase.RUNNING.value
+                ),
+                timeout_sec=resolved_settings.pod_startup_timeout,
+                api_request_timeout=resolved_settings.api_request_timeout,
+            )
+        except Exception:
+            try:
+                kube_utils.delete_pod(
+                    core_api=self.core_api,
+                    pod_name=pod_name,
+                    namespace=self.config.kubernetes_namespace,
+                    api_request_timeout=resolved_settings.api_request_timeout,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to clean up Kubernetes sandbox pod `%s` "
+                    "after startup failure.",
+                    pod_name,
+                    exc_info=True,
+                )
+            raise
+
+        return KubernetesSandboxSession(
+            id=session_id,
+            pod_name=pod_name,
+            namespace=self.config.kubernetes_namespace,
+            parent=self,
+        )
+
+    def attach(self, session_id: str) -> SandboxSession:
+        """Attach to a running sandbox session.
+
+        Args:
+            session_id: The ID of the running sandbox session.
+
+        Raises:
+            RuntimeError: If no pod exists for the session, the pod belongs
+                to a different sandbox component, or the pod is not running.
+
+        Returns:
+            A Kubernetes sandbox session.
+        """
+        pods = kube_utils.retry_on_api_exception(
+            self.core_api.list_namespaced_pod,
+            api_request_timeout=self.config.api_request_timeout,
+        )(
+            namespace=self.config.kubernetes_namespace,
+            label_selector=(
+                f"zenml-sandbox-id="
+                f"{kube_utils.sanitize_label_value(session_id)}"
+            ),
+        )
+        if not pods.items:
+            raise RuntimeError(
+                f"No sandbox pod found for session `{session_id}`."
+            )
+
+        pod = pods.items[0]
+        labels = pod.metadata.labels or {}
+        if labels.get(
+            "zenml-sandbox-component-id"
+        ) != kube_utils.sanitize_label_value(str(self.id)):
+            raise RuntimeError(
+                f"Sandbox pod for session `{session_id}` belongs to a "
+                "different sandbox component."
+            )
+
+        if (
+            pod.status is None
+            or pod.status.phase != kube_utils.PodPhase.RUNNING.value
+        ):
+            raise RuntimeError(
+                f"Sandbox pod for session `{session_id}` is not running."
+            )
+
+        return KubernetesSandboxSession(
+            id=session_id,
+            pod_name=pod.metadata.name,
+            namespace=self.config.kubernetes_namespace,
+            parent=self,
+        )

--- a/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
+++ b/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
@@ -54,6 +54,8 @@ _STREAM_BUFFER_MAX_LINES = 100_000
 # Characters per stdin frame during file uploads.
 _FILE_TRANSFER_CHUNK_CHARS = 1024 * 1024
 
+_FILE_UPLOAD_MAX_BYTES = 256 * 1024 * 1024
+
 
 def _split_lines_with_buffer(chunk: str, buffer: str) -> Tuple[List[str], str]:
     """Split a chunk into lines and remaining buffer.
@@ -304,17 +306,23 @@ class KubernetesSandboxSession(SandboxSession):
         """
         self._pod_name = pod_name
         self._namespace = namespace
+        self._core_api: Optional[k8s_client.CoreV1Api] = None
+        # `kubernetes.stream` swaps `ApiClient.request` in place during exec
+        # handshakes, so all calls on the client are serialized behind this lock.
+        self._client_lock = threading.Lock()
         super().__init__(id=id, parent=parent)
 
-    @property
-    def _core_api(self) -> k8s_client.CoreV1Api:
-        """Return Kubernetes Core API client.
+    def _get_core_api(self) -> k8s_client.CoreV1Api:
+        """Get the session-private Kubernetes Core API client.
 
         Returns:
             The CoreV1Api client.
         """
         sandbox = cast(KubernetesSandbox, self._parent)
-        return sandbox.core_api
+        if self._core_api is None or sandbox.connector_has_expired():
+            self._core_api = k8s_client.CoreV1Api(sandbox.build_kube_client())
+
+        return self._core_api
 
     @staticmethod
     def _build_shell_command(
@@ -409,17 +417,18 @@ class KubernetesSandboxSession(SandboxSession):
             The websocket client.
         """
         try:
-            return k8s_stream(
-                self._core_api.connect_get_namespaced_pod_exec,
-                self._pod_name,
-                self._namespace,
-                command=command,
-                stderr=True,
-                stdin=stdin,
-                stdout=True,
-                tty=False,
-                _preload_content=False,
-            )
+            with self._client_lock:
+                return k8s_stream(
+                    self._get_core_api().connect_get_namespaced_pod_exec,
+                    self._pod_name,
+                    self._namespace,
+                    command=command,
+                    stderr=True,
+                    stdin=stdin,
+                    stdout=True,
+                    tty=False,
+                    _preload_content=False,
+                )
         except Exception as e:
             raise SandboxExecError(
                 f"Kubernetes sandbox execution failed to launch: {e}"
@@ -440,20 +449,21 @@ class KubernetesSandboxSession(SandboxSession):
         Returns:
             The captured stdout.
         """
-        stdout = ""
-        stderr = ""
+        stdout_chunks: List[str] = []
+        stderr_chunks: List[str] = []
         for channel, chunk in _iter_stream_chunks(websocket_client):
             if channel == "stdout":
-                stdout += chunk
+                stdout_chunks.append(chunk)
             else:
-                stderr += chunk
+                stderr_chunks.append(chunk)
 
         if _read_exit_code(websocket_client) != 0:
+            stderr = "".join(stderr_chunks)
             raise SandboxExecError(
                 f"Kubernetes sandbox file transfer failed: {stderr.strip()}"
             )
 
-        return stdout
+        return "".join(stdout_chunks)
 
     def _upload_file(self, local_path: str, remote_path: str) -> None:
         """Upload a file to the sandbox pod.
@@ -461,7 +471,16 @@ class KubernetesSandboxSession(SandboxSession):
         Args:
             local_path: Path of the local file to upload.
             remote_path: Destination path in the sandbox pod.
+
+        Raises:
+            ValueError: If the file exceeds the upload size limit.
         """
+        if os.path.getsize(local_path) > _FILE_UPLOAD_MAX_BYTES:
+            raise ValueError(
+                f"File `{local_path}` exceeds the "
+                f"{_FILE_UPLOAD_MAX_BYTES} byte upload limit."
+            )
+
         # The file content is transferred base64-encoded because the
         # websocket client decodes frames as UTF-8, which corrupts raw
         # binary.
@@ -510,12 +529,13 @@ class KubernetesSandboxSession(SandboxSession):
     def _destroy(self) -> None:
         """Delete the backing sandbox pod from Kubernetes."""
         sandbox = cast(KubernetesSandbox, self._parent)
-        kube_utils.delete_pod(
-            core_api=self._core_api,
-            pod_name=self._pod_name,
-            namespace=self._namespace,
-            api_request_timeout=sandbox.config.api_request_timeout,
-        )
+        with self._client_lock:
+            kube_utils.delete_pod(
+                core_api=self._get_core_api(),
+                pod_name=self._pod_name,
+                namespace=self._namespace,
+                api_request_timeout=sandbox.config.api_request_timeout,
+            )
 
 
 class KubernetesSandbox(BaseSandbox):
@@ -541,8 +561,8 @@ class KubernetesSandbox(BaseSandbox):
         """
         return KubernetesSandboxSettings
 
-    def get_kube_client(self) -> k8s_client.ApiClient:
-        """Get the Kubernetes API client.
+    def build_kube_client(self) -> k8s_client.ApiClient:
+        """Build a new Kubernetes API client.
 
         Returns:
             The Kubernetes API client.
@@ -552,11 +572,7 @@ class KubernetesSandbox(BaseSandbox):
         """
         if self.config.incluster:
             kube_utils.load_kube_config(incluster=True)
-            self._k8s_client = k8s_client.ApiClient()
-            return self._k8s_client
-
-        if self._k8s_client and not self.connector_has_expired():
-            return self._k8s_client
+            return k8s_client.ApiClient()
 
         connector = self.get_connector()
         if connector:
@@ -566,12 +582,25 @@ class KubernetesSandbox(BaseSandbox):
                     f"Expected a k8s_client.ApiClient while trying to use "
                     f"the linked connector, but got {type(client)}."
                 )
-            self._k8s_client = client
-        else:
-            kube_utils.load_kube_config(
-                context=self.config.kubernetes_context,
-            )
-            self._k8s_client = k8s_client.ApiClient()
+
+            return client
+
+        kube_utils.load_kube_config(
+            context=self.config.kubernetes_context,
+        )
+
+        return k8s_client.ApiClient()
+
+    def get_kube_client(self) -> k8s_client.ApiClient:
+        """Get the cached Kubernetes API client.
+
+        Returns:
+            The Kubernetes API client.
+        """
+        if self._k8s_client and not self.connector_has_expired():
+            return self._k8s_client
+
+        self._k8s_client = self.build_kube_client()
 
         return self._k8s_client
 

--- a/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
+++ b/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
@@ -13,7 +13,10 @@
 #  permissions and limitations under the License.
 """Kubernetes sandbox implementation."""
 
+import base64
 import logging
+import os
+import posixpath
 import queue
 import re
 import shlex
@@ -45,10 +48,11 @@ _STREAM_END = object()
 # shell-identifier keys are safe there.
 _ENV_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# Per-stream line cap for the websocket drain queues. A caller that only
-# wait()s on a noisy command would otherwise grow these queues without
-# bound. Past the cap the oldest lines are dropped (logged once).
+# Per-stream line cap for the websocket drain queues.
 _STREAM_BUFFER_MAX_LINES = 100_000
+
+# Characters per stdin frame during file uploads.
+_FILE_TRANSFER_CHUNK_CHARS = 1024 * 1024
 
 
 def _split_lines_with_buffer(chunk: str, buffer: str) -> Tuple[List[str], str]:
@@ -66,6 +70,46 @@ def _split_lines_with_buffer(chunk: str, buffer: str) -> Tuple[List[str], str]:
     if lines and not lines[-1].endswith("\n"):
         return lines[:-1], lines[-1]
     return lines, ""
+
+
+def _iter_stream_chunks(
+    websocket_client: "k8s_stream.ws_client.WSClient",
+) -> Iterator[Tuple[str, str]]:
+    """Iterate output chunks of a websocket client until it closes.
+
+    Args:
+        websocket_client: The websocket client to read from.
+
+    Yields:
+        Tuples of channel name (`stdout` or `stderr`) and chunk.
+    """
+    while websocket_client.is_open():
+        websocket_client.update(timeout=1)
+        if websocket_client.peek_stdout():
+            yield "stdout", websocket_client.read_stdout()
+        if websocket_client.peek_stderr():
+            yield "stderr", websocket_client.read_stderr()
+
+
+def _read_exit_code(
+    websocket_client: "k8s_stream.ws_client.WSClient",
+) -> Optional[int]:
+    """Read the exec exit code from a closed websocket client.
+
+    Args:
+        websocket_client: The websocket client to read the exit code from.
+
+    Returns:
+        The exit code or `None` if it cannot be determined.
+    """
+    try:
+        return cast(Optional[int], websocket_client.returncode)
+    except Exception:
+        logger.debug(
+            "Failed to read Kubernetes sandbox exec exit code.",
+            exc_info=True,
+        )
+        return None
 
 
 class KubernetesSandboxProcess(SandboxProcess):
@@ -128,19 +172,16 @@ class KubernetesSandboxProcess(SandboxProcess):
         stdout_buffer = ""
         stderr_buffer = ""
         try:
-            while self._websocket_client.is_open():
-                self._websocket_client.update(timeout=1)
-                if self._websocket_client.peek_stdout():
-                    stdout_chunk = self._websocket_client.read_stdout()
+            for channel, chunk in _iter_stream_chunks(self._websocket_client):
+                if channel == "stdout":
                     lines, stdout_buffer = _split_lines_with_buffer(
-                        chunk=stdout_chunk, buffer=stdout_buffer
+                        chunk=chunk, buffer=stdout_buffer
                     )
                     for line in lines:
                         self._enqueue_line(self._stdout_queue, line)
-                if self._websocket_client.peek_stderr():
-                    stderr_chunk = self._websocket_client.read_stderr()
+                else:
                     lines, stderr_buffer = _split_lines_with_buffer(
-                        chunk=stderr_chunk, buffer=stderr_buffer
+                        chunk=chunk, buffer=stderr_buffer
                     )
                     for line in lines:
                         self._enqueue_line(self._stderr_queue, line)
@@ -157,13 +198,7 @@ class KubernetesSandboxProcess(SandboxProcess):
             if stderr_buffer:
                 self._enqueue_line(self._stderr_queue, stderr_buffer)
             if self._exit_code is None:
-                try:
-                    self._exit_code = self._websocket_client.returncode
-                except Exception:
-                    logger.debug(
-                        "Failed to read Kubernetes sandbox exec exit code.",
-                        exc_info=True,
-                    )
+                self._exit_code = _read_exit_code(self._websocket_client)
             if self._exit_code is None:
                 self._exit_code = 1
             self._stdout_queue.put(_STREAM_END)
@@ -341,9 +376,6 @@ class KubernetesSandboxSession(SandboxSession):
             cwd: Optional working directory override.
             env: Optional environment variables to set in the command process.
 
-        Raises:
-            SandboxExecError: If command execution cannot be started.
-
         Returns:
             Process handle.
         """
@@ -353,14 +385,37 @@ class KubernetesSandboxSession(SandboxSession):
             command=command, cwd=cwd, env=env
         )
         started_at = time.time()
+        websocket_client = self._open_exec_stream(command=exec_command)
+
+        return KubernetesSandboxProcess(
+            session=self,
+            websocket_client=websocket_client,
+            started_at=started_at,
+        )
+
+    def _open_exec_stream(
+        self, command: List[str], stdin: bool = False
+    ) -> "k8s_stream.ws_client.WSClient":
+        """Open a websocket exec stream in the sandbox pod.
+
+        Args:
+            command: Command to execute.
+            stdin: Whether to open a stdin channel.
+
+        Raises:
+            SandboxExecError: If command execution cannot be started.
+
+        Returns:
+            The websocket client.
+        """
         try:
-            websocket_client = k8s_stream(
+            return k8s_stream(
                 self._core_api.connect_get_namespaced_pod_exec,
                 self._pod_name,
                 self._namespace,
-                command=exec_command,
+                command=command,
                 stderr=True,
-                stdin=False,
+                stdin=stdin,
                 stdout=True,
                 tty=False,
                 _preload_content=False,
@@ -370,11 +425,84 @@ class KubernetesSandboxSession(SandboxSession):
                 f"Kubernetes sandbox execution failed to launch: {e}"
             ) from e
 
-        return KubernetesSandboxProcess(
-            session=self,
-            websocket_client=websocket_client,
-            started_at=started_at,
+    @staticmethod
+    def _collect_exec_output(
+        websocket_client: "k8s_stream.ws_client.WSClient",
+    ) -> str:
+        """Collect exec output until the command finishes.
+
+        Args:
+            websocket_client: The websocket client to drain.
+
+        Raises:
+            SandboxExecError: If the command fails.
+
+        Returns:
+            The captured stdout.
+        """
+        stdout = ""
+        stderr = ""
+        for channel, chunk in _iter_stream_chunks(websocket_client):
+            if channel == "stdout":
+                stdout += chunk
+            else:
+                stderr += chunk
+
+        if _read_exit_code(websocket_client) != 0:
+            raise SandboxExecError(
+                f"Kubernetes sandbox file transfer failed: {stderr.strip()}"
+            )
+
+        return stdout
+
+    def _upload_file(self, local_path: str, remote_path: str) -> None:
+        """Upload a file to the sandbox pod.
+
+        Args:
+            local_path: Path of the local file to upload.
+            remote_path: Destination path in the sandbox pod.
+        """
+        # The file content is transferred base64-encoded because the
+        # websocket client decodes frames as UTF-8, which corrupts raw
+        # binary.
+        with open(local_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("ascii")
+
+        # `head -c N` makes the remote pipeline exit after the exact encoded
+        # byte count, since the websocket client cannot signal stdin EOF.
+        parent_dir = posixpath.dirname(remote_path) or "."
+        script = (
+            f"mkdir -p {shlex.quote(parent_dir)} && "
+            f"head -c {len(encoded)} | base64 -d > {shlex.quote(remote_path)}"
         )
+        websocket_client = self._open_exec_stream(
+            command=["/bin/sh", "-c", script], stdin=True
+        )
+        for index in range(0, len(encoded), _FILE_TRANSFER_CHUNK_CHARS):
+            websocket_client.write_stdin(
+                encoded[index : index + _FILE_TRANSFER_CHUNK_CHARS]
+            )
+
+        self._collect_exec_output(websocket_client)
+
+    def _download_file(self, remote_path: str, local_path: str) -> None:
+        """Download a file from the sandbox pod.
+
+        Args:
+            remote_path: Path of the file in the sandbox pod.
+            local_path: Local destination path.
+        """
+        websocket_client = self._open_exec_stream(
+            command=["/bin/sh", "-c", f"base64 < {shlex.quote(remote_path)}"]
+        )
+        stdout = self._collect_exec_output(websocket_client)
+
+        local_dir = os.path.dirname(local_path)
+        if local_dir:
+            os.makedirs(local_dir, exist_ok=True)
+
+        with open(local_path, "wb") as f:
+            f.write(base64.b64decode(stdout))
 
     def _close(self) -> None:
         """Close session handle without terminating the pod."""

--- a/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
@@ -14,6 +14,7 @@
 """Tests for the Kubernetes sandbox."""
 
 import queue
+from pathlib import Path
 from typing import List, Optional
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -210,3 +211,99 @@ def test_attach_fails_for_non_running_pod() -> None:
 
     with pytest.raises(RuntimeError, match="is not running"):
         KubernetesSandbox.attach(sandbox, "k8s-abc")
+
+
+def _make_session(
+    sandbox: Optional[MagicMock] = None,
+) -> KubernetesSandboxSession:
+    if sandbox is None:
+        sandbox = _make_sandbox([])
+        sandbox.connector_has_expired.return_value = False
+        sandbox.build_kube_client.side_effect = lambda: MagicMock()
+
+    return KubernetesSandboxSession(
+        id="k8s-abc",
+        pod_name="zenml-sandbox-k8s-abc",
+        namespace="zenml",
+        parent=sandbox,
+    )
+
+
+def test_sessions_do_not_share_api_clients() -> None:
+    """Test that each session builds its own private API client."""
+    sandbox = _make_sandbox([])
+    sandbox.connector_has_expired.return_value = False
+    sandbox.build_kube_client.side_effect = lambda: MagicMock()
+    first = _make_session(sandbox)
+    second = _make_session(sandbox)
+
+    assert (
+        first._get_core_api().api_client
+        is not second._get_core_api().api_client
+    )
+
+
+def test_session_caches_api_client_until_connector_expires() -> None:
+    """Test that the session client is rebuilt once the connector expires."""
+    session = _make_session()
+    sandbox = session._parent
+
+    core_api = session._get_core_api()
+    assert session._get_core_api() is core_api
+
+    sandbox.connector_has_expired.return_value = True
+    assert session._get_core_api() is not core_api
+
+
+def test_upload_file_rejects_oversized_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that uploads larger than the upload limit are rejected."""
+    monkeypatch.setattr(kubernetes_sandbox, "_FILE_UPLOAD_MAX_BYTES", 4)
+    local_file = tmp_path / "payload.bin"
+    local_file.write_bytes(b"12345")
+    session = _make_session()
+
+    with pytest.raises(ValueError, match="upload limit"):
+        session._upload_file(str(local_file), "/remote/payload.bin")
+
+
+class _FakeWSClient:
+    """Websocket client stub yielding canned stdout chunks."""
+
+    def __init__(self, stdout_chunks: List[str], returncode: int = 0) -> None:
+        self._stdout_chunks = list(stdout_chunks)
+        self.returncode = returncode
+        self.closed = False
+
+    def is_open(self) -> bool:
+        return not self.closed and bool(self._stdout_chunks)
+
+    def update(self, timeout: Optional[int] = None) -> None:
+        pass
+
+    def peek_stdout(self) -> bool:
+        return bool(self._stdout_chunks)
+
+    def read_stdout(self) -> str:
+        return self._stdout_chunks.pop(0)
+
+    def peek_stderr(self) -> bool:
+        return False
+
+    def read_stderr(self) -> str:
+        return ""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_collect_exec_output_joins_chunks() -> None:
+    """Test that exec output chunks are joined into the full stdout."""
+    websocket_client = _FakeWSClient(["abc", "def"])
+
+    output = KubernetesSandboxSession._collect_exec_output(
+        websocket_client  # type: ignore[arg-type]
+    )
+
+    assert output == "abcdef"

--- a/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
@@ -1,0 +1,212 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the Kubernetes sandbox."""
+
+import queue
+from typing import List, Optional
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from kubernetes import client as k8s_client
+
+from zenml.integrations.kubernetes import kube_utils
+from zenml.integrations.kubernetes.sandboxes import kubernetes_sandbox
+from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+    KubernetesSandbox,
+    KubernetesSandboxProcess,
+    KubernetesSandboxSession,
+)
+
+
+def _build_script(
+    command,
+    cwd: Optional[str] = None,
+    env=None,
+) -> str:
+    shell_command = KubernetesSandboxSession._build_shell_command(
+        command, cwd, env
+    )
+    assert shell_command[:2] == ["/bin/sh", "-c"]
+    return shell_command[2]
+
+
+def test_build_shell_command_quotes_list_commands() -> None:
+    """Test that list commands are quoted argv-style."""
+    assert _build_script(["echo", "hello world"]) == "echo 'hello world'"
+
+
+def test_build_shell_command_passes_string_commands_through() -> None:
+    """Test that string commands are passed through unmodified."""
+    assert _build_script("echo $HOME && ls") == "echo $HOME && ls"
+
+
+def test_build_shell_command_cwd_uses_brace_group() -> None:
+    """Test that the cwd guard wraps the whole command in a brace group."""
+    assert _build_script("ls", cwd="/tmp") == "cd /tmp && { ls\n}"
+
+
+def test_build_shell_command_cwd_guard_covers_raw_separators() -> None:
+    """Test that raw `;` commands stay inside the cwd guard."""
+    assert _build_script("a; b", cwd="/work") == "cd /work && { a; b\n}"
+
+
+def test_build_shell_command_cwd_guard_survives_trailing_comment() -> None:
+    """Test that a trailing comment does not swallow the group close."""
+    assert (
+        _build_script("ls # comment", cwd="/tmp")
+        == "cd /tmp && { ls # comment\n}"
+    )
+
+
+def test_build_shell_command_prefixes_env_exports() -> None:
+    """Test that env vars are prepended as export statements."""
+    assert (
+        _build_script("env", env={"FOO": "bar baz"})
+        == "export FOO='bar baz'; env"
+    )
+
+
+def test_build_shell_command_env_inside_cwd_guard() -> None:
+    """Test that env exports are placed inside the cwd guard."""
+    assert (
+        _build_script("env", cwd="/tmp", env={"FOO": "bar baz"})
+        == "cd /tmp && { export FOO='bar baz'; env\n}"
+    )
+
+
+def test_build_shell_command_rejects_invalid_env_keys() -> None:
+    """Test that non-identifier env keys raise instead of being injected."""
+    with pytest.raises(ValueError, match="Invalid environment variable"):
+        _build_script("x", env={"A; whoami #": "v"})
+
+
+def test_split_lines_with_buffer_keeps_trailing_partial_line() -> None:
+    """Test that incomplete trailing lines are kept in the buffer."""
+    lines, buffer = kubernetes_sandbox._split_lines_with_buffer(
+        chunk="a\nb\nc", buffer=""
+    )
+    assert lines == ["a\n", "b\n"]
+    assert buffer == "c"
+
+    lines, buffer = kubernetes_sandbox._split_lines_with_buffer(
+        chunk="d\n", buffer=buffer
+    )
+    assert lines == ["cd\n"]
+    assert buffer == ""
+
+
+class _ClosedWSClient:
+    """Websocket client stub that is already closed."""
+
+    returncode = 0
+
+    def is_open(self) -> bool:
+        return False
+
+
+def test_enqueue_line_drops_oldest_past_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that the stream queues drop the oldest lines past the cap."""
+    monkeypatch.setattr(kubernetes_sandbox, "_STREAM_BUFFER_MAX_LINES", 3)
+    process = KubernetesSandboxProcess(
+        session=MagicMock(),
+        websocket_client=_ClosedWSClient(),  # type: ignore[arg-type]
+        started_at=0.0,
+    )
+
+    q: "queue.Queue[object]" = queue.Queue()
+    for i in range(5):
+        process._enqueue_line(q, f"line-{i}\n")
+
+    assert [q.get_nowait() for _ in range(q.qsize())] == [
+        "line-2\n",
+        "line-3\n",
+        "line-4\n",
+    ]
+
+
+def _session_pod(
+    session_id: str,
+    component_id: str,
+    phase: str = "Running",
+) -> k8s_client.V1Pod:
+    return k8s_client.V1Pod(
+        metadata=k8s_client.V1ObjectMeta(
+            name=f"zenml-sandbox-{session_id}",
+            labels={
+                "zenml-sandbox-id": kube_utils.sanitize_label_value(
+                    session_id
+                ),
+                "zenml-sandbox-component-id": (
+                    kube_utils.sanitize_label_value(component_id)
+                ),
+            },
+        ),
+        status=k8s_client.V1PodStatus(phase=phase),
+    )
+
+
+def _make_sandbox(pods: List[k8s_client.V1Pod]) -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.id = uuid4()
+    sandbox.config.kubernetes_namespace = "zenml"
+    sandbox.config.api_request_timeout = None
+    sandbox.core_api.list_namespaced_pod.return_value = k8s_client.V1PodList(
+        items=pods
+    )
+    return sandbox
+
+
+def test_attach_returns_session_for_running_pod() -> None:
+    """Test that attach returns a session handle for a running pod."""
+    sandbox = _make_sandbox([])
+    sandbox.core_api.list_namespaced_pod.return_value = k8s_client.V1PodList(
+        items=[_session_pod("k8s-abc", str(sandbox.id))]
+    )
+
+    session = KubernetesSandbox.attach(sandbox, "k8s-abc")
+
+    assert isinstance(session, KubernetesSandboxSession)
+    assert session.id == "k8s-abc"
+    assert session._pod_name == "zenml-sandbox-k8s-abc"
+    assert session._namespace == "zenml"
+
+
+def test_attach_fails_without_pod() -> None:
+    """Test that attach fails when no pod exists for the session."""
+    sandbox = _make_sandbox([])
+
+    with pytest.raises(RuntimeError, match="No sandbox pod found"):
+        KubernetesSandbox.attach(sandbox, "k8s-abc")
+
+
+def test_attach_fails_for_other_component() -> None:
+    """Test that attach rejects pods of a different sandbox component."""
+    sandbox = _make_sandbox([_session_pod("k8s-abc", str(uuid4()))])
+
+    with pytest.raises(RuntimeError, match="different sandbox component"):
+        KubernetesSandbox.attach(sandbox, "k8s-abc")
+
+
+def test_attach_fails_for_non_running_pod() -> None:
+    """Test that attach rejects pods that are not running."""
+    sandbox = _make_sandbox([])
+    sandbox.core_api.list_namespaced_pod.return_value = k8s_client.V1PodList(
+        items=[_session_pod("k8s-abc", str(sandbox.id), phase="Pending")]
+    )
+
+    with pytest.raises(RuntimeError, match="is not running"):
+        KubernetesSandbox.attach(sandbox, "k8s-abc")


### PR DESCRIPTION
This PR adds a `kubernetes` sandbox flavor that backs each sandbox session with a dedicated pod on a Kubernetes cluster. Sessions support streamed command execution and re-attaching to a running session via `attach(session_id)`.

**Example:**
```bash
zenml integration install kubernetes
zenml sandbox register k8s-sb --flavor=kubernetes --connector=<CONNECTOR_NAME>
zenml stack update --sandbox k8s-sb
```

**Limitations:**
- `snapshot()` / `restore()` and file upload/download are not supported.
- `kill()` only stops streaming output. The command keeps running until the pod is deleted.
- Session pod images must provide `/bin/sh`.
