### PR TITLE
Exclude `zenml` from its own dependency audit

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -63,6 +63,15 @@ jobs:
           uv venv --python 3.11 .venv-audit-target
           uv pip install --python .venv-audit-target/bin/python '.[server,dev,local]'
           uv pip check --python .venv-audit-target/bin/python
+      - name: Drop zenml itself from the audit target
+        run: |
+          # pip-audit looks up installed package versions in advisory databases;
+          # ZenML's own package cannot be meaningfully audited that way, and during
+          # release prep its version is intentionally ahead of PyPI, which makes
+          # pip-audit --strict abort before it can scan anything. Uninstalling
+          # zenml removes only its own dist-info and leaves every dependency
+          # installed, so the audit still covers the full dependency set.
+          uv pip uninstall --python .venv-audit-target/bin/python zenml
       - name: Audit installed dependencies with pip-audit
         id: pip-audit
         run: |


### PR DESCRIPTION
## What this does

Adds one step to the **Python Dependency Audit** workflow that uninstalls `zenml` from the isolated audit venv *before* `pip-audit` runs, leaving all of its dependencies in place.

## Why

During release prep we bump the in-repo version ahead of PyPI (e.g. `0.95.0` before it is published). The audit installs `.[server,dev,local]` and runs `pip-audit --path <site-packages> --strict`. `pip-audit` looks up each installed package **version** in advisory databases — including `zenml` itself. When it tries to resolve `zenml==0.95.0` against PyPI and finds nothing (because the release isn't published yet), `--strict` treats that as a **fatal** error: it aborts before writing any JSON, producing a 0-byte report. `scripts/dependency_audit_severity_gate.py` then can't parse the empty file, sets `audit_error=true`, and the **Gate dependency audit result** job fails — with zero actual vulnerabilities found.

This reproduces on every release-prep branch. A concrete instance: https://github.com/zenml-io/zenml/actions/runs/27689670244 (the `zenml: Dependency not found on PyPI and could not be audited: zenml (0.95.0)` error).

## Why uninstall rather than loosen the gate

`pip-audit` is a version-lookup tool, not a code scanner — it never analyzed ZenML's source, only checked whether ZenML's version string appears in an advisory feed. Auditing our own package is meaningless (any advisory against a released zenml version is something we'd be publishing ourselves), so dropping it loses no real coverage. Source-level security is already handled separately by CodeQL / Trivy / zizmor.

`uv pip uninstall zenml` removes **only** the `zenml` dist-info; pip has no dependency cascade, so all ~170 dependencies stay installed and continue to be audited. `--strict` is preserved for every real dependency, so the gate is not weakened. The `uv pip check` consistency check still runs against the full environment first.

## Testing

- Verified empirically that `uv pip uninstall <pkg>` removes only the named package and leaves its dependencies installed.
- Confirmed `zenml 0.95.0` is not on PyPI (latest published is `0.94.6`), which is the trigger condition.
- `yamlfix` leaves the file unchanged; YAML parses.
