### PR TITLE
Feature/prevent trigger execution loops

### DIFF
--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -207,6 +207,8 @@ trigger tried to launch this snapshot?" The status can be:
   rule said not to start another one yet.
 - `SKIPPED_MAX_RUNS`: a run was skipped because the configured run limit for
   this trigger-snapshot attachment has already been reached.
+- `SKIPPED_TRIGGER_CYCLE`: a platform event trigger dispatch was skipped
+  because it would revisit a pipeline already present in the trigger chain.
 - `ERROR`: ZenML tried to dispatch the run, but something failed.
 
 When the last status is `ERROR`, the dispatch state can also include the last
@@ -573,8 +575,38 @@ turn can trigger Pipeline C. This enables lightweight orchestration patterns dir
 to break down complex workflows into smaller, reusable pipeline components that execute in sequence based on platform events.
 
 {% hint style="warning" %}
-However, care must be taken when designing such workflows. Since cyclic dependencies are not currently validated, 
-it is possible to create loops where pipelines continuously trigger each other (for example, Pipeline 
-A triggers B, and B triggers A). This can lead to unintended behavior such as infinite execution cycles and 
-resource exhaustion. Users should ensure that their trigger configurations form an acyclic graph and avoid circular dependencies.
+ZenML detects trigger loops at the **pipeline level** while dispatching platform
+event triggers. Snapshots, runs, trigger IDs, and trigger configuration do not
+create separate nodes in the cycle: two different snapshots of the same
+pipeline still refer to the same pipeline in the trigger chain.
+
+If a downstream snapshot would revisit a pipeline that is already in the
+current chain, ZenML skips only that trigger-snapshot dispatch and records
+`SKIPPED_TRIGGER_CYCLE`. Other non-cyclic snapshots attached to the same trigger
+continue to dispatch normally. This protection does not disable or modify the
+trigger configuration, and it does not cancel runs that have already started.
 {% endhint %}
+
+Dispatch states are stored per attached snapshot, and
+`cycle_pipeline_ids` contains the ordered closed cycle (the first and last IDs
+are the pipeline that closes the loop):
+
+```python
+from zenml.client import Client
+from zenml.models import TriggerDispatchStatusCode
+
+client = Client()
+trigger = client.get_platform_event_trigger(
+    trigger_name_id_or_prefix="on-hello-pipeline-complete",
+)
+
+for snapshot_id, state in trigger.snapshot_dispatch_states.items():
+    if state.last_status == TriggerDispatchStatusCode.SKIPPED_TRIGGER_CYCLE:
+        cycle_pipeline_ids = (state.last_status_details or {}).get(
+            "cycle_pipeline_ids", []
+        )
+        print(
+            f"Snapshot {snapshot_id} was skipped because of pipeline cycle: "
+            f"{cycle_pipeline_ids}"
+        )
+```

--- a/src/zenml/models/v2/core/pipeline_snapshot.py
+++ b/src/zenml/models/v2/core/pipeline_snapshot.py
@@ -241,6 +241,10 @@ class PipelineSnapshotResponseBody(ProjectScopedResponseBody):
     is_dynamic: bool = Field(
         title="Whether this is a snapshot of a dynamic pipeline.",
     )
+    pipeline_id: UUID | None = Field(
+        default=None,
+        title="The ID of the pipeline associated with the snapshot.",
+    )
 
 
 class PipelineSnapshotResponseMetadata(ProjectScopedResponseMetadata):
@@ -550,6 +554,18 @@ class PipelineSnapshotResponse(
             the value of the property.
         """
         return self.get_resources().pipeline
+
+    @property
+    def pipeline_id(self) -> UUID | None:
+        """The ID of the pipeline associated with this snapshot.
+
+        This foreign key is exposed on the response body to avoid unnecessary
+        resource hydration when callers only need the pipeline ID.
+
+        Returns:
+            The pipeline ID.
+        """
+        return self.get_body().pipeline_id
 
     @property
     def stack(self) -> Optional[StackResponse]:

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -68,6 +68,7 @@ class TriggerDispatchStatusCode(StrEnum):
     SUCCESS = "SUCCESS"
     SKIPPED_CONCURRENCY = "SKIPPED_CONCURRENCY"
     SKIPPED_MAX_RUNS = "SKIPPED_MAX_RUNS"
+    SKIPPED_TRIGGER_CYCLE = "SKIPPED_TRIGGER_CYCLE"
     ERROR = "ERROR"
 
 
@@ -94,6 +95,10 @@ class TriggerSnapshotDispatchState(BaseModel):
     last_status_at: datetime | None = Field(
         default=None,
         description="Timestamp of the latest recorded status transition.",
+    )
+    last_status_details: dict[str, Any] | None = Field(
+        default=None,
+        description="Structured details for the latest dispatch status.",
     )
     last_error_message: str | None = Field(
         default=None,
@@ -221,6 +226,7 @@ class TriggerSnapshotDispatchState(BaseModel):
 
         self.last_status = new_state.last_status
         self.last_status_at = new_state.last_status_at or utc_now()
+        self.last_status_details = new_state.last_status_details
 
     def clear_error_details(self) -> None:
         """Clear stored error details while keeping the last status."""
@@ -1065,6 +1071,7 @@ class TriggerExecutionInfo(BaseModel):
     """Class representing a trigger execution information."""
 
     upstream_run_id: UUID | None = None
+    upstream_pipeline_ids: list[UUID] = Field(default_factory=list)
 
 
 TRIGGER_UPDATE_TYPE_UNION: TypeAlias = Annotated[

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -830,6 +830,17 @@ class TriggerResponse(
         return self.get_resources().executable_snapshots
 
     @property
+    def snapshot_dispatch_states(
+        self,
+    ) -> dict[UUID, TriggerSnapshotDispatchState]:
+        """Get the latest dispatch state for each attached snapshot.
+
+        Returns:
+            Dispatch states keyed by snapshot ID.
+        """
+        return self.get_resources().snapshot_dispatch_states
+
+    @property
     def latest_run(self) -> Optional["PipelineRunResponse"]:
         """Implements the 'latest_run' property.
 

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -533,6 +533,7 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             runnable=self.is_runnable,
             deployable=deployable,
             is_dynamic=self.is_dynamic,
+            pipeline_id=self.pipeline_id,
         )
         metadata = None
         if include_metadata:

--- a/tests/unit/models/test_pipeline_models.py
+++ b/tests/unit/models/test_pipeline_models.py
@@ -13,12 +13,41 @@
 #  permissions and limitations under the License.
 
 
+from datetime import datetime, timezone
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
 from zenml.config.pipeline_spec import PipelineSpec
 from zenml.constants import STR_FIELD_MAX_LENGTH, TEXT_FIELD_MAX_LENGTH
-from zenml.models import PipelineFilter, PipelineRequest
+from zenml.models import (
+    PipelineFilter,
+    PipelineRequest,
+    PipelineSnapshotResponse,
+    PipelineSnapshotResponseBody,
+)
+
+
+def test_snapshot_pipeline_id_is_available_without_resources() -> None:
+    """The snapshot pipeline ID should not require resource hydration."""
+    pipeline_id = uuid4()
+    snapshot = PipelineSnapshotResponse(
+        id=uuid4(),
+        body=PipelineSnapshotResponseBody(
+            user_id=uuid4(),
+            project_id=uuid4(),
+            created=datetime.now(tz=timezone.utc),
+            updated=datetime.now(tz=timezone.utc),
+            runnable=True,
+            deployable=True,
+            is_dynamic=False,
+            pipeline_id=pipeline_id,
+        ),
+    )
+
+    assert snapshot.resources is None
+    assert snapshot.pipeline_id == pipeline_id
 
 
 def test_pipeline_request_model_fails_with_long_name():

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -12,12 +12,16 @@ from zenml.enums import (
 )
 from zenml.models import (
     PlatformEventTriggerRequest,
+    PlatformEventTriggerResponse,
     PlatformEventTriggerResponseBody,
     PlatformEventTriggerUpdate,
     ScheduleTriggerRequest,
     ScheduleTriggerResponseBody,
     ScheduleTriggerUpdate,
+    TriggerDispatchStatusCode,
     TriggerExecutionInfo,
+    TriggerResponseResources,
+    TriggerSnapshotDispatchState,
 )
 
 
@@ -234,6 +238,21 @@ def test_platform_event_valid_and_inheritance():
         target_events=["completed"],
     )
     assert body.source_entity.type == SourceType.PIPELINE_RUN
+
+    snapshot_id = uuid4()
+    dispatch_state = TriggerSnapshotDispatchState(
+        last_status=TriggerDispatchStatusCode.SKIPPED_TRIGGER_CYCLE,
+        last_status_details={"cycle_pipeline_ids": [uuid4(), uuid4()]},
+    )
+    response = PlatformEventTriggerResponse(
+        id=uuid4(),
+        body=body,
+        resources=TriggerResponseResources(
+            snapshot_dispatch_states={snapshot_id: dispatch_state}
+        ),
+    )
+
+    assert response.snapshot_dispatch_states == {snapshot_id: dispatch_state}
 
 
 def test_platform_event_snapshot_source_valid():

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -17,7 +17,21 @@ from zenml.models import (
     ScheduleTriggerRequest,
     ScheduleTriggerResponseBody,
     ScheduleTriggerUpdate,
+    TriggerExecutionInfo,
 )
+
+
+def test_trigger_execution_info_defaults_pipeline_lineage() -> None:
+    """Legacy trigger execution payloads should get an empty lineage."""
+    upstream_run_id = uuid4()
+
+    info = TriggerExecutionInfo.model_validate(
+        {"upstream_run_id": str(upstream_run_id)}
+    )
+
+    assert info.upstream_run_id == upstream_run_id
+    assert info.upstream_pipeline_ids == []
+    assert "upstream_pipeline_ids" in info.model_dump()
 
 
 def test_schedule_trigger_valid_and_inheritance():

--- a/tests/unit/zen_stores/test_trigger_dispatch_state_policy.py
+++ b/tests/unit/zen_stores/test_trigger_dispatch_state_policy.py
@@ -90,6 +90,24 @@ def test_success_keeps_previous_error_details() -> None:
     assert state.first_error_at is not None
 
 
+def test_new_status_replaces_previous_status_details() -> None:
+    """Status details should always describe the latest transition."""
+    pipeline_id = uuid4()
+    state = TriggerSnapshotDispatchState(
+        last_status=TriggerDispatchStatusCode.SKIPPED_TRIGGER_CYCLE,
+        last_status_details={"cycle_pipeline_ids": [pipeline_id, pipeline_id]},
+    )
+
+    state.apply_new_state(
+        new_state=TriggerSnapshotDispatchState(
+            last_status=TriggerDispatchStatusCode.SUCCESS,
+        )
+    )
+
+    assert state.last_status == TriggerDispatchStatusCode.SUCCESS
+    assert state.last_status_details is None
+
+
 def test_clear_error_details_resets_error_counter() -> None:
     """Clearing errors should also reset the consecutive error counter."""
     state = TriggerSnapshotDispatchState(


### PR DESCRIPTION
## Describe changes

ZenML now detects execution loops in Platform Event Trigger chains at the pipeline level, preventing cyclic configurations from launching pipelines indefinitely and consuming workspace resources. When a loop is detected, only the cyclic trigger-snapshot dispatch is skipped, while unrelated downstream snapshots continue normally. Users can identify these skips through the new SKIPPED_TRIGGER_CYCLE dispatch status and inspect the affected pipeline cycle through the SDK. Existing trigger configurations and already-running pipelines remain unchanged.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

