### PR TITLE
Fix local sandbox unit tests on Windows

### DIFF
--- a/src/zenml/sandboxes/local_sandbox.py
+++ b/src/zenml/sandboxes/local_sandbox.py
@@ -49,6 +49,27 @@ DEFAULT_FORWARDED_ENV_VARS = [
     "TERM",
 ]
 
+# Variables the host OS needs to launch a child process at all, injected
+# beneath the user's `forward_env` selection rather than gated behind it.
+# On Windows a child interpreter started without SYSTEMROOT aborts during
+# pre-init ("failed to get random numbers to initialize Python"), so a
+# curated forward list (which never includes OS plumbing) would otherwise
+# break every exec.
+_OS_REQUIRED_ENV_VARS = ["SYSTEMROOT"] if os.name == "nt" else []
+
+
+def _os_required_env() -> Dict[str, str]:
+    """Collect the host-OS variables required to launch any subprocess.
+
+    Returns:
+        The required OS environment variables present in the parent process.
+    """
+    return {
+        key: os.environ[key]
+        for key in _OS_REQUIRED_ENV_VARS
+        if key in os.environ
+    }
+
 
 class LocalSandboxSettings(BaseSandboxSettings):
     """Local sandbox settings."""
@@ -246,6 +267,7 @@ class LocalSandboxSession(SandboxSession):
             effective_cwd = os.path.join(self._workdir, cwd)
 
         env = {
+            **_os_required_env(),
             **self._env,
             **(env or {}),
         }

--- a/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
+++ b/tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py
@@ -55,7 +55,7 @@ def test_build_shell_command_passes_string_commands_through() -> None:
 
 def test_build_shell_command_cwd_uses_brace_group() -> None:
     """Test that the cwd guard wraps the whole command in a brace group."""
-    assert _build_script("ls", cwd="/tmp") == "cd /tmp && { ls\n}"
+    assert _build_script("ls", cwd="/work") == "cd /work && { ls\n}"
 
 
 def test_build_shell_command_cwd_guard_covers_raw_separators() -> None:
@@ -66,8 +66,8 @@ def test_build_shell_command_cwd_guard_covers_raw_separators() -> None:
 def test_build_shell_command_cwd_guard_survives_trailing_comment() -> None:
     """Test that a trailing comment does not swallow the group close."""
     assert (
-        _build_script("ls # comment", cwd="/tmp")
-        == "cd /tmp && { ls # comment\n}"
+        _build_script("ls # comment", cwd="/work")
+        == "cd /work && { ls # comment\n}"
     )
 
 
@@ -82,8 +82,8 @@ def test_build_shell_command_prefixes_env_exports() -> None:
 def test_build_shell_command_env_inside_cwd_guard() -> None:
     """Test that env exports are placed inside the cwd guard."""
     assert (
-        _build_script("env", cwd="/tmp", env={"FOO": "bar baz"})
-        == "cd /tmp && { export FOO='bar baz'; env\n}"
+        _build_script("env", cwd="/work", env={"FOO": "bar baz"})
+        == "cd /work && { export FOO='bar baz'; env\n}"
     )
 
 

--- a/tests/unit/sandboxes/test_local_sandbox.py
+++ b/tests/unit/sandboxes/test_local_sandbox.py
@@ -32,6 +32,9 @@ from zenml.sandboxes import (
     SandboxSessionClosedError,
 )
 
+# Portable long-running child (the `sleep` binary is POSIX-only).
+_LONG_RUNNING_CMD = [sys.executable, "-c", "import time; time.sleep(3600)"]
+
 
 def _make_local_sandbox(
     *,
@@ -140,6 +143,10 @@ class TestExec:
         finally:
             session.close()
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX shlex splitting mangles the Windows exe path",
+    )
     def test_string_command_is_shell_split(self) -> None:
         session = _make_local_sandbox().create_session()
         try:
@@ -369,7 +376,7 @@ class TestCloseAndDestroy:
         # A long-running child must not outlive the session: close()
         # terminates anything exec() spawned that is still alive.
         session = _make_local_sandbox().create_session()
-        proc = session.exec(["sleep", "3600"])
+        proc = session.exec(_LONG_RUNNING_CMD)
         popen = proc._process  # type: ignore[attr-defined]
         assert popen.poll() is None
         session.close()
@@ -399,7 +406,7 @@ class TestNoFdLeakAcrossExecs:
     def test_exec_keeps_running_processes_tracked(self) -> None:
         sandbox = _make_local_sandbox()
         with sandbox.create_session() as session:
-            running = session.exec(["sleep", "3600"])
+            running = session.exec(_LONG_RUNNING_CMD)
             running_popen = running._process  # type: ignore[attr-defined]
             session.exec([sys.executable, "-c", "pass"]).collect()
             assert running_popen in session._processes  # type: ignore[attr-defined]


### PR DESCRIPTION
The sandbox core (#4866) merged with a `windows-latest` unit-test lane that goes red on `tests/unit/sandboxes/test_local_sandbox.py`. There are two distinct causes — one a **real product bug**, one POSIX-only test assumptions.

## Product bug: local sandbox is broken on Windows (`SYSTEMROOT`)

`LocalSandbox` launches every subprocess with a curated environment (the user's `forward_env` selection, default `PATH/HOME/LANG/LC_ALL/TMPDIR/TERM`). On Windows that set omits `SYSTEMROOT`, and a child Python interpreter started without it aborts during pre-init:

```
Fatal Python error: _Py_HashRandomization_Init: failed to get random numbers to initialize Python
```

So **every** `exec` returned exit code 1 with empty stdout — the local sandbox was unusable on Windows for any forwarded-env command, not just in tests. This was the real cause of 11 failing tests (`exit_code == 0` getting 1, `wait() == 3` getting 1, empty `stdout`, the env-propagation cases). Verified directly against a native Windows interpreter: with the stripped env the child dies as above; adding `SYSTEMROOT` → exit 0, correct stdout.

The fix injects the OS-required variables **beneath** `forward_env` at the `Popen` boundary, so user-selected env and per-exec overrides still win, and `forward_env=False` semantics are unchanged on POSIX (the list is empty off-Windows). Kept minimal to the one variable empirically required for the interpreter to start.

## POSIX-only test assumptions

- `test_close_terminates_running_processes` / `test_exec_keeps_running_processes_tracked` spawned `["sleep", "3600"]` — no `sleep` binary on Windows, so `Popen` raises `FileNotFoundError`. They now spawn a portable Python sleep (`_LONG_RUNNING_CMD`), keeping the tests running on Windows rather than skipping. (These previously appeared to "pass" only because nothing asserted the child stayed alive — the `SYSTEMROOT` bug killed it instantly.)
- `test_string_command_is_shell_split` builds `f"{sys.executable} -c ..."` and relies on `shlex.split` (POSIX mode), which mangles the backslashes in a Windows `C:\...\python.exe` path. Skipped on Windows — the string-command path is POSIX-shell semantics by design; the list form is the cross-platform API.

The `/proc/self/fd` fd-count test was already correctly guarded with `pytest.skip`.

## Also: unblock slow CI (Bandit B108)

While bringing this branch up to date with `develop`, slow CI (`small-checks`) goes red on a Bandit **B108 hardcoded_tmp_directory** finding that is **not** from this PR — it came in via the Kubernetes sandbox PR #4926 (cc @schustmi). `tests/unit/integrations/kubernetes/test_kubernetes_sandbox.py` asserts the cwd-prefixing of `_build_script` using a literal `/tmp`, and `small-checks` runs `bandit -ll` (fail on Medium+), so it reddens slow CI on every branch that includes the file.

The cwd value is arbitrary to those assertions, so this switches `/tmp` → `/work` — the same non-flagged path the file already uses in `test_build_shell_command_cwd_guard_covers_raw_separators`. No `# nosec` noise; the test still passes and Bandit is clean on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
