### PR TITLE
Improved tag resource RBAC checks and consistent RBAC access to tags

### DIFF
--- a/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
+++ b/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
@@ -14,16 +14,12 @@
 """RBAC SQL Zen Store implementation."""
 
 from typing import (
-    TYPE_CHECKING,
     List,
     Optional,
-    Sequence,
-    Set,
     Tuple,
 )
 from uuid import UUID
 
-from zenml.enums import TaggableResourceTypes
 from zenml.logger import get_logger
 from zenml.models import (
     ModelRequest,
@@ -37,80 +33,19 @@ from zenml.zen_server.feature_gate.endpoint_utils import (
     check_entitlement,
     report_usage,
 )
-from zenml.zen_server.rbac.models import Action, Resource, ResourceType
+from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import (
-    batch_verify_permissions,
+    batch_verify_permissions_for_schemas,
     verify_permission,
     verify_permission_for_model,
 )
-from zenml.zen_server.utils import get_auth_context
 from zenml.zen_stores.sql_zen_store import Session, SqlZenStore
-
-if TYPE_CHECKING:
-    from zenml.zen_stores.schemas import BaseSchema
-
 
 logger = get_logger(__name__)
 
 
 class RBACSqlZenStore(SqlZenStore):
     """Wrapper around the SQLZenStore that implements RBAC functionality."""
-
-    def _get_rbac_resource_type_for_taggable_resource_type(
-        self, resource_type: TaggableResourceTypes
-    ) -> ResourceType:
-        """Get the RBAC resource type for a taggable resource type.
-
-        Args:
-            resource_type: The taggable resource type.
-
-        Returns:
-            The corresponding RBAC resource type.
-        """
-        if resource_type == TaggableResourceTypes.PIPELINE_SNAPSHOT:
-            return ResourceType.PIPELINE_SNAPSHOT
-
-        return ResourceType(resource_type.value)
-
-    def _get_rbac_resources_from_tag_resources(
-        self,
-        tag_resources: List[TagResourceRequest],
-        resolved_resources: Sequence["BaseSchema"],
-    ) -> Set[Resource]:
-        """Get RBAC resources referenced by tag resource requests in bulk.
-
-        Args:
-            tag_resources: The tag resource requests.
-            resolved_resources: The resources referenced by the tag resource
-                requests.
-
-        Returns:
-            The RBAC resources referenced by the tag resource requests.
-        """
-        auth_context = get_auth_context()
-        assert auth_context
-        authenticated_user_id = auth_context.user.id
-
-        resources = set()
-        for tag_resource, resource in zip(tag_resources, resolved_resources):
-            user_id = getattr(resource, "user_id", None)
-            if not user_id or user_id == authenticated_user_id:
-                continue
-
-            rbac_resource_type = (
-                self._get_rbac_resource_type_for_taggable_resource_type(
-                    tag_resource.resource_type
-                )
-            )
-            resources.add(
-                Resource(
-                    type=rbac_resource_type,
-                    id=resource.id,
-                    project_id=getattr(resource, "project_id"),
-                )
-            )
-
-        return resources
 
     def batch_create_tag_resource(
         self, tag_resources: List[TagResourceRequest]
@@ -127,11 +62,9 @@ class RBACSqlZenStore(SqlZenStore):
             resolved_resources = self._get_resources_from_tag_resources(
                 tag_resources=tag_resources, session=session
             )
-            resources = self._get_rbac_resources_from_tag_resources(
-                tag_resources=tag_resources,
-                resolved_resources=resolved_resources,
+            batch_verify_permissions_for_schemas(
+                schemas=resolved_resources, action=Action.UPDATE
             )
-            batch_verify_permissions(resources=resources, action=Action.UPDATE)
 
             return self._batch_create_tag_resource(
                 tag_resources=tag_resources,
@@ -151,11 +84,9 @@ class RBACSqlZenStore(SqlZenStore):
             resolved_resources = self._get_resources_from_tag_resources(
                 tag_resources=tag_resources, session=session
             )
-            resources = self._get_rbac_resources_from_tag_resources(
-                tag_resources=tag_resources,
-                resolved_resources=resolved_resources,
+            batch_verify_permissions_for_schemas(
+                schemas=resolved_resources, action=Action.UPDATE
             )
-            batch_verify_permissions(resources=resources, action=Action.UPDATE)
 
             self._delete_tag_resource_schemas(
                 tag_resources=tag_resources,

--- a/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
+++ b/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
@@ -43,10 +43,12 @@ from zenml.zen_server.rbac.utils import (
     verify_permission,
     verify_permission_for_model,
 )
+from zenml.zen_server.utils import get_auth_context
 from zenml.zen_stores.sql_zen_store import Session, SqlZenStore
 
 if TYPE_CHECKING:
     from zenml.zen_stores.schemas import BaseSchema
+
 
 logger = get_logger(__name__)
 
@@ -85,8 +87,16 @@ class RBACSqlZenStore(SqlZenStore):
         Returns:
             The RBAC resources referenced by the tag resource requests.
         """
+        auth_context = get_auth_context()
+        assert auth_context
+        authenticated_user_id = auth_context.user.id
+
         resources = set()
         for tag_resource, resource in zip(tag_resources, resolved_resources):
+            user_id = getattr(resource, "user_id", None)
+            if not user_id or user_id == authenticated_user_id:
+                continue
+
             rbac_resource_type = (
                 self._get_rbac_resource_type_for_taggable_resource_type(
                     tag_resource.resource_type

--- a/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
+++ b/src/zenml/zen_server/rbac/rbac_sql_zen_store.py
@@ -14,34 +14,143 @@
 """RBAC SQL Zen Store implementation."""
 
 from typing import (
+    TYPE_CHECKING,
+    List,
     Optional,
+    Sequence,
+    Set,
     Tuple,
 )
 from uuid import UUID
 
+from zenml.enums import TaggableResourceTypes
 from zenml.logger import get_logger
 from zenml.models import (
     ModelRequest,
     ModelResponse,
     ModelVersionRequest,
     ModelVersionResponse,
+    TagResourceRequest,
+    TagResourceResponse,
 )
 from zenml.zen_server.feature_gate.endpoint_utils import (
     check_entitlement,
     report_usage,
 )
-from zenml.zen_server.rbac.models import Action, ResourceType
+from zenml.zen_server.rbac.models import Action, Resource, ResourceType
 from zenml.zen_server.rbac.utils import (
+    batch_verify_permissions,
     verify_permission,
     verify_permission_for_model,
 )
-from zenml.zen_stores.sql_zen_store import SqlZenStore
+from zenml.zen_stores.sql_zen_store import Session, SqlZenStore
+
+if TYPE_CHECKING:
+    from zenml.zen_stores.schemas import BaseSchema
 
 logger = get_logger(__name__)
 
 
 class RBACSqlZenStore(SqlZenStore):
     """Wrapper around the SQLZenStore that implements RBAC functionality."""
+
+    def _get_rbac_resource_type_for_taggable_resource_type(
+        self, resource_type: TaggableResourceTypes
+    ) -> ResourceType:
+        """Get the RBAC resource type for a taggable resource type.
+
+        Args:
+            resource_type: The taggable resource type.
+
+        Returns:
+            The corresponding RBAC resource type.
+        """
+        if resource_type == TaggableResourceTypes.PIPELINE_SNAPSHOT:
+            return ResourceType.PIPELINE_SNAPSHOT
+
+        return ResourceType(resource_type.value)
+
+    def _get_rbac_resources_from_tag_resources(
+        self,
+        tag_resources: List[TagResourceRequest],
+        resolved_resources: Sequence["BaseSchema"],
+    ) -> Set[Resource]:
+        """Get RBAC resources referenced by tag resource requests in bulk.
+
+        Args:
+            tag_resources: The tag resource requests.
+            resolved_resources: The resources referenced by the tag resource
+                requests.
+
+        Returns:
+            The RBAC resources referenced by the tag resource requests.
+        """
+        resources = set()
+        for tag_resource, resource in zip(tag_resources, resolved_resources):
+            rbac_resource_type = (
+                self._get_rbac_resource_type_for_taggable_resource_type(
+                    tag_resource.resource_type
+                )
+            )
+            resources.add(
+                Resource(
+                    type=rbac_resource_type,
+                    id=resource.id,
+                    project_id=getattr(resource, "project_id"),
+                )
+            )
+
+        return resources
+
+    def batch_create_tag_resource(
+        self, tag_resources: List[TagResourceRequest]
+    ) -> List[TagResourceResponse]:
+        """Create a batch of tag resource relationships.
+
+        Args:
+            tag_resources: The tag resource relationships to be created.
+
+        Returns:
+            The newly created tag resource relationships.
+        """
+        with Session(self.engine) as session:
+            resolved_resources = self._get_resources_from_tag_resources(
+                tag_resources=tag_resources, session=session
+            )
+            resources = self._get_rbac_resources_from_tag_resources(
+                tag_resources=tag_resources,
+                resolved_resources=resolved_resources,
+            )
+            batch_verify_permissions(resources=resources, action=Action.UPDATE)
+
+            return self._batch_create_tag_resource(
+                tag_resources=tag_resources,
+                resolved_resources=resolved_resources,
+                session=session,
+            )
+
+    def batch_delete_tag_resource(
+        self, tag_resources: List[TagResourceRequest]
+    ) -> None:
+        """Delete a batch of tag resource relationships.
+
+        Args:
+            tag_resources: The tag resource relationships to be deleted.
+        """
+        with Session(self.engine) as session:
+            resolved_resources = self._get_resources_from_tag_resources(
+                tag_resources=tag_resources, session=session
+            )
+            resources = self._get_rbac_resources_from_tag_resources(
+                tag_resources=tag_resources,
+                resolved_resources=resolved_resources,
+            )
+            batch_verify_permissions(resources=resources, action=Action.UPDATE)
+
+            self._delete_tag_resource_schemas(
+                tag_resources=tag_resources,
+                session=session,
+            )
 
     def _get_or_create_model(
         self, model_request: ModelRequest

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -23,6 +23,7 @@ from typing import (
     Set,
     Type,
     TypeVar,
+    Union,
 )
 from uuid import UUID
 
@@ -158,9 +159,7 @@ def _dehydrate_value(
 
         has_permissions = (permissions or {}).get(resource)
 
-        if has_permissions or is_owned_by_authenticated_user(
-            model=permission_model
-        ):
+        if has_permissions or is_owned_by_authenticated_user(permission_model):
             return dehydrate_response_model(value, permissions=permissions)
 
         if has_permissions is None:
@@ -256,6 +255,36 @@ def batch_verify_permissions_for_models(
 
         if resource := get_resource_for_model(permission_model):
             resources.add(resource)
+
+    batch_verify_permissions(resources=resources, action=action)
+
+
+def batch_verify_permissions_for_schemas(
+    schemas: Sequence["BaseSchema"],
+    action: Action,
+) -> None:
+    """Batch permission verification for schemas.
+
+    Args:
+        schemas: The schemas the user wants to perform the action on.
+        action: The action the user wants to perform.
+    """
+    if not server_config().rbac_enabled:
+        return
+
+    resources = set()
+    for schema in schemas:
+        if is_owned_by_authenticated_user(schema):
+            continue
+
+        if resource_type := get_resource_type_for_schema(schema):
+            resources.add(
+                Resource(
+                    type=resource_type,
+                    id=schema.id,
+                    project_id=getattr(schema, "project_id", None),
+                )
+            )
 
     batch_verify_permissions(resources=resources, action=action)
 
@@ -557,27 +586,35 @@ def get_resource_type_for_model(
     return mapping.get(type(model))
 
 
-def is_owned_by_authenticated_user(model: AnyModel) -> bool:
-    """Returns whether the currently authenticated user owns the model.
+def is_owned_by_authenticated_user(
+    resource: Union[AnyModel, "BaseSchema"],
+) -> bool:
+    """Returns whether the currently authenticated user owns the resource.
 
     Args:
-        model: The model for which to check the ownership.
+        resource: The model or schema for which to check the ownership.
 
     Returns:
-        Whether the currently authenticated user owns the model.
+        Whether the currently authenticated user owns the resource.
     """
     auth_context = get_auth_context()
     assert auth_context
 
-    if isinstance(model, UserScopedResponse):
-        if model.user_id:
-            return model.user_id == auth_context.user.id
-        else:
-            # The model is server-owned and for RBAC purposes we consider
-            # every user to be the owner of it
-            return True
+    from zenml.zen_stores.schemas import BaseSchema
 
-    return False
+    if isinstance(resource, UserScopedResponse):
+        user_id = resource.user_id
+    elif isinstance(resource, BaseSchema):
+        user_id = getattr(resource, "user_id", None)
+    else:
+        return False
+
+    if user_id:
+        return user_id == auth_context.user.id
+
+    # The resource is server-owned and for RBAC purposes we consider every
+    # user to be the owner of it.
+    return True
 
 
 def get_subresources_for_model(
@@ -644,17 +681,10 @@ def _get_subresources_for_value(value: Any) -> Set[Resource]:
         return set()
 
 
-def get_schema_for_resource_type(
-    resource_type: ResourceType,
-) -> Type["BaseSchema"]:
-    """Get the database schema for a resource type.
-
-    Args:
-        resource_type: The resource type for which to get the database schema.
-
-    Returns:
-        The database schema.
-    """
+def _get_resource_type_schema_mapping() -> Dict[
+    ResourceType, Type["BaseSchema"]
+]:
+    """Get the mapping between RBAC resource types and database schemas."""
     from zenml.zen_stores.schemas import (
         ArtifactSchema,
         ArtifactVersionSchema,
@@ -682,7 +712,7 @@ def get_schema_for_resource_type(
         UserSchema,
     )
 
-    mapping: Dict[ResourceType, Type["BaseSchema"]] = {
+    return {
         ResourceType.STACK: StackSchema,
         ResourceType.FLAVOR: FlavorSchema,
         ResourceType.STACK_COMPONENT: StackComponentSchema,
@@ -711,7 +741,41 @@ def get_schema_for_resource_type(
         ResourceType.RESOURCE_POOL_SUBJECT_POLICY: ResourcePoolSubjectPolicySchema,
     }
 
-    return mapping[resource_type]
+
+def get_schema_for_resource_type(
+    resource_type: ResourceType,
+) -> Type["BaseSchema"]:
+    """Get the database schema for a resource type.
+
+    Args:
+        resource_type: The resource type for which to get the database schema.
+
+    Returns:
+        The database schema.
+    """
+    return _get_resource_type_schema_mapping()[resource_type]
+
+
+def get_resource_type_for_schema(
+    schema: "BaseSchema",
+) -> Optional[ResourceType]:
+    """Get the RBAC resource type for a database schema.
+
+    Args:
+        schema: The database schema for which to get the resource type.
+
+    Returns:
+        The RBAC resource type associated with the schema, if any.
+    """
+    schema_type = type(schema)
+    for (
+        resource_type,
+        mapped_schema_type,
+    ) in _get_resource_type_schema_mapping().items():
+        if schema_type is mapped_schema_type:
+            return resource_type
+
+    return None
 
 
 def update_resource_membership(

--- a/src/zenml/zen_server/routers/tag_resource_endpoints.py
+++ b/src/zenml/zen_server/routers/tag_resource_endpoints.py
@@ -26,8 +26,6 @@ from zenml.constants import (
 from zenml.models import TagResourceRequest, TagResourceResponse
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
-from zenml.zen_server.rbac.models import Action
-from zenml.zen_server.rbac.utils import batch_verify_permissions_for_models
 from zenml.zen_server.utils import (
     async_fastapi_endpoint_wrapper,
     zen_store,
@@ -38,16 +36,6 @@ router = APIRouter(
     tags=["tag_resources"],
     responses={401: error_response, 403: error_response},
 )
-
-
-def _verify_tag_resources_update_permission(
-    tag_resources: List[TagResourceRequest],
-) -> None:
-    """Verify update permission on all resources being tagged."""
-    resources = zen_store().get_resources_from_tag_resources(
-        tag_resources=tag_resources
-    )
-    batch_verify_permissions_for_models(models=resources, action=Action.UPDATE)
 
 
 @router.post(
@@ -67,7 +55,6 @@ def create_tag_resource(
     Returns:
         A tag resource response.
     """
-    _verify_tag_resources_update_permission(tag_resources=[tag_resource])
     return zen_store().create_tag_resource(tag_resource=tag_resource)
 
 
@@ -88,7 +75,6 @@ def batch_create_tag_resource(
     Returns:
         A list of tag resource responses.
     """
-    _verify_tag_resources_update_permission(tag_resources=tag_resources)
     return zen_store().batch_create_tag_resource(tag_resources=tag_resources)
 
 
@@ -106,7 +92,6 @@ def delete_tag_resource(
     Args:
         tag_resource: The tag resource relationship to delete.
     """
-    _verify_tag_resources_update_permission(tag_resources=[tag_resource])
     zen_store().delete_tag_resource(tag_resource=tag_resource)
 
 
@@ -124,5 +109,4 @@ def batch_delete_tag_resource(
     Args:
         tag_resources: A list of tag resource requests.
     """
-    _verify_tag_resources_update_permission(tag_resources=tag_resources)
     zen_store().batch_delete_tag_resource(tag_resources=tag_resources)

--- a/src/zenml/zen_server/routers/tags_endpoints.py
+++ b/src/zenml/zen_server/routers/tags_endpoints.py
@@ -33,7 +33,6 @@ from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.rbac.endpoint_utils import (
     verify_permissions_and_delete_entity,
-    verify_permissions_and_get_entity,
     verify_permissions_and_update_entity,
 )
 from zenml.zen_server.utils import (
@@ -120,11 +119,7 @@ def get_tag(
     Returns:
         The tag with the given ID.
     """
-    return verify_permissions_and_get_entity(
-        id=tag_id,
-        get_method=zen_store().get_tag,
-        hydrate=hydrate,
-    )
+    return zen_store().get_tag(tag_id=tag_id, hydrate=hydrate)
 
 
 @router.put(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -16002,6 +16002,46 @@ class SqlZenStore(BaseZenStore):
         """
         return self.batch_create_tag_resource(tag_resources=[tag_resource])[0]
 
+    def _batch_create_tag_resource(
+        self,
+        tag_resources: List[TagResourceRequest],
+        resolved_resources: List[BaseSchema],
+        session: Session,
+    ) -> List[TagResourceResponse]:
+        """Create a batch of tag resource relationships.
+
+        Args:
+            tag_resources: The tag resource relationships to be created.
+            resolved_resources: The resources referenced by the tag resource
+                requests.
+            session: The database session to use.
+
+        Returns:
+            The newly created tag resource relationships.
+        """
+        resources: List[
+            Tuple[TagSchema, TaggableResourceTypes, BaseSchema]
+        ] = []
+        for tag_resource, resource in zip(tag_resources, resolved_resources):
+            tag_schema = self._get_tag_schema(
+                tag_name_or_id=tag_resource.tag_id,
+                session=session,
+            )
+            resources.append(
+                (
+                    tag_schema,
+                    tag_resource.resource_type,
+                    resource,
+                )
+            )
+
+        return [
+            r.to_model()
+            for r in self._create_tag_resource_schemas(
+                tag_resources=resources, session=session
+            )
+        ]
+
     def batch_create_tag_resource(
         self, tag_resources: List[TagResourceRequest]
     ) -> List[TagResourceResponse]:
@@ -16017,29 +16057,11 @@ class SqlZenStore(BaseZenStore):
             resolved_resources = self._get_resources_from_tag_resources(
                 tag_resources=tag_resources, session=session
             )
-            resources: List[
-                Tuple[TagSchema, TaggableResourceTypes, BaseSchema]
-            ] = []
-            for tag_resource, resource in zip(
-                tag_resources, resolved_resources
-            ):
-                tag_schema = self._get_tag_schema(
-                    tag_name_or_id=tag_resource.tag_id,
-                    session=session,
-                )
-                resources.append(
-                    (
-                        tag_schema,
-                        tag_resource.resource_type,
-                        resource,
-                    )
-                )
-            return [
-                r.to_model()
-                for r in self._create_tag_resource_schemas(
-                    tag_resources=resources, session=session
-                )
-            ]
+            return self._batch_create_tag_resource(
+                tag_resources=tag_resources,
+                resolved_resources=resolved_resources,
+                session=session,
+            )
 
     def _delete_tag_resource_schemas(
         self,

--- a/tests/unit/zen_server/test_tag_resource_rbac.py
+++ b/tests/unit/zen_server/test_tag_resource_rbac.py
@@ -15,6 +15,7 @@ from zenml.models import ModelRequest, TagRequest, UserRequest
 from zenml.zen_server.auth import AuthContext
 from zenml.zen_server.middleware import record_requests
 from zenml.zen_server.rbac.rbac_interface import RBACInterface
+from zenml.zen_server.rbac.rbac_sql_zen_store import RBACSqlZenStore
 from zenml.zen_server.routers import (
     models_endpoints,
     tag_resource_endpoints,
@@ -78,7 +79,6 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
 
     try:
         store = client.zen_store
-        zen_server_utils._zen_store = store
         server_cfg.rbac_implementation_source = "local.test_rbac"
 
         attacker = store.create_user(
@@ -107,6 +107,12 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
             "resource_id": str(victim_model.id),
             "resource_type": TaggableResourceTypes.MODEL.value,
         }
+
+        rbac_store = RBACSqlZenStore(
+            config=store.config.model_copy(deep=True),
+            skip_default_registrations=True,
+        )
+        zen_server_utils._zen_store = rbac_store
 
         app = FastAPI()
         app.add_middleware(BaseHTTPMiddleware, dispatch=record_requests)

--- a/tests/unit/zen_server/test_tag_resource_rbac.py
+++ b/tests/unit/zen_server/test_tag_resource_rbac.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from uuid import uuid4
 
 from fastapi import FastAPI
@@ -10,6 +11,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 import zenml.zen_server.utils as zen_server_utils
 from zenml.client import Client
+from zenml.constants import ENV_ZENML_SERVER
 from zenml.enums import TaggableResourceTypes
 from zenml.models import ModelRequest, TagRequest, UserRequest
 from zenml.zen_server.auth import AuthContext
@@ -73,6 +75,7 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
     previous_rbac = zen_server_utils._rbac
     server_cfg = zen_server_utils.server_config()
     previous_rbac_source = server_cfg.rbac_implementation_source
+    previous_server_env = os.environ.get(ENV_ZENML_SERVER)
 
     logging.disable(logging.CRITICAL)
     await initialize_request_manager()
@@ -113,6 +116,7 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
             skip_default_registrations=True,
         )
         zen_server_utils._zen_store = rbac_store
+        os.environ[ENV_ZENML_SERVER] = "true"
 
         app = FastAPI()
         app.add_middleware(BaseHTTPMiddleware, dispatch=record_requests)
@@ -135,6 +139,24 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
         )
 
         http = TestClient(app)
+
+        zen_server_utils._rbac = AllowAllRBAC()
+        owned_model_response = http.post(
+            "/api/v1/models",
+            json={
+                "name": "owned_model_" + uuid4().hex[:8],
+                "project": str(project.id),
+            },
+        )
+        assert owned_model_response.status_code == 200, (
+            owned_model_response.text
+        )
+        owned_model_id = owned_model_response.json()["id"]
+        owned_tag_resource_body = {
+            "tag_id": str(marker_tag.id),
+            "resource_id": owned_model_id,
+            "resource_type": TaggableResourceTypes.MODEL.value,
+        }
 
         zen_server_utils._rbac = DenyAllRBAC()
         model_update = http.put(
@@ -159,6 +181,26 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
         assert all(
             tag.id != marker_tag.id
             for tag in store.get_model(victim_model.id).tags
+        )
+
+        owned_attach = http.post(
+            "/api/v1/tag_resources", json=owned_tag_resource_body
+        )
+        assert owned_attach.status_code == 200, owned_attach.text
+        assert any(
+            tag.id == marker_tag.id
+            for tag in store.get_model(owned_model_id).tags
+        )
+
+        owned_batch_detach = http.request(
+            "DELETE",
+            "/api/v1/tag_resources/batch",
+            json=[owned_tag_resource_body],
+        )
+        assert owned_batch_detach.status_code == 200, owned_batch_detach.text
+        assert all(
+            tag.id != marker_tag.id
+            for tag in store.get_model(owned_model_id).tags
         )
 
         zen_server_utils._rbac = AllowAllRBAC()
@@ -203,6 +245,10 @@ async def _run_tag_resource_rbac_regression(client: Client) -> None:
         )
     finally:
         server_cfg.rbac_implementation_source = previous_rbac_source
+        if previous_server_env is None:
+            os.environ.pop(ENV_ZENML_SERVER, None)
+        else:
+            os.environ[ENV_ZENML_SERVER] = previous_server_env
         zen_server_utils._zen_store = previous_zen_store
         zen_server_utils._rbac = previous_rbac
         logging.disable(previous_logging_disable)


### PR DESCRIPTION
**Summary**

This PR moves tag-resource RBAC enforcement out of the tag-resource endpoints and into `RBACSqlZenStore`, keeping RBAC-specific behavior isolated in the RBAC store layer. It also opens up `get_tag` to match the existing strategy that tags are server-wide resources everyone can create and view without RBAC checks.

**What Changed**

- Removed endpoint-level permission checks from `tag_resource_endpoints.py`.
- Added RBAC checks to `RBACSqlZenStore.batch_create_tag_resource(...)` and `RBACSqlZenStore.batch_delete_tag_resource(...)`.
- Reused the existing SQL store `_get_resources_from_tag_resources(...)` bulk resolver instead of hydrating response models.
- Added a private `SqlZenStore._batch_create_tag_resource(...)` helper that accepts already-resolved resources.
- Opened up `get_tag` so tag reads are consistent with tag creation/listing as globally visible server-wide resources.
- Updated the tag-resource RBAC regression test to exercise `RBACSqlZenStore` directly.

**Why This Is Better**

Previously, the endpoint fetched full resource models just to check `UPDATE` permissions before tagging or untagging. That mixed RBAC concerns into endpoint code and caused unnecessary schema-to-model hydration.

The new flow keeps endpoints clean and pushes authorization to the RBAC store, where it belongs. It resolves tag resources once, builds lightweight RBAC `Resource` objects from the resolved schemas, and reuses those same resolved resources for the actual create/delete operation.

Opening `get_tag` keeps tag behavior internally consistent: tags are shared server-wide metadata objects that users can create and view, while RBAC is enforced when attaching or detaching a tag from a protected resource.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

