### PR TITLE
Add isolated step cleanup hooks

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -599,6 +599,10 @@ class DynamicPipelineRunner:
                             wrap_step_failure(exc, invocation_id=invocation_id)
                         )
 
+                # Either infra or DB status indicates that the step has
+                # finished -> we run the step cleanup
+                self._cleanup_isolated_step(step_run)
+
                 # Get the updated status that we might have just published
                 db_status = step_run.status
 
@@ -795,6 +799,24 @@ class DynamicPipelineRunner:
             return self._step_operator.get_status(step_run)
         else:
             return self._orchestrator.get_isolated_step_status(step_run)
+
+    def _cleanup_isolated_step(self, step_run: "StepRunResponse") -> None:
+        """Clean up after an isolated step has finished.
+
+        Args:
+            step_run: The finished step run.
+        """
+        try:
+            if step_run.config.step_operator:
+                assert self._step_operator
+                self._step_operator.cleanup_step_submission(step_run)
+            else:
+                self._orchestrator.cleanup_isolated_step(step_run)
+        except Exception:
+            logger.exception(
+                "Failed to run cleanup for isolated step `%s`.",
+                step_run.name,
+            )
 
     def run_pipeline(self) -> None:
         """Run the pipeline.

--- a/src/zenml/orchestrators/base_orchestrator.py
+++ b/src/zenml/orchestrators/base_orchestrator.py
@@ -671,6 +671,13 @@ class BaseOrchestrator(StackComponent, ABC):
             f"the {self.__class__.__name__} orchestrator."
         )
 
+    def cleanup_isolated_step(self, step_run: "StepRunResponse") -> None:
+        """Clean up after an isolated step run has finished.
+
+        Args:
+            step_run: The finished step run.
+        """
+
     @staticmethod
     def requires_resources_in_orchestration_environment(
         step: "Step",

--- a/src/zenml/orchestrators/step_launcher.py
+++ b/src/zenml/orchestrators/step_launcher.py
@@ -535,11 +535,22 @@ class StepLauncher:
                     "step operator `%s`.",
                     step_operator.name,
                 )
-                step_operator.launch(
-                    info=step_run_info,
-                    entrypoint_command=entrypoint_command,
-                    environment=environment,
-                )
+                try:
+                    step_operator.launch(
+                        info=step_run_info,
+                        entrypoint_command=entrypoint_command,
+                        environment=environment,
+                    )
+                finally:
+                    try:
+                        step_operator.cleanup_step_submission(
+                            step_run_info.step_run
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to clean up for step `%s`.",
+                            self._invocation_id,
+                        )
             else:
                 raise NotImplementedError(
                     f"The step operator `{step_operator.name}` does not "
@@ -549,12 +560,15 @@ class StepLauncher:
             # We submitted the step run asynchronously, now we potentially need
             # to wait for it to finish.
             if self._wait:
-                status = step_operator.wait(
-                    step_run=step_run_info.step_run,
-                )
-                self._finalize_remote_step(
-                    status=status, step_run_info=step_run_info
-                )
+                try:
+                    status = step_operator.wait(
+                        step_run=step_run_info.step_run,
+                    )
+                    self._finalize_remote_step(
+                        status=status, step_run_info=step_run_info
+                    )
+                finally:
+                    self._cleanup_remote_step(step_run_info.step_run)
 
     def _run_step_with_dynamic_orchestrator(
         self,
@@ -585,12 +599,15 @@ class StepLauncher:
             environment=environment,
         )
         if self._wait:
-            status = self._stack.orchestrator.wait_for_isolated_step(
-                step_run_info.step_run
-            )
-            self._finalize_remote_step(
-                status=status, step_run_info=step_run_info
-            )
+            try:
+                status = self._stack.orchestrator.wait_for_isolated_step(
+                    step_run_info.step_run
+                )
+                self._finalize_remote_step(
+                    status=status, step_run_info=step_run_info
+                )
+            finally:
+                self._cleanup_remote_step(step_run_info.step_run)
 
     def _finalize_remote_step(
         self, status: ExecutionStatus, step_run_info: StepRunInfo
@@ -620,6 +637,32 @@ class StepLauncher:
             publish_utils.publish_successful_step_run(
                 step_run_id=step_run_info.step_run_id,
                 output_artifact_ids={},
+            )
+
+    def _cleanup_remote_step(self, step_run: StepRunResponse) -> None:
+        """Clean up infrastructure after a remote step has finished.
+
+        Args:
+            step_run: The finished step run.
+        """
+        try:
+            if self._step.config.step_operator:
+                step_operator_name = (
+                    self._step.config.step_operator
+                    if isinstance(self._step.config.step_operator, str)
+                    else None
+                )
+                step_operator = _get_step_operator(
+                    stack=self._stack,
+                    step_operator_name=step_operator_name,
+                )
+                step_operator.cleanup_step_submission(step_run)
+            else:
+                self._stack.orchestrator.cleanup_isolated_step(step_run)
+        except Exception:
+            logger.exception(
+                "Failed to clean up for step `%s`.",
+                self._invocation_id,
             )
 
     def _run_step_in_current_thread(

--- a/src/zenml/step_operators/base_step_operator.py
+++ b/src/zenml/step_operators/base_step_operator.py
@@ -162,6 +162,13 @@ class BaseStepOperator(StackComponent, ABC):
             f"the {self.__class__.__name__} step operator."
         )
 
+    def cleanup_step_submission(self, step_run: "StepRunResponse") -> None:
+        """Clean up after a submitted step run has finished.
+
+        Args:
+            step_run: The finished step run.
+        """
+
 
 class BaseStepOperatorFlavor(Flavor):
     """Base class for all ZenML step operator flavors."""

--- a/tests/unit/orchestrators/test_step_launcher.py
+++ b/tests/unit/orchestrators/test_step_launcher.py
@@ -136,3 +136,104 @@ def test_dynamic_command_step_failure_raises(mocker):
     # Publishing the failed status is the responsibility of the generic
     # exception handling in `StepLauncher.launch(...)`.
     publish_failed.assert_not_called()
+
+
+def _make_isolated_step_launcher(mocker, status):
+    launcher = object.__new__(StepLauncher)
+    launcher._stack = mocker.Mock()
+    launcher._stack.orchestrator.wait_for_isolated_step.return_value = status
+    launcher._wait = True
+    launcher._invocation_id = "step_name"
+    launcher._step = mocker.Mock()
+    launcher._step.config.command = None
+    launcher._step.config.step_operator = None
+
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.orchestrator_utils.get_config_environment_vars",
+        return_value=({}, {}),
+    )
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.env_utils.get_runtime_environment",
+        return_value={},
+    )
+    return launcher
+
+
+def test_isolated_step_cleanup_called_on_success(mocker):
+    launcher = _make_isolated_step_launcher(mocker, ExecutionStatus.COMPLETED)
+    step_run_info = mocker.Mock()
+
+    launcher._run_step_with_dynamic_orchestrator(step_run_info=step_run_info)
+
+    launcher._stack.orchestrator.cleanup_isolated_step.assert_called_once_with(
+        step_run_info.step_run
+    )
+
+
+def test_isolated_step_cleanup_called_on_failure(mocker):
+    launcher = _make_isolated_step_launcher(mocker, ExecutionStatus.FAILED)
+    step_run_info = mocker.Mock()
+    step_run_info.pipeline_step_name = "step_name"
+
+    mocker.patch("zenml.orchestrators.step_launcher.Client.get_run_step")
+    mocker.patch(
+        "zenml.orchestrators.step_launcher.exception_utils.reconstruct_exception",
+        return_value=RuntimeError("step failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="step failed"):
+        launcher._run_step_with_dynamic_orchestrator(
+            step_run_info=step_run_info
+        )
+
+    launcher._stack.orchestrator.cleanup_isolated_step.assert_called_once_with(
+        step_run_info.step_run
+    )
+
+
+def test_isolated_step_cleanup_skipped_when_not_waiting(mocker):
+    launcher = _make_isolated_step_launcher(mocker, ExecutionStatus.COMPLETED)
+    launcher._wait = False
+    step_run_info = mocker.Mock()
+
+    launcher._run_step_with_dynamic_orchestrator(step_run_info=step_run_info)
+
+    launcher._stack.orchestrator.wait_for_isolated_step.assert_not_called()
+    launcher._stack.orchestrator.cleanup_isolated_step.assert_not_called()
+
+
+def test_cleanup_remote_step_dispatches_to_step_operator(mocker):
+    launcher = object.__new__(StepLauncher)
+    launcher._stack = mocker.Mock()
+    launcher._invocation_id = "step_name"
+    launcher._step = mocker.Mock()
+    launcher._step.config.step_operator = "my_operator"
+
+    step_operator = mocker.Mock()
+    get_step_operator = mocker.patch(
+        "zenml.orchestrators.step_launcher._get_step_operator",
+        return_value=step_operator,
+    )
+    step_run = mocker.Mock()
+
+    launcher._cleanup_remote_step(step_run)
+
+    get_step_operator.assert_called_once_with(
+        stack=launcher._stack, step_operator_name="my_operator"
+    )
+    step_operator.cleanup_step_submission.assert_called_once_with(step_run)
+    launcher._stack.orchestrator.cleanup_isolated_step.assert_not_called()
+
+
+def test_cleanup_remote_step_swallows_errors(mocker):
+    launcher = object.__new__(StepLauncher)
+    launcher._stack = mocker.Mock()
+    launcher._invocation_id = "step_name"
+    launcher._step = mocker.Mock()
+    launcher._step.config.step_operator = None
+    launcher._stack.orchestrator.cleanup_isolated_step.side_effect = (
+        RuntimeError("cleanup boom")
+    )
+
+    with does_not_raise():
+        launcher._cleanup_remote_step(mocker.Mock())


### PR DESCRIPTION
This PR provides some hooks that can be used in step operator or orchestrator implementations to run some cleanup after an isolated step finishes. For example, clean up secrets created for container registry authentication.