### PR TITLE
OAuth2 service connector

### DIFF
--- a/docs/book/component-guide/service-connectors/connector-types/oauth2-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/oauth2-service-connector.md
@@ -1,0 +1,112 @@
+---
+description: Configuring the OAuth2 Service Connector to connect ZenML to OAuth2-protected HTTP APIs.
+---
+
+# OAuth2 Service Connector
+
+The ZenML OAuth2 Service Connector authenticates to an HTTP API using OAuth2 and provides connector consumers with a pre-authenticated `requests` session that has a bearer token set on the `Authorization` header. The client credentials and refresh token methods exchange long-lived credentials for a short-lived access token, so that consumers only ever receive a temporary token and never the underlying client secret or refresh token.
+
+```shell
+zenml service-connector list-types --type oauth2
+```
+
+```
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━┯━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━┯━━━━━━━━┓
+┃           NAME           │ TYPE      │ RESOURCE TYPES │ AUTH METHODS                             │ LOCAL │ REMOTE ┃
+┠──────────────────────────┼───────────┼────────────────┼──────────────────────────────────────────┼───────┼────────┨
+┃ OAuth2 Service Connector │ 🔐 oauth2 │ 🌐 oauth2-api  │ client-credentials, refresh-token, token │ ✅    │ ✅     ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━┷━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━┷━━━━━━━━┛
+```
+
+## Prerequisites
+
+No Python packages are required for this Service Connector. All prerequisites are included in the base ZenML Python package.
+
+## Resource Types
+
+The OAuth2 Service Connector supports a single resource type, `oauth2-api`, which represents an HTTP API protected by OAuth2. The resource name is the base URL of the API, for example `https://api.example.com`.
+
+This resource type does not support multiple instances. A single connector grants access to a single API, identified by the configured `api_url`.
+
+## Authentication Methods
+
+The connector supports three authentication methods. Two of them exchange long-lived credentials for a temporary access token at the OAuth2 token endpoint and hand consumers only the temporary token. The third lets you supply an access token directly.
+
+### Client credentials
+
+Use the OAuth2 client credentials grant to authenticate as a service identity, for machine-to-machine access with no user context. Configure the token endpoint, the client ID and secret, and optionally a scope and audience.
+
+```sh
+zenml service-connector register my-api --type oauth2 --auth-method client-credentials \
+    --api_url=https://api.example.com \
+    --token_url=https://auth.example.com/oauth/token \
+    --client_id=<CLIENT_ID> \
+    --client_secret=<CLIENT_SECRET> \
+    --scope="read write"
+```
+
+The client secret stays on the connector. Every consumer receives a freshly minted access token instead.
+
+### Refresh token
+
+Use the OAuth2 refresh token grant to authenticate as a user-delegated identity. The connector will exchange the refresh token for access tokens as needed. The client secret is optional, so public clients are supported.
+
+```sh
+zenml service-connector register my-api --type oauth2 --auth-method refresh-token \
+    --api_url=https://api.example.com \
+    --token_url=https://auth.example.com/oauth/token \
+    --client_id=<CLIENT_ID> \
+    --refresh_token=<REFRESH_TOKEN>
+```
+
+{% hint style="warning" %}
+Some providers issue a new refresh token on every exchange and invalidate the previous one. These rotating refresh tokens are currently not supported. 
+{% endhint %}
+
+### Token
+
+Supply a pre-obtained OAuth2 access token directly. The connector uses it as-is and does not refresh it.
+
+```sh
+zenml service-connector register my-api --type oauth2 --auth-method token \
+    --api_url=https://api.example.com \
+    --access_token=<ACCESS_TOKEN>
+```
+
+If you know when the token expires, set the connector expiration when registering so that ZenML stops using it once it is no longer valid.
+
+## Token expiration
+
+For the client credentials and refresh token methods, the lifetime of a minted access token is dictated by the OAuth2 server and read from the `expires_in` field of the token response. ZenML always respects the server value and does not let you request a different lifetime. If the server does not return an expiration, ZenML treats the token as non-expiring and keeps using it until the API rejects it.
+
+## Auto-configuration
+
+{% hint style="info" %}
+This Service Connector does not support auto-discovery and extraction of authentication credentials from the local environment.
+{% endhint %}
+
+## Local client provisioning
+
+This Service Connector does not configure a local client. OAuth2 is consumed directly through the authenticated `requests` session returned by the connector.
+
+## How to use
+
+No built-in Stack Component requires the `oauth2-api` resource type. This connector is intended for your use as an easy way to get credentials for accessing an OAuth2 authenticated API. A consumer obtains an authenticated `requests` session from the connector and uses it to call the API:
+
+```python
+from zenml.client import Client
+
+client = Client()
+
+# Get a Service Connector client for the API
+connector_client = client.get_service_connector_client(
+    name_id_or_prefix="my-api",
+    resource_type="oauth2-api",
+)
+
+# Get a pre-authenticated requests Session from the Service Connector client
+session = connector_client.connect()
+
+# Call the API using the temporary token that was issued to the client
+response = session.get("https://api.example.com/v1/resource")
+```

--- a/docs/book/component-guide/service-connectors/connector-types/oauth2-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/oauth2-service-connector.md
@@ -75,6 +75,30 @@ zenml service-connector register my-api --type oauth2 --auth-method token \
 
 If you know when the token expires, set the connector expiration when registering so that ZenML stops using it once it is no longer valid.
 
+## Client authentication method
+
+For the client credentials and refresh token methods, ZenML sends the client ID and secret to the token endpoint using HTTP Basic authentication by default (`client_secret_basic`). Some providers instead expect the client credentials in the request body (`client_secret_post`). Select the method with `client_auth_method`:
+
+```sh
+zenml service-connector register my-api --type oauth2 --auth-method client-credentials \
+    --api_url=https://api.example.com \
+    --token_url=https://auth.example.com/oauth/token \
+    --client_id=<CLIENT_ID> \
+    --client_secret=<CLIENT_SECRET> \
+    --client_auth_method=client_secret_post
+```
+
+For public refresh token clients that have no secret, this setting has no effect, since the client ID is always sent in the request body.
+
+## Custom token request parameters and headers
+
+Some providers require extra parameters or headers on the token request, such as a `resource` identifier for Azure AD or a vendor-specific flag. The client credentials and refresh token methods accept two optional dictionaries for this:
+
+- `token_params` adds form parameters to the token request body.
+- `token_headers` adds headers to the token request.
+
+The parameters `grant_type`, `client_id`, `client_secret`, `refresh_token`, `scope` and `audience`, as well as the `Authorization` header, are managed by the connector and cannot be overwritten through these options.
+
 ## Token expiration
 
 For the client credentials and refresh token methods, the lifetime of a minted access token is dictated by the OAuth2 server and read from the `expires_in` field of the token response. ZenML always respects the server value and does not let you request a different lifetime. If the server does not return an expiration, ZenML treats the token as non-expiring and keeps using it until the API rejects it.

--- a/docs/book/component-guide/toc.md
+++ b/docs/book/component-guide/toc.md
@@ -121,6 +121,7 @@
   * [AWS Service Connector](service-connectors/connector-types/aws-service-connector.md)
   * [GCP Service Connector](service-connectors/connector-types/gcp-service-connector.md)
   * [Azure Service Connector](service-connectors/connector-types/azure-service-connector.md)
+  * [OAuth2 Service Connector](service-connectors/connector-types/oauth2-service-connector.md)
   * [HyperAI Service Connector](service-connectors/connector-types/hyperai-service-connector.md)
 
 ## Popular Stacks

--- a/src/zenml/service_connectors/oauth2_service_connector.py
+++ b/src/zenml/service_connectors/oauth2_service_connector.py
@@ -1,0 +1,385 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""OAuth2 Service Connector."""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from pydantic import Field
+
+from zenml.exceptions import AuthorizationException
+from zenml.logger import get_logger
+from zenml.models import (
+    AuthenticationMethodModel,
+    ResourceTypeModel,
+    ServiceConnectorTypeModel,
+)
+from zenml.service_connectors.service_connector import (
+    AuthenticationConfig,
+    ServiceConnector,
+)
+from zenml.utils.enum_utils import StrEnum
+from zenml.utils.secret_utils import PlainSerializedSecretStr
+from zenml.utils.time_utils import utc_now
+
+logger = get_logger(__name__)
+
+OAUTH2_CONNECTOR_TYPE = "oauth2"
+OAUTH2_API_RESOURCE_TYPE = "oauth2-api"
+OAUTH2_SESSION_EXPIRATION_BUFFER = 15  # 15 minutes
+
+
+class OAuth2AuthenticationMethods(StrEnum):
+    """OAuth2 authentication methods."""
+
+    CLIENT_CREDENTIALS = "client-credentials"
+    REFRESH_TOKEN = "refresh-token"
+    TOKEN = "token"
+
+
+class OAuth2BaseConfig(AuthenticationConfig):
+    """OAuth2 base configuration."""
+
+    api_url: str = Field(title="API base URL")
+
+
+class OAuth2TokenConfig(OAuth2BaseConfig):
+    """OAuth2 token configuration."""
+
+    access_token: PlainSerializedSecretStr = Field(title="OAuth2 access token")
+
+
+class OAuth2GrantConfig(OAuth2BaseConfig):
+    """OAuth2 base configuration for grants that mint access tokens."""
+
+    token_url: str = Field(title="OAuth2 token endpoint URL")
+    client_id: str = Field(title="OAuth2 client ID")
+    scope: Optional[str] = Field(
+        default=None,
+        title="Space-separated OAuth2 scopes",
+    )
+
+
+class OAuth2ClientCredentialsConfig(OAuth2GrantConfig):
+    """OAuth2 client credentials configuration."""
+
+    client_secret: PlainSerializedSecretStr = Field(
+        title="OAuth2 client secret",
+    )
+    audience: Optional[str] = Field(default=None, title="OAuth2 audience")
+
+
+class OAuth2RefreshTokenConfig(OAuth2GrantConfig):
+    """OAuth2 refresh token configuration."""
+
+    refresh_token: PlainSerializedSecretStr = Field(
+        title="OAuth2 refresh token",
+    )
+    client_secret: Optional[PlainSerializedSecretStr] = Field(
+        default=None,
+        title="OAuth2 client secret",
+    )
+
+
+OAUTH2_SERVICE_CONNECTOR_TYPE_SPEC = ServiceConnectorTypeModel(
+    name="OAuth2 Service Connector",
+    connector_type=OAUTH2_CONNECTOR_TYPE,
+    description="""
+The ZenML OAuth2 Service Connector authenticates to an HTTP API using OAuth2.
+
+The client credentials and refresh token methods exchange long-lived
+credentials for a temporary access token at a token endpoint. Connector
+consumers only ever receive the temporary token, never the underlying
+credentials. A pre-obtained access token can also be supplied directly.
+
+Connecting returns an authenticated requests Session with the bearer token set
+on the Authorization header.
+""",
+    emoji=":closed_lock_with_key:",
+    auth_methods=[
+        AuthenticationMethodModel(
+            name="OAuth2 Client Credentials",
+            auth_method=OAuth2AuthenticationMethods.CLIENT_CREDENTIALS,
+            description="""
+Exchange a client ID and secret for a temporary access token using the OAuth2
+client credentials grant.
+""",
+            config_class=OAuth2ClientCredentialsConfig,
+        ),
+        AuthenticationMethodModel(
+            name="OAuth2 Refresh Token",
+            auth_method=OAuth2AuthenticationMethods.REFRESH_TOKEN,
+            description="""
+Exchange a refresh token for a temporary access token using the OAuth2 refresh
+token grant. Rotating refresh tokens are not supported.
+""",
+            config_class=OAuth2RefreshTokenConfig,
+        ),
+        AuthenticationMethodModel(
+            name="OAuth2 Token",
+            auth_method=OAuth2AuthenticationMethods.TOKEN,
+            description="""
+Use a pre-obtained OAuth2 access token to authenticate with the API.
+""",
+            config_class=OAuth2TokenConfig,
+        ),
+    ],
+    resource_types=[
+        ResourceTypeModel(
+            name="OAuth2 API",
+            resource_type=OAUTH2_API_RESOURCE_TYPE,
+            description="""
+Allows access to an HTTP API protected by OAuth2. When used by connector
+consumers, the connector provides an authenticated requests Session with the
+bearer token set on the Authorization header.
+""",
+            auth_methods=OAuth2AuthenticationMethods.values(),
+            supports_instances=False,
+            emoji=":globe_with_meridians:",
+        ),
+    ],
+)
+
+
+class OAuth2ServiceConnector(ServiceConnector):
+    """OAuth2 service connector."""
+
+    config: OAuth2BaseConfig
+
+    _token_cache: Dict[str, Tuple[str, Optional[datetime]]] = {}
+
+    @classmethod
+    def _get_connector_type(cls) -> ServiceConnectorTypeModel:
+        """Get the service connector specification.
+
+        Returns:
+            The service connector specification.
+        """
+        return OAUTH2_SERVICE_CONNECTOR_TYPE_SPEC
+
+    def _get_default_resource_id(self, resource_type: str) -> str:
+        """Get the default resource ID for a resource type.
+
+        Args:
+            resource_type: The type of the resource to get a default resource ID
+                for. Only called with resource types that do not support
+                multiple instances.
+
+        Returns:
+            The default resource ID for the resource type.
+        """
+        return self.config.api_url
+
+    def _fetch_token(self) -> Tuple[str, Optional[datetime]]:
+        """Fetch an access token from the token endpoint.
+
+        Raises:
+            AuthorizationException: If a token could not be fetched.
+
+        Returns:
+            The access token and its expiration timestamp, if known.
+        """
+        cfg = self.config
+        assert isinstance(cfg, OAuth2GrantConfig)
+
+        data: Dict[str, str] = {}
+        auth: Optional[Tuple[str, str]] = None
+
+        if isinstance(cfg, OAuth2ClientCredentialsConfig):
+            data["grant_type"] = "client_credentials"
+            if cfg.audience:
+                data["audience"] = cfg.audience
+            auth = (cfg.client_id, cfg.client_secret.get_secret_value())
+        elif isinstance(cfg, OAuth2RefreshTokenConfig):
+            data["grant_type"] = "refresh_token"
+            data["refresh_token"] = cfg.refresh_token.get_secret_value()
+            if cfg.client_secret is not None:
+                auth = (cfg.client_id, cfg.client_secret.get_secret_value())
+            else:
+                # Public clients without a secret send the client ID in the
+                # request body.
+                data["client_id"] = cfg.client_id
+
+        if cfg.scope:
+            data["scope"] = cfg.scope
+
+        try:
+            response = requests.post(
+                cfg.token_url,
+                data=data,
+                auth=auth,
+                timeout=30,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            token = payload["access_token"]
+        except (requests.RequestException, KeyError, ValueError) as e:
+            raise AuthorizationException(
+                f"Failed to fetch an OAuth2 token from {cfg.token_url}: {e}"
+            ) from e
+
+        if not isinstance(token, str):
+            raise AuthorizationException(
+                f"The OAuth2 token endpoint at {cfg.token_url} returned an "
+                f"invalid access token."
+            )
+
+        expires_at: Optional[datetime] = None
+        expires_in = payload.get("expires_in")
+        if expires_in is not None:
+            expires_at = utc_now(tz_aware=True) + timedelta(
+                seconds=int(expires_in)
+            )
+
+        return token, expires_at
+
+    def _get_token(self) -> Tuple[str, Optional[datetime]]:
+        """Get the access token and its expiration timestamp, if known.
+
+        Returns:
+            The access token and its expiration timestamp, if known.
+        """
+        if isinstance(self.config, OAuth2TokenConfig):
+            # Use the user-configured expires_at timestamp on the connector
+            # configuration for static tokens.
+            return self.config.access_token.get_secret_value(), self.expires_at
+
+        key = self.auth_method
+        if key in self._token_cache:
+            token, expires_at = self._token_cache[key]
+            if expires_at is None:
+                return token, None
+
+            # Reuse the cached token unless it expires in the near future.
+            if expires_at > utc_now(tz_aware=expires_at) + timedelta(
+                minutes=OAUTH2_SESSION_EXPIRATION_BUFFER
+            ):
+                return token, expires_at
+
+        token, expires_at = self._fetch_token()
+        self._token_cache[key] = (token, expires_at)
+        return token, expires_at
+
+    def _get_connector_client(
+        self,
+        resource_type: str,
+        resource_id: str,
+    ) -> "ServiceConnector":
+        """Get a connector client scoped to a temporary access token.
+
+        Args:
+            resource_type: The type of the resource to connect to.
+            resource_id: The ID of the resource to connect to.
+
+        Returns:
+            A service connector client that can be used to connect to the
+            resource.
+        """
+        token, expires_at = self._get_token()
+
+        return OAuth2ServiceConnector(
+            auth_method=OAuth2AuthenticationMethods.TOKEN,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            config=OAuth2TokenConfig(
+                access_token=token,
+                api_url=self.config.api_url,
+            ),
+            expires_at=expires_at,
+            expires_skew_tolerance=self.expires_skew_tolerance,
+        )
+
+    def _connect_to_resource(
+        self,
+        **kwargs: Any,
+    ) -> Any:
+        """Authenticate and return a requests session for the API.
+
+        Args:
+            kwargs: Additional implementation specific keyword arguments.
+
+        Returns:
+            An authenticated requests Session.
+        """
+        token, _ = self._get_token()
+
+        session = requests.Session()
+        session.headers["Authorization"] = f"Bearer {token}"
+        return session
+
+    def _configure_local_client(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        """Configure a local client to connect to the API.
+
+        Args:
+            kwargs: Additional implementation specific keyword arguments.
+
+        Raises:
+            NotImplementedError: Always, since there is no local client to
+                configure.
+        """
+        raise NotImplementedError(
+            "Local client configuration is not supported by the OAuth2 "
+            "connector."
+        )
+
+    @classmethod
+    def _auto_configure(
+        cls,
+        auth_method: Optional[str] = None,
+        resource_type: Optional[str] = None,
+        resource_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "OAuth2ServiceConnector":
+        """Auto-configure the connector.
+
+        Args:
+            auth_method: The authentication method to use.
+            resource_type: The type of resource to configure.
+            resource_id: The ID of the resource to configure.
+            kwargs: Additional implementation specific keyword arguments.
+
+        Raises:
+            NotImplementedError: Always, since auto-configuration is not
+                supported.
+
+        Returns:
+            The auto-configured connector.
+        """
+        raise NotImplementedError(
+            "Auto-configuration is not supported by the OAuth2 connector."
+        )
+
+    def _verify(
+        self,
+        resource_type: Optional[str] = None,
+        resource_id: Optional[str] = None,
+    ) -> List[str]:
+        """Verify that the connector can authenticate and access the API.
+
+        Args:
+            resource_type: The type of resource to verify.
+            resource_id: The ID of the resource to verify.
+
+        Returns:
+            The list of resource IDs that the connector can access.
+        """
+        # We can only verify grant-based methods by fetching a token. A static
+        # token cannot be verified without calling the API.
+        if isinstance(self.config, OAuth2GrantConfig):
+            self._get_token()
+        return [resource_id] if resource_id else []

--- a/src/zenml/service_connectors/oauth2_service_connector.py
+++ b/src/zenml/service_connectors/oauth2_service_connector.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from zenml.exceptions import AuthorizationException
 from zenml.logger import get_logger
@@ -39,6 +39,14 @@ logger = get_logger(__name__)
 OAUTH2_CONNECTOR_TYPE = "oauth2"
 OAUTH2_API_RESOURCE_TYPE = "oauth2-api"
 OAUTH2_SESSION_EXPIRATION_BUFFER = 15  # 15 minutes
+OAUTH2_RESERVED_TOKEN_PARAMS = {
+    "grant_type",
+    "client_id",
+    "client_secret",
+    "refresh_token",
+    "scope",
+    "audience",
+}
 
 
 class OAuth2AuthenticationMethods(StrEnum):
@@ -47,6 +55,13 @@ class OAuth2AuthenticationMethods(StrEnum):
     CLIENT_CREDENTIALS = "client-credentials"
     REFRESH_TOKEN = "refresh-token"
     TOKEN = "token"
+
+
+class OAuth2ClientAuthenticationMethods(StrEnum):
+    """OAuth2 client authentication methods."""
+
+    CLIENT_SECRET_BASIC = "client_secret_basic"
+    CLIENT_SECRET_POST = "client_secret_post"
 
 
 class OAuth2BaseConfig(AuthenticationConfig):
@@ -70,6 +85,44 @@ class OAuth2GrantConfig(OAuth2BaseConfig):
         default=None,
         title="Space-separated OAuth2 scopes",
     )
+    client_auth_method: OAuth2ClientAuthenticationMethods = Field(
+        default=OAuth2ClientAuthenticationMethods.CLIENT_SECRET_BASIC,
+        title="OAuth2 client authentication method",
+    )
+    token_params: Dict[str, str] = Field(
+        default_factory=dict,
+        title="Additional OAuth2 token endpoint request parameters",
+    )
+    token_headers: Dict[str, str] = Field(
+        default_factory=dict,
+        title="Additional OAuth2 token endpoint request headers",
+    )
+
+    @model_validator(mode="after")
+    def _validate_token_request_overrides(self) -> "OAuth2GrantConfig":
+        """Reject token parameters or headers that override reserved fields.
+
+        Raises:
+            ValueError: If a reserved token parameter or header is set.
+
+        Returns:
+            The validated configuration.
+        """
+        reserved = OAUTH2_RESERVED_TOKEN_PARAMS.intersection(self.token_params)
+        if reserved:
+            raise ValueError(
+                f"The following OAuth2 token parameters are reserved and "
+                f"cannot be set through `token_params`: "
+                f"{', '.join(sorted(reserved))}."
+            )
+        if any(
+            header.lower() == "authorization" for header in self.token_headers
+        ):
+            raise ValueError(
+                "The `Authorization` OAuth2 token header is reserved and "
+                "cannot be set through `token_headers`."
+            )
+        return self
 
 
 class OAuth2ClientCredentialsConfig(OAuth2GrantConfig):
@@ -196,17 +249,31 @@ class OAuth2ServiceConnector(ServiceConnector):
 
         data: Dict[str, str] = {}
         auth: Optional[Tuple[str, str]] = None
+        send_secret_in_body = (
+            cfg.client_auth_method
+            == OAuth2ClientAuthenticationMethods.CLIENT_SECRET_POST
+        )
 
         if isinstance(cfg, OAuth2ClientCredentialsConfig):
             data["grant_type"] = "client_credentials"
             if cfg.audience:
                 data["audience"] = cfg.audience
-            auth = (cfg.client_id, cfg.client_secret.get_secret_value())
+            client_secret = cfg.client_secret.get_secret_value()
+            if send_secret_in_body:
+                data["client_id"] = cfg.client_id
+                data["client_secret"] = client_secret
+            else:
+                auth = (cfg.client_id, client_secret)
         elif isinstance(cfg, OAuth2RefreshTokenConfig):
             data["grant_type"] = "refresh_token"
             data["refresh_token"] = cfg.refresh_token.get_secret_value()
             if cfg.client_secret is not None:
-                auth = (cfg.client_id, cfg.client_secret.get_secret_value())
+                client_secret = cfg.client_secret.get_secret_value()
+                if send_secret_in_body:
+                    data["client_id"] = cfg.client_id
+                    data["client_secret"] = client_secret
+                else:
+                    auth = (cfg.client_id, client_secret)
             else:
                 # Public clients without a secret send the client ID in the
                 # request body.
@@ -215,33 +282,61 @@ class OAuth2ServiceConnector(ServiceConnector):
         if cfg.scope:
             data["scope"] = cfg.scope
 
+        data.update(cfg.token_params)
+
         try:
             response = requests.post(
                 cfg.token_url,
                 data=data,
                 auth=auth,
+                headers=cfg.token_headers,
                 timeout=30,
             )
             response.raise_for_status()
             payload = response.json()
-            token = payload["access_token"]
-        except (requests.RequestException, KeyError, ValueError) as e:
+        except (requests.RequestException, ValueError) as e:
             raise AuthorizationException(
                 f"Failed to fetch an OAuth2 token from {cfg.token_url}: {e}"
             ) from e
 
+        if not isinstance(payload, dict):
+            raise AuthorizationException(
+                f"The OAuth2 token endpoint at {cfg.token_url} returned an "
+                f"unexpected response."
+            )
+
+        token = payload.get("access_token")
         if not isinstance(token, str):
             raise AuthorizationException(
                 f"The OAuth2 token endpoint at {cfg.token_url} returned an "
                 f"invalid access token."
             )
 
+        token_type = payload.get("token_type")
+        if token_type is not None and str(token_type).lower() != "bearer":
+            raise AuthorizationException(
+                f"The OAuth2 token endpoint at {cfg.token_url} returned an "
+                f"unsupported token type '{token_type}'. Only Bearer tokens "
+                f"are supported."
+            )
+
         expires_at: Optional[datetime] = None
         expires_in = payload.get("expires_in")
         if expires_in is not None:
-            expires_at = utc_now(tz_aware=True) + timedelta(
-                seconds=int(expires_in)
-            )
+            try:
+                expires_in = int(expires_in)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "The OAuth2 token endpoint at %s returned an invalid "
+                    "'expires_in' value: %r. The token expiration will be "
+                    "treated as unknown.",
+                    cfg.token_url,
+                    expires_in,
+                )
+            else:
+                expires_at = utc_now(tz_aware=True) + timedelta(
+                    seconds=expires_in
+                )
 
         return token, expires_at
 

--- a/src/zenml/service_connectors/service_connector_registry.py
+++ b/src/zenml/service_connectors/service_connector_registry.py
@@ -251,6 +251,15 @@ class ServiceConnectorRegistry:
                 )
 
             try:
+                from zenml.service_connectors.oauth2_service_connector import (  # noqa
+                    OAuth2ServiceConnector,
+                )
+            except ImportError as e:
+                logger.debug(
+                    f"Could not import OAuth2 service connector: {e}."
+                )
+
+            try:
                 from zenml.integrations.hyperai.service_connectors.hyperai_service_connector import (  # noqa
                     HyperAIServiceConnector,
                 )


### PR DESCRIPTION
This PR adds a generic OAuth2 service connector, which can be configured either with a static token, client ID and secret or client ID and refresh token.

Limitations:
- Rotating refresh tokens are not supported yet, as there is no public API for updating the secrets that back credentials of a service connector. Can be extended in the future.