### PR TITLE
Validate artifact content hash when loading pickled artifacts

### DIFF
--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -582,6 +582,7 @@ def load_artifact_from_response(artifact: "ArtifactVersionResponse") -> Any:
         data_type=artifact.data_type,
         uri=artifact.uri,
         artifact_store=artifact_store,
+        expected_content_hash=artifact.content_hash,
     )
 
 
@@ -765,6 +766,7 @@ def _load_artifact_from_uri(
     data_type: Union["Source", str],
     uri: str,
     artifact_store: Optional["BaseArtifactStore"] = None,
+    expected_content_hash: Optional[str] = None,
 ) -> Any:
     """Load an artifact using the given materializer.
 
@@ -773,6 +775,8 @@ def _load_artifact_from_uri(
         data_type: The source of the artifact data type.
         uri: The uri of the artifact.
         artifact_store: The artifact store used to store this artifact.
+        expected_content_hash: Content hash recorded for this artifact version,
+            forwarded to the materializer to validate the stored file on load.
 
     Returns:
         The artifact loaded into memory.
@@ -821,6 +825,7 @@ def _load_artifact_from_uri(
     materializer_object: BaseMaterializer = materializer_class(
         uri, artifact_store
     )
+    materializer_object.expected_content_hash = expected_content_hash
     artifact = materializer_object.load(artifact_class)
     logger.debug("Artifact loaded successfully.")
 
@@ -1039,12 +1044,14 @@ def load_model_from_metadata(model_uri: str) -> Any:
     """
     # Load the model from its metadata
     artifact_versions_by_uri = Client().list_artifact_versions(uri=model_uri)
+    expected_content_hash: Optional[str] = None
     if artifact_versions_by_uri.total == 1:
         artifact_store = (
             _get_artifact_store_from_response_or_from_active_stack(
                 artifact_versions_by_uri.items[0]
             )
         )
+        expected_content_hash = artifact_versions_by_uri.items[0].content_hash
     else:
         artifact_store = Client().active_stack.artifact_store
 
@@ -1059,6 +1066,7 @@ def load_model_from_metadata(model_uri: str) -> Any:
         data_type=data_type,
         uri=model_uri,
         artifact_store=artifact_store,
+        expected_content_hash=expected_content_hash,
     )
 
     # Switch to eval mode if the model is a torch model

--- a/src/zenml/materializers/base_materializer.py
+++ b/src/zenml/materializers/base_materializer.py
@@ -122,6 +122,11 @@ class BaseMaterializer(metaclass=BaseMaterializerMeta):
 
     _DOCS_BUILDING_MODE: ClassVar[bool] = False
 
+    # Content hash recorded for this artifact version, if known. Set by the
+    # loading machinery before `load` so materializers can validate the stored
+    # file against it. `None` means no hash is available.
+    expected_content_hash: Optional[str] = None
+
     def __init__(
         self, uri: str, artifact_store: Optional[BaseArtifactStore] = None
     ):

--- a/src/zenml/materializers/cloudpickle_materializer.py
+++ b/src/zenml/materializers/cloudpickle_materializer.py
@@ -13,8 +13,10 @@
 #  permissions and limitations under the License.
 """Implementation of ZenML's cloudpickle materializer."""
 
+import hashlib
+import hmac
 import os
-from typing import Any, ClassVar, Tuple, Type
+from typing import IO, Any, ClassVar, Optional, Tuple, Type
 
 import cloudpickle
 
@@ -32,6 +34,56 @@ logger = get_logger(__name__)
 DEFAULT_FILENAME = "artifact.pkl"
 DEFAULT_PYTHON_VERSION_FILENAME = "python_version.txt"
 
+# Chunk size used when streaming the stored artifact to compute its hash.
+_HASH_CHUNK_SIZE = 65536
+
+
+class _HashingWriter:
+    """Write proxy that hashes everything written through it.
+
+    Wrapping the artifact store's write handle lets the content hash be
+    computed in the same streaming pass as `save`, so the artifact does not
+    have to be buffered in memory or read back from the store afterwards.
+    Operations other than `write` are delegated to the wrapped handle.
+
+    This assumes a byte-faithful handle: the bytes passed to `write` are the
+    bytes the store returns on read. Every ZenML artifact store satisfies this
+    (none transform bytes on write), and pickle loading already required it.
+    """
+
+    def __init__(self, fid: IO[bytes], digest: "hashlib._Hash") -> None:
+        """Initializes the proxy.
+
+        Args:
+            fid: The underlying binary write handle.
+            digest: The hash object fed with every chunk written.
+        """
+        self._fid = fid
+        self._digest = digest
+
+    def write(self, data: bytes) -> int:
+        """Writes `data` and feeds the same bytes to the digest.
+
+        Args:
+            data: The bytes to write.
+
+        Returns:
+            The number of bytes written by the wrapped handle.
+        """
+        self._digest.update(data)
+        return self._fid.write(data)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegates any other attribute access to the wrapped handle.
+
+        Args:
+            name: The attribute to look up on the wrapped handle.
+
+        Returns:
+            The attribute resolved on the wrapped handle.
+        """
+        return getattr(self._fid, name)
+
 
 class CloudpickleMaterializer(BaseMaterializer):
     """Materializer using cloudpickle.
@@ -48,14 +100,26 @@ class CloudpickleMaterializer(BaseMaterializer):
     ASSOCIATED_ARTIFACT_TYPE: ClassVar[ArtifactType] = ArtifactType.DATA
     SKIP_REGISTRATION: ClassVar[bool] = True
 
+    # SHA-256 of the stored file, computed while writing it in `save` and
+    # reused by `compute_content_hash` so the artifact is not read back.
+    # `None` until a save has happened on this instance.
+    _content_hash: Optional[str] = None
+
     def load(self, data_type: Type[Any]) -> Any:
         """Reads an artifact from a cloudpickle file.
+
+        When a content hash was recorded for this artifact version, the stored
+        file is checked against it before it is read back.
 
         Args:
             data_type: The data type of the artifact.
 
         Returns:
             The loaded artifact data.
+
+        Raises:
+            RuntimeError: If the stored file does not match the recorded content
+                hash.
         """
         # validate python version
         source_python_version = self._load_python_version()
@@ -69,11 +133,22 @@ class CloudpickleMaterializer(BaseMaterializer):
                 "versions. Attempting to load anyway..."
             )
 
-        # load data
         filepath = os.path.join(self.uri, DEFAULT_FILENAME)
         with self.artifact_store.open(filepath, "rb") as fid:
-            data = cloudpickle.load(fid)
-        return data
+            serialized_data = fid.read()
+
+        expected_content_hash = self.expected_content_hash
+        if expected_content_hash is not None:
+            actual_content_hash = hashlib.sha256(serialized_data).hexdigest()
+            if not hmac.compare_digest(
+                actual_content_hash, expected_content_hash
+            ):
+                raise RuntimeError(
+                    f"The artifact at '{self.uri}' does not match the content "
+                    f"hash recorded for it and was not loaded."
+                )
+
+        return cloudpickle.loads(serialized_data)
 
     def _load_python_version(self) -> str:
         """Loads the Python version that was used to materialize the artifact.
@@ -108,13 +183,53 @@ class CloudpickleMaterializer(BaseMaterializer):
         # save python version for validation on loading
         self._save_python_version()
 
-        # save data
+        # Hash the serialized bytes as they stream to the store, so the content
+        # hash is obtained in the same pass as the write rather than by reading
+        # the (possibly large, possibly remote) artifact back. The hash covers
+        # the stored bytes - not `data` - so `load` can verify the file before
+        # unpickling it.
         filepath = os.path.join(self.uri, DEFAULT_FILENAME)
+        digest = hashlib.sha256()
         with self.artifact_store.open(filepath, "wb") as fid:
-            cloudpickle.dump(data, fid)
+            cloudpickle.dump(data, _HashingWriter(fid, digest))
+        self._content_hash = digest.hexdigest()
 
     def _save_python_version(self) -> None:
         """Saves the Python version used to materialize the artifact."""
         filepath = os.path.join(self.uri, DEFAULT_PYTHON_VERSION_FILENAME)
         current_python_version = Environment().python_version()
         write_file_contents_as_string(filepath, current_python_version)
+
+    def compute_content_hash(self, data: Any) -> Optional[str]:
+        """Return the SHA-256 of the stored artifact file.
+
+        When the file was written by `save` on this instance, the hash computed
+        during that write is reused; otherwise the stored file is read back and
+        hashed. The hash is taken over the stored bytes (not over `data`) so it
+        can be recomputed on load without reading the object back.
+
+        Args:
+            data: The saved data. Unused; the hash is taken over the stored file.
+
+        Returns:
+            The hex-encoded SHA-256 of the stored file, or `None` if it cannot
+            be read.
+        """
+        if self._content_hash is not None:
+            return self._content_hash
+
+        filepath = os.path.join(self.uri, DEFAULT_FILENAME)
+        try:
+            digest = hashlib.sha256()
+            with self.artifact_store.open(filepath, "rb") as fid:
+                for chunk in iter(lambda: fid.read(_HASH_CHUNK_SIZE), b""):
+                    digest.update(chunk)
+            return digest.hexdigest()
+        except Exception as e:
+            logger.warning(
+                "Could not compute the content hash for the artifact at "
+                "'%s'. (%s)",
+                self.uri,
+                e,
+            )
+            return None

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -609,6 +609,7 @@ class StepRunner:
             materializer: BaseMaterializer = materializer_class(
                 uri=artifact.uri, artifact_store=artifact_store
             )
+            materializer.expected_content_hash = artifact.content_hash
 
             if artifact.chunk_index is not None:
                 # We need to skip the type compatibility check here because

--- a/tests/unit/materializers/test_cloudpickle_materializer.py
+++ b/tests/unit/materializers/test_cloudpickle_materializer.py
@@ -17,6 +17,9 @@ import os
 import pickle
 from tempfile import TemporaryDirectory
 
+import cloudpickle
+import pytest
+
 from tests.unit.test_general import _test_materializer
 from zenml.environment import Environment
 from zenml.materializers.cloudpickle_materializer import (
@@ -69,3 +72,82 @@ def test_cloudpickle_materializer_can_load_pickle(clean_client):
         materializer = CloudpickleMaterializer(uri=artifact_uri)
         loaded_object = materializer.load(data_type=Unmaterializable)
         assert loaded_object.cat == "aria"
+
+
+def test_load_without_recorded_hash_is_not_checked(clean_client):
+    """With no recorded hash there is nothing to check, so the file loads.
+
+    This keeps nested element loads (e.g. items of a `List[CustomObj]`, which
+    have no per-element recorded hash) and artifacts written by older versions
+    working unchanged.
+    """
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        with open(os.path.join(artifact_uri, DEFAULT_FILENAME), "wb") as f:
+            pickle.dump(Unmaterializable(), f)
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        assert materializer.expected_content_hash is None
+        loaded = materializer.load(data_type=Unmaterializable)
+        assert loaded.cat == "aria"
+
+
+def test_load_with_matching_hash_succeeds(clean_client):
+    """A stored file whose bytes match the recorded hash loads without opt-in."""
+    original = Unmaterializable()
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        materializer.save(original)
+        recorded_hash = materializer.compute_content_hash(original)
+        assert recorded_hash is not None
+
+        loader = CloudpickleMaterializer(uri=artifact_uri)
+        loader.expected_content_hash = recorded_hash
+        loaded = loader.load(data_type=Unmaterializable)
+        assert loaded.cat == "aria"
+
+
+def test_content_hash_from_save_matches_reread(clean_client):
+    """The hash cached during `save` equals an independent re-read of the file.
+
+    `save` computes the hash while streaming the bytes to the store; a fresh
+    instance with no cached hash falls back to reading the stored file. Both
+    paths must agree, otherwise a load would wrongly reject a valid artifact.
+    """
+    original = Unmaterializable()
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        writer = CloudpickleMaterializer(uri=artifact_uri)
+        writer.save(original)
+        cached_hash = writer.compute_content_hash(original)
+        assert cached_hash is not None
+
+        reader = CloudpickleMaterializer(uri=artifact_uri)
+        assert reader._content_hash is None
+        assert reader.compute_content_hash(original) == cached_hash
+
+
+def test_content_hash_mismatch_is_rejected(clean_client):
+    """A stored file that does not match the recorded hash is not loaded."""
+    original = Unmaterializable()
+    with TemporaryDirectory(
+        dir=clean_client.active_stack.artifact_store.path
+    ) as artifact_uri:
+        materializer = CloudpickleMaterializer(uri=artifact_uri)
+        materializer.save(original)
+        recorded_hash = materializer.compute_content_hash(original)
+        assert recorded_hash is not None
+
+        # Replace the stored file with different bytes.
+        with open(os.path.join(artifact_uri, DEFAULT_FILENAME), "wb") as f:
+            cloudpickle.dump({"other": "object"}, f)
+
+        loader = CloudpickleMaterializer(uri=artifact_uri)
+        loader.expected_content_hash = recorded_hash
+        with pytest.raises(
+            RuntimeError, match="does not match the content hash"
+        ):
+            loader.load(data_type=Unmaterializable)

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -108,6 +108,12 @@ def _test_materializer(
             assert isinstance(key, str)
             assert isinstance(value, MetadataTypeTuple)
 
+        # Mirror the loading machinery, which feeds the recorded content hash
+        # back to the materializer before load.
+        materializer.expected_content_hash = materializer.compute_content_hash(
+            step_output
+        )
+
         # Assert that materializer loads the data with the correct type
         loaded_data = materializer.load(step_output_type)
         if assert_data_type:


### PR DESCRIPTION
## What

The cloudpickle fallback materializer now records the SHA-256 of the stored
artifact file and verifies it before the file is read back on load. When a
content hash is recorded for the artifact version, the stored bytes are checked
against it; artifacts with no recorded hash load unchanged.

The hash is computed in a single streaming pass while the artifact is written in
`save()` (a small `_HashingWriter` wraps the store write handle), and cached on
the materializer, so loading needs no extra read of the (possibly remote)
artifact. The recorded hash reaches the materializer through a
`BaseMaterializer.expected_content_hash` field, set in `_load_artifact_from_uri`,
the model-metadata loader, and step-input loading.

## Why

Gives the pickle-based fallback an integrity check that ties the stored file to
the content hash recorded for its artifact version, so a stored file that no
longer matches what was recorded is not read back. Computing the hash during
`save()` avoids re-reading the artifact on load.

## Tests

Unit tests for matching-hash loads, content-hash mismatches, the no-hash path,
and save/re-read hash equivalence.
