### PR TITLE
More query improvements

### DIFF
--- a/src/zenml/zen_stores/migrations/alembic.py
+++ b/src/zenml/zen_stores/migrations/alembic.py
@@ -116,9 +116,10 @@ class Alembic:
             True if the database is empty, False otherwise.
         """
         # Check the existence of any of the SQLModel tables
-        return not self.engine.dialect.has_table(
-            self.engine.connect(), schemas.StackSchema.__tablename__
-        )
+        with self.engine.connect() as connection:
+            return not self.engine.dialect.has_table(
+                connection, schemas.StackSchema.__tablename__
+            )
 
     def run_migrations(
         self,

--- a/src/zenml/zen_stores/migrations/versions/c033e0f0f0d0_add_pipeline_run_triggered_by_index.py
+++ b/src/zenml/zen_stores/migrations/versions/c033e0f0f0d0_add_pipeline_run_triggered_by_index.py
@@ -1,0 +1,34 @@
+"""Add pipeline_run triggered_by index [c033e0f0f0d0].
+
+Revision ID: c033e0f0f0d0
+Revises: c1d964b6075c
+Create Date: 2026-06-25 12:04:34.959049
+
+"""
+
+from zenml.zen_stores.migrations.utils import (
+    create_index_if_missing,
+    drop_index_if_exists,
+)
+
+# revision identifiers, used by Alembic.
+revision = "c033e0f0f0d0"
+down_revision = "c1d964b6075c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    create_index_if_missing(
+        "pipeline_run",
+        "ix_pipeline_run_triggered_by_triggered_by_type",
+        ["triggered_by", "triggered_by_type"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    drop_index_if_exists(
+        "pipeline_run", "ix_pipeline_run_triggered_by_triggered_by_type"
+    )

--- a/src/zenml/zen_stores/schemas/AGENTS.md
+++ b/src/zenml/zen_stores/schemas/AGENTS.md
@@ -248,6 +248,11 @@ class SecretSchema(NamedSchema, table=True):
 - Docstrings are mandatory for all classes and methods; include arguments, returns, and raised exceptions where applicable.
 - Comments where mapping/business rules are non-obvious; avoid redundant or change-log style comments.
 
+### `get_query_options` eager-loading rules
+- Collections (`List[...]`) always use `selectinload`. `joinedload` on a collection Cartesian-multiplies rows and breaks the list path.
+- Single-valued relationships use `single_loader = selectinload if many else joinedload` (joinedload for `get_*`, selectinload for lists)
+- Use `joinedload` for a single-valued relationship when the related row usually exists, or when it is a 1:1 where the other table points back to this one (like `pipeline_run.trigger_execution`, where `trigger_execution` holds `pipeline_run_id`): selectinload always runs a query there even when there is no match, so joinedload always wins. Keep `selectinload` only for a nullable foreign key on this table that is usually empty (like snapshot's `build`/`schedule`): selectinload already skips it when the column is null, so `joinedload` would only add a useless JOIN.
+
 Practical Checklist for New/Updated Schemas
 - Pick BaseSchema vs. NamedSchema appropriately.
 - Set table=True and __tablename__.

--- a/src/zenml/zen_stores/schemas/artifact_schemas.py
+++ b/src/zenml/zen_stores/schemas/artifact_schemas.py
@@ -404,13 +404,12 @@ class ArtifactVersionSchema(BaseSchema, RunMetadataInterface, table=True):
             selectinload(jl_arg(ArtifactVersionSchema.artifact)),
         ]
 
-        # if include_metadata:
-        #     options.extend(
-        #         [
-        #             joinedload(jl_arg(ArtifactVersionSchema.visualizations)),
-        #             joinedload(jl_arg(ArtifactVersionSchema.run_metadata)),
-        #         ]
-        #     )
+        if include_metadata:
+            options.extend(
+                [
+                    selectinload(jl_arg(ArtifactVersionSchema.run_metadata)),
+                ]
+            )
 
         if include_resources:
             options.extend(

--- a/src/zenml/zen_stores/schemas/artifact_schemas.py
+++ b/src/zenml/zen_stores/schemas/artifact_schemas.py
@@ -416,6 +416,7 @@ class ArtifactVersionSchema(BaseSchema, RunMetadataInterface, table=True):
                 [
                     selectinload(jl_arg(ArtifactVersionSchema.user)),
                     selectinload(jl_arg(ArtifactVersionSchema.tags)),
+                    selectinload(jl_arg(ArtifactVersionSchema.visualizations)),
                 ]
             )
 

--- a/src/zenml/zen_stores/schemas/model_schemas.py
+++ b/src/zenml/zen_stores/schemas/model_schemas.py
@@ -463,12 +463,12 @@ class ModelVersionSchema(NamedSchema, RunMetadataInterface, table=True):
             joinedload(jl_arg(ModelVersionSchema.model), innerjoin=True),
         ]
 
-        # if include_metadata:
-        #     options.extend(
-        #         [
-        #             joinedload(jl_arg(ModelVersionSchema.run_metadata)),
-        #         ]
-        #     )
+        if include_metadata:
+            options.extend(
+                [
+                    selectinload(jl_arg(ModelVersionSchema.run_metadata)),
+                ]
+            )
 
         if include_resources:
             options.extend(

--- a/src/zenml/zen_stores/schemas/model_schemas.py
+++ b/src/zenml/zen_stores/schemas/model_schemas.py
@@ -474,8 +474,8 @@ class ModelVersionSchema(NamedSchema, RunMetadataInterface, table=True):
             options.extend(
                 [
                     joinedload(jl_arg(ModelVersionSchema.user)),
-                    # joinedload(jl_arg(ModelVersionSchema.services)),
-                    # joinedload(jl_arg(ModelVersionSchema.tags)),
+                    selectinload(jl_arg(ModelVersionSchema.services)),
+                    selectinload(jl_arg(ModelVersionSchema.tags)),
                 ]
             )
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -129,6 +129,11 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             table_name=__tablename__,
             column_names=["pipeline_id", "created"],
         ),
+        # Resolves step-triggered child runs without scanning pipeline_run.
+        build_index(
+            table_name=__tablename__,
+            column_names=["triggered_by", "triggered_by_type"],
+        ),
     )
 
     # Fields

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -21,7 +21,12 @@ from uuid import UUID
 from pydantic import ConfigDict
 from sqlalchemy import String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import Session, object_session, selectinload
+from sqlalchemy.orm import (
+    Session,
+    joinedload,
+    object_session,
+    selectinload,
+)
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import TEXT, Column, Field, Relationship, col, select
 
@@ -381,6 +386,8 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
         cls,
         include_metadata: bool = False,
         include_resources: bool = False,
+        many: bool = False,
+        include_full_metadata: bool = False,
         **kwargs: Any,
     ) -> Sequence[ExecutableOption]:
         """Get the query options for the schema.
@@ -390,60 +397,71 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 the schema to a model.
             include_resources: Whether resources will be included when
                 converting the schema to a model.
+            many: Whether the options are applied to a query that returns many
+                rows. Single-valued relationships then use selectin loading to
+                avoid duplicating their columns across every row. For a single
+                fetch they use joined loading to save a round-trip.
+            include_full_metadata: Whether step-level metadata will be included.
             **kwargs: Keyword arguments to allow schema specific logic
 
         Returns:
             A list of query options.
         """
-        from zenml.zen_stores.schemas import ModelVersionSchema
+        from zenml.zen_stores.schemas import (
+            ModelVersionSchema,
+            StepRunSchema,
+        )
+
+        single = selectinload if many else joinedload
 
         options = []
 
         if include_metadata:
             options.extend(
                 [
-                    selectinload(jl_arg(PipelineRunSchema.trigger_execution)),
+                    single(jl_arg(PipelineRunSchema.trigger_execution)),
+                    selectinload(jl_arg(PipelineRunSchema.run_metadata)),
                 ]
             )
+            if include_full_metadata:
+                options.append(
+                    selectinload(
+                        jl_arg(PipelineRunSchema.step_runs)
+                    ).selectinload(jl_arg(StepRunSchema.run_metadata))
+                )
 
         if include_resources:
             options.extend(
                 [
                     selectinload(jl_arg(PipelineRunSchema.outputs)),
-                    selectinload(jl_arg(PipelineRunSchema.parent_run)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.model_version)
-                    ).joinedload(
+                    single(jl_arg(PipelineRunSchema.parent_run)),
+                    single(jl_arg(PipelineRunSchema.model_version)).joinedload(
                         jl_arg(ModelVersionSchema.model), innerjoin=True
                     ),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
                         jl_arg(PipelineSnapshotSchema.source_snapshot)
                     ),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(jl_arg(PipelineSnapshotSchema.pipeline)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(jl_arg(PipelineSnapshotSchema.stack)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(jl_arg(PipelineSnapshotSchema.build)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(jl_arg(PipelineSnapshotSchema.schedule)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.snapshot)
-                    ).joinedload(
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                        jl_arg(PipelineSnapshotSchema.pipeline)
+                    ),
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                        jl_arg(PipelineSnapshotSchema.stack)
+                    ),
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                        jl_arg(PipelineSnapshotSchema.build)
+                    ),
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                        jl_arg(PipelineSnapshotSchema.schedule)
+                    ),
+                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
                         jl_arg(PipelineSnapshotSchema.code_reference)
                     ),
                     selectinload(jl_arg(PipelineRunSchema.logs)),
                     selectinload(jl_arg(PipelineRunSchema.wait_conditions)),
-                    selectinload(jl_arg(PipelineRunSchema.user)),
+                    single(jl_arg(PipelineRunSchema.user)),
                     selectinload(jl_arg(PipelineRunSchema.tags)),
                     selectinload(jl_arg(PipelineRunSchema.visualizations)),
-                    selectinload(jl_arg(PipelineRunSchema.trigger)),
+                    single(jl_arg(PipelineRunSchema.trigger)),
                 ]
             )
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -398,9 +398,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             include_resources: Whether resources will be included when
                 converting the schema to a model.
             many: Whether the options are applied to a query that returns many
-                rows. Single-valued relationships then use selectin loading to
-                avoid duplicating their columns across every row. For a single
-                fetch they use joined loading to save a round-trip.
+                rows.
             include_full_metadata: Whether step-level metadata will be included.
             **kwargs: Keyword arguments to allow schema specific logic
 
@@ -412,14 +410,14 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             StepRunSchema,
         )
 
-        single = selectinload if many else joinedload
+        single_loader = selectinload if many else joinedload
 
         options = []
 
         if include_metadata:
             options.extend(
                 [
-                    single(jl_arg(PipelineRunSchema.trigger_execution)),
+                    single_loader(jl_arg(PipelineRunSchema.trigger_execution)),
                     selectinload(jl_arg(PipelineRunSchema.run_metadata)),
                 ]
             )
@@ -434,34 +432,40 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             options.extend(
                 [
                     selectinload(jl_arg(PipelineRunSchema.outputs)),
-                    single(jl_arg(PipelineRunSchema.parent_run)),
-                    single(jl_arg(PipelineRunSchema.model_version)).joinedload(
+                    single_loader(jl_arg(PipelineRunSchema.parent_run)),
+                    single_loader(
+                        jl_arg(PipelineRunSchema.model_version)
+                    ).joinedload(
                         jl_arg(ModelVersionSchema.model), innerjoin=True
                     ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(
                         jl_arg(PipelineSnapshotSchema.source_snapshot)
                     ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
-                        jl_arg(PipelineSnapshotSchema.pipeline)
-                    ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
-                        jl_arg(PipelineSnapshotSchema.stack)
-                    ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
-                        jl_arg(PipelineSnapshotSchema.build)
-                    ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
-                        jl_arg(PipelineSnapshotSchema.schedule)
-                    ),
-                    single(jl_arg(PipelineRunSchema.snapshot)).joinedload(
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(jl_arg(PipelineSnapshotSchema.pipeline)),
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(jl_arg(PipelineSnapshotSchema.stack)),
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(jl_arg(PipelineSnapshotSchema.build)),
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(jl_arg(PipelineSnapshotSchema.schedule)),
+                    single_loader(
+                        jl_arg(PipelineRunSchema.snapshot)
+                    ).joinedload(
                         jl_arg(PipelineSnapshotSchema.code_reference)
                     ),
                     selectinload(jl_arg(PipelineRunSchema.logs)),
                     selectinload(jl_arg(PipelineRunSchema.wait_conditions)),
-                    single(jl_arg(PipelineRunSchema.user)),
+                    single_loader(jl_arg(PipelineRunSchema.user)),
                     selectinload(jl_arg(PipelineRunSchema.tags)),
                     selectinload(jl_arg(PipelineRunSchema.visualizations)),
-                    single(jl_arg(PipelineRunSchema.trigger)),
+                    single_loader(jl_arg(PipelineRunSchema.trigger)),
                 ]
             )
 

--- a/src/zenml/zen_stores/schemas/run_wait_condition_schemas.py
+++ b/src/zenml/zen_stores/schemas/run_wait_condition_schemas.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy import TEXT, CheckConstraint, Column, UniqueConstraint
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship
 
@@ -158,6 +158,8 @@ class RunWaitConditionSchema(BaseSchema, RunMetadataInterface, table=True):
             SQLAlchemy query options.
         """
         options: List[ExecutableOption] = [joinedload(jl_arg(cls.run))]
+        if include_metadata:
+            options.append(selectinload(jl_arg(cls.run_metadata)))
         if include_resources:
             options.extend(
                 [

--- a/src/zenml/zen_stores/schemas/schedule_schema.py
+++ b/src/zenml/zen_stores/schemas/schedule_schema.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy import UniqueConstraint
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship
 
@@ -148,12 +148,12 @@ class ScheduleSchema(NamedSchema, RunMetadataInterface, table=True):
         """
         options = []
 
-        # if include_metadata:
-        #     options.extend(
-        #         [
-        #             joinedload(jl_arg(ScheduleSchema.run_metadata)),
-        #         ]
-        #     )
+        if include_metadata:
+            options.extend(
+                [
+                    selectinload(jl_arg(ScheduleSchema.run_metadata)),
+                ]
+            )
 
         if include_resources:
             options.extend([joinedload(jl_arg(ScheduleSchema.user))])

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -21,7 +21,7 @@ from uuid import UUID
 from pydantic import ConfigDict
 from sqlalchemy import TEXT, Column, String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -265,6 +265,7 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         cls,
         include_metadata: bool = False,
         include_resources: bool = False,
+        many: bool = False,
         **kwargs: Any,
     ) -> Sequence[ExecutableOption]:
         """Get the query options for the schema.
@@ -274,6 +275,8 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 the schema to a model.
             include_resources: Whether resources will be included when
                 converting the schema to a model.
+            many: Whether the options are applied to a query that returns many
+                rows.
             **kwargs: Keyword arguments to allow schema specific logic
 
         Returns:
@@ -284,16 +287,18 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             ModelVersionSchema,
         )
 
+        single_loader = selectinload if many else joinedload
+
         options = [
-            selectinload(jl_arg(StepRunSchema.snapshot)).load_only(
+            single_loader(jl_arg(StepRunSchema.snapshot)).load_only(
                 jl_arg(PipelineSnapshotSchema.pipeline_configuration),
                 jl_arg(PipelineSnapshotSchema.is_dynamic),
             ),
-            selectinload(jl_arg(StepRunSchema.pipeline_run)).load_only(
+            single_loader(jl_arg(StepRunSchema.pipeline_run)).load_only(
                 jl_arg(PipelineRunSchema.start_time)
             ),
-            selectinload(jl_arg(StepRunSchema.static_config)),
-            selectinload(jl_arg(StepRunSchema.dynamic_config)),
+            single_loader(jl_arg(StepRunSchema.static_config)),
+            single_loader(jl_arg(StepRunSchema.dynamic_config)),
         ]
 
         if include_metadata:
@@ -307,13 +312,13 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         if include_resources:
             options.extend(
                 [
-                    selectinload(
+                    single_loader(
                         jl_arg(StepRunSchema.model_version)
                     ).joinedload(
                         jl_arg(ModelVersionSchema.model), innerjoin=True
                     ),
-                    selectinload(jl_arg(StepRunSchema.user)),
-                    selectinload(jl_arg(StepRunSchema.resource_request)),
+                    single_loader(jl_arg(StepRunSchema.user)),
+                    single_loader(jl_arg(StepRunSchema.resource_request)),
                     selectinload(jl_arg(StepRunSchema.input_artifacts))
                     .joinedload(
                         jl_arg(StepRunInputArtifactSchema.artifact_version),

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -286,7 +286,8 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
 
         options = [
             selectinload(jl_arg(StepRunSchema.snapshot)).load_only(
-                jl_arg(PipelineSnapshotSchema.pipeline_configuration)
+                jl_arg(PipelineSnapshotSchema.pipeline_configuration),
+                jl_arg(PipelineSnapshotSchema.is_dynamic),
             ),
             selectinload(jl_arg(StepRunSchema.pipeline_run)).load_only(
                 jl_arg(PipelineRunSchema.start_time)
@@ -298,6 +299,7 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         if include_metadata:
             options.extend(
                 [
+                    selectinload(jl_arg(StepRunSchema.parents)),
                     selectinload(jl_arg(StepRunSchema.run_metadata)),
                 ]
             )
@@ -311,6 +313,7 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
                         jl_arg(ModelVersionSchema.model), innerjoin=True
                     ),
                     selectinload(jl_arg(StepRunSchema.user)),
+                    selectinload(jl_arg(StepRunSchema.resource_request)),
                     selectinload(jl_arg(StepRunSchema.input_artifacts))
                     .joinedload(
                         jl_arg(StepRunInputArtifactSchema.artifact_version),

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -295,13 +295,12 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             selectinload(jl_arg(StepRunSchema.dynamic_config)),
         ]
 
-        # if include_metadata:
-        #     options.extend(
-        #         [
-        #             joinedload(jl_arg(StepRunSchema.parents)),
-        #             joinedload(jl_arg(StepRunSchema.run_metadata)),
-        #         ]
-        #     )
+        if include_metadata:
+            options.extend(
+                [
+                    selectinload(jl_arg(StepRunSchema.run_metadata)),
+                ]
+            )
 
         if include_resources:
             options.extend(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1363,12 +1363,7 @@ class SqlZenStore(BaseZenStore):
                 filter_model.offset : filter_model.offset + filter_model.size
             ]
         else:
-            # Apply sorting for the data fetch. Sorting can introduce its own
-            # join (e.g. ordering by a related column), so re-check before
-            # applying DISTINCT.
             query = filter_model.apply_sorting(query=query, table=table)
-            if cls._query_requires_distinct(query):
-                query = query.distinct()
 
             query_options = table.get_query_options(
                 include_metadata=hydrate,
@@ -1378,6 +1373,12 @@ class SqlZenStore(BaseZenStore):
             )
             if apply_query_options_from_schema and query_options:
                 query = query.options(*query_options)
+
+            # Check for DISTINCT after sorting and query options are applied so
+            # the check sees every join in the final query, including the ones
+            # added by sorting on a related column and by eager loaders.
+            if cls._query_requires_distinct(query):
+                query = query.distinct()
 
             query_result = session.exec(
                 query.limit(filter_model.size).offset(filter_model.offset)

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -96,7 +96,6 @@ from sqlalchemy.exc import (
 )
 from sqlalchemy.orm import (
     Mapped,
-    joinedload,
     load_only,
     noload,
     selectinload,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1274,6 +1274,7 @@ class SqlZenStore(BaseZenStore):
         ] = None,
         hydrate: bool = False,
         apply_query_options_from_schema: bool = False,
+        query_options_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Page[AnyResponse]:
         """Given a query, return a Page instance with a list of filtered Models.
 
@@ -1296,6 +1297,8 @@ class SqlZenStore(BaseZenStore):
                 by including metadata fields in the response.
             apply_query_options_from_schema: Flag deciding whether to apply
                 query options defined on the schema.
+            query_options_kwargs: Extra keyword arguments forwarded to the
+                schema's `get_query_options`.
 
         Returns:
             The Domain Model representation of the DB resource
@@ -1369,7 +1372,10 @@ class SqlZenStore(BaseZenStore):
                 query = query.distinct()
 
             query_options = table.get_query_options(
-                include_metadata=hydrate, include_resources=True
+                include_metadata=hydrate,
+                include_resources=True,
+                many=True,
+                **(query_options_kwargs or {}),
             )
             if apply_query_options_from_schema and query_options:
                 query = query.options(*query_options)
@@ -6925,7 +6931,9 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineRunSchema,
                 session=session,
                 query_options=PipelineRunSchema.get_query_options(
-                    include_metadata=hydrate, include_resources=True
+                    include_metadata=hydrate,
+                    include_resources=True,
+                    include_full_metadata=include_full_metadata,
                 ),
             )
             return run.to_model(
@@ -7266,6 +7274,9 @@ class SqlZenStore(BaseZenStore):
                     )
                 ),
                 apply_query_options_from_schema=True,
+                query_options_kwargs={
+                    "include_full_metadata": include_full_metadata
+                },
             )
 
     def update_run(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -96,6 +96,7 @@ from sqlalchemy.exc import (
 )
 from sqlalchemy.orm import (
     Mapped,
+    joinedload,
     load_only,
     noload,
     selectinload,
@@ -6177,12 +6178,15 @@ class SqlZenStore(BaseZenStore):
         """
         helper = DAGGeneratorHelper()
         with Session(self.engine) as session:
-            # TODO: better loads for dynamic/static pipelines
             run = self._get_schema_by_id(
                 resource_id=pipeline_run_id,
                 schema_class=PipelineRunSchema,
                 session=session,
                 query_options=[
+                    load_only(
+                        jl_arg(PipelineRunSchema.status),
+                        jl_arg(PipelineRunSchema.start_time),
+                    ),
                     selectinload(jl_arg(PipelineRunSchema.snapshot)).load_only(
                         jl_arg(PipelineSnapshotSchema.pipeline_configuration),
                         jl_arg(PipelineSnapshotSchema.is_dynamic),
@@ -6194,10 +6198,34 @@ class SqlZenStore(BaseZenStore):
                     ),
                     selectinload(
                         jl_arg(PipelineRunSchema.step_runs)
-                    ).selectinload(jl_arg(StepRunSchema.input_artifacts)),
-                    selectinload(
-                        jl_arg(PipelineRunSchema.step_runs)
-                    ).selectinload(jl_arg(StepRunSchema.output_artifacts)),
+                    ).load_only(
+                        jl_arg(StepRunSchema.name),
+                        jl_arg(StepRunSchema.status),
+                        jl_arg(StepRunSchema.start_time),
+                        jl_arg(StepRunSchema.end_time),
+                    ),
+                    selectinload(jl_arg(PipelineRunSchema.step_runs))
+                    .selectinload(jl_arg(StepRunSchema.input_artifacts))
+                    .joinedload(
+                        jl_arg(StepRunInputArtifactSchema.artifact_version),
+                        innerjoin=True,
+                    )
+                    .load_only(
+                        jl_arg(ArtifactVersionSchema.type),
+                        jl_arg(ArtifactVersionSchema.data_type),
+                        jl_arg(ArtifactVersionSchema.save_type),
+                    ),
+                    selectinload(jl_arg(PipelineRunSchema.step_runs))
+                    .selectinload(jl_arg(StepRunSchema.output_artifacts))
+                    .joinedload(
+                        jl_arg(StepRunOutputArtifactSchema.artifact_version),
+                        innerjoin=True,
+                    )
+                    .load_only(
+                        jl_arg(ArtifactVersionSchema.type),
+                        jl_arg(ArtifactVersionSchema.data_type),
+                        jl_arg(ArtifactVersionSchema.save_type),
+                    ),
                     selectinload(
                         jl_arg(PipelineRunSchema.step_runs)
                     ).selectinload(jl_arg(StepRunSchema.dynamic_config)),


### PR DESCRIPTION
Follow up to #4982, this PR adds more query option and index improvements.

- Only load required columns during DAG query
- `selectinload` run metadata for all entities
- add missing `selectinload`s for artifact version and model version
- use `joinedload` instead of `selectinload` for `get_step_run` and `get_pipeline_run` for certain 1:1 relationships
- fix: release connection during alembic migration