### PR TITLE
Improve DB query plans by using selectinload

### DIFF
--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -21,7 +21,7 @@ from uuid import UUID
 from pydantic import ConfigDict
 from sqlalchemy import String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import Session, joinedload, object_session, selectinload
+from sqlalchemy.orm import Session, object_session, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import TEXT, Column, Field, Relationship, col, select
 
@@ -433,7 +433,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
                     selectinload(jl_arg(PipelineRunSchema.user)),
                     selectinload(jl_arg(PipelineRunSchema.tags)),
                     selectinload(jl_arg(PipelineRunSchema.visualizations)),
-                    joinedload(jl_arg(PipelineRunSchema.trigger)),
+                    selectinload(jl_arg(PipelineRunSchema.trigger)),
                 ]
             )
 

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -21,7 +21,7 @@ from uuid import UUID
 from pydantic import ConfigDict
 from sqlalchemy import TEXT, Column, String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -291,8 +291,8 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             selectinload(jl_arg(StepRunSchema.pipeline_run)).load_only(
                 jl_arg(PipelineRunSchema.start_time)
             ),
-            joinedload(jl_arg(StepRunSchema.static_config)),
-            joinedload(jl_arg(StepRunSchema.dynamic_config)),
+            selectinload(jl_arg(StepRunSchema.static_config)),
+            selectinload(jl_arg(StepRunSchema.dynamic_config)),
         ]
 
         # if include_metadata:


### PR DESCRIPTION
Switch some `joinedloads` to `selectinloads` to improve the query plans for common pipeline run/step run queries.

**Explanation:**
The `joinedloads` in these relationships caused them to be included in the main `SELECT DISTINCT ... ORDER BY created LIMIT 20`. This caused mysql to use a temp table + filesort over the entire table. With `selectinload`, the relationships now get fetched in a separate follow up query, which means the main query just runs on the main table. This allows it to use indexes and also gets rid of the entire temp table + filesort.

**Improvements:**
For a DB with 20k pipeline runs and 70k step runs, this leads to a
- local (direct mysql connection): ~8x improvement for unhydrated list calls
- remote: ~4x improvement, but this includes all the RBAC calls and network latency