### PR TITLE
Add Missing Doc Links for Trackio

### DIFF
--- a/docs/book/component-guide/.gitbook.yaml
+++ b/docs/book/component-guide/.gitbook.yaml
@@ -41,6 +41,7 @@ redirects:
   experiment-trackers/neptune: experiment-trackers/neptune.md
   experiment-trackers/vertexai: experiment-trackers/vertexai.md
   experiment-trackers/wandb: experiment-trackers/wandb.md
+  experiment-trackers/trackio: experiment-trackers/trackio.md
   feature-stores: feature-stores/README.md
   feature-stores/custom: feature-stores/custom.md
   feature-stores/feast: feature-stores/feast.md

--- a/docs/book/component-guide/toc.md
+++ b/docs/book/component-guide/toc.md
@@ -69,6 +69,7 @@
   * [MLflow](experiment-trackers/mlflow.md)
   * [Neptune](experiment-trackers/neptune.md)
   * [Weights & Biases](experiment-trackers/wandb.md)
+  * [Trackio](experiment-trackers/trackio.md)
   * [Google Cloud VertexAI Experiment Tracker](experiment-trackers/vertexai.md)
   * [Develop a custom experiment tracker](experiment-trackers/custom.md)
 * [Image Builders](image-builders/README.md)


### PR DESCRIPTION
## Describe changes
Following-up to #4841

Added the missing doc entry for trackio to ensure that docs are rendered correctly on `gitbook`. Could you please review?

cc: @schustmi 

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

