### PR TITLE
Link to correct hooks page

### DIFF
--- a/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
+++ b/docs/book/user-guide/tutorial/managing-scheduled-pipelines.md
@@ -281,7 +281,7 @@ for run in runs.items:
 
 #### Monitoring with Alerters
 
-For critical pipelines, [add alerting](https://docs.zenml.io/stacks/alerters) to notify you of failures via a [failure hook](https://docs.zenml.io/concepts/steps_and_pipelines/advanced_features#hooks):
+For critical pipelines, [add alerting](https://docs.zenml.io/stacks/alerters) to notify you of failures via a [failure hook](https://docs.zenml.io/concepts/steps_and_pipelines/hooks):
 
 ```python
 from zenml.hooks import alerter_failure_hook


### PR DESCRIPTION
## Describe changes
#4925 tried to fix the absolute broken links check by linking to a wrong docs page. The absolute links check obviously is broken until the new docs are released, that doesn't mean we keep links to legacy docs pages.
