### PR TITLE
Cache artifact store in server to avoid OOM kills

### DIFF
--- a/src/zenml/artifact_stores/base_artifact_store.py
+++ b/src/zenml/artifact_stores/base_artifact_store.py
@@ -16,6 +16,7 @@
 import inspect
 import os
 import textwrap
+import threading
 from abc import abstractmethod
 from pathlib import Path
 from typing import (
@@ -462,12 +463,32 @@ class BaseArtifactStore(StackComponent):
             **kwargs: The keyword arguments to pass to the Pydantic object.
         """
         super(BaseArtifactStore, self).__init__(*args, **kwargs)
+        self._filesystem_lock = threading.RLock()
         self._add_path_sanitization()
 
         # If running in a ZenML server environment, we don't register
         # the filesystems. We always use the artifact stores directly.
         if ENV_ZENML_SERVER not in os.environ:
             self._register()
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """Get state.
+
+        Returns:
+            The state.
+        """
+        state = self.__dict__.copy()
+        state.pop("_filesystem_lock", None)
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Set state.
+
+        Args:
+            state: The state to set.
+        """
+        self.__dict__.update(state)
+        self._filesystem_lock = threading.RLock()
 
     def _add_path_sanitization(self) -> None:
         """Add path sanitization to the artifact store."""

--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -68,7 +68,6 @@ from zenml.models import (
     StepRunResponse,
     StepRunUpdate,
 )
-from zenml.stack import StackComponent
 from zenml.steps.step_context import get_step_context
 from zenml.utils import source_utils
 from zenml.utils.uuid_utils import to_uuid
@@ -79,6 +78,7 @@ if TYPE_CHECKING:
     from zenml.config.source import Source
     from zenml.materializers.base_materializer import BaseMaterializer
     from zenml.metadata.metadata_types import MetadataType
+    from zenml.models import ComponentResponse
     from zenml.zen_stores.base_zen_store import BaseZenStore
 
     MaterializerClassOrSource = Union[str, Source, Type[BaseMaterializer]]
@@ -547,21 +547,18 @@ def load_artifact_visualization(
     artifact_store = load_artifact_store(
         artifact_store_id=artifact.artifact_store_id, zen_store=zen_store
     )
-    try:
-        mode = "rb" if visualization.type == VisualizationType.IMAGE else "r"
-        value = _load_file_from_artifact_store(
-            uri=visualization.uri,
-            artifact_store=artifact_store,
-            mode=mode,
-        )
+    mode = "rb" if visualization.type == VisualizationType.IMAGE else "r"
+    value = _load_file_from_artifact_store(
+        uri=visualization.uri,
+        artifact_store=artifact_store,
+        mode=mode,
+    )
 
-        # Encode image visualizations if requested
-        if visualization.type == VisualizationType.IMAGE and encode_image:
-            value = base64.b64encode(bytes(value))
+    # Encode image visualizations if requested
+    if visualization.type == VisualizationType.IMAGE and encode_image:
+        value = base64.b64encode(bytes(value))
 
-        return LoadedVisualization(type=visualization.type, value=value)
-    finally:
-        artifact_store.cleanup()
+    return LoadedVisualization(type=visualization.type, value=value)
 
 
 def load_artifact_from_response(artifact: "ArtifactVersionResponse") -> Any:
@@ -827,6 +824,45 @@ def _load_artifact_from_uri(
     return artifact
 
 
+def should_use_artifact_store_cache() -> bool:
+    """Whether the server should serve artifact stores from the cache.
+
+    Returns:
+        Whether the artifact store cache is active.
+    """
+    if ENV_ZENML_SERVER not in os.environ:
+        return False
+
+    from zenml.config.server_config import ServerConfiguration
+
+    return ServerConfiguration.get_server_config().artifact_store_cache_enabled
+
+
+def instantiate_artifact_store(
+    model: "ComponentResponse",
+) -> "BaseArtifactStore":
+    """Return an artifact store for the model, cached when on the server.
+
+    On the server the returned instance is shared across requests, so callers
+    must not call `cleanup()` on it. The cache owns its lifecycle and closes
+    cached stores on server shutdown.
+
+    Args:
+        model: The artifact store component model.
+
+    Returns:
+        A cached or freshly built artifact store instance.
+    """
+    if should_use_artifact_store_cache():
+        from zenml.zen_server.utils import artifact_store_cache
+
+        return artifact_store_cache().get_or_create(model)
+
+    from zenml.stack import StackComponent
+
+    return cast("BaseArtifactStore", StackComponent.from_model(model))
+
+
 def load_artifact_store(
     artifact_store_id: Union[str, "UUID"],
     zen_store: Optional["BaseZenStore"] = None,
@@ -871,10 +907,7 @@ def load_artifact_store(
         )
 
     try:
-        artifact_store = cast(
-            "BaseArtifactStore",
-            StackComponent.from_model(artifact_store_model),
-        )
+        return instantiate_artifact_store(artifact_store_model)
     except ImportError:
         link = "https://docs.zenml.io/stacks/stack-components/artifact-stores/custom#enabling-artifact-visualizations-with-custom-artifact-stores"
         raise NotImplementedError(
@@ -882,8 +915,6 @@ def load_artifact_store(
             f"instantiated. This is likely because the artifact store's "
             f"dependencies are not installed. For more information, see {link}."
         )
-
-    return artifact_store
 
 
 def _get_artifact_store_from_response_or_from_active_stack(
@@ -904,10 +935,7 @@ def _get_artifact_store_from_response_or_from_active_stack(
                 component_type=StackComponentType.ARTIFACT_STORE,
                 name_id_or_prefix=artifact.artifact_store_id,
             )
-            return cast(
-                "BaseArtifactStore",
-                StackComponent.from_model(artifact_store_model),
-            )
+            return instantiate_artifact_store(artifact_store_model)
         except KeyError:
             raise RuntimeError(
                 "Unable to fetch the artifact store with id: "

--- a/src/zenml/config/server_config.py
+++ b/src/zenml/config/server_config.py
@@ -260,6 +260,9 @@ class ServerConfiguration(BaseModel):
         server_request_timeout: The timeout for server requests in seconds. If
             not specified, the default value of 20 seconds will be used. This
             value should be lower than the client's request timeout.
+        artifact_store_cache_enabled: Whether the server caches and reuses
+            artifact store instances across requests instead of rebuilding them
+            on every request.
         api_transaction_cleanup_interval: The interval in seconds between
             cleanup batches.
         dashboard_files_path: The path to the dashboard files directory. If not
@@ -388,6 +391,7 @@ class ServerConfiguration(BaseModel):
     request_timeout: int = DEFAULT_ZENML_SERVER_REQUEST_TIMEOUT
     request_deduplication: bool = True
     request_cache_timeout: int = DEFAULT_ZENML_SERVER_REQUEST_CACHE_TIMEOUT
+    artifact_store_cache_enabled: bool = True
 
     api_transaction_cleanup_interval: int = (
         DEFAULT_ZENML_SERVER_API_TXN_CLEANUP_INTERVAL

--- a/src/zenml/integrations/azure/artifact_stores/azure_artifact_store.py
+++ b/src/zenml/integrations/azure/artifact_stores/azure_artifact_store.py
@@ -111,7 +111,13 @@ class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
         Returns:
             The adlfs filesystem to access this artifact store.
         """
-        if not self._filesystem:
+        if self._filesystem:
+            return self._filesystem
+
+        with self._filesystem_lock:
+            if self._filesystem:
+                return self._filesystem
+
             secret = self.get_credentials()
             credentials = secret.get_values() if secret else {}
 
@@ -120,7 +126,7 @@ class AzureArtifactStore(BaseArtifactStore, AuthenticationMixin):
                 anon=False,
                 use_listings_cache=False,
             )
-        return self._filesystem
+            return self._filesystem
 
     def _split_path(self, path: PathType) -> Tuple[str, str]:
         """Splits a path into the filesystem prefix and remainder.

--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -95,10 +95,14 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
         if self._filesystem and not self.connector_has_expired():
             return self._filesystem
 
-        token = self.get_credentials()
-        self._filesystem = gcsfs.GCSFileSystem(token=token)
+        with self._filesystem_lock:
+            if self._filesystem and not self.connector_has_expired():
+                return self._filesystem
 
-        return self._filesystem
+            token = self.get_credentials()
+            self._filesystem = gcsfs.GCSFileSystem(token=token)
+
+            return self._filesystem
 
     def open(self, path: PathType, mode: str = "r") -> Any:
         """Open a file at the given path.

--- a/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
+++ b/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
@@ -164,8 +164,7 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
     """Artifact Store for S3 based artifacts."""
 
     _filesystem: Optional[ZenMLS3Filesystem] = None
-
-    is_versioned: bool = False
+    _is_versioned: Optional[bool] = None
 
     def __init__(
         self,
@@ -181,18 +180,6 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         super().__init__(*args, **kwargs)
         self._boto3_bucket_holder = None
 
-        # determine bucket versioning status
-        versioning = self._boto3_bucket.Versioning()
-        with self._shield_lack_of_versioning_permissions(
-            "s3:GetBucketVersioning"
-        ):
-            if versioning.status == "Enabled":
-                self.is_versioned = True
-                logger.warning(
-                    f"The artifact store bucket `{self.config.bucket}` is versioned, "
-                    "this may slow down logging process significantly."
-                )
-
     @property
     def config(self) -> S3ArtifactStoreConfig:
         """Get the config of this artifact store.
@@ -201,6 +188,37 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
             The config of this artifact store.
         """
         return cast(S3ArtifactStoreConfig, self._config)
+
+    @property
+    def is_versioned(self) -> bool:
+        """Whether the artifact store bucket has versioning enabled.
+
+        Returns:
+            Whether the artifact store bucket has versioning enabled.
+        """
+        # Determined lazily on first use. The versioning status is only needed
+        # on the log-writing path, so the server read endpoints never pay for
+        # the boto3 client build and `GetBucketVersioning` call this requires.
+        if self._is_versioned is None:
+            with self._filesystem_lock:
+                if self._is_versioned is None:
+                    self._determine_versioning()
+        return bool(self._is_versioned)
+
+    def _determine_versioning(self) -> None:
+        """Query and cache the bucket versioning status."""
+        is_versioned = False
+        versioning = self._boto3_bucket.Versioning()
+        with self._shield_lack_of_versioning_permissions(
+            "s3:GetBucketVersioning"
+        ):
+            if versioning.status == "Enabled":
+                is_versioned = True
+                logger.warning(
+                    f"The artifact store bucket `{self.config.bucket}` is versioned, "
+                    "this may slow down logging process significantly."
+                )
+        self._is_versioned = is_versioned
 
     def get_credentials(
         self,
@@ -260,26 +278,30 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         if self._filesystem and not self.connector_has_expired():
             return self._filesystem
 
-        key, secret, token, region = self.get_credentials()
+        with self._filesystem_lock:
+            if self._filesystem and not self.connector_has_expired():
+                return self._filesystem
 
-        # Use the region from the connector if available, otherwise some
-        # remote workloads (e.g. Sagemaker) might not work correctly because
-        # they look for the bucket in the wrong region
-        client_kwargs = {}
-        if region:
-            client_kwargs["region_name"] = region
-        if self.config.client_kwargs:
-            client_kwargs.update(self.config.client_kwargs)
+            key, secret, token, region = self.get_credentials()
 
-        self._filesystem = ZenMLS3Filesystem(
-            key=key,
-            secret=secret,
-            token=token,
-            client_kwargs=client_kwargs,
-            config_kwargs=self.config.config_kwargs,
-            s3_additional_kwargs=self.config.s3_additional_kwargs,
-        )
-        return self._filesystem
+            # Use the region from the connector if available, otherwise some
+            # remote workloads (e.g. Sagemaker) might not work correctly because
+            # they look for the bucket in the wrong region
+            client_kwargs = {}
+            if region:
+                client_kwargs["region_name"] = region
+            if self.config.client_kwargs:
+                client_kwargs.update(self.config.client_kwargs)
+
+            self._filesystem = ZenMLS3Filesystem(
+                key=key,
+                secret=secret,
+                token=token,
+                client_kwargs=client_kwargs,
+                config_kwargs=self.config.config_kwargs,
+                s3_additional_kwargs=self.config.s3_additional_kwargs,
+            )
+            return self._filesystem
 
     def cleanup(self) -> None:
         """Close the filesystem."""
@@ -563,9 +585,13 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
         if self._boto3_bucket_holder and not self.connector_has_expired():
             return self._boto3_bucket_holder
 
-        s3 = boto3.resource("s3", **self._build_boto3_kwargs())
-        self._boto3_bucket_holder = s3.Bucket(self.config.bucket)
-        return self._boto3_bucket_holder
+        with self._filesystem_lock:
+            if self._boto3_bucket_holder and not self.connector_has_expired():
+                return self._boto3_bucket_holder
+
+            s3 = boto3.resource("s3", **self._build_boto3_kwargs())
+            self._boto3_bucket_holder = s3.Bucket(self.config.bucket)
+            return self._boto3_bucket_holder
 
     @contextmanager
     def _shield_lack_of_versioning_permissions(
@@ -581,4 +607,4 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
                     "This is needed to remove previous versions of log files from your "
                     "Artifact Store bucket."
                 )
-                self.is_versioned = False
+                self._is_versioned = False

--- a/src/zenml/utils/logging_utils.py
+++ b/src/zenml/utils/logging_utils.py
@@ -584,8 +584,6 @@ def fetch_logs(
             "environment. Use the log store directly instead."
         )
 
-    log_store: Optional[BaseLogStore] = None
-
     if logs.log_store_id:
         try:
             log_store_model = verify_permissions_and_get_entity(
@@ -612,8 +610,14 @@ def fetch_logs(
                 f"Log store '{log_store_model.name}' could not be "
                 "instantiated."
             )
-    elif logs.artifact_store_id:
-        from zenml.artifact_stores.base_artifact_store import BaseArtifactStore
+
+        try:
+            return log_store.fetch(logs_model=logs, limit=limit)
+        finally:
+            log_store.cleanup()
+
+    if logs.artifact_store_id:
+        from zenml.artifacts.utils import instantiate_artifact_store
         from zenml.log_stores.artifact.artifact_log_store import (
             ArtifactLogStore,
         )
@@ -631,21 +635,14 @@ def fetch_logs(
             raise DoesNotExistException(
                 f"Stack component '{logs.artifact_store_id}' is not an artifact store."
             )
-        artifact_store = cast(
-            "BaseArtifactStore",
-            StackComponent.from_model(artifact_store_model),
-        )
+
+        artifact_store = instantiate_artifact_store(artifact_store_model)
         log_store = ArtifactLogStore.from_artifact_store(
             artifact_store=artifact_store
         )
-
-    else:
-        return []
-
-    try:
         return log_store.fetch(logs_model=logs, limit=limit)
-    finally:
-        log_store.cleanup()
+
+    return []
 
 
 def setup_logging_context(

--- a/src/zenml/zen_server/artifact_store_cache.py
+++ b/src/zenml/zen_server/artifact_store_cache.py
@@ -1,0 +1,167 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Bounded LRU cache of artifact store instances."""
+
+import threading
+import time
+from collections import OrderedDict
+from datetime import datetime
+from typing import TYPE_CHECKING, NamedTuple, cast
+from uuid import UUID
+
+from zenml.logger import get_logger
+
+if TYPE_CHECKING:
+    from zenml.artifact_stores import BaseArtifactStore
+    from zenml.models import ComponentResponse
+
+logger = get_logger(__name__)
+
+DEFAULT_ARTIFACT_STORE_CACHE_SIZE = 20
+DEFAULT_ARTIFACT_STORE_CACHE_TTL = 3600.0
+
+
+class _CacheEntry(NamedTuple):
+    """Artifact store cache entry."""
+
+    store: "BaseArtifactStore"
+    updated: datetime
+    inserted_at: float
+
+
+class ArtifactStoreCache:
+    """Bounded LRU cache of artifact store instances."""
+
+    def __init__(
+        self,
+        max_size: int = DEFAULT_ARTIFACT_STORE_CACHE_SIZE,
+        ttl: float = DEFAULT_ARTIFACT_STORE_CACHE_TTL,
+    ) -> None:
+        """Initialize the cache.
+
+        Args:
+            max_size: Maximum number of artifact store instances to retain.
+            ttl: Seconds after which a cached instance is rebuilt.
+        """
+        self._max_size = max_size
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        self._entries: "OrderedDict[UUID, _CacheEntry]" = OrderedDict()
+
+    def get_or_create(self, model: "ComponentResponse") -> "BaseArtifactStore":
+        """Return a cached artifact store for the model, building it if needed.
+
+        Args:
+            model: The artifact store component model.
+
+        Returns:
+            A cached or freshly built artifact store instance.
+        """
+        updated = self._effective_updated(model)
+
+        with self._lock:
+            entry = self._entries.get(model.id)
+            if entry is not None and not self._is_expired(entry, updated):
+                self._entries.move_to_end(model.id)
+                return entry.store
+
+        # Instantiate outside the lock
+        store = self._instantiate(model)
+
+        with self._lock:
+            entry = self._entries.get(model.id)
+            if entry is not None and not self._is_expired(entry, updated):
+                # Another thread instantiated the same store concurrently. We
+                # throw ours away and use the existing one.
+                self._safe_cleanup(store)
+                self._entries.move_to_end(model.id)
+                return entry.store
+
+            # Replace the stale entry without cleaning it up. A concurrent
+            # request may still hold and use the old instance, and cleanup()
+            # closes its filesystem. The orphaned instance is reclaimed by GC.
+            self._entries.pop(model.id, None)
+            self._entries[model.id] = _CacheEntry(
+                store, updated, time.monotonic()
+            )
+            self._maybe_evict()
+            return store
+
+    def clear(self) -> None:
+        """Cleanup and drop all cached artifact stores."""
+        with self._lock:
+            for entry in self._entries.values():
+                self._safe_cleanup(entry.store)
+            self._entries.clear()
+
+    def _effective_updated(self, model: "ComponentResponse") -> datetime:
+        """The most recent of the component and its connector update timestamps.
+
+        Args:
+            model: The artifact store component model.
+
+        Returns:
+            The most recent update timestamp of the component and its connector.
+        """
+        if connector := model.connector:
+            return max(model.updated, connector.updated)
+        return model.updated
+
+    def _is_expired(self, entry: _CacheEntry, updated: datetime) -> bool:
+        """Whether a cache entry is expired.
+
+        Args:
+            entry: The cached entry.
+            updated: The effective update timestamp of the current model.
+
+        Returns:
+            Whether the entry is expired.
+        """
+        return (
+            entry.updated != updated
+            or (time.monotonic() - entry.inserted_at) > self._ttl
+        )
+
+    def _instantiate(self, model: "ComponentResponse") -> "BaseArtifactStore":
+        """Instantiate an artifact store from a component model.
+
+        Args:
+            model: The artifact store component model.
+
+        Returns:
+            The instantiated artifact store.
+        """
+        from zenml.stack import StackComponent
+
+        return cast("BaseArtifactStore", StackComponent.from_model(model))
+
+    def _maybe_evict(self) -> None:
+        """Evict least-recently-used entries if the cache is full."""
+        # Evicted instances are dropped without cleanup. A concurrent request
+        # may still hold one, and cleanup() closes its filesystem. GC reclaims
+        # the orphaned instance once no request references it.
+        while len(self._entries) > self._max_size:
+            self._entries.popitem(last=False)
+
+    @staticmethod
+    def _safe_cleanup(store: "BaseArtifactStore") -> None:
+        """Run an artifact store cleanup, swallowing errors.
+
+        Args:
+            store: The artifact store to clean up.
+        """
+        try:
+            store.cleanup()
+        except Exception as e:
+            logger.debug("Error cleaning up cached artifact store: %s", e)

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -73,6 +73,7 @@ from zenml.zen_stores.sql_zen_store import SqlZenStore
 if TYPE_CHECKING:
     from fastapi import Request
 
+    from zenml.zen_server.artifact_store_cache import ArtifactStoreCache
     from zenml.zen_server.auth import AuthContext
     from zenml.zen_server.pipeline_execution.utils import (
         BoundedThreadPoolExecutor,
@@ -98,6 +99,7 @@ _request_manager: Optional[RequestManager] = None
 _stream_broker: Optional[StreamBroker] = None
 _stream_broadcaster: Optional[StreamBroadcaster] = None
 _stream_end_handler: Optional["StreamEndEventHandler"] = None
+_artifact_store_cache: Optional["ArtifactStoreCache"] = None
 _auth_context: ContextVar[Optional["AuthContext"]] = ContextVar(
     "auth_context", default=None
 )
@@ -479,6 +481,37 @@ async def cleanup_request_manager() -> None:
     if _request_manager is not None:
         await _request_manager.shutdown()
         _request_manager = None
+
+
+def artifact_store_cache() -> "ArtifactStoreCache":
+    """Return the artifact store cache.
+
+    Returns:
+        The artifact store cache.
+
+    Raises:
+        RuntimeError: If the artifact store cache is not initialized.
+    """
+    global _artifact_store_cache
+    if _artifact_store_cache is None:
+        raise RuntimeError("Artifact store cache not initialized")
+    return _artifact_store_cache
+
+
+def initialize_artifact_store_cache() -> None:
+    """Initialize the artifact store cache."""
+    global _artifact_store_cache
+    from zenml.zen_server.artifact_store_cache import ArtifactStoreCache
+
+    _artifact_store_cache = ArtifactStoreCache()
+
+
+def cleanup_artifact_store_cache() -> None:
+    """Cleanup the artifact store cache."""
+    global _artifact_store_cache
+    if _artifact_store_cache is not None:
+        _artifact_store_cache.clear()
+        _artifact_store_cache = None
 
 
 def handle_endpoint_errors(

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -100,7 +100,9 @@ from zenml.zen_server.secure_headers import (
     initialize_secure_headers,
 )
 from zenml.zen_server.utils import (
+    cleanup_artifact_store_cache,
     cleanup_request_manager,
+    initialize_artifact_store_cache,
     initialize_feature_gate,
     initialize_rbac,
     initialize_request_manager,
@@ -207,6 +209,7 @@ async def initialize() -> None:
     initialize_workload_manager()
     initialize_resource_pool_store()
     initialize_snapshot_executor()
+    initialize_artifact_store_cache()
     await initialize_streaming()
     initialize_secure_headers()
     if cfg.deployment_type == ServerDeploymentType.CLOUD:
@@ -229,6 +232,7 @@ async def shutdown() -> None:
     snapshot_executor().shutdown(wait=True)
     await shutdown_streaming()
     await cleanup_request_manager()
+    cleanup_artifact_store_cache()
 
 
 DASHBOARD_REDIRECT_URL = None

--- a/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
+++ b/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
@@ -94,7 +94,7 @@ def test_boto3_resource_receives_client_kwargs():
         bucket.Versioning.return_value.status = "Enabled"
         mock_resource.return_value.Bucket.return_value = bucket
 
-        S3ArtifactStore(
+        artifact_store = S3ArtifactStore(
             name="",
             id=uuid4(),
             config=S3ArtifactStoreConfig(
@@ -110,6 +110,8 @@ def test_boto3_resource_receives_client_kwargs():
             created=datetime.now(),
             updated=datetime.now(),
         )
+
+        _ = artifact_store._boto3_bucket
 
     assert (
         mock_resource.call_args.kwargs["endpoint_url"] == "http://minio:9000"
@@ -139,12 +141,12 @@ def test_remove_previous_versions_uses_client_kwargs():
             updated=datetime.now(),
         )
 
-        artifact_store.is_versioned = True
+        artifact_store._is_versioned = True
         artifact_store._boto3_bucket_holder = None
 
         artifact_store._remove_previous_file_versions("s3://mybucket/path")
 
-    assert len(mock_resource.call_args_list) == 2
+    assert len(mock_resource.call_args_list) == 1
     for call in mock_resource.call_args_list:
         assert call.kwargs["endpoint_url"] == "http://minio:9000"
 

--- a/tests/unit/artifacts/test_utils.py
+++ b/tests/unit/artifacts/test_utils.py
@@ -14,16 +14,22 @@
 import os
 import shutil
 import tempfile
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from pydantic import BaseModel
 
+import zenml.artifacts.utils as au
 from zenml.artifacts.utils import (
     _load_artifact_from_uri,
     _strip_timestamp_from_multiline_string,
     load_artifact_from_response,
     load_model_from_metadata,
     save_model_metadata,
+    should_use_artifact_store_cache,
 )
 from zenml.client import Client
 from zenml.constants import MODEL_METADATA_YAML_FILE_NAME
@@ -225,3 +231,55 @@ def test__load_artifact(builtin_type_file_uri):
 def test__strip_timestamp_from_multiline_string(raw: str, expected: str):
     """Test the _strip_timestamp_from_multiline_string function to properly strip the logs."""
     assert _strip_timestamp_from_multiline_string(raw) == expected
+
+
+def _artifact_store_model():
+    """Build a fake component model exposing id, updated and name."""
+    return SimpleNamespace(
+        id=uuid4(),
+        updated=datetime(2024, 1, 1),
+        name="artifact-store",
+    )
+
+
+def test_should_use_cache_respects_server_env_and_config(monkeypatch):
+    """The gate requires the server env and honors the config toggle."""
+    monkeypatch.delenv("ZENML_SERVER", raising=False)
+    monkeypatch.delenv(
+        "ZENML_SERVER_ARTIFACT_STORE_CACHE_ENABLED", raising=False
+    )
+    # Outside the server the config is never consulted.
+    assert should_use_artifact_store_cache() is False
+
+    monkeypatch.setenv("ZENML_SERVER", "true")
+    monkeypatch.setenv("ZENML_SERVER_ARTIFACT_STORE_CACHE_ENABLED", "true")
+    assert should_use_artifact_store_cache() is True
+
+    monkeypatch.setenv("ZENML_SERVER_ARTIFACT_STORE_CACHE_ENABLED", "false")
+    assert should_use_artifact_store_cache() is False
+
+
+def test_instantiate_artifact_store_uses_cache_when_active(monkeypatch):
+    """With the cache active, the store is served from the server cache."""
+    monkeypatch.setattr(au, "should_use_artifact_store_cache", lambda: True)
+    store = MagicMock()
+    cache = MagicMock()
+    cache.get_or_create.return_value = store
+    monkeypatch.setattr(
+        "zenml.zen_server.utils.artifact_store_cache", lambda: cache
+    )
+
+    model = _artifact_store_model()
+    assert au.instantiate_artifact_store(model) is store
+    cache.get_or_create.assert_called_once_with(model)
+
+
+def test_instantiate_artifact_store_builds_when_disabled(monkeypatch):
+    """With the cache off, a fresh store is built."""
+    monkeypatch.setattr(au, "should_use_artifact_store_cache", lambda: False)
+    store = MagicMock()
+    monkeypatch.setattr(
+        "zenml.stack.StackComponent.from_model", lambda model: store
+    )
+
+    assert au.instantiate_artifact_store(_artifact_store_model()) is store

--- a/tests/unit/zen_server/test_artifact_store_cache.py
+++ b/tests/unit/zen_server/test_artifact_store_cache.py
@@ -1,0 +1,146 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the server-side artifact store cache."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from zenml.zen_server.artifact_store_cache import ArtifactStoreCache
+
+
+def _model(id_=None, updated=None, connector_updated=None):
+    """Build a fake component model exposing id, updated, name and connector."""
+    connector = (
+        SimpleNamespace(updated=connector_updated)
+        if connector_updated is not None
+        else None
+    )
+    return SimpleNamespace(
+        id=id_ or uuid4(),
+        updated=updated or datetime(2024, 1, 1),
+        name="artifact-store",
+        connector=connector,
+    )
+
+
+@pytest.fixture
+def built_stores():
+    """Patch `from_model` to return a fresh mock store per call."""
+    stores = []
+
+    def _build(model):
+        store = MagicMock(name=f"store-{len(stores)}")
+        stores.append(store)
+        return store
+
+    with patch("zenml.stack.StackComponent.from_model", side_effect=_build):
+        yield stores
+
+
+def test_same_model_reuses_instance(built_stores):
+    """The same model returns the same cached instance, built once."""
+    cache = ArtifactStoreCache()
+    model = _model()
+
+    first = cache.get_or_create(model)
+    second = cache.get_or_create(model)
+
+    assert first is second
+    assert len(built_stores) == 1
+
+
+def test_updated_timestamp_rebuilds_without_cleanup(built_stores):
+    """A changed `updated` timestamp rebuilds without cleaning up the old store.
+
+    Cleanup is deferred to GC because a concurrent request may still hold the
+    old instance.
+    """
+    cache = ArtifactStoreCache()
+    component_id = uuid4()
+
+    old = cache.get_or_create(_model(component_id, datetime(2024, 1, 1)))
+    new = cache.get_or_create(_model(component_id, datetime(2024, 6, 1)))
+
+    assert old is not new
+    assert len(built_stores) == 2
+    old.cleanup.assert_not_called()
+
+
+def test_connector_update_rebuilds(built_stores):
+    """A newer connector `updated` timestamp invalidates the cached store."""
+    cache = ArtifactStoreCache()
+    component_id = uuid4()
+
+    old = cache.get_or_create(
+        _model(
+            component_id,
+            updated=datetime(2024, 1, 1),
+            connector_updated=datetime(2024, 1, 1),
+        )
+    )
+    # Connector rotated after the component was last updated.
+    new = cache.get_or_create(
+        _model(
+            component_id,
+            updated=datetime(2024, 1, 1),
+            connector_updated=datetime(2024, 6, 1),
+        )
+    )
+
+    assert old is not new
+    assert len(built_stores) == 2
+
+
+def test_ttl_expiry_rebuilds_without_cleanup(built_stores):
+    """An entry past its TTL is rebuilt without cleaning up the old store."""
+    cache = ArtifactStoreCache(ttl=0.0)
+    model = _model()
+
+    first = cache.get_or_create(model)
+    second = cache.get_or_create(model)
+
+    assert first is not second
+    first.cleanup.assert_not_called()
+
+
+def test_lru_eviction_drops_oldest_without_cleanup(built_stores):
+    """Exceeding the size cap evicts the oldest entry without cleaning it up."""
+    cache = ArtifactStoreCache(max_size=2)
+
+    a = cache.get_or_create(_model())
+    b = cache.get_or_create(_model())
+    c = cache.get_or_create(_model())
+
+    # inserting the third entry evicts the least-recently-used (a)
+    assert len(cache._entries) == 2
+    a.cleanup.assert_not_called()
+    b.cleanup.assert_not_called()
+    c.cleanup.assert_not_called()
+
+
+def test_clear_cleans_up_all(built_stores):
+    """Clearing the cache cleans up every cached store."""
+    cache = ArtifactStoreCache()
+    a = cache.get_or_create(_model())
+    b = cache.get_or_create(_model())
+
+    cache.clear()
+
+    a.cleanup.assert_called_once()
+    b.cleanup.assert_called_once()
+    assert len(cache._entries) == 0


### PR DESCRIPTION
Introduce a server-side artifact store cache to avoid OOM kills when a store is used to e.g. read logs or visualizations.

**Root cause:**
Each logs/visualization request rebuilt a botocore client, parsing the entire S3 service model into tens of thousands of small objects. Those graphs are reference cycles, so refcounting never frees them.