### PR TITLE
Enforce update permissions for tag-resource endpoints

### DIFF
--- a/src/zenml/zen_server/routers/tag_resource_endpoints.py
+++ b/src/zenml/zen_server/routers/tag_resource_endpoints.py
@@ -26,6 +26,8 @@ from zenml.constants import (
 from zenml.models import TagResourceRequest, TagResourceResponse
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
+from zenml.zen_server.rbac.models import Action
+from zenml.zen_server.rbac.utils import batch_verify_permissions_for_models
 from zenml.zen_server.utils import (
     async_fastapi_endpoint_wrapper,
     zen_store,
@@ -36,6 +38,16 @@ router = APIRouter(
     tags=["tag_resources"],
     responses={401: error_response, 403: error_response},
 )
+
+
+def _verify_tag_resources_update_permission(
+    tag_resources: List[TagResourceRequest],
+) -> None:
+    """Verify update permission on all resources being tagged."""
+    resources = zen_store().get_resources_from_tag_resources(
+        tag_resources=tag_resources
+    )
+    batch_verify_permissions_for_models(models=resources, action=Action.UPDATE)
 
 
 @router.post(
@@ -55,6 +67,7 @@ def create_tag_resource(
     Returns:
         A tag resource response.
     """
+    _verify_tag_resources_update_permission(tag_resources=[tag_resource])
     return zen_store().create_tag_resource(tag_resource=tag_resource)
 
 
@@ -75,10 +88,8 @@ def batch_create_tag_resource(
     Returns:
         A list of tag resource responses.
     """
-    return [
-        zen_store().create_tag_resource(tag_resource=tag_resource)
-        for tag_resource in tag_resources
-    ]
+    _verify_tag_resources_update_permission(tag_resources=tag_resources)
+    return zen_store().batch_create_tag_resource(tag_resources=tag_resources)
 
 
 @router.delete(
@@ -95,6 +106,7 @@ def delete_tag_resource(
     Args:
         tag_resource: The tag resource relationship to delete.
     """
+    _verify_tag_resources_update_permission(tag_resources=[tag_resource])
     zen_store().delete_tag_resource(tag_resource=tag_resource)
 
 
@@ -112,4 +124,5 @@ def batch_delete_tag_resource(
     Args:
         tag_resources: A list of tag resource requests.
     """
+    _verify_tag_resources_update_permission(tag_resources=tag_resources)
     zen_store().batch_delete_tag_resource(tag_resources=tag_resources)

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -15205,6 +15205,74 @@ class SqlZenStore(BaseZenStore):
 
         return resource_type_to_schema_mapping[resource_type]
 
+    def _get_resources_from_tag_resources(
+        self,
+        tag_resources: List[TagResourceRequest],
+        session: Session,
+    ) -> List[BaseSchema]:
+        """Get resources referenced by tag resource requests in bulk.
+
+        Args:
+            tag_resources: The tag resource requests.
+            session: The database session to use.
+
+        Returns:
+            The resources referenced by the tag resource requests.
+
+        Raises:
+            KeyError: If a referenced resource does not exist.
+        """
+        resource_ids_by_type: Dict[TaggableResourceTypes, Set[UUID]] = (
+            defaultdict(set)
+        )
+        for tag_resource in tag_resources:
+            resource_ids_by_type[tag_resource.resource_type].add(
+                tag_resource.resource_id
+            )
+
+        resources_by_key: Dict[
+            Tuple[TaggableResourceTypes, UUID], BaseSchema
+        ] = {}
+        for resource_type, resource_ids in resource_ids_by_type.items():
+            schema_class = self._get_schema_from_resource_type(resource_type)
+            query = select(schema_class).where(
+                col(schema_class.id).in_(resource_ids)
+            )
+            resources = session.exec(query).all()
+            for resource in resources:
+                resources_by_key[(resource_type, resource.id)] = resource
+
+        resolved_resources: List[BaseSchema] = []
+        for tag_resource in tag_resources:
+            key = (tag_resource.resource_type, tag_resource.resource_id)
+            try:
+                resolved_resources.append(resources_by_key[key])
+            except KeyError:
+                raise KeyError(
+                    f"{tag_resource.resource_type.value} with ID "
+                    f"`{tag_resource.resource_id}` not found."
+                )
+
+        return resolved_resources
+
+    def get_resources_from_tag_resources(
+        self,
+        tag_resources: List[TagResourceRequest],
+    ) -> List[Any]:
+        """Get resource models referenced by tag resource requests in bulk.
+
+        Args:
+            tag_resources: The tag resource requests.
+
+        Returns:
+            The resource models referenced by the tag resource requests.
+        """
+        with Session(self.engine) as session:
+            resources = self._get_resources_from_tag_resources(
+                tag_resources=tag_resources, session=session
+            )
+            return [resource.to_model() for resource in resources]
+
     def _get_tag_schema(
         self,
         tag_name_or_id: Union[str, UUID],
@@ -15964,18 +16032,15 @@ class SqlZenStore(BaseZenStore):
             The newly created tag resource relationships.
         """
         with Session(self.engine) as session:
+            resolved_resources = self._get_resources_from_tag_resources(
+                tag_resources=tag_resources, session=session
+            )
             resources: List[
                 Tuple[TagSchema, TaggableResourceTypes, BaseSchema]
             ] = []
-            for tag_resource in tag_resources:
-                resource_schema = self._get_schema_from_resource_type(
-                    tag_resource.resource_type
-                )
-                resource = self._get_schema_by_id(
-                    resource_id=tag_resource.resource_id,
-                    schema_class=resource_schema,
-                    session=session,
-                )
+            for tag_resource, resource in zip(
+                tag_resources, resolved_resources
+            ):
                 tag_schema = self._get_tag_schema(
                     tag_name_or_id=tag_resource.tag_id,
                     session=session,

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -5624,6 +5624,41 @@ class TestTagResource:
             ]
         )
 
+    def test_batch_create_tag_resource_resolves_resources_in_bulk(
+        self, clean_client: "Client"
+    ):
+        """Tests batch tag resource creation resolves resources in bulk."""
+        if clean_client.zen_store.type != StoreType.SQL:
+            pytest.skip("Only SQL Zen Stores support tagging resources")
+
+        tag1 = clean_client.create_tag(name="foo1", color="red")
+        tag2 = clean_client.create_tag(name="foo2", color="green")
+        model1 = clean_client.create_model(name="bar1")
+        model2 = clean_client.create_model(name="bar2")
+
+        with patch.object(
+            clean_client.zen_store,
+            "_get_schema_by_id",
+            side_effect=AssertionError(
+                "Batch tag resource creation should not resolve resources "
+                "with individual get calls."
+            ),
+        ):
+            clean_client.zen_store.batch_create_tag_resource(
+                [
+                    TagResourceRequest(
+                        tag_id=tag1.id,
+                        resource_id=model1.id,
+                        resource_type=TaggableResourceTypes.MODEL,
+                    ),
+                    TagResourceRequest(
+                        tag_id=tag2.id,
+                        resource_id=model2.id,
+                        resource_type=TaggableResourceTypes.MODEL,
+                    ),
+                ]
+            )
+
     def test_delete_tag_resource_pass(self, clean_client: "Client"):
         """Tests deleting tag<>resource mapping pass."""
         if clean_client.zen_store.type != StoreType.SQL:

--- a/tests/unit/zen_server/test_tag_resource_rbac.py
+++ b/tests/unit/zen_server/test_tag_resource_rbac.py
@@ -1,0 +1,208 @@
+"""Tests for tag-resource RBAC enforcement."""
+
+import asyncio
+import logging
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+import zenml.zen_server.utils as zen_server_utils
+from zenml.client import Client
+from zenml.enums import TaggableResourceTypes
+from zenml.models import ModelRequest, TagRequest, UserRequest
+from zenml.zen_server.auth import AuthContext
+from zenml.zen_server.middleware import record_requests
+from zenml.zen_server.rbac.rbac_interface import RBACInterface
+from zenml.zen_server.routers import (
+    models_endpoints,
+    tag_resource_endpoints,
+)
+from zenml.zen_server.utils import (
+    cleanup_request_manager,
+    initialize_request_manager,
+    set_auth_context,
+)
+
+
+class DenyAllRBAC(RBACInterface):
+    """RBAC provider that denies every permission check."""
+
+    def check_permissions(self, user, resources, action):
+        """Deny permissions for all resources."""
+        return {resource: False for resource in resources}
+
+    def list_allowed_resource_ids(self, user, resource, action):
+        """Return no allowed resource IDs."""
+        return False, set()
+
+    def update_resource_membership(self, resource, member, role):
+        """No-op membership update."""
+        return None
+
+    def delete_resources(self, resources):
+        """No-op resource deletion hook."""
+        return None
+
+
+class AllowAllRBAC(RBACInterface):
+    """RBAC provider that allows every permission check."""
+
+    def check_permissions(self, user, resources, action):
+        """Allow permissions for all resources."""
+        return {resource: True for resource in resources}
+
+    def list_allowed_resource_ids(self, user, resource, action):
+        """Return all resource IDs as allowed."""
+        return True, set()
+
+    def update_resource_membership(self, resource, member, role):
+        """No-op membership update."""
+        return None
+
+    def delete_resources(self, resources):
+        """No-op resource deletion hook."""
+        return None
+
+
+async def _run_tag_resource_rbac_regression(client: Client) -> None:
+    previous_logging_disable = logging.root.manager.disable
+    previous_zen_store = zen_server_utils._zen_store
+    previous_rbac = zen_server_utils._rbac
+    server_cfg = zen_server_utils.server_config()
+    previous_rbac_source = server_cfg.rbac_implementation_source
+
+    logging.disable(logging.CRITICAL)
+    await initialize_request_manager()
+
+    try:
+        store = client.zen_store
+        zen_server_utils._zen_store = store
+        server_cfg.rbac_implementation_source = "local.test_rbac"
+
+        attacker = store.create_user(
+            UserRequest(
+                name="attacker_" + uuid4().hex[:8],
+                password="password-1234567890",
+                active=True,
+                is_admin=False,
+            )
+        )
+        project = store.get_project("default")
+        victim_model = store.create_model(
+            ModelRequest(
+                name="victim_model_" + uuid4().hex[:8],
+                project=project.id,
+            )
+        )
+        marker_tag = store.create_tag(
+            TagRequest(
+                name="attacker_marker_" + uuid4().hex[:8],
+                color="red",
+            )
+        )
+        tag_resource_body = {
+            "tag_id": str(marker_tag.id),
+            "resource_id": str(victim_model.id),
+            "resource_type": TaggableResourceTypes.MODEL.value,
+        }
+
+        app = FastAPI()
+        app.add_middleware(BaseHTTPMiddleware, dispatch=record_requests)
+        app.include_router(models_endpoints.router)
+        app.include_router(tag_resource_endpoints.router)
+
+        async def attacker_auth() -> AuthContext:
+            ctx = AuthContext(user=attacker)
+            set_auth_context(ctx)
+            current_request = (
+                zen_server_utils.request_manager().current_request
+            )
+            if current_request is not None:
+                current_request.auth_context = ctx
+            return ctx
+
+        app.dependency_overrides[models_endpoints.authorize] = attacker_auth
+        app.dependency_overrides[tag_resource_endpoints.authorize] = (
+            attacker_auth
+        )
+
+        http = TestClient(app)
+
+        zen_server_utils._rbac = DenyAllRBAC()
+        model_update = http.put(
+            f"/api/v1/models/{victim_model.id}",
+            json={"description": "attacker update should be denied"},
+        )
+        assert model_update.status_code == 403, model_update.text
+
+        denied_attach = http.post(
+            "/api/v1/tag_resources", json=tag_resource_body
+        )
+        assert denied_attach.status_code == 403, denied_attach.text
+        assert all(
+            tag.id != marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+
+        denied_batch_attach = http.post(
+            "/api/v1/tag_resources/batch", json=[tag_resource_body]
+        )
+        assert denied_batch_attach.status_code == 403, denied_batch_attach.text
+        assert all(
+            tag.id != marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+
+        zen_server_utils._rbac = AllowAllRBAC()
+        allowed_attach = http.post(
+            "/api/v1/tag_resources", json=tag_resource_body
+        )
+        assert allowed_attach.status_code == 200, allowed_attach.text
+        assert any(
+            tag.id == marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+
+        allowed_detach = http.request(
+            "DELETE", "/api/v1/tag_resources", json=tag_resource_body
+        )
+        assert allowed_detach.status_code == 200, allowed_detach.text
+        assert all(
+            tag.id != marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+
+        allowed_batch_attach = http.post(
+            "/api/v1/tag_resources/batch", json=[tag_resource_body]
+        )
+        assert allowed_batch_attach.status_code == 200, (
+            allowed_batch_attach.text
+        )
+        assert any(
+            tag.id == marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+
+        allowed_batch_detach = http.request(
+            "DELETE", "/api/v1/tag_resources/batch", json=[tag_resource_body]
+        )
+        assert allowed_batch_detach.status_code == 200, (
+            allowed_batch_detach.text
+        )
+        assert all(
+            tag.id != marker_tag.id
+            for tag in store.get_model(victim_model.id).tags
+        )
+    finally:
+        server_cfg.rbac_implementation_source = previous_rbac_source
+        zen_server_utils._zen_store = previous_zen_store
+        zen_server_utils._rbac = previous_rbac
+        logging.disable(previous_logging_disable)
+        await cleanup_request_manager()
+
+
+def test_tag_resource_requires_update_permission(clean_client: Client) -> None:
+    """Tag attach/detach requires UPDATE on the referenced resource."""
+    asyncio.run(_run_tag_resource_rbac_regression(clean_client))


### PR DESCRIPTION
## Summary
- require UPDATE permission on the referenced resource before creating or deleting tag-resource relationships
- apply the check to single and batch tag-resource endpoints
- add a regression test covering denied and allowed RBAC paths

## Tests
- python -m pytest tests/unit/zen_server/test_tag_resource_rbac.py -q
- python -m pytest tests/integration/functional/zen_stores/test_zen_store.py::TestTagResource -q
- python -m ruff check src/zenml/zen_server/routers/tag_resource_endpoints.py tests/unit/zen_server/test_tag_resource_rbac.py
- python -m ruff format --check src/zenml/zen_server/routers/tag_resource_endpoints.py tests/unit/zen_server/test_tag_resource_rbac.py
- git diff --check