### PR TITLE
Fix CI-blocking dead docs links and transformers version floor

### DIFF
--- a/docs/book/component-guide/experiment-trackers/comet.md
+++ b/docs/book/component-guide/experiment-trackers/comet.md
@@ -123,7 +123,7 @@ def my_step():
 ```
 
 {% hint style="info" %}
-Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/reference/python-client) to dynamically use the experiment tracker of your active stack, as shown in the example above.
+Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/sdk-reference/zenml/client) to dynamically use the experiment tracker of your active stack, as shown in the example above.
 {% endhint %}
 
 ### Comet UI

--- a/docs/book/component-guide/experiment-trackers/mlflow.md
+++ b/docs/book/component-guide/experiment-trackers/mlflow.md
@@ -204,7 +204,7 @@ def tf_trainer(
 ```
 
 {% hint style="info" %}
-Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/reference/python-client) to dynamically use the experiment tracker of your active stack:
+Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/sdk-reference/zenml/client) to dynamically use the experiment tracker of your active stack:
 
 ```python
 from zenml.client import Client

--- a/docs/book/component-guide/experiment-trackers/neptune.md
+++ b/docs/book/component-guide/experiment-trackers/neptune.md
@@ -131,7 +131,7 @@ def train_model() -> SVC:
 ```
 
 {% hint style="info" %}
-Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/reference/python-client) to dynamically use the experiment tracker of your active stack:
+Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/sdk-reference/zenml/client) to dynamically use the experiment tracker of your active stack:
 
 ```python
 from zenml.client import Client

--- a/docs/book/component-guide/experiment-trackers/vertexai.md
+++ b/docs/book/component-guide/experiment-trackers/vertexai.md
@@ -258,7 +258,7 @@ def train_model(
 ```
 
 {% hint style="info" %}
-Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/reference/python-client) to dynamically use the experiment tracker of your active stack:
+Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/sdk-reference/zenml/client) to dynamically use the experiment tracker of your active stack:
 
 ```python
 from zenml.client import Client

--- a/docs/book/component-guide/experiment-trackers/wandb.md
+++ b/docs/book/component-guide/experiment-trackers/wandb.md
@@ -125,7 +125,7 @@ def tf_trainer(
 ```
 
 {% hint style="info" %}
-Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/reference/python-client) to dynamically use the experiment tracker of your active stack:
+Instead of hardcoding an experiment tracker name, you can also use the [Client](https://docs.zenml.io/sdk-reference/zenml/client) to dynamically use the experiment tracker of your active stack:
 
 ```python
 from zenml.client import Client

--- a/docs/book/user-guide/tutorial/fetching-pipelines.md
+++ b/docs/book/user-guide/tutorial/fetching-pipelines.md
@@ -51,7 +51,7 @@ pipeline_model = Client().get_pipeline("first_pipeline")
 ```
 
 {% hint style="info" %}
-Check out the [ZenML Client Documentation](https://docs.zenml.io/reference/python-client) for more information on the `Client` class and its purpose.
+Check out the [ZenML Client Documentation](https://docs.zenml.io/sdk-reference/zenml/client) for more information on the `Client` class and its purpose.
 {% endhint %}
 
 ### Discovering and Listing All Pipelines
@@ -98,7 +98,7 @@ runs = pipeline_model.runs
 The result will be a list of the most recent runs of this pipeline, ordered from newest to oldest.
 
 {% hint style="info" %}
-Alternatively, you can also use the `pipeline_model.get_runs()` method which allows you to specify detailed parameters for filtering or pagination. See the [ZenML SDK Docs](https://docs.zenml.io/reference/python-client#list-of-resources) for more information.
+Alternatively, you can also use the `pipeline_model.get_runs()` method which allows you to specify detailed parameters for filtering or pagination. See the [ZenML SDK Docs](https://docs.zenml.io/sdk-reference/zenml/example-usages) for more information.
 {% endhint %}
 
 ### Getting the Last Run of a Pipeline

--- a/src/zenml/integrations/huggingface/__init__.py
+++ b/src/zenml/integrations/huggingface/__init__.py
@@ -55,7 +55,12 @@ class HuggingfaceIntegration(Integration):
             "accelerate",
             "bitsandbytes>=0.41.3",
             "peft",
-            "transformers<4.55.0",
+            # Lower bound stops the resolver from backtracking to ancient
+            # transformers (e.g. 4.12.x) when the combined integration
+            # install hits a conflict. Those versions pin tokenizers<0.11,
+            # which has no wheels and fails to build from source on modern
+            # Rust toolchains.
+            "transformers>=4.40,<4.55.0",
         ]
 
         # Add the pandas integration requirements


### PR DESCRIPTION
**Breaking change:**
- `transformers` min version bumped