### PR TITLE
Allow overwriting step inputs for all invocations when replaying

### DIFF
--- a/docs/book/user-guide/tutorial/replaying-runs-steps.md
+++ b/docs/book/user-guide/tutorial/replaying-runs-steps.md
@@ -173,6 +173,52 @@ Client().replay_pipeline_run(
 {% endtab %}
 {% endtabs %}
 
+#### Overriding an input for every invocation of a step
+
+If you want to override inputs for **every invocation** of a step, you can
+use `step_default_input_overrides`. It is keyed by the step's name instead of
+the invocation ID. Per-invocation overrides in `step_input_overrides` take
+precedence per input key.
+
+{% hint style="warning" %}
+The override applies to every invocation that shares the given name, and ZenML
+does not enforce that a name maps to a single step function. If two different
+steps share a name (for example two functions named `train` in different
+modules both default to the name `train`), the override is applied to both.
+Give such steps distinct names if you want to target only one of them.
+{% endhint %}
+
+{% tabs %}
+{% tab title="From local code" %}
+```python
+training_pipeline.replay(
+    pipeline_run="run_name_or_id",
+    step_default_input_overrides={
+        "llm_call": {
+            "model": "claude-fable-5"
+        }
+    },
+)
+```
+{% endtab %}
+{% tab title="From the server" %}
+```python
+from zenml import Client
+
+Client().replay_pipeline_run(
+    name_id_or_prefix="run_name_or_id",
+    run_configuration={
+        "step_default_input_overrides": {
+            "llm_call": {
+                "model": "claude-fable-5"
+            }
+        }
+    },
+)
+```
+{% endtab %}
+{% endtabs %}
+
 ---
 
 ## Replaying a single step

--- a/src/zenml/artifacts/utils.py
+++ b/src/zenml/artifacts/utils.py
@@ -25,6 +25,7 @@ from typing import (
     Any,
     Dict,
     List,
+    Mapping,
     Optional,
     Type,
     Union,
@@ -317,6 +318,50 @@ def save_artifact(
         )
 
     return artifact_version
+
+
+def upload_input_artifact_overrides(
+    overrides: Optional[Mapping[str, Mapping[str, Any]]],
+    artifact_store: Optional["BaseArtifactStore"] = None,
+) -> Dict[str, Dict[str, UUID]]:
+    """Upload input artifact override values to the artifact store.
+
+    Args:
+        overrides: The input artifact overrides to upload.
+        artifact_store: The artifact store to upload to. If not provided, the
+            active stack's artifact store is used.
+
+    Returns:
+        The overrides with values replaced by artifact version IDs.
+    """
+    from zenml.artifacts.external_artifact import ExternalArtifact
+
+    if not overrides:
+        return {}
+
+    processed_overrides: Dict[str, Dict[str, UUID]] = {}
+
+    for outer_key, input_overrides in overrides.items():
+        processed_overrides[outer_key] = {}
+        for input_name, value in input_overrides.items():
+            # UUIDs and existing artifact versions are already uploaded. We
+            # upload everything else to the artifact store.
+            if isinstance(value, UUID):
+                artifact_version_id = value
+            elif isinstance(value, ArtifactVersionResponse):
+                artifact_version_id = value.id
+            elif isinstance(value, ExternalArtifact):
+                artifact_version_id = value.id or value.upload_by_value(
+                    artifact_store=artifact_store
+                )
+            else:
+                artifact_version_id = ExternalArtifact(
+                    value=value
+                ).upload_by_value(artifact_store=artifact_store)
+
+            processed_overrides[outer_key][input_name] = artifact_version_id
+
+    return processed_overrides
 
 
 def register_artifact(

--- a/src/zenml/config/pipeline_configurations.py
+++ b/src/zenml/config/pipeline_configurations.py
@@ -115,6 +115,7 @@ class PipelineConfiguration(PipelineConfigurationUpdate):
     steps_to_skip: Set[str] = set()
     skip_successful_steps: bool = False
     step_input_overrides: Dict[str, Dict[str, UUID]] = {}
+    step_default_input_overrides: Dict[str, Dict[str, UUID]] = {}
 
     @property
     def docker_settings(self) -> "DockerSettings":
@@ -163,3 +164,31 @@ class PipelineConfiguration(PipelineConfigurationUpdate):
         if isinstance(model_or_dict, BaseSettings):
             model_or_dict = model_or_dict.model_dump()
         return DeploymentSettings.model_validate(model_or_dict)
+
+    def get_invocation_input_overrides(
+        self,
+        invocation_id: str,
+        step_name: str,
+        include_step_defaults: bool = True,
+    ) -> Dict[str, UUID]:
+        """Step input overrides for an invocation.
+
+        This method merges the step-wide overrides and the per-invocation
+        overrides.
+
+        Args:
+            invocation_id: The invocation ID of the step.
+            step_name: The name of the step.
+            include_step_defaults: Whether to include the step-wide default
+                overrides.
+
+        Returns:
+            The step input overrides for the invocation.
+        """
+        overrides: Dict[str, UUID] = {}
+        if include_step_defaults:
+            overrides.update(
+                self.step_default_input_overrides.get(step_name, {})
+            )
+        overrides.update(self.step_input_overrides.get(invocation_id, {}))
+        return overrides

--- a/src/zenml/config/pipeline_run_configuration.py
+++ b/src/zenml/config/pipeline_run_configuration.py
@@ -180,3 +180,11 @@ class ReplayRunConfiguration(PipelineRunConfiguration):
         default=None,
         description="The step input overrides for the pipeline run.",
     )
+    step_default_input_overrides: Optional[Mapping[str, Mapping[str, Any]]] = (
+        Field(
+            default=None,
+            description="Input overrides applied to every invocation of a step, "
+            "keyed by the step's name. Per-invocation overrides in "
+            "`step_input_overrides` take precedence.",
+        )
+    )

--- a/src/zenml/execution/pipeline/utils.py
+++ b/src/zenml/execution/pipeline/utils.py
@@ -191,7 +191,9 @@ def skip_steps_and_prune_snapshot(
 
     for invocation_id, step in snapshot.step_configurations.items():
         explicitly_skipped = invocation_id in explicitly_skipped_steps
-        should_skip = request_factory.should_skip_step(invocation_id)
+        should_skip = request_factory.should_skip_step(
+            invocation_id, step=step
+        )
 
         if not should_skip:
             continue

--- a/src/zenml/orchestrators/step_run_utils.py
+++ b/src/zenml/orchestrators/step_run_utils.py
@@ -100,11 +100,12 @@ class StepRunRequestFactory:
         self._original_step_run_cache[invocation_id] = original_step_run
         return original_step_run
 
-    def should_skip_step(self, invocation_id: str) -> bool:
+    def should_skip_step(self, invocation_id: str, step: "Step") -> bool:
         """Check whether a step should be skipped.
 
         Args:
             invocation_id: The invocation ID to check.
+            step: The step configuration.
 
         Returns:
             Whether the step should be skipped.
@@ -115,7 +116,12 @@ class StepRunRequestFactory:
         if not self.snapshot.pipeline_configuration.skip_successful_steps:
             return False
 
-        if self._get_input_overrides(invocation_id):
+        if self._get_input_overrides(
+            invocation_id,
+            step=step,
+            warn_on_invalid_keys=False,
+            include_step_defaults=False,
+        ):
             logger.warning(
                 "Step `%s` should be skipped, but there are input overrides "
                 "configured. The step will be executed.",
@@ -193,14 +199,15 @@ class StepRunRequestFactory:
                 input resolution. This will be updated in-place with newly
                 fetched step runs.
         """
-        if self.should_skip_step(request.name):
-            self._populate_skipped_step(request)
-            return
-
         step = (
             request.dynamic_config
             or self.snapshot.step_configurations[request.name]
         )
+
+        if self.should_skip_step(request.name, step=step):
+            self._populate_skipped_step(request)
+            return
+
         input_overrides = self._get_input_overrides(request.name, step=step)
 
         input_artifacts = input_utils.resolve_step_inputs(
@@ -425,41 +432,45 @@ class StepRunRequestFactory:
         return None, None
 
     def _get_input_overrides(
-        self, invocation_id: str, step: Optional["Step"] = None
+        self,
+        invocation_id: str,
+        step: "Step",
+        warn_on_invalid_keys: bool = True,
+        include_step_defaults: bool = True,
     ) -> Dict[str, "UUID"]:
         """Get input overrides for a step.
 
         Args:
             invocation_id: The invocation ID to look up.
-            step: The step configuration. If not provided, no input key
-                validation is performed.
+            step: The step configuration.
+            warn_on_invalid_keys: Whether to log a warning for overrides that
+                reference inputs not available on the step.
+            include_step_defaults: Whether to include the step-wide default
+                overrides.
 
         Returns:
             The input overrides for the step.
         """
-        overrides = (
-            self.snapshot.pipeline_configuration.step_input_overrides.get(
-                invocation_id, {}
-            )
+        overrides = self.snapshot.pipeline_configuration.get_invocation_input_overrides(
+            invocation_id=invocation_id,
+            step_name=step.config.name,
+            include_step_defaults=include_step_defaults,
         )
 
-        if step:
-            available_input_keys = step.available_input_keys
-            invalid_keys = overrides.keys() - available_input_keys
-            if invalid_keys:
-                logger.warning(
-                    "Ignoring invalid input overrides for step `%s`: %s",
-                    invocation_id,
-                    invalid_keys,
-                )
+        available_input_keys = step.available_input_keys
+        invalid_keys = overrides.keys() - available_input_keys
+        if invalid_keys and warn_on_invalid_keys:
+            logger.warning(
+                "Ignoring invalid input overrides for step `%s`: %s",
+                invocation_id,
+                invalid_keys,
+            )
 
-            overrides = {
-                key: value
-                for key, value in overrides.items()
-                if key in available_input_keys
-            }
-
-        return overrides
+        return {
+            key: value
+            for key, value in overrides.items()
+            if key in available_input_keys
+        }
 
 
 def find_cacheable_invocation_candidates(

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -1913,48 +1913,6 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         self._parameters = {}
         self._output_artifacts = []
 
-    def _prepare_step_input_overrides(
-        self,
-        step_input_overrides: Optional[Mapping[str, Mapping[str, Any]]],
-    ) -> Dict[str, Dict[str, "UUID"]]:
-        """Prepares replay step input overrides.
-
-        Args:
-            step_input_overrides: User-provided step input overrides.
-
-        Returns:
-            Artifact version IDs for step input overrides.
-        """
-        from zenml import ExternalArtifact
-        from zenml.models import ArtifactVersionResponse
-
-        if not step_input_overrides:
-            return {}
-
-        processed_overrides: Dict[str, Dict[str, UUID]] = {}
-
-        for invocation_id, overrides in step_input_overrides.items():
-            invocation_overrides: Dict[str, UUID] = {}
-
-            for input_name, value in overrides.items():
-                if isinstance(value, ArtifactVersionResponse):
-                    artifact_version_id = value.id
-                elif isinstance(value, ExternalArtifact):
-                    if value.id:
-                        artifact_version_id = value.id
-                    else:
-                        artifact_version_id = value.upload_by_value()
-                else:
-                    artifact_version_id = ExternalArtifact(
-                        value=value
-                    ).upload_by_value()
-
-                invocation_overrides[input_name] = artifact_version_id
-
-            processed_overrides[invocation_id] = invocation_overrides
-
-        return processed_overrides
-
     def replay(
         self,
         pipeline: Union[UUID, str, None] = None,
@@ -1963,6 +1921,9 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         skip_successful_steps: bool = False,
         input_overrides: Optional[Mapping[str, Any]] = None,
         step_input_overrides: Optional[Mapping[str, Mapping[str, Any]]] = None,
+        step_default_input_overrides: Optional[
+            Mapping[str, Mapping[str, Any]]
+        ] = None,
         debug: bool = False,
     ) -> PipelineRunResponse:
         """Replay the pipeline.
@@ -1985,6 +1946,10 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 Keys must be step invocation IDs and values must map input names
                 to either plain Python values, `ExternalArtifact` instances, or
                 `ArtifactVersionResponse` objects.
+            step_default_input_overrides: Input overrides applied to every
+                invocation of a step, keyed by the step's name. Values follow
+                the same shape as `step_input_overrides`. Per-invocation
+                overrides in `step_input_overrides` take precedence.
             debug: Whether to run the pipeline in debug mode. In debug mode, the
                 pipeline is executed using a local orchestrator, while
                 keeping the remaining components of your active stack.
@@ -1995,6 +1960,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         Returns:
             The replayed pipeline run.
         """
+        from zenml.artifacts.utils import upload_input_artifact_overrides
         from zenml.client import Client
         from zenml.execution.utils import DebugModeContext
 
@@ -2026,7 +1992,12 @@ To avoid this consider setting pipeline parameters only in one place (config or 
 
         if step_input_overrides:
             configuration_update["step_input_overrides"] = (
-                self._prepare_step_input_overrides(step_input_overrides)
+                upload_input_artifact_overrides(step_input_overrides)
+            )
+
+        if step_default_input_overrides:
+            configuration_update["step_default_input_overrides"] = (
+                upload_input_artifact_overrides(step_default_input_overrides)
             )
 
         if configuration_update:

--- a/src/zenml/zen_server/pipeline_execution/utils.py
+++ b/src/zenml/zen_server/pipeline_execution/utils.py
@@ -211,7 +211,7 @@ def create_snapshot_from_source(
         A new pipeline snapshot response.
     """
     if isinstance(run_configuration, ReplayRunConfiguration):
-        run_configuration = _maybe_upload_step_input_overrides(
+        run_configuration = _maybe_upload_input_artifact_overrides(
             run_configuration=run_configuration,
             stack=stack,
         )
@@ -229,29 +229,35 @@ def create_snapshot_from_source(
     return zen_store().create_snapshot(snapshot_request)
 
 
-def _maybe_upload_step_input_overrides(
+def _maybe_upload_input_artifact_overrides(
     run_configuration: ReplayRunConfiguration,
     stack: StackResponse,
 ) -> ReplayRunConfiguration:
-    """Maybe upload step input overrides for a replay run.
+    """Maybe upload input artifact overrides for a replay run.
 
     Args:
         run_configuration: The run configuration.
         stack: The stack for the run.
 
     Returns:
-        The run configuration with the step input overrides uploaded.
+        The run configuration with the input artifact overrides uploaded.
     """
-    from zenml.artifacts.external_artifact import ExternalArtifact
-    from zenml.artifacts.utils import load_artifact_store
+    from zenml.artifacts.utils import (
+        load_artifact_store,
+        upload_input_artifact_overrides,
+    )
 
-    if not run_configuration.step_input_overrides:
-        return run_configuration
+    override_maps = {
+        "step_input_overrides": run_configuration.step_input_overrides,
+        "step_default_input_overrides": run_configuration.step_default_input_overrides,
+    }
 
     if all(
         isinstance(value, UUID)
-        for overrides in run_configuration.step_input_overrides.values()
-        for value in overrides.values()
+        for overrides in override_maps.values()
+        if overrides
+        for inner in overrides.values()
+        for value in inner.values()
     ):
         return run_configuration
 
@@ -260,28 +266,15 @@ def _maybe_upload_step_input_overrides(
         zen_store=zen_store(),
     )
 
-    override_ids: Dict[str, Dict[str, UUID]] = {}
+    update = {
+        field: upload_input_artifact_overrides(
+            overrides, artifact_store=artifact_store
+        )
+        for field, overrides in override_maps.items()
+        if overrides
+    }
 
-    for (
-        invocation_id,
-        overrides,
-    ) in run_configuration.step_input_overrides.items():
-        override_ids[invocation_id] = {}
-        for input_name, value in overrides.items():
-            # We treat UUIDs as already uploaded artifact versions, and for the
-            # rest we try to upload them to the artifact store.
-            if isinstance(value, UUID):
-                artifact_version_id = value
-            else:
-                artifact_version_id = ExternalArtifact(
-                    value=value
-                ).upload_by_value(artifact_store=artifact_store)
-
-            override_ids[invocation_id][input_name] = artifact_version_id
-
-    return run_configuration.model_copy(
-        update={"step_input_overrides": override_ids}
-    )
+    return run_configuration.model_copy(update=update)
 
 
 def run_snapshot(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -11661,8 +11661,9 @@ class SqlZenStore(BaseZenStore):
                         # artifacts we receive at creation time are inputs that
                         # are defined in the step config.
                         input_overrides = set(
-                            run.get_pipeline_configuration().step_input_overrides.get(
-                                step_run.name, {}
+                            run.get_pipeline_configuration().get_invocation_input_overrides(
+                                invocation_id=step_run.name,
+                                step_name=step_config.config.name,
                             )
                         )
                         input_type = self._get_step_run_input_type_from_config(

--- a/tests/unit/config/test_pipeline_configurations.py
+++ b/tests/unit/config/test_pipeline_configurations.py
@@ -1,0 +1,87 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+from uuid import uuid4
+
+from zenml.config.pipeline_configurations import PipelineConfiguration
+
+
+def test_resolve_step_input_overrides_step_level_only():
+    """Tests that step-level overrides apply when no per-invocation override exists."""
+    value = uuid4()
+    config = PipelineConfiguration(
+        name="test",
+        step_default_input_overrides={"train": {"data": value}},
+    )
+
+    assert config.get_invocation_input_overrides(
+        invocation_id="train", step_name="train"
+    ) == {"data": value}
+    assert config.get_invocation_input_overrides(
+        invocation_id="train_2", step_name="train"
+    ) == {"data": value}
+
+
+def test_resolve_step_input_overrides_per_invocation_only():
+    """Tests that per-invocation overrides apply without a step-level override."""
+    value = uuid4()
+    config = PipelineConfiguration(
+        name="test",
+        step_input_overrides={"train": {"data": value}},
+    )
+
+    assert config.get_invocation_input_overrides(
+        invocation_id="train", step_name="train"
+    ) == {"data": value}
+    assert (
+        config.get_invocation_input_overrides(
+            invocation_id="train_2", step_name="train"
+        )
+        == {}
+    )
+
+
+def test_resolve_step_input_overrides_per_invocation_wins_per_key():
+    """Tests that per-invocation overrides win per key over step-level overrides."""
+    step_level_data = uuid4()
+    step_level_extra = uuid4()
+    per_invocation_data = uuid4()
+    config = PipelineConfiguration(
+        name="test",
+        step_default_input_overrides={
+            "train": {
+                "data": step_level_data,
+                "extra": step_level_extra,
+            }
+        },
+        step_input_overrides={"train": {"data": per_invocation_data}},
+    )
+
+    assert config.get_invocation_input_overrides(
+        invocation_id="train", step_name="train"
+    ) == {"data": per_invocation_data, "extra": step_level_extra}
+
+
+def test_resolve_step_input_overrides_missing_keys():
+    """Tests that a missing name or invocation resolves to an empty dict."""
+    config = PipelineConfiguration(
+        name="test",
+        step_default_input_overrides={"train": {"data": uuid4()}},
+    )
+
+    assert (
+        config.get_invocation_input_overrides(
+            invocation_id="train", step_name="other"
+        )
+        == {}
+    )

--- a/tests/unit/pipelines/dynamic/test_pipeline.py
+++ b/tests/unit/pipelines/dynamic/test_pipeline.py
@@ -150,6 +150,31 @@ def test_replay_skips_first_step_and_overrides_second_step_input():
     )
 
 
+@pipeline(enable_cache=False, dynamic=True)
+def replay_pipeline_with_two_invocations(expected_consumer_input: int) -> None:
+    consumer(producer(), expected_input=expected_consumer_input)
+    consumer(producer(), expected_input=expected_consumer_input)
+
+
+def test_replay_overrides_step_input_by_name():
+    """Tests that a step-wide override applies to every invocation of a step."""
+    original_run = replay_pipeline_with_two_invocations(
+        expected_consumer_input=1
+    )
+
+    consumer_name = original_run.steps["consumer"].config.name
+
+    # Step-wide override applies to both `consumer` and `consumer_2`, while the
+    # per-invocation override wins for `consumer_2` only.
+    replay_pipeline_with_two_invocations.replay(
+        pipeline_run=original_run.id,
+        input_overrides={"expected_consumer_input": 42},
+        skip={"producer", "producer_2"},
+        step_default_input_overrides={consumer_name: {"input_": 42}},
+        step_input_overrides={"consumer_2": {"input_": 42}},
+    )
+
+
 def pipeline_function_definition() -> None:
     producer()
 


### PR DESCRIPTION
When replaying a run, you can now override a step input for **every invocation of a step** using `step_default_input_overrides`, keyed by the step's name. The existing per-invocation `step_input_overrides` still take precedence per input key.

**Limitations:**
- Step names are not enforced to be unique. If two different steps share a name, a `step_default_input_overrides` entry applies to every step with that name.