### PR TITLE
Normalize REST store URL before moving credentials

### DIFF
--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -361,9 +361,8 @@ class RestZenStoreConfiguration(StoreConfiguration):
     http_timeout: int = DEFAULT_HTTP_TIMEOUT
     connection_pool_size: int = 10
 
-    @field_validator("url")
-    @classmethod
-    def validate_url(cls, url: str) -> str:
+    @staticmethod
+    def _validate_url(url: str) -> str:
         """Validates that the URL is a well-formed REST store URL.
 
         Args:
@@ -455,7 +454,8 @@ class RestZenStoreConfiguration(StoreConfiguration):
         if not url:
             return data
 
-        url = replace_localhost_with_internal_hostname(url)
+        url = cls._validate_url(url)
+        data["url"] = url
 
         if api_token := data.pop("api_token", None):
             credentials_store = get_credentials_store()

--- a/tests/unit/zen_stores/test_rest_zen_store.py
+++ b/tests/unit/zen_stores/test_rest_zen_store.py
@@ -1,0 +1,42 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the REST ZenML store."""
+
+from pytest_mock import MockerFixture
+
+from zenml.zen_stores.rest_zen_store import RestZenStoreConfiguration
+
+SERVER_URL = "https://server.example"
+SERVER_URL_WITH_SLASH = f"{SERVER_URL}/"
+
+
+def test_rest_store_url_is_normalized_before_moving_credentials(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that REST store API tokens use the normalized server URL."""
+    credentials_store = mocker.Mock()
+    mocker.patch(
+        "zenml.zen_stores.rest_zen_store.get_credentials_store",
+        return_value=credentials_store,
+    )
+
+    config = RestZenStoreConfiguration(
+        url=SERVER_URL_WITH_SLASH,
+        api_token="test-api-token",
+    )
+
+    assert config.url == SERVER_URL
+    credentials_store.set_bare_token.assert_called_once_with(
+        SERVER_URL, "test-api-token"
+    )


### PR DESCRIPTION
## Describe changes

Bugfix: Normalizes REST store URL before moving credentials

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

