### PR TITLE
Improve listing pipelines sorted by latest run

### DIFF
--- a/src/zenml/models/v2/core/pipeline.py
+++ b/src/zenml/models/v2/core/pipeline.py
@@ -397,7 +397,7 @@ class PipelineFilter(ProjectScopedFilter, TaggableFilter):
         Returns:
             The query with sorting applied.
         """
-        from sqlmodel import asc, case, col, desc, func, select
+        from sqlmodel import asc, col, desc, func, select
 
         from zenml.enums import SorterOps
         from zenml.zen_stores.schemas import PipelineRunSchema, PipelineSchema
@@ -405,38 +405,41 @@ class PipelineFilter(ProjectScopedFilter, TaggableFilter):
         sort_by, operand = self.sorting_params
 
         if sort_by == SORT_PIPELINES_BY_LATEST_RUN_KEY:
-            # Subquery to find the latest run per pipeline
+            # First aggregate pipeline run creation date by pipeline id. This
+            # is done separately so the DB can use a loose index scan on the
+            # `(pipeline_id, created)` index instead of scanning every run.
             latest_run_subquery = (
                 select(
-                    PipelineSchema.id,
-                    case(
-                        (
-                            func.max(PipelineRunSchema.created).is_(None),
-                            PipelineSchema.created,
-                        ),
-                        else_=func.max(PipelineRunSchema.created),
-                    ).label("latest_run"),
+                    col(PipelineRunSchema.pipeline_id).label("pipeline_id"),
+                    func.max(PipelineRunSchema.created).label(
+                        "latest_run_created"
+                    ),
                 )
-                .outerjoin(
-                    PipelineRunSchema,
-                    PipelineSchema.id == PipelineRunSchema.pipeline_id,  # type: ignore[arg-type]
-                )
-                .group_by(col(PipelineSchema.id))
+                .group_by(col(PipelineRunSchema.pipeline_id))
                 .subquery()
             )
 
+            # Add fallback to pipeline creation time if no runs are found
+            latest_run_created = func.coalesce(
+                latest_run_subquery.c.latest_run_created,
+                PipelineSchema.created,
+            )
+
             query = query.add_columns(
-                latest_run_subquery.c.latest_run,
-            ).where(PipelineSchema.id == latest_run_subquery.c.id)
+                latest_run_created.label("latest_run_created"),
+            ).outerjoin(
+                latest_run_subquery,
+                PipelineSchema.id == latest_run_subquery.c.pipeline_id,
+            )
 
             if operand == SorterOps.ASCENDING:
                 query = query.order_by(
-                    asc(latest_run_subquery.c.latest_run),
+                    asc(latest_run_created),
                     asc(PipelineSchema.id),
                 )
             else:
                 query = query.order_by(
-                    desc(latest_run_subquery.c.latest_run),
+                    desc(latest_run_created),
                     desc(PipelineSchema.id),
                 )
             return query

--- a/src/zenml/zen_stores/migrations/versions/c1d964b6075c_add_pipeline_run_pipeline_id_created_.py
+++ b/src/zenml/zen_stores/migrations/versions/c1d964b6075c_add_pipeline_run_pipeline_id_created_.py
@@ -1,0 +1,32 @@
+"""Add pipeline_run pipeline_id created index [c1d964b6075c].
+
+Revision ID: c1d964b6075c
+Revises: 0.95.1
+Create Date: 2026-06-18 13:43:52.380599
+
+"""
+
+from zenml.zen_stores.migrations.utils import (
+    create_index_if_missing,
+    drop_index_if_exists,
+)
+
+# revision identifiers, used by Alembic.
+revision = "c1d964b6075c"
+down_revision = "0.95.1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    create_index_if_missing(
+        "pipeline_run",
+        "ix_pipeline_run_pipeline_id_created",
+        ["pipeline_id", "created"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    drop_index_if_exists("pipeline_run", "ix_pipeline_run_pipeline_id_created")

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -124,6 +124,11 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             table_name=__tablename__,
             column_names=["project_id", "created", "id"],
         ),
+        # Composite index for sorting pipelines by their latest run (UI default)
+        build_index(
+            table_name=__tablename__,
+            column_names=["pipeline_id", "created"],
+        ),
     )
 
     # Fields


### PR DESCRIPTION
Restructure the latest-run subquery and add a supporting index to improve the query plan when sorting pipelines by their latest run.

**Explanation:**
The latest-run subquery joined pipeline_run into the pipeline scan and grouped by pipeline.id, which made MySQL scan every run of every pipeline to compute `MAX(created)`. The new query aggregates over pipeline runs first (which uses the new `pipeline_id, created` index), and then joins the result with the outer query.

**Improvements:**
- locally: 20k pipelines, ~5x improvement on the raw DB query
- remote: 5k pipelines, 1.2mil runs, ~20x improvement on the client method (median 7s -> 330ms)