### PR TITLE
Improved snapshot fetching

### DIFF
--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -19,7 +19,7 @@ from uuid import UUID
 
 from sqlalchemy import TEXT, CheckConstraint, Column, String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import joinedload, object_session, selectinload
+from sqlalchemy.orm import defer, object_session, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship, asc, col, desc, select
 
@@ -372,21 +372,31 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
         """
         options = []
 
-        if include_metadata:
+        if not include_metadata:
+            # pipeline_configuration and client_environment are large columns
+            # only read when metadata is included. Skip fetching them otherwise.
             options.extend(
                 [
-                    joinedload(jl_arg(PipelineSnapshotSchema.stack)),
-                    joinedload(jl_arg(PipelineSnapshotSchema.build)),
-                    joinedload(jl_arg(PipelineSnapshotSchema.pipeline)),
-                    joinedload(jl_arg(PipelineSnapshotSchema.schedule)),
-                    joinedload(jl_arg(PipelineSnapshotSchema.code_reference)),
+                    defer(
+                        jl_arg(PipelineSnapshotSchema.pipeline_configuration)
+                    ),
+                    defer(jl_arg(PipelineSnapshotSchema.client_environment)),
                 ]
             )
 
         if include_resources:
             options.extend(
                 [
-                    joinedload(jl_arg(PipelineSnapshotSchema.user)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.stack)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.build)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.pipeline)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.schedule)),
+                    selectinload(
+                        jl_arg(PipelineSnapshotSchema.code_reference)
+                    ),
+                    selectinload(jl_arg(PipelineSnapshotSchema.user)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.deployment)),
+                    selectinload(jl_arg(PipelineSnapshotSchema.tags)),
                     selectinload(
                         jl_arg(PipelineSnapshotSchema.visualizations)
                     ),

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -5334,6 +5334,7 @@ class SqlZenStore(BaseZenStore):
                 table=PipelineSnapshotSchema,
                 filter_model=snapshot_filter_model,
                 hydrate=hydrate,
+                apply_query_options_from_schema=True,
             )
 
     def update_snapshot(


### PR DESCRIPTION
Results on DB with ~1M snapshots:
- ~10% quicker for hydrated list calls (page size 20)
- ~15% quicker for unhydrated list calls (page size 20)
- ~20% quicker for hydrated list calls (page size 200)
- ~30% quicker for unhydrated list calls (page size 200)

Unhydrated improvements are for relatively small values in `pipeline_configuration` and `client_environment` columns, so might be even more for most users.