### PR TITLE
Fix IndexError for bare list step input annotations

### DIFF
--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -542,9 +542,17 @@ class StepRunner:
                         pass
                     elif issubclass(arg_type, (list, tuple)):
                         assert annotation
-                        item_arg_type = get_args(annotation)[0]
-                        item_arg_type = resolve_type_annotation(item_arg_type)
                         collection_type = arg_type
+                        type_args = get_args(annotation)
+                        if type_args:
+                            item_arg_type = resolve_type_annotation(
+                                type_args[0]
+                            )
+                        else:
+                            # Bare `list` or `tuple` annotation without type
+                            # arguments, load each item using the data type
+                            # stored with the artifact.
+                            item_arg_type = Any
                     else:
                         raise StepInterfaceError(
                             "Passing multiple artifacts to a step is only "

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -122,6 +122,22 @@ def test_step_with_single_artifact_list_input_works() -> None:
         pipeline_with_single_artifact_list_input()
 
 
+@step
+def bare_list_consumer(input_: list) -> None:
+    assert input_ == [1, 1]
+
+
+@pipeline(enable_cache=False, dynamic=True)
+def pipeline_with_bare_list_input() -> None:
+    bare_list_consumer([producer(), producer()])
+
+
+def test_step_with_bare_list_input_annotation_works() -> None:
+    """Tests that a step input annotated with bare `list` works."""
+    with does_not_raise():
+        pipeline_with_bare_list_input()
+
+
 def test_replay_skips_first_step_and_overrides_second_step_input():
     """Tests that replaying a pipeline and overriding step inputs works."""
     original_run = replay_pipeline(expected_consumer_input=1)


### PR DESCRIPTION
Step inputs annotated with bare `list` or `tuple` crashed with an `IndexError` when receiving multiple input artifacts, because `typing.get_args` returns an empty tuple for annotations without type arguments. Each artifact in the collection is now loaded using the data type stored with the artifact, same as for inputs annotated with `Any` or without annotation.

Fixes #4881