### PR TITLE
Improve internal future awaiting error handling

### DIFF
--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -283,7 +283,7 @@ def custom_loop():
 
 ### Parallel Step Execution
 
-Dynamic pipelines support true parallel execution using `step.submit()`. This method returns a `StepRunFuture` that you can use to wait for results or pass to downstream steps:
+Dynamic pipelines support true parallel execution using `step.submit()`. This method returns a `StepFuture` that you can use to wait for results or pass to downstream steps:
 
 ```python
 from zenml import step, pipeline
@@ -311,11 +311,11 @@ def dynamic_pipeline():
         some_step.submit(arg=idx)
 ```
 
-The `StepRunFuture` object provides several methods:
+The `StepFuture` object provides several methods:
 
 - **`result()`**: Wait for the step to complete and return the artifact response(s)
 - **`load()`**: Wait for the step to complete and load the actual artifact data
-- **Pass directly**: You can pass a `StepRunFuture` directly to downstream steps, and ZenML will automatically wait for it
+- **Pass directly**: You can pass a `StepFuture` directly to downstream steps, and ZenML will automatically wait for it
 
 {% hint style="info" %}
 When using `step.submit()`, steps with `runtime="isolated"` will execute in separate containers/processes, while steps with `runtime="inline"` will execute in separate threads within the orchestration environment.
@@ -517,7 +517,7 @@ Client().trigger_pipeline(snapshot_id=<ID>, run_configuration={"parameters": {"m
 
 ### Execution modes and error handling
 
-- The `CONTINUE_ON_FAILURE` execution mode is currently not supported in dynamic pipelines. Instead, you can use `try...except` to catch step exceptions and continue the pipeline.
+- The `CONTINUE_ON_FAILURE` execution mode is currently not supported in dynamic pipelines. Instead, you can use `try...except` to catch step exceptions and continue the pipeline. When you await a step explicitly (a synchronous call, or `future.result()` / `future.wait()`), the exception raised inside the step propagates as-is. When a failure surfaces implicitly (a failed future passed as a step input or to `after=`, or a submitted step still running when the pipeline function returns), ZenML raises a `StepExecutionException` whose `original_exception` holds the underlying error.
 - When using the `FAIL_FAST` execution mode, failure of a step does not immediately cancel other other **inline** steps. Instead, they continue executing until finished. **Isolated** steps on the other hand will be shut down immediately.
 
 ### Orchestrator Support

--- a/src/zenml/exceptions.py
+++ b/src/zenml/exceptions.py
@@ -130,6 +130,24 @@ class RunInterruptedException(ZenMLBaseException):
     """Raised when a ZenML step gets interrupted for an unknown reason."""
 
 
+class StepExecutionException(ZenMLBaseException):
+    """Raised when a step fails and its result was not explicitly awaited."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        original_exception: Optional[BaseException] = None,
+    ):
+        """Initializes the exception.
+
+        Args:
+            message: Message with details of the exception.
+            original_exception: The original step failure that this wraps.
+        """
+        super().__init__(message)
+        self.original_exception = original_exception
+
+
 class MethodNotAllowedError(ZenMLBaseException):
     """Raised when the server does not allow a request method."""
 

--- a/src/zenml/execution/pipeline/dynamic/compilation.py
+++ b/src/zenml/execution/pipeline/dynamic/compilation.py
@@ -35,6 +35,7 @@ from zenml.config.step_configurations import (
 )
 from zenml.enums import StepRuntime
 from zenml.execution.pipeline.dynamic.inputs import (
+    _await_input_future,
     await_step_inputs,
     convert_to_keyword_arguments,
 )
@@ -93,7 +94,7 @@ def compile_dynamic_step_invocation(
     upstream_steps = set()
 
     for future in collect_futures(after=after, expand_map_results=True):
-        future.wait()
+        _await_input_future(future, return_result=False)
         if isinstance(future, PipelineFuture):
             # A pipeline future means we're waiting for a child pipeline to
             # finish. No such step exists in our pipeline, so we can't track

--- a/src/zenml/execution/pipeline/dynamic/inputs.py
+++ b/src/zenml/execution/pipeline/dynamic/inputs.py
@@ -30,24 +30,61 @@ from zenml.execution.pipeline.dynamic.outputs import (
     BaseStepFuture,
     MapResultsFuture,
     PipelineFuture,
+    PipelineRunOutputs,
     StepFuture,
+    wrap_step_failure,
 )
 from zenml.execution.pipeline.dynamic.utils import collect_futures
 from zenml.models import ArtifactVersionResponse
 
 
-def _resolve_single_child_pipeline_artifact(
-    future: PipelineFuture, key: str
-) -> ArtifactVersionResponse:
-    """Resolve a child pipeline future to its single output artifact.
-
-    Awaits the future and inspects the actual outputs rather than the
-    declared output count. This matters for unannotated child pipeline
-    entrypoints, whose `PipelineFuture.__len__` is `0` even when the
-    pipeline returns exactly one artifact at runtime.
+def _await_input_future(
+    future: AnyOutputFuture, return_result: bool = True
+) -> Any:
+    """Wait for a future used implicitly as a step input.
 
     Args:
-        future: The child pipeline future to resolve.
+        future: The future to wait for.
+        return_result: Whether to return the resolved result or only wait.
+
+    Raises:
+        StepExecutionException: If a step future failed.
+        Exception: If a non-step future failed.
+
+    Returns:
+        The resolved result if `return_result` is True, otherwise None.
+    """  # noqa: DOC502, DOC503
+    # A child pipeline failure is not a step failure, so it propagates raw.
+    if isinstance(future, PipelineFuture):
+        if return_result:
+            return future.result()
+        future.wait()
+        return None
+
+    try:
+        if return_result:
+            return future.result()
+        future.wait()
+        return None
+    except Exception as exc:
+        wrapped = wrap_step_failure(exc, invocation_id=future.invocation_id)
+        if wrapped is exc:
+            raise
+        raise wrapped
+
+
+def _resolve_single_child_pipeline_artifact(
+    outputs: PipelineRunOutputs, key: str
+) -> ArtifactVersionResponse:
+    """Extract the single output artifact from a child pipeline result.
+
+    Inspects the actual outputs rather than the declared output count. This
+    matters for unannotated child pipeline entrypoints, whose
+    `PipelineFuture.__len__` is `0` even when the pipeline returns exactly one
+    artifact at runtime.
+
+    Args:
+        outputs: The resolved child pipeline outputs.
         key: The step input name, used in the error message.
 
     Raises:
@@ -57,13 +94,12 @@ def _resolve_single_child_pipeline_artifact(
     Returns:
         The single output artifact produced by the child pipeline.
     """
-    artifacts = future.artifacts()
-    if isinstance(artifacts, ArtifactVersionResponse):
-        return artifacts
-    if isinstance(artifacts, tuple) and len(artifacts) == 1:
-        return artifacts[0]
+    if isinstance(outputs, ArtifactVersionResponse):
+        return outputs
+    if isinstance(outputs, tuple) and len(outputs) == 1:
+        return outputs[0]
 
-    actual_count = 0 if artifacts is None else len(artifacts)
+    actual_count = 0 if outputs is None else len(outputs)
     raise RuntimeError(
         f"Invalid step input `{key}`: a child pipeline future used as a "
         f"step input must produce exactly one output artifact, but the "
@@ -125,7 +161,7 @@ def await_step_inputs(inputs: Dict[str, Any]) -> Dict[str, Any]:
                     "to multiple output artifacts as an input to another step "
                     "is not allowed."
                 )
-            value = [item.artifacts() for item in value]
+            value = [_await_input_future(item) for item in value]
         elif isinstance(value, StepFuture):
             if len(value._output_keys) != 1:
                 raise RuntimeError(
@@ -133,28 +169,32 @@ def await_step_inputs(inputs: Dict[str, Any]) -> Dict[str, Any]:
                     "to multiple output artifacts as an input to another step "
                     "is not allowed."
                 )
-            value = value.artifacts()
+            value = _await_input_future(value)
         elif (
             isinstance(value, (list, tuple))
             and value
             and all(isinstance(item, PipelineFuture) for item in value)
         ):
             value = [
-                _resolve_single_child_pipeline_artifact(item, key=key)
+                _resolve_single_child_pipeline_artifact(
+                    _await_input_future(item), key=key
+                )
                 for item in value
             ]
         elif isinstance(value, PipelineFuture):
-            value = _resolve_single_child_pipeline_artifact(value, key=key)
+            value = _resolve_single_child_pipeline_artifact(
+                _await_input_future(value), key=key
+            )
 
         if (
             isinstance(value, (list, tuple))
             and value
             and all(isinstance(item, ArtifactFuture) for item in value)
         ):
-            value = [item.result() for item in value]
+            value = [_await_input_future(item) for item in value]
 
         if isinstance(value, ArtifactFuture):
-            value = value.result()
+            value = _await_input_future(value)
 
         result[key] = value
 

--- a/src/zenml/execution/pipeline/dynamic/outputs.py
+++ b/src/zenml/execution/pipeline/dynamic/outputs.py
@@ -32,6 +32,7 @@ from typing import (
 from uuid import UUID
 
 from zenml.enums import ExecutionStatus
+from zenml.exceptions import StepExecutionException
 from zenml.logger import get_logger
 from zenml.models import (
     ArtifactVersionResponse,
@@ -43,6 +44,33 @@ from zenml.utils import exception_utils
 logger = get_logger(__name__)
 
 T = TypeVar("T")
+
+
+def wrap_step_failure(
+    exception: BaseException, invocation_id: Optional[str] = None
+) -> StepExecutionException:
+    """Wrap a step failure that was not explicitly awaited.
+
+    Args:
+        exception: The original step failure.
+        invocation_id: The invocation ID of the failed step, if known.
+
+    Returns:
+        The exception unchanged if it already is a `StepExecutionException`,
+        otherwise a new `StepExecutionException` chaining the original.
+    """
+    if isinstance(exception, StepExecutionException):
+        return exception
+
+    if invocation_id:
+        message = f"Step `{invocation_id}` failed."
+    else:
+        message = "A step failed during pipeline execution."
+
+    wrapped = StepExecutionException(message, original_exception=exception)
+    wrapped.__cause__ = exception
+    wrapped.__suppress_context__ = True
+    return wrapped
 
 
 def _maybe_release_pipeline_thread() -> AbstractContextManager[None]:

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -103,6 +103,7 @@ from zenml.execution.pipeline.dynamic.outputs import (
     StepRunOutputs,
     _InlineStepFuture,
     _IsolatedStepFuture,
+    wrap_step_failure,
 )
 from zenml.execution.pipeline.dynamic.pipeline_output_utils import (
     get_pipeline_entrypoint_output_names,
@@ -594,7 +595,9 @@ class DynamicPipelineRunner:
                             "infrastructure side but its status was not "
                             "updated."
                         )
-                        self.record_failure(exc)
+                        self.record_failure(
+                            wrap_step_failure(exc, invocation_id=invocation_id)
+                        )
 
                 # Get the updated status that we might have just published
                 db_status = step_run.status
@@ -1237,7 +1240,11 @@ class DynamicPipelineRunner:
                         initial_state=NodeState.FAILED,
                     )
                     self.mark_node_failed(node_id=invocation_id)
-                    self.record_failure(exception=exception)
+                    self.record_failure(
+                        exception=wrap_step_failure(
+                            exception, invocation_id=invocation_id
+                        )
+                    )
                     return future
                 else:
                     raise exception
@@ -2076,7 +2083,11 @@ class DynamicPipelineRunner:
                 )
             except BaseException as e:
                 self.mark_node_failed(node_id=step.spec.invocation_id)
-                self.record_failure(exception=e)
+                self.record_failure(
+                    exception=wrap_step_failure(
+                        e, invocation_id=step.spec.invocation_id
+                    )
+                )
                 raise e
 
             self._register_isolated_step_for_monitoring(
@@ -2113,7 +2124,11 @@ class DynamicPipelineRunner:
                 )
             except BaseException as e:
                 self.mark_node_failed(node_id=step.spec.invocation_id)
-                self.record_failure(exception=e)
+                self.record_failure(
+                    exception=wrap_step_failure(
+                        e, invocation_id=step.spec.invocation_id
+                    )
+                )
                 raise e
 
             self._on_step_finished(step_run=step_run)
@@ -2182,7 +2197,11 @@ class DynamicPipelineRunner:
         ):
             exception = self._get_step_exception(step_run=step_run)
             self.mark_node_failed(node_id=step_run.name)
-            self.record_failure(exception=exception)
+            self.record_failure(
+                exception=wrap_step_failure(
+                    exception, invocation_id=step_run.name
+                )
+            )
 
     # Concurrent map lifecycle
 

--- a/tests/unit/execution/__init__.py
+++ b/tests/unit/execution/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/execution/pipeline/__init__.py
+++ b/tests/unit/execution/pipeline/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/execution/pipeline/dynamic/__init__.py
+++ b/tests/unit/execution/pipeline/dynamic/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
+++ b/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
@@ -1,0 +1,122 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the exception raised when a dynamic step fails."""
+
+import pytest
+
+from zenml import pipeline, step
+from zenml.exceptions import StepExecutionException
+
+
+@step
+def failing_step() -> int:
+    raise RuntimeError("boom")
+
+
+@step
+def consume_int(value: int) -> int:
+    return value
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def sync_failure_pipeline() -> None:
+    failing_step()
+
+
+def test_sync_failure_raises_original_exception() -> None:
+    with pytest.raises(RuntimeError):
+        sync_failure_pipeline()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def explicit_wait_pipeline() -> None:
+    future = failing_step.submit()
+    future.wait()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def explicit_result_pipeline() -> None:
+    future = failing_step.submit()
+    future.result()
+
+
+def test_explicit_wait_raises_original_exception() -> None:
+    with pytest.raises(RuntimeError):
+        explicit_wait_pipeline()
+
+
+def test_explicit_result_raises_original_exception() -> None:
+    with pytest.raises(RuntimeError):
+        explicit_result_pipeline()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def implicit_sync_input_pipeline() -> None:
+    future = failing_step.submit()
+    consume_int(future)
+
+
+def test_implicit_sync_input_raises_step_execution_exception() -> None:
+    with pytest.raises(StepExecutionException) as exc_info:
+        implicit_sync_input_pipeline()
+    assert isinstance(exc_info.value.original_exception, RuntimeError)
+    assert exc_info.value.__cause__ is exc_info.value.original_exception
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def implicit_async_input_pipeline() -> None:
+    future = failing_step.submit()
+    consume_int.submit(future)
+
+
+def test_implicit_async_input_raises_step_execution_exception() -> None:
+    with pytest.raises(StepExecutionException):
+        implicit_async_input_pipeline()
+
+
+@step
+def noop_step() -> None:
+    return None
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def unawaited_pipeline() -> None:
+    failing_step.submit()
+
+
+def test_unawaited_failure_raises_step_execution_exception() -> None:
+    with pytest.raises(StepExecutionException):
+        unawaited_pipeline()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def after_sync_pipeline() -> None:
+    future = failing_step.submit()
+    noop_step(after=future)
+
+
+def test_after_sync_raises_step_execution_exception() -> None:
+    with pytest.raises(StepExecutionException):
+        after_sync_pipeline()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def after_async_pipeline() -> None:
+    future = failing_step.submit()
+    noop_step.submit(after=future)
+
+
+def test_after_async_raises_step_execution_exception() -> None:
+    with pytest.raises(StepExecutionException):
+        after_async_pipeline()


### PR DESCRIPTION
Previously, we always re-raised the exception that happened during step execution when it caused a pipeline to fail. This PR adjusts this in the following way:
- When a step is explicitly awaited (run synchronously or `future.wait()`/`future.result()`), we re-raise the step exception
- When a step is implicitly awaited (future passed to downstream step, or the future being awaited after the pipeline function returns), a `StepExecutionException` with a generic message is raised instead.

**Breaking changes:**
- If users had a `try...except` block around their pipeline execution, their code could break because different exceptions get raised.