### PR TITLE
Print pytest rerun failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,16 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Log the traceback of attempts that were retried by pytest-rerunfailures.
+
+    Args:
+        report: Test report for a single test phase.
+    """
+    if report.outcome == "rerun" and report.longrepr is not None:
+        print(f"\nRERUN traceback for {report.nodeid}:\n{report.longreprtext}")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def auto_environment(
     session_mocker: MockerFixture,


### PR DESCRIPTION
Our CI runs pytest with `--reruns 3` by default. In some cases, the initial test run fails and leaves some global state (e.g. DB entries) in a messed up state. This then causes the reruns to fail with a downstream error which isn't helpful for debugging. This PR logs the failures of each test that fails and gets rerun.