### PR TITLE
Fix databricks test leaking the global custom source root

### DIFF
--- a/tests/integration/integrations/databricks/test_databricks_utils.py
+++ b/tests/integration/integrations/databricks/test_databricks_utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -114,22 +115,20 @@ def _get_base_settings(
 
 
 @pytest.fixture(autouse=True)
-def _restore_custom_source_root(monkeypatch: pytest.MonkeyPatch) -> None:
+def _restore_custom_source_root() -> Iterator[None]:
     """Stop a test's custom source root from leaking into other tests.
 
     ``configure_databricks_wheel_environment`` sets a process-global source
     root via ``set_custom_source_root``. Without restoring it, a later test in
     the same (randomly-ordered) run inherits the stale value and fails to
-    resolve its own modules. Snapshotting it with monkeypatch restores it on
+    resolve its own modules. Snapshot it before the test and restore it on
     teardown.
     """
     from zenml.utils import source_utils
 
-    monkeypatch.setattr(
-        source_utils,
-        "_CUSTOM_SOURCE_ROOT",
-        source_utils._CUSTOM_SOURCE_ROOT,
-    )
+    original = source_utils._CUSTOM_SOURCE_ROOT
+    yield
+    source_utils._CUSTOM_SOURCE_ROOT = original
 
 
 def test_add_wheel_package_to_sys_path_is_idempotent(

--- a/tests/integration/integrations/databricks/test_databricks_utils.py
+++ b/tests/integration/integrations/databricks/test_databricks_utils.py
@@ -26,6 +26,7 @@ from pytest_mock import MockerFixture
 from zenml.config import DockerSettings
 from zenml.constants import ENV_ZENML_CUSTOM_SOURCE_ROOT
 from zenml.stack.stack import Stack
+from zenml.utils import source_utils
 
 DATABRICKS_INSTALLED = importlib.util.find_spec("databricks") is not None
 pytestmark = pytest.mark.skipif(
@@ -124,8 +125,6 @@ def _restore_custom_source_root() -> Iterator[None]:
     resolve its own modules. Snapshot it before the test and restore it on
     teardown.
     """
-    from zenml.utils import source_utils
-
     original = source_utils._CUSTOM_SOURCE_ROOT
     yield
     source_utils._CUSTOM_SOURCE_ROOT = original

--- a/tests/integration/integrations/databricks/test_databricks_utils.py
+++ b/tests/integration/integrations/databricks/test_databricks_utils.py
@@ -113,6 +113,25 @@ def _get_base_settings(
     return DatabricksBaseSettings(**overrides)
 
 
+@pytest.fixture(autouse=True)
+def _restore_custom_source_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop a test's custom source root from leaking into other tests.
+
+    ``configure_databricks_wheel_environment`` sets a process-global source
+    root via ``set_custom_source_root``. Without restoring it, a later test in
+    the same (randomly-ordered) run inherits the stale value and fails to
+    resolve its own modules. Snapshotting it with monkeypatch restores it on
+    teardown.
+    """
+    from zenml.utils import source_utils
+
+    monkeypatch.setattr(
+        source_utils,
+        "_CUSTOM_SOURCE_ROOT",
+        source_utils._CUSTOM_SOURCE_ROOT,
+    )
+
+
 def test_add_wheel_package_to_sys_path_is_idempotent(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## What this fixes

`tests/integration/integrations/databricks/test_databricks_utils.py::test_configure_databricks_wheel_environment_sets_source_root` calls `configure_databricks_wheel_environment(...)`, which sets ZenML's **process-global custom source root** via `set_custom_source_root()` (`source_utils._CUSTOM_SOURCE_ROOT`). The test only `monkeypatch`es `sys.path` and a couple of env vars — it never resets that global.

Because the `integration-tests-fast` suite runs under `pytest-randomly`, whenever a seed happens to order this test **before** another test in the same shard that runs a pipeline in a subprocess (e.g. `tests/integration/functional/pipelines/test_pipeline_parallel.py::test_parallel_runs_get_different_run_indexes`), the later test inherits the stale source root and fails with:

```
RuntimeError: Unable to resolve module ... The file ... is outside the source root
(/opt/tmp/pytest-of-runner/pytest-0/test_configure_databricks_whee0/project_package).
```

That looked like a random per-branch CI failure but is actually **seed-dependent test contamination** — nothing to do with the PR it shows up on.

## The fix

An autouse fixture in that test module snapshots and restores `source_utils._CUSTOM_SOURCE_ROOT` (via `monkeypatch`), so the global can't leak across tests.

## Proof

Minimal repro of the mechanism (the exact fixture):
- **with** the fixture → a test that sets the source root, followed by one that asserts it's clean, both pass;
- **without** it → the second test fails with the leaked value.

(The databricks tests themselves skip in environments without `databricks-sdk` installed, which is why this only manifested in the full CI shard.)
