### PR TITLE
Add option to destroy sandbox on session exit

### DIFF
--- a/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
+++ b/src/zenml/integrations/kubernetes/sandboxes/kubernetes_sandbox.py
@@ -295,6 +295,7 @@ class KubernetesSandboxSession(SandboxSession):
         pod_name: str,
         namespace: str,
         parent: "BaseSandbox",
+        destroy_on_exit: bool = False,
     ) -> None:
         """Initialize a Kubernetes sandbox session.
 
@@ -303,6 +304,8 @@ class KubernetesSandboxSession(SandboxSession):
             pod_name: Name of the backing Kubernetes pod.
             namespace: Kubernetes namespace of the pod.
             parent: The sandbox component that created this session.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
         """
         self._pod_name = pod_name
         self._namespace = namespace
@@ -310,7 +313,7 @@ class KubernetesSandboxSession(SandboxSession):
         # `kubernetes.stream` swaps `ApiClient.request` in place during exec
         # handshakes, so all calls on the client are serialized behind this lock.
         self._client_lock = threading.Lock()
-        super().__init__(id=id, parent=parent)
+        super().__init__(id=id, parent=parent, destroy_on_exit=destroy_on_exit)
 
     def _get_core_api(self) -> k8s_client.CoreV1Api:
         """Get the session-private Kubernetes Core API client.
@@ -614,12 +617,16 @@ class KubernetesSandbox(BaseSandbox):
         return k8s_client.CoreV1Api(self.get_kube_client())
 
     def create_session(
-        self, settings: Optional[BaseSandboxSettings] = None
+        self,
+        settings: Optional[BaseSandboxSettings] = None,
+        destroy_on_exit: bool = False,
     ) -> SandboxSession:
         """Create a sandbox session backed by a Kubernetes pod.
 
         Args:
             settings: Optional settings overrides.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
 
         Raises:
             Exception: If the sandbox pod fails to start.
@@ -696,6 +703,7 @@ class KubernetesSandbox(BaseSandbox):
             pod_name=pod_name,
             namespace=self.config.kubernetes_namespace,
             parent=self,
+            destroy_on_exit=destroy_on_exit,
         )
 
     def attach(self, session_id: str) -> SandboxSession:

--- a/src/zenml/integrations/modal/sandboxes/modal_sandbox.py
+++ b/src/zenml/integrations/modal/sandboxes/modal_sandbox.py
@@ -169,18 +169,25 @@ class ModalSandboxSession(SandboxSession):
         sandbox: "modal.Sandbox",
         *,
         parent: "ModalSandbox",
+        destroy_on_exit: bool = False,
     ) -> None:
         """Initialize the session wrapper.
 
         Args:
             sandbox: The live Modal ``Sandbox`` object.
             parent: The owning Modal sandbox component.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
         """
         # Assign _sandbox before super().__init__ so the dashboard hook,
         # which is called during base __init__ via _publish_sandbox_metadata,
         # has the state it needs.
         self._sandbox = sandbox
-        super().__init__(id=sandbox.object_id, parent=parent)
+        super().__init__(
+            id=sandbox.object_id,
+            parent=parent,
+            destroy_on_exit=destroy_on_exit,
+        )
 
     def _get_dashboard_url(self) -> Optional[str]:
         """Returns the Modal sandbox's dashboard URL.
@@ -426,12 +433,16 @@ class ModalSandbox(BaseSandbox):
         )
 
     def create_session(
-        self, settings: Optional[BaseSandboxSettings] = None
+        self,
+        settings: Optional[BaseSandboxSettings] = None,
+        destroy_on_exit: bool = False,
     ) -> SandboxSession:
         """Boot a fresh Modal Sandbox.
 
         Args:
             settings: Optional per-step overrides for image / env.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
 
         Returns:
             A ``ModalSandboxSession`` wrapping the live Modal Sandbox.
@@ -450,7 +461,9 @@ class ModalSandbox(BaseSandbox):
                 environment=self._resolve_session_environment(settings),
             )
         )
-        return ModalSandboxSession(sandbox, parent=self)
+        return ModalSandboxSession(
+            sandbox, parent=self, destroy_on_exit=destroy_on_exit
+        )
 
     def attach(self, session_id: str) -> SandboxSession:
         """Reconnect to a still-live Modal Sandbox by id.

--- a/src/zenml/sandboxes/base.py
+++ b/src/zenml/sandboxes/base.py
@@ -74,12 +74,16 @@ class BaseSandbox(StackComponent, ABC):
 
     @abstractmethod
     def create_session(
-        self, settings: Optional[BaseSandboxSettings] = None
+        self,
+        settings: Optional[BaseSandboxSettings] = None,
+        destroy_on_exit: bool = False,
     ) -> SandboxSession:
         """Create a fresh sandbox session.
 
         Args:
             settings: The sandbox settings.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
 
         Returns:
             A new sandbox session.

--- a/src/zenml/sandboxes/local_sandbox.py
+++ b/src/zenml/sandboxes/local_sandbox.py
@@ -199,6 +199,7 @@ class LocalSandboxSession(SandboxSession):
         env: Dict[str, str],
         *,
         parent: "BaseSandbox",
+        destroy_on_exit: bool = False,
     ) -> None:
         """Initialize the local sandbox session.
 
@@ -207,10 +208,13 @@ class LocalSandboxSession(SandboxSession):
                 This directory is cleaned up when the session is closed.
             env: Environment variables to set for this session.
             parent: The sandbox component that created this session.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
         """
         super().__init__(
             id=f"local-{uuid.uuid4().hex[:12]}",
             parent=parent,
+            destroy_on_exit=destroy_on_exit,
         )
         self._workdir = workdir
         self._env = env
@@ -392,12 +396,16 @@ class LocalSandbox(BaseSandbox):
         return env
 
     def create_session(
-        self, settings: Optional[BaseSandboxSettings] = None
+        self,
+        settings: Optional[BaseSandboxSettings] = None,
+        destroy_on_exit: bool = False,
     ) -> SandboxSession:
         """Create a local sandbox session in a clean working directory.
 
         Args:
             settings: Optional settings overrides.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
 
         Returns:
             A local sandbox session.
@@ -416,6 +424,7 @@ class LocalSandbox(BaseSandbox):
             workdir=workdir,
             env=env,
             parent=self,
+            destroy_on_exit=destroy_on_exit,
         )
 
 

--- a/src/zenml/sandboxes/session.py
+++ b/src/zenml/sandboxes/session.py
@@ -52,15 +52,19 @@ class SandboxSession(ABC):
         *,
         id: str,
         parent: "BaseSandbox",
+        destroy_on_exit: bool = False,
     ) -> None:
         """Initialize the sandbox session.
 
         Args:
             id: Session identifier.
             parent: The sandbox component that created this session.
+            destroy_on_exit: Whether to destroy the sandbox session when the
+                session context manager exits.
         """
         self.id = id
         self._parent = parent
+        self._destroy_on_exit = destroy_on_exit
         self._closed = False
         self._logging_context: Optional["LoggingContext"] = None
         self._logging_disabled = False
@@ -467,5 +471,8 @@ class SandboxSession(ABC):
         return self
 
     def __exit__(self, *_: Any) -> None:
-        """Close the session."""
-        self.close()
+        """Destroy or close the session, depending on `destroy_on_exit`."""
+        if self._destroy_on_exit:
+            self.destroy()
+        else:
+            self.close()

--- a/tests/unit/sandboxes/test_base_sandbox.py
+++ b/tests/unit/sandboxes/test_base_sandbox.py
@@ -69,10 +69,12 @@ class _FakeSession(SandboxSession):
         self,
         session_id: str = "sess-1",
         parent: Optional["BaseSandbox"] = None,
+        destroy_on_exit: bool = False,
     ) -> None:
         super().__init__(
             id=session_id,
             parent=parent or MagicMock(spec=BaseSandbox, flavor="fake"),
+            destroy_on_exit=destroy_on_exit,
         )
         self.was_closed = False
         self.close_count = 0
@@ -95,9 +97,11 @@ class _FakeSandbox(BaseSandbox):
     """Minimal BaseSandbox for testing. `create_session` returns a fake."""
 
     def create_session(
-        self, settings: Optional[BaseSandboxSettings] = None
+        self,
+        settings: Optional[BaseSandboxSettings] = None,
+        destroy_on_exit: bool = False,
     ) -> SandboxSession:
-        return _FakeSession()
+        return _FakeSession(destroy_on_exit=destroy_on_exit)
 
 
 class _FakeSandboxFlavor(BaseSandboxFlavor):
@@ -182,6 +186,25 @@ class TestSessionContextManager:
             assert session.was_closed is False
         assert session.was_closed is True
         assert session.closed is True
+
+    def test_with_block_destroys_when_destroy_on_exit(self) -> None:
+        class _DestroyableSession(_FakeSession):
+            def __init__(self) -> None:
+                super().__init__(destroy_on_exit=True)
+                self.destroyed = False
+
+            def _destroy(self) -> None:
+                self.destroyed = True
+
+        session = _DestroyableSession()
+        with session:
+            assert session.destroyed is False
+        assert session.destroyed is True
+        assert session.closed is True
+
+    def test_create_session_forwards_destroy_on_exit(self) -> None:
+        session = _make_sandbox().create_session(destroy_on_exit=True)
+        assert session._destroy_on_exit is True
 
     def test_use_after_close_raises(self) -> None:
         # close() is terminal: every session-using operation on a closed


### PR DESCRIPTION
- Add option to destroy sandbox on session exit
- `False` by default to mirror behaviour of previous releases
