### PR TITLE
Fix the GCP service connector DNS endpoint access

### DIFF
--- a/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
+++ b/src/zenml/integrations/gcp/service_connectors/gcp_service_connector.py
@@ -2238,12 +2238,21 @@ class GCPServiceConnector(ServiceConnector):
             if dns_endpoint_config:
                 dns_host = dns_endpoint_config.endpoint.strip()
                 if dns_host:
+                    if dns_endpoint_config.allow_external_traffic:
+                        logger.debug(
+                            "Using GKE DNS control plane endpoint for Kubernetes API "
+                            "access: %s instead of IP-based endpoint: %s",
+                            dns_host,
+                            cluster.endpoint.strip(),
+                        )
+                        return f"https://{dns_host}", None
+
                     logger.debug(
-                        "Using GKE DNS control plane endpoint for Kubernetes API "
-                        "access: %s",
+                        "Skipping GKE DNS control plane endpoint for Kubernetes "
+                        "API access because it does not allow external/user "
+                        "traffic: %s",
                         dns_host,
                     )
-                    return f"https://{dns_host}", None
 
         ip_endpoint = cluster.endpoint.strip()
         if not ip_endpoint:

--- a/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
+++ b/tests/unit/integrations/gcp/test_gke_kubernetes_api_endpoint.py
@@ -15,6 +15,7 @@ def _cluster(
     endpoint: str = "10.0.0.1",
     cluster_ca: str = "Y2x1c3Rlci1jYQ==",
     dns_endpoint: str | None = None,
+    allow_external_traffic: bool = False,
 ) -> GKECluster:
     cluster = GKECluster(
         endpoint=endpoint,
@@ -23,14 +24,16 @@ def _cluster(
     if dns_endpoint is not None:
         dns_config = cluster.control_plane_endpoints_config.dns_endpoint_config
         dns_config.endpoint = dns_endpoint
+        dns_config.allow_external_traffic = allow_external_traffic
     return cluster
 
 
 def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
-    """Prefers the DNS endpoint whenever GKE exposes a DNS hostname."""
+    """Prefers the DNS endpoint when it allows external/user traffic."""
     cluster = _cluster(
         endpoint="10.128.0.13",
         dns_endpoint="gke-abc-123.europe-west4.gke.goog",
+        allow_external_traffic=True,
     )
 
     server, ca_cert = (
@@ -39,6 +42,23 @@ def test_prefers_dns_endpoint_over_ip_endpoint() -> None:
 
     assert server == "https://gke-abc-123.europe-west4.gke.goog"
     assert ca_cert is None
+
+
+def test_falls_back_to_ip_endpoint_when_dns_blocks_external_traffic() -> None:
+    """Falls back to the IP endpoint when DNS blocks user traffic."""
+    cluster = _cluster(
+        endpoint="10.128.0.13",
+        cluster_ca="Y2E=",
+        dns_endpoint="gke-abc-123.europe-west4.gke.goog",
+        allow_external_traffic=False,
+    )
+
+    server, ca_cert = (
+        GCPServiceConnector._resolve_gke_kubernetes_api_connection(cluster)
+    )
+
+    assert server == "https://10.128.0.13"
+    assert ca_cert == "Y2E="
 
 
 def test_falls_back_to_ip_endpoint_without_dns() -> None:


### PR DESCRIPTION
**Summary**

Fix GKE Kubernetes API endpoint selection in the GCP service connector.

The connector was using the GKE DNS control plane endpoint whenever a DNS hostname was present. However, GKE may expose a DNS endpoint while still blocking user/external traffic to it via `dnsEndpointConfig.allowExternalTraffic=false`. In that case, the DNS endpoint can return a Google-level `403 Forbidden`, even though the IP-based cluster endpoint is still usable.

This change only uses the DNS endpoint when `allow_external_traffic` is enabled. If the DNS endpoint exists but does not allow external/user traffic, the connector falls back to the IP-based endpoint and cluster CA.

**Changes**

- Check `dns_endpoint_config.allow_external_traffic` before using the GKE DNS control plane endpoint.
- Fall back to the IP-based endpoint when DNS user traffic is not allowed.
- Add unit test coverage for DNS-present-but-blocked behavior.
- Update the existing DNS preference test to explicitly enable external DNS traffic.

**Why**

This preserves the intended DNS endpoint support for clusters configured to allow it, while avoiding regressions for clusters where the DNS hostname exists but is not usable by ZenML clients.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

