### PR TITLE
Support databricks oauth m2m for MLFlow

### DIFF
--- a/docs/book/component-guide/experiment-trackers/mlflow.md
+++ b/docs/book/component-guide/experiment-trackers/mlflow.md
@@ -54,16 +54,27 @@ Due to a [critical severity vulnerability](https://github.com/advisories/GHSA-xg
 
 ### Authentication Methods
 
-You need to configure the following credentials for authentication to a remote MLflow tracking server:
+Remote MLflow tracking servers require a `tracking_uri` and exactly one authentication method. Set `tracking_uri` to the URL of a remote MLflow Tracking Server, or to `"databricks"` when using the MLflow Tracking Server managed by Databricks. You can also set `tracking_insecure_tls=True` to skip SSL certificate verification when connecting to the tracking server.
 
-* `tracking_uri`: The URL pointing to the MLflow tracking server. If using an MLflow Tracking Server managed by Databricks, then the value of this attribute should be `"databricks"`.
-* `tracking_username`: Username for authenticating with the MLflow tracking server.
-* `tracking_password`: Password for authenticating with the MLflow tracking server.
-* `tracking_token` (in place of `tracking_username` and `tracking_password`): Token for authenticating with the MLflow tracking server.
-* `tracking_insecure_tls` (optional): Set to skip verifying the MLflow tracking server SSL certificate.
-* `databricks_host`: The host of the Databricks workspace with the MLflow-managed server to connect to. This is only required if the `tracking_uri` value is set to `"databricks"`. More information: [Access the MLflow tracking server from outside Databricks](https://docs.databricks.com/applications/mlflow/access-hosted-tracking-server.html)
+The supported authentication methods are:
 
-Either `tracking_token` or `tracking_username` and `tracking_password` must be specified.
+* **Username/password:** set both `tracking_username` and `tracking_password`. Use this for tracking servers that accept basic authentication.
+* **Token:** set `tracking_token`. Use this for tracking servers that accept bearer token authentication.
+* **Databricks OAuth M2M:** set `tracking_uri="databricks"`, `databricks_host`, `databricks_client_id`, and `databricks_client_secret`. Use this for Databricks-managed MLflow with a service principal, as described in the section below.
+
+For Databricks-managed MLflow, `databricks_host` must be the Databricks workspace URL. The `databricks_client_id` and `databricks_client_secret` fields are only used for Databricks OAuth M2M authentication.
+
+#### Databricks OAuth M2M
+
+Databricks OAuth machine-to-machine (M2M) authentication authorizes unattended workloads, such as pipelines and automation scripts, to access Databricks resources as a service principal. See the Databricks documentation on [authorizing service principal access with OAuth](https://docs.databricks.com/aws/en/dev-tools/auth/oauth-m2m) for the full setup flow.
+
+For ZenML, the Databricks OAuth M2M values map to the MLflow experiment tracker configuration as follows:
+
+* Databricks workspace URL: `databricks_host`
+* Service principal application ID / client ID: `databricks_client_id`
+* Service principal OAuth secret: `databricks_client_secret`
+
+To get these values, create or select a service principal in your Databricks workspace, generate an OAuth secret for it, and copy the displayed client ID and secret value. Make sure the service principal has access to the workspace and to the MLflow experiment path you want to use.
 
 {% tabs %}
 {% tab title="Basic Authentication" %}
@@ -85,6 +96,28 @@ zenml experiment-tracker register mlflow_experiment_tracker --flavor=mlflow \
 # Register and set a stack with the new experiment tracker
 zenml stack register custom_stack -e mlflow_experiment_tracker ... --set
 ```
+{% endtab %}
+
+{% tab title="Databricks OAuth M2M" %}
+This option configures authentication to a Databricks-managed MLflow tracking server with a Databricks-managed service principal and OAuth M2M credentials.
+
+```shell
+# Create a secret with the Databricks service principal OAuth credentials
+zenml secret create databricks_oauth_secret \
+    --client_id=<CLIENT_ID> \
+    --client_secret=<CLIENT_SECRET>
+
+# Register the MLflow experiment tracker
+zenml experiment-tracker register mlflow_databricks --flavor=mlflow \
+    --tracking_uri=databricks \
+    --databricks_host=<DATABRICKS_WORKSPACE_URL> \
+    --databricks_client_id={{databricks_oauth_secret.client_id}} \
+    --databricks_client_secret={{databricks_oauth_secret.client_secret}}
+
+# Register and set a stack with the new experiment tracker
+zenml stack register custom_stack -e mlflow_databricks ... --set
+```
+
 {% endtab %}
 
 {% tab title="ZenML Secret (Recommended)" %}

--- a/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
+++ b/src/zenml/integrations/mlflow/experiment_trackers/mlflow_experiment_tracker.py
@@ -60,7 +60,11 @@ DATABRICKS_HOST = "DATABRICKS_HOST"
 DATABRICKS_USERNAME = "DATABRICKS_USERNAME"
 DATABRICKS_PASSWORD = "DATABRICKS_PASSWORD"
 DATABRICKS_TOKEN = "DATABRICKS_TOKEN"
+DATABRICKS_CLIENT_ID = "DATABRICKS_CLIENT_ID"
+DATABRICKS_CLIENT_SECRET = "DATABRICKS_CLIENT_SECRET"
+DATABRICKS_AUTH_TYPE = "DATABRICKS_AUTH_TYPE"
 DATABRICKS_UNITY_CATALOG = "databricks-uc"
+MLFLOW_ENABLE_DB_SDK = "MLFLOW_ENABLE_DB_SDK"
 
 
 class MLFlowExperimentTracker(BaseExperimentTracker):
@@ -338,6 +342,18 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
                 os.environ[DATABRICKS_PASSWORD] = self.config.tracking_password
             if self.config.tracking_token:
                 os.environ[DATABRICKS_TOKEN] = self.config.tracking_token
+            if (
+                self.config.databricks_client_id
+                and self.config.databricks_client_secret
+            ):
+                os.environ[DATABRICKS_CLIENT_ID] = (
+                    self.config.databricks_client_id
+                )
+                os.environ[DATABRICKS_CLIENT_SECRET] = (
+                    self.config.databricks_client_secret
+                )
+                os.environ[DATABRICKS_AUTH_TYPE] = "oauth-m2m"
+                os.environ[MLFLOW_ENABLE_DB_SDK] = "true"
             if self.config.enable_unity_catalog:
                 mlflow.set_registry_uri(DATABRICKS_UNITY_CATALOG)
         else:

--- a/src/zenml/integrations/mlflow/flavors/mlflow_experiment_tracker_flavor.py
+++ b/src/zenml/integrations/mlflow/flavors/mlflow_experiment_tracker_flavor.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """MLflow experiment tracker flavor."""
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from pydantic import Field, model_validator
 
@@ -45,7 +45,7 @@ def is_remote_mlflow_tracking_uri(tracking_uri: str) -> bool:
     ) or is_databricks_tracking_uri(tracking_uri)
 
 
-def is_databricks_tracking_uri(tracking_uri: str) -> bool:
+def is_databricks_tracking_uri(tracking_uri: Optional[str]) -> bool:
     """Checks whether the given tracking uri is a Databricks tracking uri.
 
     Args:
@@ -101,6 +101,18 @@ class MLFlowExperimentTrackerConfig(
         description="Token for authenticating with the MLflow tracking server. "
         "Alternative to username/password authentication for remote tracking URIs.",
     )
+    databricks_client_id: Optional[str] = SecretField(
+        default=None,
+        description="Client ID of the Databricks service principal to use for "
+        "OAuth M2M authentication. Only applies when tracking_uri is set to "
+        "'databricks'.",
+    )
+    databricks_client_secret: Optional[str] = SecretField(
+        default=None,
+        description="Client secret of the Databricks service principal to use "
+        "for OAuth M2M authentication. Only applies when tracking_uri is set "
+        "to 'databricks'.",
+    )
     tracking_insecure_tls: bool = Field(
         False,
         description="Skips verification of TLS connection to the MLflow tracking "
@@ -118,54 +130,156 @@ class MLFlowExperimentTrackerConfig(
     )
 
     @model_validator(mode="after")
-    def _ensure_authentication_if_necessary(
+    def _ensure_complete_credential_pairs(
         self,
     ) -> "MLFlowExperimentTrackerConfig":
-        """Ensures that credentials or a token for authentication exist.
-
-        We make this check when running MLflow tracking with a remote backend.
+        """Ensures that credential pair authentication is complete.
 
         Returns:
             The validated values.
 
         Raises:
-             ValueError: If neither credentials nor a token are provided.
+             ValueError: If only one value of a credential pair is configured.
         """
-        if self.tracking_uri:
-            if is_databricks_tracking_uri(self.tracking_uri):
-                # If the tracking uri is "databricks", then we need the
-                # databricks host to be set.
-                if not self.databricks_host:
-                    raise ValueError(
-                        "MLflow experiment tracking with a Databricks MLflow "
-                        "managed tracking server requires the "
-                        "`databricks_host` to be set in your stack component. "
-                        "To update your component, run "
-                        "`zenml experiment-tracker update "
-                        "<NAME> --databricks_host=DATABRICKS_HOST` "
-                        "and specify the hostname of your Databricks workspace."
-                    )
+        if bool(self.tracking_username) != bool(self.tracking_password):
+            raise ValueError(
+                "MLflow username/password authentication requires both "
+                "`tracking_username` and `tracking_password` to be "
+                "configured."
+            )
 
-            if is_remote_mlflow_tracking_uri(self.tracking_uri):
-                # we need either username + password or a token to authenticate
-                # to the remote backend
-                basic_auth = self.tracking_username and self.tracking_password
-
-                if not (basic_auth or self.tracking_token):
-                    raise ValueError(
-                        f"MLflow experiment tracking with a remote backend "
-                        f"{self.tracking_uri} is only possible when specifying "
-                        f"either username and password or an authentication "
-                        f"token in your stack component. To update your "
-                        f"component, run the following command: "
-                        f"`zenml experiment-tracker update "
-                        f"<NAME> --tracking_username=MY_USERNAME "
-                        f"--tracking_password=MY_PASSWORD "
-                        f"--tracking_token=MY_TOKEN` and specify either your "
-                        f"username and password or token."
-                    )
+        if bool(self.databricks_client_id) != bool(
+            self.databricks_client_secret
+        ):
+            raise ValueError(
+                "Databricks OAuth M2M authentication requires both "
+                "`databricks_client_id` and `databricks_client_secret` to be "
+                "configured."
+            )
 
         return self
+
+    @model_validator(mode="after")
+    def _ensure_databricks_tracking_uri(
+        self,
+    ) -> "MLFlowExperimentTrackerConfig":
+        """Ensures that Databricks-specific options only target Databricks.
+
+        Returns:
+            The validated values.
+
+        Raises:
+             ValueError: If a Databricks option is configured for another URI.
+        """
+        if is_databricks_tracking_uri(self.tracking_uri):
+            return self
+
+        databricks_options = []
+        if self.databricks_host:
+            databricks_options.append("databricks_host")
+        if self.databricks_client_id:
+            databricks_options.append("databricks_client_id")
+        if self.databricks_client_secret:
+            databricks_options.append("databricks_client_secret")
+        if self.enable_unity_catalog:
+            databricks_options.append("enable_unity_catalog")
+
+        if databricks_options:
+            formatted_options = ", ".join(
+                f"`{option}`" for option in databricks_options
+            )
+            raise ValueError(
+                f"Databricks options {formatted_options} require "
+                "`tracking_uri` to be set to `databricks`."
+            )
+
+        return self
+
+    @model_validator(mode="after")
+    def _ensure_databricks_host_if_necessary(
+        self,
+    ) -> "MLFlowExperimentTrackerConfig":
+        """Ensures that Databricks tracking has a workspace host.
+
+        Returns:
+            The validated values.
+
+        Raises:
+             ValueError: If Databricks tracking is missing a host.
+        """
+        if (
+            is_databricks_tracking_uri(self.tracking_uri)
+            and not self.databricks_host
+        ):
+            raise ValueError(
+                "MLflow experiment tracking with a Databricks MLflow "
+                "managed tracking server requires the `databricks_host` to "
+                "be set in your stack component. To update your component, "
+                "run `zenml experiment-tracker update <NAME> "
+                "--databricks_host=DATABRICKS_HOST` and specify the hostname "
+                "of your Databricks workspace."
+            )
+
+        return self
+
+    @model_validator(mode="after")
+    def _ensure_exactly_one_authentication_method_if_necessary(
+        self,
+    ) -> "MLFlowExperimentTrackerConfig":
+        """Ensures that remote tracking uses one authentication method.
+
+        Returns:
+            The validated values.
+
+        Raises:
+             ValueError: If remote tracking has zero or multiple auth methods.
+        """
+        if not self.tracking_uri or not is_remote_mlflow_tracking_uri(
+            self.tracking_uri
+        ):
+            return self
+
+        auth_methods = self._configured_authentication_methods()
+        if len(auth_methods) == 1:
+            return self
+
+        valid_options = (
+            "`tracking_token`, `tracking_username` with `tracking_password`"
+        )
+        if is_databricks_tracking_uri(self.tracking_uri):
+            valid_options = (
+                f"{valid_options}, or `databricks_client_id` with "
+                "`databricks_client_secret`"
+            )
+
+        if not auth_methods:
+            raise ValueError(
+                f"MLflow experiment tracking with remote backend "
+                f"`{self.tracking_uri}` requires exactly one authentication "
+                f"method. Valid options are {valid_options}."
+            )
+
+        raise ValueError(
+            f"MLflow experiment tracking with remote backend "
+            f"`{self.tracking_uri}` requires exactly one authentication "
+            f"method, but received multiple authentication methods: "
+            f"{', '.join(auth_methods)}. Valid options are {valid_options}."
+        )
+
+    def _configured_authentication_methods(self) -> List[str]:
+        """Returns the authentication methods configured on the component.
+
+        Returns:
+            The configured authentication method names.
+        """
+        auth_methods = []
+        if self.tracking_username and self.tracking_password:
+            auth_methods.append("username/password")
+        if self.tracking_token:
+            auth_methods.append("token")
+        if self.databricks_client_id and self.databricks_client_secret:
+            auth_methods.append("Databricks OAuth M2M")
+        return auth_methods
 
     @property
     def is_local(self) -> bool:

--- a/tests/integration/integrations/mlflow/experiment_trackers/test_mlflow_experiment_tracker.py
+++ b/tests/integration/integrations/mlflow/experiment_trackers/test_mlflow_experiment_tracker.py
@@ -11,10 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+"""Integration tests for the MLflow experiment tracker."""
 
 import os
 from contextlib import ExitStack as does_not_raise
 from datetime import datetime
+from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -25,15 +27,17 @@ from pydantic import ValidationError
 from zenml.enums import StackComponentType
 from zenml.exceptions import StackValidationError
 from zenml.integrations.mlflow.experiment_trackers.mlflow_experiment_tracker import (
+    DATABRICKS_AUTH_TYPE,
+    DATABRICKS_CLIENT_ID,
+    DATABRICKS_CLIENT_SECRET,
     DATABRICKS_HOST,
     DATABRICKS_PASSWORD,
-    DATABRICKS_TOKEN,
     DATABRICKS_USERNAME,
     LOCAL_MLFLOW_ARTIFACTS_DIRECTORY,
     LOCAL_MLFLOW_BACKEND_FILENAME,
+    MLFLOW_ENABLE_DB_SDK,
     MLFLOW_TRACKING_INSECURE_TLS,
     MLFLOW_TRACKING_PASSWORD,
-    MLFLOW_TRACKING_TOKEN,
     MLFLOW_TRACKING_USERNAME,
     MLFlowExperimentTracker,
 )
@@ -52,9 +56,7 @@ def test_mlflow_experiment_tracker_attributes() -> None:
             tracking_uri="http://localhost:5000",
             tracking_username="john_doe",
             tracking_password="password",
-            tracking_token="token1234",
             tracking_insecure_tls=True,
-            databricks_host="https://databricks.com",
         ),
         flavor="mlflow",
         type=StackComponentType.EXPERIMENT_TRACKER,
@@ -101,107 +103,180 @@ def test_mlflow_experiment_tracker_stack_validation(
         ).validate()
 
 
-def test_mlflow_experiment_tracker_authentication() -> None:
-    """Tests that the MLflow experiment tracker validates the authentication parameters."""
-    # should raise because no authentication parameters are set
+def _create_mlflow_experiment_tracker(
+    config: MLFlowExperimentTrackerConfig,
+) -> MLFlowExperimentTracker:
+    """Creates an MLflow experiment tracker for validation tests."""
+    return MLFlowExperimentTracker(
+        name="",
+        id=uuid4(),
+        config=config,
+        flavor="mlflow",
+        type=StackComponentType.EXPERIMENT_TRACKER,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="http://localhost:5000",
+            tracking_username="john_doe",
+            tracking_password="password",
+        ),
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="http://localhost:5000",
+            tracking_token="token1234",
+        ),
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="databricks",
+            tracking_username="john_doe",
+            tracking_password="password",
+            databricks_host="https://databricks.com",
+        ),
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="databricks",
+            tracking_token="token1234",
+            databricks_host="https://databricks.com",
+        ),
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="databricks",
+            databricks_client_id="client-id",
+            databricks_client_secret="client-secret",
+            databricks_host="https://databricks.com",
+        ),
+    ],
+)
+def test_mlflow_experiment_tracker_authentication_options_are_valid(
+    config: MLFlowExperimentTrackerConfig,
+) -> None:
+    """Tests that each supported MLflow authentication option is valid."""
+    with does_not_raise():
+        _create_mlflow_experiment_tracker(config)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"tracking_uri": "http://localhost:5000"},
+        {
+            "tracking_uri": "databricks",
+            "databricks_host": "https://databricks.com",
+        },
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_username": "john_doe",
+            "tracking_password": "password",
+            "tracking_token": "token1234",
+        },
+        {
+            "tracking_uri": "databricks",
+            "tracking_username": "john_doe",
+            "tracking_password": "password",
+            "tracking_token": "token1234",
+            "databricks_host": "https://databricks.com",
+        },
+        {
+            "tracking_uri": "databricks",
+            "tracking_token": "token1234",
+            "databricks_client_id": "client-id",
+            "databricks_client_secret": "client-secret",
+            "databricks_host": "https://databricks.com",
+        },
+    ],
+)
+def test_mlflow_experiment_tracker_requires_exactly_one_remote_authentication_method(
+    config: Dict[str, str],
+) -> None:
+    """Tests that remote tracking requires exactly one auth method."""
     with pytest.raises(ValidationError):
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="http://localhost:5000",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
+        MLFlowExperimentTrackerConfig(**config)
 
-    # should raise because no authentication parameters are set
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_username": "john_doe",
+        },
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_password": "password",
+        },
+        {
+            "tracking_uri": "databricks",
+            "databricks_client_id": "client-id",
+            "databricks_host": "https://databricks.com",
+        },
+        {
+            "tracking_uri": "databricks",
+            "databricks_client_secret": "client-secret",
+            "databricks_host": "https://databricks.com",
+        },
+    ],
+)
+def test_mlflow_experiment_tracker_requires_complete_credential_pairs(
+    config: Dict[str, str],
+) -> None:
+    """Tests that paired authentication credentials are configured together."""
     with pytest.raises(ValidationError):
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="databricks",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
+        MLFlowExperimentTrackerConfig(**config)
 
-    # should not raise because username and password are set
-    with does_not_raise():
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="http://localhost:5000",
-                tracking_username="john_doe",
-                tracking_password="password",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
 
-    with does_not_raise():
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="databricks",
-                tracking_username="john_doe",
-                tracking_password="password",
-                databricks_host="https://databricks.com",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_token": "token1234",
+            "databricks_host": "https://databricks.com",
+        },
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_token": "token1234",
+            "databricks_client_id": "client-id",
+            "databricks_client_secret": "client-secret",
+        },
+        {
+            "tracking_uri": "http://localhost:5000",
+            "tracking_token": "token1234",
+            "enable_unity_catalog": True,
+        },
+    ],
+)
+def test_mlflow_experiment_tracker_rejects_databricks_options_without_databricks_tracking_uri(
+    config: Dict[str, Any],
+) -> None:
+    """Tests that Databricks options require a Databricks tracking URI."""
+    with pytest.raises(ValidationError):
+        MLFlowExperimentTrackerConfig(**config)
 
-    # should not raise because token is set
-    with does_not_raise():
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="http://localhost:5000",
-                tracking_token="token1234",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
-        )
 
-    with does_not_raise():
-        MLFlowExperimentTracker(
-            name="",
-            id=uuid4(),
-            config=MLFlowExperimentTrackerConfig(
-                tracking_uri="databricks",
-                tracking_token="token1234",
-                databricks_host="https://databricks.com",
-            ),
-            flavor="mlflow",
-            type=StackComponentType.EXPERIMENT_TRACKER,
-            user=uuid4(),
-            created=datetime.now(),
-            updated=datetime.now(),
+def test_mlflow_experiment_tracker_requires_databricks_host() -> None:
+    """Tests that Databricks tracking requires a workspace host."""
+    with pytest.raises(ValidationError):
+        MLFlowExperimentTrackerConfig(
+            tracking_uri="databricks",
+            tracking_token="token1234",
         )
 
 
-def test_mlflow_experiment_tracker_set_config(local_stack: Stack) -> None:
+def test_mlflow_experiment_tracker_set_config(
+    local_stack: Stack, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Tests that the MLflow experiment tracker sets the MLflow configuration correctly."""
+    for env_var in [
+        DATABRICKS_AUTH_TYPE,
+        DATABRICKS_CLIENT_ID,
+        DATABRICKS_CLIENT_SECRET,
+        MLFLOW_ENABLE_DB_SDK,
+    ]:
+        monkeypatch.delenv(env_var, raising=False)
+
     local_stack._experiment_tracker = MLFlowExperimentTracker(
         name="",
         id=uuid4(),
@@ -209,7 +284,6 @@ def test_mlflow_experiment_tracker_set_config(local_stack: Stack) -> None:
             tracking_uri="http://localhost:5000",
             tracking_username="john_doe",
             tracking_password="password",
-            tracking_token="token1234",
             tracking_insecure_tls=True,
         ),
         flavor="mlflow",
@@ -223,7 +297,6 @@ def test_mlflow_experiment_tracker_set_config(local_stack: Stack) -> None:
 
     assert os.environ[MLFLOW_TRACKING_USERNAME] == "john_doe"
     assert os.environ[MLFLOW_TRACKING_PASSWORD] == "password"
-    assert os.environ[MLFLOW_TRACKING_TOKEN] == "token1234"
     assert os.environ[MLFLOW_TRACKING_INSECURE_TLS] == "true"
 
     local_stack._experiment_tracker = MLFlowExperimentTracker(
@@ -233,7 +306,6 @@ def test_mlflow_experiment_tracker_set_config(local_stack: Stack) -> None:
             tracking_uri="databricks",
             tracking_username="john_doe",
             tracking_password="password",
-            tracking_token="token1234",
             databricks_host="https://databricks.com",
         ),
         flavor="mlflow",
@@ -247,8 +319,31 @@ def test_mlflow_experiment_tracker_set_config(local_stack: Stack) -> None:
 
     assert os.environ[DATABRICKS_USERNAME] == "john_doe"
     assert os.environ[DATABRICKS_PASSWORD] == "password"
-    assert os.environ[DATABRICKS_TOKEN] == "token1234"
     assert os.environ[DATABRICKS_HOST] == "https://databricks.com"
+
+    local_stack._experiment_tracker = MLFlowExperimentTracker(
+        name="",
+        id=uuid4(),
+        config=MLFlowExperimentTrackerConfig(
+            tracking_uri="databricks",
+            databricks_client_id="client-id",
+            databricks_client_secret="client-secret",
+            databricks_host="https://databricks.com",
+        ),
+        flavor="mlflow",
+        type=StackComponentType.EXPERIMENT_TRACKER,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+
+    local_stack._experiment_tracker.configure_mlflow()
+
+    assert os.environ[DATABRICKS_HOST] == "https://databricks.com"
+    assert os.environ[DATABRICKS_CLIENT_ID] == "client-id"
+    assert os.environ[DATABRICKS_CLIENT_SECRET] == "client-secret"
+    assert os.environ[DATABRICKS_AUTH_TYPE] == "oauth-m2m"
+    assert os.environ[MLFLOW_ENABLE_DB_SDK] == "true"
 
 
 def test_mlflow_experiment_tracker_uses_sqlite_for_local_backend(


### PR DESCRIPTION
## Describe changes

This PR introduces support for M2M Oauth on Databricks-managed MLFLow instances. M2M authentication via service principals is more secure and production-recommended than existing authentication mechanisms (username/password or PAT token authentication).

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

