### PR TITLE
Document multi-node distributed training via CommandStep

### DIFF
--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -93,7 +93,7 @@ Environment variables and secrets are passed to the command as environment varia
 
 ## Multi-node distributed training
 
-Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive **multi-node** training: point the command at an external launcher (TorchX, Ray, SkyPilot) that owns the worker gang while ZenML owns the run. See [Train with GPUs and Accelerate](https://docs.zenml.io/user-guide/tutorial/distributed-training) for the full pattern and worked examples.
+Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive distributed training — both single-node multi-GPU (`torchrun`) and **multi-node** (TorchX, Ray): point the command at a launcher that owns the worker processes while ZenML owns the run. See [Train with GPUs and Accelerate](https://docs.zenml.io/user-guide/tutorial/distributed-training) for the full pattern and worked examples.
 
 ## Limitations
 

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -93,7 +93,7 @@ Environment variables and secrets are passed to the command as environment varia
 
 ## Multi-node distributed training
 
-Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive distributed training — both single-node multi-GPU (`torchrun`) and **multi-node** (TorchX, Ray): point the command at a launcher that owns the worker processes while ZenML owns the run. See [Train with GPUs and Accelerate](https://docs.zenml.io/user-guide/tutorial/distributed-training) for the full pattern and worked examples.
+Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive distributed training — both single-node multi-GPU (`torchrun`) and **multi-node** (TorchX, Ray): point the command at a launcher that owns the worker processes while ZenML owns the run. See [Train with GPUs and Accelerate](../../user-guide/tutorial/distributed-training.md) for the full pattern and worked examples.
 
 ## Limitations
 

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -93,7 +93,7 @@ Environment variables and secrets are passed to the command as environment varia
 
 ## Multi-node distributed training
 
-Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive distributed training — both single-node multi-GPU (`torchrun`) and **multi-node** (TorchX, Ray): point the command at a launcher that owns the worker processes while ZenML owns the run. See [Train with GPUs and Accelerate](../../user-guide/tutorial/distributed-training.md) for the full pattern and worked examples.
+For **multi-node** distributed training, a command step is the recommended launcher: point the command at a tool that owns the worker gang (TorchX, Ray) while ZenML owns the run. It's also one option for single-node multi-GPU (for example wrapping `torchrun`), though a native step works there too. See [Train with GPUs and Accelerate](../../user-guide/tutorial/distributed-training.md) for all the patterns and worked examples.
 
 ## Limitations
 

--- a/docs/book/how-to/steps-pipelines/command_steps.md
+++ b/docs/book/how-to/steps-pipelines/command_steps.md
@@ -91,6 +91,10 @@ def my_pipeline() -> None:
 
 Environment variables and secrets are passed to the command as environment variables. The step succeeds when the command exits with status `0` and fails on any non-zero exit. See [Configuration](configuration.md) for the full set of options and the difference between `.with_options()` and `.configure()`.
 
+## Multi-node distributed training
+
+Because a command step is an opaque launcher that runs on a step operator, it's the recommended way to drive **multi-node** training: point the command at an external launcher (TorchX, Ray, SkyPilot) that owns the worker gang while ZenML owns the run. See [Train with GPUs and Accelerate](https://docs.zenml.io/user-guide/tutorial/distributed-training) for the full pattern and worked examples.
+
 ## Limitations
 
 - Command steps do not support inputs and outputs.

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -144,16 +144,21 @@ def _worker(rank: int, world_size: int) -> None:
     # ... your DDP training ...
     dist.destroy_process_group()
 
-@step(settings={"resources": ResourceSettings(gpu_count=4)})
+@step(
+    runtime="isolated",  # run in its own container with the GPUs, not inline
+    settings={"resources": ResourceSettings(gpu_count=4)},
+)
 def train() -> None:
     import torch.multiprocessing as mp
 
     mp.spawn(_worker, args=(4,), nprocs=4)  # one process per GPU
 
-@pipeline
+@pipeline(dynamic=True)
 def training() -> None:
     train()
 ```
+
+`runtime="isolated"` tells the orchestrator to run the step in a fresh container (sized for the GPUs it requests) instead of inline in the orchestration process — which is what you want for a heavy training step. It's a dynamic-pipeline feature, so the pipeline is `dynamic=True`. The isolated container uses the pipeline image, so make sure that image carries CUDA and torch (see section 2).
 
 **2. The Accelerate integration.** If you'd rather not wire up the process group yourself, decorate the step with `run_with_accelerate` (see section 3) and it handles the fan-out:
 
@@ -219,9 +224,10 @@ train = CommandStep(
     settings={"docker": DockerSettings(requirements=["<launcher-package>"])},
 )
 
-# A dynamic pipeline runs its body at runtime, so ZenML can't see which steps
-# it calls by static analysis. List the step in depends_on so ZenML builds and
-# registers it (and dynamic=True is what unlocks resource pools).
+# A command step runs on a step operator. In a dynamic pipeline, only steps
+# named in depends_on get their own image built — list it here so ZenML builds
+# an image with the launcher installed (otherwise the step falls back to the
+# orchestrator image). dynamic=True also unlocks resource pools.
 @pipeline(dynamic=True, depends_on=[train])
 def training() -> None:
     train()
@@ -319,7 +325,7 @@ train = CommandStep(
 
 #### Things to keep in mind
 
-- **Declare the command step with `depends_on`.** A dynamic pipeline runs its body at runtime, so ZenML can't discover which steps it calls by static analysis. Listing the step in `@pipeline(dynamic=True, depends_on=[train])` tells ZenML to build and register it. `dynamic=True` is also what unlocks [resource pools](../../getting-started/zenml-pro/resource-pools.md).
+- **List the command step in `depends_on`.** A command step runs on a step operator, and in a dynamic pipeline only the steps named in `depends_on` get a dedicated image built — otherwise the step falls back to the orchestrator image and won't have the launcher installed. `@pipeline(dynamic=True, depends_on=[train])` builds the right image; `dynamic=True` also unlocks [resource pools](../../getting-started/zenml-pro/resource-pools.md). (Regular steps like the single-node examples above don't need `depends_on` — they use the pipeline image.)
 - **The image must carry the launcher (and `zenml`).** The `CommandStep` runs through ZenML's entrypoint on the step operator, so the launcher image needs both `zenml` and the launcher package. Either let ZenML install them with `requirements=[...]` (as above), or bake your own image and use `DockerSettings(skip_build=True, parent_image=...)` — a custom `parent_image` must already contain `zenml`. The *worker* image (passed to the launcher, e.g. `--image`) only needs your training stack, not `zenml`.
 - **Logs live in the launcher's backend.** Command-step logs are not tracked by ZenML — worker logs stay where the launcher puts them (pod logs, the Ray dashboard, etc.). See the [command steps limitations](../../how-to/steps-pipelines/command_steps.md).
 - **Two capacity managers, two jobs.** The launcher's gang scheduler (e.g. Volcano) reserves the *worker* capacity all-or-nothing; ZenML resource pools (if you use them) govern the *launcher* step. They don't overlap.

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -11,7 +11,7 @@ Need more compute than your laptop can offer?  This tutorial shows how to:
 2. Build a **CUDA‑enabled container image** so the GPU is actually visible.
 3. Reset the CUDA cache between steps (optional but handy for memory‑heavy jobs).
 4. Scale to *multiple* GPUs or nodes with the [🤗 Accelerate](https://github.com/huggingface/accelerate) integration.
-5. Run **true multi-node** training by wrapping any distributed launcher (TorchX, Ray, SkyPilot) in a `CommandStep`.
+5. Run multi-GPU and **multi-node** training by wrapping a distributed launcher (`torchrun`, TorchX, Ray) in a `CommandStep`.
 
 ---
 
@@ -120,13 +120,13 @@ DockerSettings(
 
 ---
 
-## 4 Multi-node training: bring your own launcher with a `CommandStep`
+## 4 Distributed training with a `CommandStep`
 
-Accelerate is the easy path for a *single* machine with several GPUs. For **true multi-node** training (several machines, each with GPUs) the cleanest pattern is to let a dedicated *launcher* own the worker gang and let ZenML own the run. You wrap the launcher's CLI in a [`CommandStep`](https://docs.zenml.io/how-to/steps-pipelines/command_steps) that runs on a step operator.
+Accelerate (section 3) is one way to fan a step out over GPUs. The more general pattern is to wrap a *distributed launcher* in a [`CommandStep`](https://docs.zenml.io/how-to/steps-pipelines/command_steps) that runs on a step operator. The same approach covers both **single-node multi-GPU** (one machine, several GPUs) and **true multi-node** training (several machines): ZenML owns the run, the launcher owns the worker processes.
 
 ### Why a launcher (and not ZenML) starts the workers
 
-`torch.distributed` / `torchrun` only *coordinate* ranks through a rendezvous — they assign `RANK`, `WORLD_SIZE` and `LOCAL_RANK` and wire the processes together. They do **not** provision machines or start processes on other nodes. Something external has to launch N processes across N nodes that can all reach the rendezvous endpoint. That "something" is a launcher: TorchX, Ray, SkyPilot, Slurm, and so on.
+`torch.distributed` / `torchrun` only *coordinate* ranks through a rendezvous — they assign `RANK`, `WORLD_SIZE` and `LOCAL_RANK` and wire the processes together. They do **not** provision machines or start processes on other nodes. Something has to launch N worker processes that can all reach the rendezvous endpoint. On a single node `torchrun` can spawn those processes itself; across nodes you need a launcher that provisions and gang-schedules them: TorchX, Ray, Slurm, and so on.
 
 ZenML doesn't reimplement that. Instead it gives you a clean seam:
 
@@ -141,7 +141,7 @@ from zenml import CommandStep, pipeline
 from zenml.config import DockerSettings
 
 train = CommandStep(
-    command=[...launcher CLI...],          # TorchX / Ray / SkyPilot / torchrun
+    command=[...launcher CLI...],          # torchrun / TorchX / Ray
     step_operator="<your-step-operator>",  # where the launcher itself runs
     settings={"docker": DockerSettings(requirements=["<launcher-package>"])},
 )
@@ -155,12 +155,38 @@ def training() -> None:
 
 | Launcher | Starts workers on | Needs | Best when |
 |----------|-------------------|-------|-----------|
-| **TorchX** (`dist.ddp`) | Kubernetes, Slurm, local | [Volcano](https://volcano.sh) for gang scheduling on K8s | You're on bare Kubernetes and want plain `torch.distributed` |
+| **torchrun** (`--standalone`) | The node it runs on | Nothing extra | Single node, multiple GPUs |
+| **TorchX** (`dist.ddp`) | Kubernetes, Slurm, local | [Volcano](https://volcano.sh) for gang scheduling on K8s | Multi-node on bare Kubernetes with plain `torch.distributed` |
 | **Ray** (`ray job submit`) | A Ray cluster / KubeRay | A running Ray cluster | You already run Ray; Ray Train sets up `torch.distributed` for you |
-| **SkyPilot** (`sky launch`) | Cloud VMs or Kubernetes | Cloud creds / kubeconfig | Multi-cloud VMs without installing a gang scheduler |
-| **torchrun / Accelerate** | The node it runs on | Nothing extra | Single node, multiple GPUs (see section 3) |
 
-### Worked example: TorchX + Volcano on Kubernetes
+### Single node, multiple GPUs
+
+If you just need several GPUs on **one** machine, you don't need an external scheduler at all — `torchrun` spawns one process per GPU inside the step's own container. The whole thing runs in a single step operator pod that you size with the GPUs it needs:
+
+```python
+from zenml import CommandStep, pipeline
+from zenml.config import DockerSettings, ResourceSettings
+
+train = CommandStep(
+    command=["torchrun", "--standalone", "--nproc-per-node=4", "train.py"],
+    step_operator="gmi-k8s",
+    settings={
+        "docker": DockerSettings(
+            parent_image="pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime",
+            requirements=["zenml"],
+        ),
+        "resources": ResourceSettings(gpu_count=4),
+    },
+)
+
+@pipeline
+def training() -> None:
+    train()
+```
+
+Here a single image carries everything (`zenml` + `torch` + `train.py`), because the launcher *and* the workers run in the same container. The same vanilla `train.py` below works unchanged — `torchrun --standalone` sets up the rendezvous locally.
+
+### Multiple nodes: TorchX + Volcano on Kubernetes
 
 Your training script is **vanilla `torch.distributed`** — it reads the rank/world-size that the launcher injects and contains nothing ZenML- or launcher-specific:
 
@@ -230,7 +256,7 @@ WORKDIR /app
 COPY train.py .
 ```
 
-### The same pattern with Ray or SkyPilot
+### The same pattern with Ray
 
 Only the command changes. With **Ray** (submitting to an existing cluster, letting Ray Train own `torch.distributed`):
 
@@ -240,16 +266,6 @@ train = CommandStep(
              "--", "python", "train_ray.py"],
     step_operator="gmi-k8s",
     settings={"docker": DockerSettings(requirements=["ray[client]"])},
-)
-```
-
-With **SkyPilot** (provisioning multi-node VMs or K8s pods, no Volcano needed):
-
-```python
-train = CommandStep(
-    command=["sky", "launch", "-y", "--num-nodes", "2", "dist.sky.yaml"],
-    step_operator="gmi-k8s",
-    settings={"docker": DockerSettings(requirements=["skypilot[kubernetes]"])},
 )
 ```
 

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -134,12 +134,13 @@ For several GPUs on **one** machine you don't need an external launcher or a gan
 **1. A native step that spawns the processes itself.** ZenML supports multi-process training out of the box — request the GPUs with `ResourceSettings` and let your code start one process per GPU (for example `torch.multiprocessing.spawn`, setting up DDP inside). No extra libraries, and you keep ZenML's input/output and log tracking.
 
 ```python
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
 from zenml import pipeline, step
 from zenml.config import ResourceSettings
 
 def _worker(rank: int, world_size: int) -> None:
-    import torch.distributed as dist
-
     dist.init_process_group("nccl", rank=rank, world_size=world_size)
     # ... your DDP training ...
     dist.destroy_process_group()
@@ -149,8 +150,6 @@ def _worker(rank: int, world_size: int) -> None:
     settings={"resources": ResourceSettings(gpu_count=4)},
 )
 def train() -> None:
-    import torch.multiprocessing as mp
-
     mp.spawn(_worker, args=(4,), nprocs=4)  # one process per GPU
 
 @pipeline(dynamic=True)

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -11,7 +11,7 @@ Need more compute than your laptop can offer?  This tutorial shows how to:
 2. Build a **CUDA‑enabled container image** so the GPU is actually visible.
 3. Reset the CUDA cache between steps (optional but handy for memory‑heavy jobs).
 4. Scale to *multiple* GPUs or nodes with the [🤗 Accelerate](https://github.com/huggingface/accelerate) integration.
-5. Run multi-GPU and **multi-node** training by wrapping a distributed launcher (`torchrun`, TorchX, Ray) in a `CommandStep`.
+5. Go **multi-node** by wrapping a distributed launcher (TorchX, Ray) in a `CommandStep`.
 
 ---
 
@@ -120,48 +120,55 @@ DockerSettings(
 
 ---
 
-## 4 Distributed training with a `CommandStep`
+## 4 Distributed training across processes and nodes
 
-Accelerate (section 3) is one way to fan a step out over GPUs. The more general pattern is to wrap a *distributed launcher* in a [`CommandStep`](../../how-to/steps-pipelines/command_steps.md) that runs on a step operator. The same approach covers both **single-node multi-GPU** (one machine, several GPUs) and **true multi-node** training (several machines): ZenML owns the run, the launcher owns the worker processes.
+Section 3 (Accelerate) already fans a single step out over the GPUs on one machine. More generally there are two cases, and they call for different tools:
 
-### Why a launcher (and not ZenML) starts the workers
+- **Single node, multiple GPUs** → a native step (your own multiprocessing, or the Accelerate integration), or a `CommandStep` running `torchrun`. No external launcher or gang scheduler needed.
+- **Multiple nodes** → wrap a distributed *launcher* in a [`CommandStep`](../../how-to/steps-pipelines/command_steps.md): ZenML owns the run, the launcher owns the worker processes.
 
-`torch.distributed` / `torchrun` only *coordinate* ranks through a rendezvous — they assign `RANK`, `WORLD_SIZE` and `LOCAL_RANK` and wire the processes together. They do **not** provision machines or start processes on other nodes. Something has to launch N worker processes that can all reach the rendezvous endpoint. On a single node `torchrun` can spawn those processes itself; across nodes you need a launcher that provisions and gang-schedules them: TorchX, Ray, Slurm, and so on.
+### Single node, multiple GPUs
 
-ZenML doesn't reimplement that. Instead it gives you a clean seam:
+For several GPUs on **one** machine you don't need an external launcher or a gang scheduler — every process lives in the step's own container. There are three patterns, and all three work today; pick whichever fits how you already train.
 
-- A `CommandStep` runs an **opaque command** in a container on a step operator.
-- Point that command at the launcher. The launcher schedules and starts the worker gang.
-- ZenML records the run and tracks the *launcher* process through the step operator's `submit`/`get_status`/`cancel` lifecycle. The launcher pod blocks until the whole job finishes, so the ZenML step succeeds or fails with the job.
-
-The skeleton is always the same — only the command changes:
+**1. A native step that spawns the processes itself.** ZenML supports multi-process training out of the box — request the GPUs with `ResourceSettings` and let your code start one process per GPU (for example `torch.multiprocessing.spawn`, setting up DDP inside). No extra libraries, and you keep ZenML's input/output and log tracking.
 
 ```python
-from zenml import CommandStep, pipeline
-from zenml.config import DockerSettings
+from zenml import pipeline, step
+from zenml.config import ResourceSettings
 
-train = CommandStep(
-    command=[...launcher CLI...],          # torchrun / TorchX / Ray
-    step_operator="<your-step-operator>",  # where the launcher itself runs
-    settings={"docker": DockerSettings(requirements=["<launcher-package>"])},
-)
+def _worker(rank: int, world_size: int) -> None:
+    import torch.distributed as dist
+
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    # ... your DDP training ...
+    dist.destroy_process_group()
+
+@step(settings={"resources": ResourceSettings(gpu_count=4)})
+def train() -> None:
+    import torch.multiprocessing as mp
+
+    mp.spawn(_worker, args=(4,), nprocs=4)  # one process per GPU
 
 @pipeline
 def training() -> None:
     train()
 ```
 
-### Pick a launcher
+**2. The Accelerate integration.** If you'd rather not wire up the process group yourself, decorate the step with `run_with_accelerate` (see section 3) and it handles the fan-out:
 
-| Launcher | Starts workers on | Needs | Best when |
-|----------|-------------------|-------|-----------|
-| **torchrun** (`--standalone`) | The node it runs on | Nothing extra | Single node, multiple GPUs |
-| **TorchX** (`dist.ddp`) | Kubernetes, Slurm, local | [Volcano](https://volcano.sh) for gang scheduling on K8s | Multi-node on bare Kubernetes with plain `torch.distributed` |
-| **Ray** (`ray job submit`) | A Ray cluster / KubeRay | A running Ray cluster | You already run Ray; Ray Train sets up `torch.distributed` for you |
+```python
+from zenml import step
+from zenml.config import ResourceSettings
+from zenml.integrations.huggingface.steps import run_with_accelerate
 
-### Single node, multiple GPUs
+@run_with_accelerate(num_processes=4, multi_gpu=True)
+@step(settings={"resources": ResourceSettings(gpu_count=4)})
+def train(...):
+    ...  # your training code
+```
 
-If you just need several GPUs on **one** machine, you don't need an external scheduler at all — `torchrun` spawns one process per GPU inside the step's own container. The whole thing runs in a single step operator pod that you size with the GPUs it needs:
+**3. A `CommandStep` running `torchrun`.** If you already drive training with `torchrun` (or any launcher CLI), wrap it in a command step. The launcher and its workers share the one container, so a single image carries `zenml` + `torch` + `train.py`:
 
 ```python
 from zenml import CommandStep, pipeline
@@ -179,14 +186,55 @@ train = CommandStep(
     },
 )
 
-@pipeline
+@pipeline(dynamic=True, depends_on=[train])
 def training() -> None:
     train()
 ```
 
-Here a single image carries everything (`zenml` + `torch` + `train.py`), because the launcher *and* the workers run in the same container. The same vanilla `train.py` below works unchanged — `torchrun --standalone` sets up the rendezvous locally.
+The trade-off: patterns 1 and 2 keep ZenML's artifact and log tracking; pattern 3 treats training as an opaque command (logs land in the backend, no inputs/outputs) but lets you reuse an existing `torchrun` entrypoint unchanged. The same vanilla `train.py` shown below works with pattern 3.
 
-### Multiple nodes: TorchX + Volcano on Kubernetes
+### Multiple nodes — wrap a launcher in a `CommandStep`
+
+Once training spans more than one machine, the cleanest approach is to let a dedicated launcher own the worker gang and let ZenML own the run.
+
+#### Why a launcher (and not ZenML) starts the workers
+
+`torch.distributed` / `torchrun` only *coordinate* ranks through a rendezvous — they assign `RANK`, `WORLD_SIZE` and `LOCAL_RANK` and wire the processes together. They do **not** provision machines or start processes on other nodes. Something has to launch N worker processes across N nodes that can all reach the rendezvous endpoint — a launcher that provisions and gang-schedules them: TorchX, Ray, Slurm, and so on.
+
+ZenML doesn't reimplement that. Instead it gives you a clean seam:
+
+- A `CommandStep` runs an **opaque command** in a container on a step operator.
+- Point that command at the launcher. The launcher schedules and starts the worker gang.
+- ZenML records the run and tracks the *launcher* process through the step operator's `submit`/`get_status`/`cancel` lifecycle. The launcher pod blocks until the whole job finishes, so the ZenML step succeeds or fails with the job.
+
+The skeleton is always the same — only the command changes:
+
+```python
+from zenml import CommandStep, pipeline
+from zenml.config import DockerSettings
+
+train = CommandStep(
+    command=[...launcher CLI...],          # TorchX / Ray
+    step_operator="<your-step-operator>",  # where the launcher itself runs
+    settings={"docker": DockerSettings(requirements=["<launcher-package>"])},
+)
+
+# A dynamic pipeline runs its body at runtime, so ZenML can't see which steps
+# it calls by static analysis. List the step in depends_on so ZenML builds and
+# registers it (and dynamic=True is what unlocks resource pools).
+@pipeline(dynamic=True, depends_on=[train])
+def training() -> None:
+    train()
+```
+
+#### Pick a launcher
+
+| Launcher | Starts workers on | Needs | Best when |
+|----------|-------------------|-------|-----------|
+| **TorchX** (`dist.ddp`) | Kubernetes, Slurm, local | [Volcano](https://volcano.sh) for gang scheduling on K8s | Multi-node on bare Kubernetes with plain `torch.distributed` |
+| **Ray** (`ray job submit`) | A Ray cluster / KubeRay | A running Ray cluster | You already run Ray; Ray Train sets up `torch.distributed` for you |
+
+#### Worked example: TorchX + Volcano on Kubernetes
 
 Your training script is **vanilla `torch.distributed`** — it reads the rank/world-size that the launcher injects and contains nothing ZenML- or launcher-specific:
 
@@ -239,7 +287,7 @@ train = CommandStep(
     },
 )
 
-@pipeline
+@pipeline(dynamic=True, depends_on=[train])
 def training() -> None:
     train()
 
@@ -256,7 +304,7 @@ WORKDIR /app
 COPY train.py .
 ```
 
-### The same pattern with Ray
+#### The same pattern with Ray
 
 Only the command changes. With **Ray** (submitting to an existing cluster, letting Ray Train own `torch.distributed`):
 
@@ -269,11 +317,11 @@ train = CommandStep(
 )
 ```
 
-### Things to keep in mind
+#### Things to keep in mind
 
+- **Declare the command step with `depends_on`.** A dynamic pipeline runs its body at runtime, so ZenML can't discover which steps it calls by static analysis. Listing the step in `@pipeline(dynamic=True, depends_on=[train])` tells ZenML to build and register it. `dynamic=True` is also what unlocks [resource pools](../../getting-started/zenml-pro/resource-pools.md).
 - **The image must carry the launcher (and `zenml`).** The `CommandStep` runs through ZenML's entrypoint on the step operator, so the launcher image needs both `zenml` and the launcher package. Either let ZenML install them with `requirements=[...]` (as above), or bake your own image and use `DockerSettings(skip_build=True, parent_image=...)` — a custom `parent_image` must already contain `zenml`. The *worker* image (passed to the launcher, e.g. `--image`) only needs your training stack, not `zenml`.
 - **Logs live in the launcher's backend.** Command-step logs are not tracked by ZenML — worker logs stay where the launcher puts them (pod logs, the Ray dashboard, etc.). See the [command steps limitations](../../how-to/steps-pipelines/command_steps.md).
-- **`dynamic=True` is only needed for [resource pools](../../getting-started/zenml-pro/resource-pools.md).** The launcher-on-a-step-operator pattern itself works in both static and dynamic pipelines.
 - **Two capacity managers, two jobs.** The launcher's gang scheduler (e.g. Volcano) reserves the *worker* capacity all-or-nothing; ZenML resource pools (if you use them) govern the *launcher* step. They don't overlap.
 
 ---

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -11,6 +11,7 @@ Need more compute than your laptop can offer?  This tutorial shows how to:
 2. Build a **CUDA‑enabled container image** so the GPU is actually visible.
 3. Reset the CUDA cache between steps (optional but handy for memory‑heavy jobs).
 4. Scale to *multiple* GPUs or nodes with the [🤗 Accelerate](https://github.com/huggingface/accelerate) integration.
+5. Run **true multi-node** training by wrapping any distributed launcher (TorchX, Ray, SkyPilot) in a `CommandStep`.
 
 ---
 
@@ -119,7 +120,149 @@ DockerSettings(
 
 ---
 
-## 4 Troubleshooting & Tips
+## 4 Multi-node training: bring your own launcher with a `CommandStep`
+
+Accelerate is the easy path for a *single* machine with several GPUs. For **true multi-node** training (several machines, each with GPUs) the cleanest pattern is to let a dedicated *launcher* own the worker gang and let ZenML own the run. You wrap the launcher's CLI in a [`CommandStep`](https://docs.zenml.io/how-to/steps-pipelines/command_steps) that runs on a step operator.
+
+### Why a launcher (and not ZenML) starts the workers
+
+`torch.distributed` / `torchrun` only *coordinate* ranks through a rendezvous — they assign `RANK`, `WORLD_SIZE` and `LOCAL_RANK` and wire the processes together. They do **not** provision machines or start processes on other nodes. Something external has to launch N processes across N nodes that can all reach the rendezvous endpoint. That "something" is a launcher: TorchX, Ray, SkyPilot, Slurm, and so on.
+
+ZenML doesn't reimplement that. Instead it gives you a clean seam:
+
+- A `CommandStep` runs an **opaque command** in a container on a step operator.
+- Point that command at the launcher. The launcher schedules and starts the worker gang.
+- ZenML records the run and tracks the *launcher* process through the step operator's `submit`/`get_status`/`cancel` lifecycle. The launcher pod blocks until the whole job finishes, so the ZenML step succeeds or fails with the job.
+
+The skeleton is always the same — only the command changes:
+
+```python
+from zenml import CommandStep, pipeline
+from zenml.config import DockerSettings
+
+train = CommandStep(
+    command=[...launcher CLI...],          # TorchX / Ray / SkyPilot / torchrun
+    step_operator="<your-step-operator>",  # where the launcher itself runs
+    settings={"docker": DockerSettings(requirements=["<launcher-package>"])},
+)
+
+@pipeline
+def training() -> None:
+    train()
+```
+
+### Pick a launcher
+
+| Launcher | Starts workers on | Needs | Best when |
+|----------|-------------------|-------|-----------|
+| **TorchX** (`dist.ddp`) | Kubernetes, Slurm, local | [Volcano](https://volcano.sh) for gang scheduling on K8s | You're on bare Kubernetes and want plain `torch.distributed` |
+| **Ray** (`ray job submit`) | A Ray cluster / KubeRay | A running Ray cluster | You already run Ray; Ray Train sets up `torch.distributed` for you |
+| **SkyPilot** (`sky launch`) | Cloud VMs or Kubernetes | Cloud creds / kubeconfig | Multi-cloud VMs without installing a gang scheduler |
+| **torchrun / Accelerate** | The node it runs on | Nothing extra | Single node, multiple GPUs (see section 3) |
+
+### Worked example: TorchX + Volcano on Kubernetes
+
+Your training script is **vanilla `torch.distributed`** — it reads the rank/world-size that the launcher injects and contains nothing ZenML- or launcher-specific:
+
+```python
+# train.py
+import os
+import torch
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+def main() -> None:
+    dist.init_process_group("nccl")                 # rendezvous via env vars
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+
+    model = DDP(MyModel().cuda(local_rank), device_ids=[local_rank])
+    # ... your normal training loop ...
+
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()
+```
+
+The pipeline wraps `torchx run` in a `CommandStep`. TorchX's `dist.ddp` builtin uses torchelastic and gang-schedules the workers on Volcano:
+
+```python
+# pipeline.py
+from zenml import CommandStep, pipeline
+from zenml.config import DockerSettings
+from zenml.integrations.kubernetes.flavors import KubernetesStepOperatorSettings
+
+NNODES, NPROC = 2, 8  # 2 nodes x 8 GPUs
+
+train = CommandStep(
+    command=[
+        "torchx", "run", "-s", "kubernetes", "-cfg", "queue=default",
+        "--wait", "--log",
+        "dist.ddp", "-j", f"{NNODES}x{NPROC}", "--gpu", str(NPROC),
+        "--image", "<registry>/ddp-worker:latest",  # the CUDA worker image
+        "--script", "train.py", "--env", "EPOCHS=5",
+    ],
+    step_operator="gmi-k8s",
+    settings={
+        # ZenML builds a slim launcher image (its base + zenml + torchx).
+        "docker": DockerSettings(requirements=["torchx"]),
+        "step_operator": KubernetesStepOperatorSettings(
+            service_account_name="torchx-launcher"
+        ),
+    },
+)
+
+@pipeline
+def training() -> None:
+    train()
+
+if __name__ == "__main__":
+    training()
+```
+
+You only hand-build the **worker** image (CUDA + torch + your script — no `zenml` needed, workers aren't ZenML steps):
+
+```dockerfile
+# worker image -> <registry>/ddp-worker:latest
+FROM pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime
+WORKDIR /app
+COPY train.py .
+```
+
+### The same pattern with Ray or SkyPilot
+
+Only the command changes. With **Ray** (submitting to an existing cluster, letting Ray Train own `torch.distributed`):
+
+```python
+train = CommandStep(
+    command=["ray", "job", "submit", "--address", "http://ray-head:8265",
+             "--", "python", "train_ray.py"],
+    step_operator="gmi-k8s",
+    settings={"docker": DockerSettings(requirements=["ray[client]"])},
+)
+```
+
+With **SkyPilot** (provisioning multi-node VMs or K8s pods, no Volcano needed):
+
+```python
+train = CommandStep(
+    command=["sky", "launch", "-y", "--num-nodes", "2", "dist.sky.yaml"],
+    step_operator="gmi-k8s",
+    settings={"docker": DockerSettings(requirements=["skypilot[kubernetes]"])},
+)
+```
+
+### Things to keep in mind
+
+- **The image must carry the launcher (and `zenml`).** The `CommandStep` runs through ZenML's entrypoint on the step operator, so the launcher image needs both `zenml` and the launcher package. Either let ZenML install them with `requirements=[...]` (as above), or bake your own image and use `DockerSettings(skip_build=True, parent_image=...)` — a custom `parent_image` must already contain `zenml`. The *worker* image (passed to the launcher, e.g. `--image`) only needs your training stack, not `zenml`.
+- **Logs live in the launcher's backend.** Command-step logs are not tracked by ZenML — worker logs stay where the launcher puts them (pod logs, the Ray dashboard, etc.). See the [command steps limitations](https://docs.zenml.io/how-to/steps-pipelines/command_steps).
+- **`dynamic=True` is only needed for [resource pools](https://docs.zenml.io/getting-started/zenml-pro/resource-pools).** The launcher-on-a-step-operator pattern itself works in both static and dynamic pipelines.
+- **Two capacity managers, two jobs.** The launcher's gang scheduler (e.g. Volcano) reserves the *worker* capacity all-or-nothing; ZenML resource pools (if you use them) govern the *launcher* step. They don't overlap.
+
+---
+
+## 5 Troubleshooting & Tips
 
 | Problem | Quick fix |
 |---------|-----------|

--- a/docs/book/user-guide/tutorial/distributed-training.md
+++ b/docs/book/user-guide/tutorial/distributed-training.md
@@ -122,7 +122,7 @@ DockerSettings(
 
 ## 4 Distributed training with a `CommandStep`
 
-Accelerate (section 3) is one way to fan a step out over GPUs. The more general pattern is to wrap a *distributed launcher* in a [`CommandStep`](https://docs.zenml.io/how-to/steps-pipelines/command_steps) that runs on a step operator. The same approach covers both **single-node multi-GPU** (one machine, several GPUs) and **true multi-node** training (several machines): ZenML owns the run, the launcher owns the worker processes.
+Accelerate (section 3) is one way to fan a step out over GPUs. The more general pattern is to wrap a *distributed launcher* in a [`CommandStep`](../../how-to/steps-pipelines/command_steps.md) that runs on a step operator. The same approach covers both **single-node multi-GPU** (one machine, several GPUs) and **true multi-node** training (several machines): ZenML owns the run, the launcher owns the worker processes.
 
 ### Why a launcher (and not ZenML) starts the workers
 
@@ -272,8 +272,8 @@ train = CommandStep(
 ### Things to keep in mind
 
 - **The image must carry the launcher (and `zenml`).** The `CommandStep` runs through ZenML's entrypoint on the step operator, so the launcher image needs both `zenml` and the launcher package. Either let ZenML install them with `requirements=[...]` (as above), or bake your own image and use `DockerSettings(skip_build=True, parent_image=...)` — a custom `parent_image` must already contain `zenml`. The *worker* image (passed to the launcher, e.g. `--image`) only needs your training stack, not `zenml`.
-- **Logs live in the launcher's backend.** Command-step logs are not tracked by ZenML — worker logs stay where the launcher puts them (pod logs, the Ray dashboard, etc.). See the [command steps limitations](https://docs.zenml.io/how-to/steps-pipelines/command_steps).
-- **`dynamic=True` is only needed for [resource pools](https://docs.zenml.io/getting-started/zenml-pro/resource-pools).** The launcher-on-a-step-operator pattern itself works in both static and dynamic pipelines.
+- **Logs live in the launcher's backend.** Command-step logs are not tracked by ZenML — worker logs stay where the launcher puts them (pod logs, the Ray dashboard, etc.). See the [command steps limitations](../../how-to/steps-pipelines/command_steps.md).
+- **`dynamic=True` is only needed for [resource pools](../../getting-started/zenml-pro/resource-pools.md).** The launcher-on-a-step-operator pattern itself works in both static and dynamic pipelines.
 - **Two capacity managers, two jobs.** The launcher's gang scheduler (e.g. Volcano) reserves the *worker* capacity all-or-nothing; ZenML resource pools (if you use them) govern the *launcher* step. They don't overlap.
 
 ---


### PR DESCRIPTION
## What

Adds a generalized **"bring your own launcher"** pattern for multi-node distributed training to the docs, in a noticeable place: the *Train with GPUs and Accelerate* tutorial (`docs/book/user-guide/tutorial/distributed-training.md`), with a cross-link from the Command Steps how-to.

The core idea: wrap **any** external distributed launcher (TorchX, Ray, SkyPilot, raw `torchrun`) in a `CommandStep` that runs on a step operator. ZenML owns the run + the launcher's submit/status/cancel lifecycle; the launcher owns the worker gang. Same skeleton, swap the command.

## Why

This keeps coming up with users running bare Kubernetes / non-Kubeflow stacks (e.g. multi-node `torch.distributed` on a Volcano-equipped cluster) who ask "how do I do multi-node from ZenML today?" There was no doc capturing the recommended pattern, so it had to be explained from scratch each time.

## Contents

- Explanation of *why* an external launcher (not ZenML) starts the workers — `torch.distributed` only coordinates ranks, it doesn't provision nodes.
- Launcher comparison table (TorchX / Ray / SkyPilot / torchrun).
- Full worked example: TorchX + Volcano on Kubernetes — vanilla `torch.distributed` `train.py`, the pipeline with the `CommandStep`, and the worker `Dockerfile`.
- Short Ray and SkyPilot variants (only the command changes).
- Notes that match the actual `CommandStep` / `DockerSettings` rules: image must carry `zenml` + the launcher (or use `skip_build` with a self-contained `parent_image`); logs live in the launcher backend; `dynamic=True` only needed for resource pools; gang scheduler vs resource pools are two separate capacity managers.

Docs-only change. Verified the `KubernetesStepOperatorSettings` import path used in the example is a real public export.