### PR TITLE
Dynamic pipeline start ordering

### DIFF
--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -321,6 +321,28 @@ The `StepFuture` object provides several methods:
 When using `step.submit()`, steps with `runtime="isolated"` will execute in separate containers/processes, while steps with `runtime="inline"` will execute in separate threads within the orchestration environment.
 {% endhint %}
 
+### Ordering submitted steps
+
+A submitted step starts as soon as its inputs are available. To impose an order between steps that have no data dependency, use `after` or `start_after`:
+
+- `after=` waits for the upstream step to **finish** before starting.
+- `start_after=` waits for the upstream step to **start** before starting.
+
+`start_after` is useful when an upstream step is long-running and you want a dependent to run alongside it rather than after it. A common case is a step that brings up a service and a second step that uses it:
+
+```python
+@pipeline(dynamic=True)
+def serve_and_query():
+    server = serve_model.submit()  # long-running
+    # Starts once the server step is running, not when it finishes.
+    query = run_inference.submit(start_after=server)
+    query.wait()
+```
+
+Using `after=server` here would deadlock, since the dependent would wait for the long-running server step to finish. Both parameters accept a single future or a list, and you can combine them: `run_inference.submit(after=preprocess, start_after=server)`. `start_after` is available on `step.submit(...)`, `step.map(...)`, `step.product(...)`, and on a direct synchronous `step(...)` call, where the entrypoint blocks until the upstream has started. The upstream can be another step or a submitted child pipeline, for example `run_inference(start_after=serve_pipeline.submit())`.
+
+`start_after` orders execution, it does not probe readiness. The dependent starts once the upstream step has launched (for isolated steps, once it is submitted to the infrastructure), which does not guarantee that whatever the upstream sets up is ready to serve. Add your own connection retries if the dependent needs to reach a service the upstream starts. A failed upstream counts as started, so a `start_after` dependent is released rather than blocked when the upstream fails. Circular `start_after` dependencies are not detected and will stall the involved steps.
+
 ### Child pipelines inside dynamic pipelines
 
 Dynamic pipelines can call other dynamic pipelines from their `@pipeline`

--- a/src/zenml/execution/pipeline/dynamic/inputs.py
+++ b/src/zenml/execution/pipeline/dynamic/inputs.py
@@ -220,6 +220,22 @@ def collect_upstream_node_ids(
     ]
 
 
+def collect_start_upstream_node_ids(
+    start_after: Union["AnyOutputFuture", Sequence["AnyOutputFuture"], None],
+) -> List[str]:
+    """Collect start-upstream node IDs from `start_after` futures.
+
+    Args:
+        start_after: Optional upstream futures for start ordering.
+
+    Returns:
+        The start-upstream node IDs.
+    """
+    return [
+        future.invocation_id for future in collect_futures(after=start_after)
+    ]
+
+
 def get_running_upstream_dependencies(
     inputs: Dict[str, Any],
     after: Union["AnyOutputFuture", Sequence["AnyOutputFuture"], None],

--- a/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
+++ b/src/zenml/execution/pipeline/dynamic/invocation_dependency_graph.py
@@ -72,7 +72,9 @@ class BaseNode:
     node_id: str
     state: NodeState = NodeState.PENDING
     upstream_ids: Set[str] = field(default_factory=set)
+    start_upstream_ids: Set[str] = field(default_factory=set)
     downstream_ids: Set[str] = field(default_factory=set)
+    start_downstream_ids: Set[str] = field(default_factory=set)
 
     @property
     def is_terminal(self) -> bool:
@@ -82,6 +84,19 @@ class BaseNode:
             True if the node is terminal, False otherwise.
         """
         return self.state.is_terminal
+
+    @property
+    def has_started(self) -> bool:
+        """Whether the node has started running.
+
+        Returns:
+            True if the node has started running, False otherwise.
+        """
+        return self.state not in {
+            NodeState.PENDING,
+            NodeState.READY,
+            NodeState.STARTING,
+        }
 
 
 @dataclass(kw_only=True)
@@ -130,6 +145,7 @@ class InvocationDependencyGraph:
         self,
         node_id: str,
         upstream_ids: Optional[Sequence[str]] = None,
+        start_upstream_ids: Optional[Sequence[str]] = None,
         state: Optional[NodeState] = None,
         step: Optional[BaseStep] = None,
         inputs: Optional[Dict[str, Any]] = None,
@@ -142,7 +158,8 @@ class InvocationDependencyGraph:
 
         Args:
             node_id: The node ID.
-            upstream_ids: Optional upstream node IDs.
+            upstream_ids: Upstream node IDs that must succeed.
+            start_upstream_ids: Upstream node IDs that must start.
             state: Optional initial state for the node.
             step: Optional step payload for startup.
             inputs: Optional input payload for startup.
@@ -162,7 +179,9 @@ class InvocationDependencyGraph:
             config_overrides=config_overrides,
         )
         registered, newly_ready = self._register_node(
-            node=node, upstream_ids=upstream_ids
+            node=node,
+            upstream_ids=upstream_ids,
+            start_upstream_ids=start_upstream_ids,
         )
         assert isinstance(registered, StepNode)
         return registered, newly_ready
@@ -174,6 +193,7 @@ class InvocationDependencyGraph:
         inputs: Dict[str, Any],
         product: bool,
         upstream_ids: Optional[Sequence[str]] = None,
+        start_upstream_ids: Optional[Sequence[str]] = None,
         state: Optional[NodeState] = None,
         after: Optional[
             Union[AnyOutputFuture, Sequence[AnyOutputFuture]]
@@ -183,7 +203,8 @@ class InvocationDependencyGraph:
 
         Args:
             node_id: The graph node ID.
-            upstream_ids: Optional upstream node IDs.
+            upstream_ids: Upstream node IDs that must succeed.
+            start_upstream_ids: Upstream node IDs that must start.
             state: Optional initial state for the node.
             step: The mapped step payload for startup.
             inputs: The input payload for startup.
@@ -203,7 +224,9 @@ class InvocationDependencyGraph:
             product=product,
         )
         registered, newly_ready = self._register_node(
-            node=node, upstream_ids=upstream_ids
+            node=node,
+            upstream_ids=upstream_ids,
+            start_upstream_ids=start_upstream_ids,
         )
         assert isinstance(registered, MapNode)
         return registered, newly_ready
@@ -215,6 +238,7 @@ class InvocationDependencyGraph:
         args: Optional[Sequence[Any]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         upstream_ids: Optional[Sequence[str]] = None,
+        start_upstream_ids: Optional[Sequence[str]] = None,
         state: Optional[NodeState] = None,
     ) -> Tuple[ChildPipelineNode, bool]:
         """Register a child pipeline node.
@@ -224,7 +248,8 @@ class InvocationDependencyGraph:
             pipeline: The child pipeline payload for startup.
             args: Optional positional payload for startup.
             kwargs: Optional keyword payload for startup.
-            upstream_ids: Optional upstream node IDs.
+            upstream_ids: Upstream node IDs that must succeed.
+            start_upstream_ids: Upstream node IDs that must start.
             state: Optional initial state for the node.
 
         Returns:
@@ -239,7 +264,9 @@ class InvocationDependencyGraph:
             kwargs=kwargs or {},
         )
         registered, newly_ready = self._register_node(
-            node=node, upstream_ids=upstream_ids
+            node=node,
+            upstream_ids=upstream_ids,
+            start_upstream_ids=start_upstream_ids,
         )
         assert isinstance(registered, ChildPipelineNode)
         return registered, newly_ready
@@ -318,7 +345,9 @@ class InvocationDependencyGraph:
             should_wake_startup_loop = False
 
             if map_node.state in {NodeState.READY, NodeState.STARTING}:
-                self._set_node_state(
+                # Running the map node latches it as started, which can release
+                # nodes that only wait for the map to start.
+                should_wake_startup_loop = self._set_node_state(
                     node_id=map_node_id, state=NodeState.RUNNING
                 )
 
@@ -328,12 +357,16 @@ class InvocationDependencyGraph:
                 child_node.parent_id = map_node_id
 
             if not child_node_ids:
-                should_wake_startup_loop = self._set_node_state(
-                    node_id=map_node_id, state=NodeState.SUCCEEDED
+                should_wake_startup_loop = (
+                    self._set_node_state(
+                        node_id=map_node_id, state=NodeState.SUCCEEDED
+                    )
+                    or should_wake_startup_loop
                 )
             else:
-                should_wake_startup_loop = self._maybe_finalize_map_node(
-                    map_node_id=map_node_id
+                should_wake_startup_loop = (
+                    self._maybe_finalize_map_node(map_node_id=map_node_id)
+                    or should_wake_startup_loop
                 )
 
             return should_wake_startup_loop
@@ -463,16 +496,30 @@ class InvocationDependencyGraph:
         with self._lock:
             return self._get_node(node_id=node_id).state
 
+    def node_has_started(self, node_id: str) -> bool:
+        """Whether a node has started running.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            True if the node has started running, False otherwise.
+        """
+        with self._lock:
+            return self._get_node(node_id=node_id).has_started
+
     def _register_node(
         self,
         node: AnyNode,
         upstream_ids: Optional[Sequence[str]],
+        start_upstream_ids: Optional[Sequence[str]] = None,
     ) -> Tuple[AnyNode, bool]:
         """Register a graph node.
 
         Args:
             node: The node to register.
-            upstream_ids: Optional upstream node IDs.
+            upstream_ids: Optional upstream node IDs that must succeed.
+            start_upstream_ids: Optional upstream node IDs that must start.
 
         Raises:
             RuntimeError: If an upstream node is unknown or a node with the same
@@ -497,6 +544,13 @@ class InvocationDependencyGraph:
                 self._get_node(node_id=upstream_id)
                 node.upstream_ids.add(upstream_id)
                 self._nodes[upstream_id].downstream_ids.add(node.node_id)
+
+            for start_upstream_id in start_upstream_ids or []:
+                self._get_node(node_id=start_upstream_id)
+                node.start_upstream_ids.add(start_upstream_id)
+                self._nodes[start_upstream_id].start_downstream_ids.add(
+                    node.node_id
+                )
 
             if node.state == NodeState.READY:
                 return node, True
@@ -587,6 +641,10 @@ class InvocationDependencyGraph:
             if node.state.is_terminal:
                 return self._handle_terminal_node_transition(node_id=node_id)
 
+            if node.state == NodeState.RUNNING:
+                # Some downstream nodes might only wait for this node to start
+                return self._refresh_downstream_readiness(node_id=node_id)
+
             return node.state == NodeState.READY
 
     def _handle_terminal_node_transition(self, node_id: str) -> bool:
@@ -608,7 +666,24 @@ class InvocationDependencyGraph:
                 map_node_id=parent_map_id
             )
 
-        for downstream_id in node.downstream_ids:
+        return (
+            self._refresh_downstream_readiness(node_id=node_id)
+            or new_nodes_ready
+        )
+
+    def _refresh_downstream_readiness(self, node_id: str) -> bool:
+        """Re-evaluate the readiness of a node's downstream nodes.
+
+        Args:
+            node_id: The node ID.
+
+        Returns:
+            Whether any downstream node became ready.
+        """
+        node = self._get_node(node_id=node_id)
+
+        new_nodes_ready = False
+        for downstream_id in node.downstream_ids | node.start_downstream_ids:
             new_nodes_ready = (
                 self._maybe_mark_node_ready(node_id=downstream_id)
                 or new_nodes_ready
@@ -654,7 +729,7 @@ class InvocationDependencyGraph:
         return self._set_node_state(node_id=map_node_id, state=aggregate_state)
 
     def _maybe_mark_node_ready(self, node_id: str) -> bool:
-        """Mark a pending node as ready when all upstream nodes succeeded.
+        """Mark a pending node as ready when its dependencies are satisfied.
 
         Args:
             node_id: The node ID.
@@ -669,6 +744,12 @@ class InvocationDependencyGraph:
         if not all(
             self._get_node(node_id=upstream_id).state == NodeState.SUCCEEDED
             for upstream_id in node.upstream_ids
+        ):
+            return False
+
+        if not all(
+            self._get_node(node_id=start_upstream_id).has_started
+            for start_upstream_id in node.start_upstream_ids
         ):
             return False
 

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -78,6 +78,7 @@ from zenml.execution.pipeline.dynamic.future_registry import (
 )
 from zenml.execution.pipeline.dynamic.inputs import (
     await_step_inputs,
+    collect_start_upstream_node_ids,
     collect_upstream_node_ids,
     convert_to_keyword_arguments,
     get_running_upstream_dependencies,
@@ -1143,6 +1144,9 @@ class DynamicPipelineRunner:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         group: Optional["GroupInfo"] = None,
         concurrent: Literal[False] = False,
     ) -> StepRunOutputs: ...
@@ -1155,6 +1159,9 @@ class DynamicPipelineRunner:
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
         after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
+        start_after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
         group: Optional["GroupInfo"] = None,
@@ -1170,6 +1177,9 @@ class DynamicPipelineRunner:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         group: Optional["GroupInfo"] = None,
         concurrent: bool = False,
     ) -> Union[StepRunOutputs, "StepFuture"]:
@@ -1181,6 +1191,7 @@ class DynamicPipelineRunner:
             args: The arguments for the step function.
             kwargs: The keyword arguments for the step function.
             after: The step run output futures to wait for.
+            start_after: The step run output futures to wait for the start of.
             group: The group information for this step.
             concurrent: Whether to launch the step concurrently.
 
@@ -1334,10 +1345,18 @@ class DynamicPipelineRunner:
                 step=step,
                 inputs=inputs,
                 after=after,
+                start_after=start_after,
                 config_overrides=config_overrides,
             )
             return future
         else:
+            # We need to explicitly wait until the start dependencies are
+            # satisfied, as we do not rely on the dependency graph for the
+            # sync execution path.
+            self._wait_until_start_dependencies_satisfied(
+                start_after=start_after
+            )
+
             if (
                 running_upstream_dependencies
                 := get_running_upstream_dependencies(inputs, after)
@@ -1361,6 +1380,31 @@ class DynamicPipelineRunner:
                 step=compiled_step, remaining_retries=remaining_retries
             )
             return load_step_run_outputs(step_run.id)
+
+    def _wait_until_start_dependencies_satisfied(
+        self,
+        start_after: Union[AnyOutputFuture, Sequence[AnyOutputFuture], None],
+    ) -> None:
+        """Block until all start-ordering dependencies are satisfied.
+
+        Args:
+            start_after: The dependencies to wait for the start of.
+
+        Raises:
+            BaseException: If a failure was detected while waiting.
+        """  # noqa: DOC503
+        node_ids = collect_start_upstream_node_ids(start_after)
+        while node_ids:
+            if self._exception:
+                raise self._exception
+
+            node_ids = [
+                node_id
+                for node_id in node_ids
+                if not self._dependency_graph.node_has_started(node_id=node_id)
+            ]
+            if node_ids:
+                time.sleep(0.5)
 
     def _run_sync_step(
         self,
@@ -1435,6 +1479,9 @@ class DynamicPipelineRunner:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         product: bool = False,
     ) -> "MapResultsFuture":
         """Map over step inputs.
@@ -1445,6 +1492,8 @@ class DynamicPipelineRunner:
             kwargs: The keyword arguments for the step function.
             after: The step run output futures to wait for before executing the
                 steps.
+            start_after: The step run output futures to wait for the start of
+                before executing the steps.
             product: Whether to produce a cartesian product of the mapped
                 inputs.
 
@@ -1462,6 +1511,7 @@ class DynamicPipelineRunner:
             step=step,
             inputs=inputs,
             after=after,
+            start_after=start_after,
             product=product,
         )
         return map_future
@@ -1970,6 +2020,9 @@ class DynamicPipelineRunner:
         step: Optional[BaseStep] = None,
         inputs: Optional[Dict[str, Any]] = None,
         after: Union[AnyOutputFuture, Sequence[AnyOutputFuture], None] = None,
+        start_after: Union[
+            AnyOutputFuture, Sequence[AnyOutputFuture], None
+        ] = None,
         config_overrides: Optional["StepConfigurationUpdate"] = None,
     ) -> None:
         """Register a concurrent step invocation.
@@ -1980,6 +2033,7 @@ class DynamicPipelineRunner:
             step: Optional step payload for startup.
             inputs: Optional input payload for startup.
             after: Optional upstream futures for startup.
+            start_after: Optional upstream futures for start ordering.
             config_overrides: Optional config overrides for the step.
         """
         if inputs is not None:
@@ -1988,6 +2042,8 @@ class DynamicPipelineRunner:
             )
         else:
             upstream_node_ids = None
+
+        start_upstream_node_ids = collect_start_upstream_node_ids(start_after)
 
         with self._lifecycle_lock:
             if self._failure_detected and initial_state in {
@@ -2012,6 +2068,7 @@ class DynamicPipelineRunner:
             node, nodes_ready = self._dependency_graph.register_step_node(
                 node_id=future.invocation_id,
                 upstream_ids=upstream_node_ids,
+                start_upstream_ids=start_upstream_node_ids,
                 state=initial_state,
                 step=step,
                 inputs=inputs,
@@ -2112,6 +2169,7 @@ class DynamicPipelineRunner:
                 )
                 raise e
 
+            self.mark_node_running(node_id=step.spec.invocation_id)
             self._register_isolated_step_for_monitoring(
                 invocation_id=step.spec.invocation_id,
                 step_run=step_run,
@@ -2140,6 +2198,7 @@ class DynamicPipelineRunner:
         """
 
         def _launch_and_wait() -> StepRunResponse:
+            self.mark_node_running(node_id=step.spec.invocation_id)
             try:
                 step_run = self._run_sync_step(
                     step=step, remaining_retries=remaining_retries
@@ -2166,7 +2225,7 @@ class DynamicPipelineRunner:
     def _handle_step_startup_succeeded(
         self, invocation_id: str, execution_future: StepExecutionFuture
     ) -> None:
-        """Store a successful step startup in the registry and graph.
+        """Store a successful step startup in the registry.
 
         Args:
             invocation_id: The step invocation ID.
@@ -2175,7 +2234,6 @@ class DynamicPipelineRunner:
         self._future_registry.bind_step_execution_future(
             invocation_id=invocation_id, future=execution_future
         )
-        self.mark_node_running(node_id=invocation_id)
 
     def _record_node_failure(
         self, node_id: str, exception: BaseException
@@ -2234,6 +2292,9 @@ class DynamicPipelineRunner:
         inputs: Dict[str, Any],
         product: bool,
         after: Union[AnyOutputFuture, Sequence[AnyOutputFuture], None] = None,
+        start_after: Union[
+            AnyOutputFuture, Sequence[AnyOutputFuture], None
+        ] = None,
     ) -> None:
         """Register a map invocation.
 
@@ -2242,12 +2303,14 @@ class DynamicPipelineRunner:
             step: The mapped step payload for startup.
             inputs: The input payload for startup.
             after: Optional upstream futures for startup.
+            start_after: Optional upstream futures for start ordering.
             product: The map expansion mode.
         """
         node_id = future.invocation_id
         upstream_node_ids = collect_upstream_node_ids(
             inputs=inputs, after=after
         )
+        start_upstream_node_ids = collect_start_upstream_node_ids(start_after)
 
         with self._lifecycle_lock:
             if self._failure_detected:
@@ -2267,6 +2330,7 @@ class DynamicPipelineRunner:
                 inputs=inputs,
                 product=product,
                 upstream_ids=upstream_node_ids,
+                start_upstream_ids=start_upstream_node_ids,
                 after=after,
             )
             if node.state == NodeState.PAUSED:
@@ -2351,6 +2415,9 @@ class DynamicPipelineRunner:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         *,
         concurrent: Literal[True],
     ) -> PipelineFuture: ...
@@ -2362,6 +2429,9 @@ class DynamicPipelineRunner:
         args: Sequence[Any],
         kwargs: Dict[str, Any],
         after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
+        start_after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
         *,
@@ -2376,6 +2446,9 @@ class DynamicPipelineRunner:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         *,
         concurrent: bool = False,
     ) -> Union[PipelineFuture, PipelineRunOutputs]:
@@ -2386,6 +2459,7 @@ class DynamicPipelineRunner:
             args: Positional pipeline arguments.
             kwargs: Keyword pipeline arguments.
             after: Optional dependency futures.
+            start_after: Optional start-ordering futures.
             concurrent: Whether to run the child pipeline concurrently.
 
         Returns:
@@ -2412,6 +2486,7 @@ class DynamicPipelineRunner:
                 args=tuple(args),
                 kwargs=kwargs,
                 after=after,
+                start_after=start_after,
                 future=pipeline_future,
             )
             return pipeline_future
@@ -2463,6 +2538,9 @@ class DynamicPipelineRunner:
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
         after: Union["AnyOutputFuture", Sequence["AnyOutputFuture"], None],
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ],
         future: PipelineFuture,
     ) -> None:
         """Register a concurrent child pipeline invocation.
@@ -2473,6 +2551,7 @@ class DynamicPipelineRunner:
             args: Positional arguments passed to the child pipeline.
             kwargs: Keyword arguments passed to the child pipeline.
             after: Optional upstream futures for startup ordering.
+            start_after: Optional upstream futures for start ordering.
             future: The child pipeline future.
         """
         inputs = convert_to_keyword_arguments(
@@ -2480,6 +2559,11 @@ class DynamicPipelineRunner:
         )
         upstream_node_ids = collect_upstream_node_ids(
             inputs=inputs, after=after
+        )
+        start_upstream_node_ids = (
+            collect_start_upstream_node_ids(start_after)
+            if start_after is not None
+            else None
         )
 
         with self._lifecycle_lock:
@@ -2501,6 +2585,7 @@ class DynamicPipelineRunner:
                     args=args,
                     kwargs=kwargs,
                     upstream_ids=upstream_node_ids,
+                    start_upstream_ids=start_upstream_node_ids,
                 )
             )
             if node.state == NodeState.PAUSED:
@@ -2532,6 +2617,7 @@ class DynamicPipelineRunner:
         node_id = node.node_id
 
         def _launch_and_wait() -> "PipelineRunResponse":
+            self.mark_node_running(node_id=node_id)
             try:
                 child_runner.run_pipeline()
                 terminal_run = self._validate_successful_child_run(
@@ -2619,7 +2705,6 @@ class DynamicPipelineRunner:
             node_id=node_id
         )
         pipeline_future._set_startup_result(execution_future)
-        self.mark_node_running(node_id=node_id)
 
     def _prepare_child_run(
         self,

--- a/src/zenml/pipelines/dynamic/pipeline_definition.py
+++ b/src/zenml/pipelines/dynamic/pipeline_definition.py
@@ -195,6 +195,11 @@ class DynamicPipeline(Pipeline):
             Sequence["AnyOutputFuture"],
             None,
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture",
+            Sequence["AnyOutputFuture"],
+            None,
+        ] = None,
         **kwargs: Any,
     ) -> "PipelineFuture":
         """Submit the pipeline to run concurrently as a child pipeline.
@@ -202,6 +207,7 @@ class DynamicPipeline(Pipeline):
         Args:
             *args: Entrypoint function arguments.
             after: Optional dependency futures.
+            start_after: Optional start-ordering futures.
             **kwargs: Entrypoint function keyword arguments.
 
         Raises:
@@ -232,6 +238,7 @@ class DynamicPipeline(Pipeline):
             args=args,
             kwargs=kwargs,
             after=after,
+            start_after=start_after,
             concurrent=True,
         )
 

--- a/src/zenml/steps/base_step.py
+++ b/src/zenml/steps/base_step.py
@@ -613,6 +613,9 @@ class BaseStep:
             Sequence[Union[str, StepArtifact, "AnyOutputFuture"]],
             None,
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         **kwargs: Any,
     ) -> Any:
         """Handle a call of the step.
@@ -626,7 +629,11 @@ class BaseStep:
             *args: Entrypoint function arguments.
             id: Invocation ID to use.
             after: Upstream steps for the invocation.
+            start_after: Upstream futures to wait for the start of.
             **kwargs: Entrypoint function keyword arguments.
+
+        Raises:
+            RuntimeError: If `start_after` is used in a static pipeline.
 
         Returns:
             The outputs of the entrypoint function call.
@@ -644,6 +651,10 @@ class BaseStep:
 
         compilation_context = PipelineCompilationContext.get()
         if compilation_context:
+            if start_after is not None:
+                raise RuntimeError(
+                    "`start_after` is only supported in dynamic pipelines."
+                )
             # We're currently compiling a static pipeline, which we want to
             # allow even while inside a running step.
             after = cast(
@@ -693,6 +704,7 @@ class BaseStep:
                 args=args,
                 kwargs=kwargs,
                 after=after,
+                start_after=start_after,
                 concurrent=False,
             )
 
@@ -751,6 +763,9 @@ class BaseStep:
         after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
+        start_after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
         **kwargs: Any,
     ) -> "StepFuture":
         """Submit the step to run concurrently in a separate thread.
@@ -760,6 +775,8 @@ class BaseStep:
             id: The invocation ID of the step.
             after: The step run output futures to wait for before executing the
                 step.
+            start_after: The step run output futures to wait for the start of
+                before executing the step.
             **kwargs: The keyword arguments to pass to the step function.
 
         Raises:
@@ -785,6 +802,7 @@ class BaseStep:
             args=args,
             kwargs=kwargs,
             after=after,
+            start_after=start_after,
             concurrent=True,
         )
 
@@ -792,6 +810,9 @@ class BaseStep:
         self,
         *args: Any,
         after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
+        start_after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
         **kwargs: Any,
@@ -832,6 +853,8 @@ class BaseStep:
             *args: The arguments to pass to the step function.
             after: The step run output futures to wait for before executing the
                 steps.
+            start_after: The step run output futures to wait for the start of
+                before executing the steps.
             **kwargs: The keyword arguments to pass to the step function.
 
         Raises:
@@ -857,6 +880,7 @@ class BaseStep:
             args=args,
             kwargs=kwargs,
             after=after,
+            start_after=start_after,
             product=False,
         )
 
@@ -864,6 +888,9 @@ class BaseStep:
         self,
         *args: Any,
         after: Union[
+            "AnyOutputFuture", Sequence["AnyOutputFuture"], None
+        ] = None,
+        start_after: Union[
             "AnyOutputFuture", Sequence["AnyOutputFuture"], None
         ] = None,
         **kwargs: Any,
@@ -904,6 +931,8 @@ class BaseStep:
             *args: The arguments to pass to the step function.
             after: The step run output futures to wait for before executing the
                 steps.
+            start_after: The step run output futures to wait for the start of
+                before executing the steps.
             **kwargs: The keyword arguments to pass to the step function.
 
         Raises:
@@ -929,6 +958,7 @@ class BaseStep:
             args=args,
             kwargs=kwargs,
             after=after,
+            start_after=start_after,
             product=True,
         )
 

--- a/tests/unit/execution/pipeline/dynamic/test_invocation_dependency_graph.py
+++ b/tests/unit/execution/pipeline/dynamic/test_invocation_dependency_graph.py
@@ -1,0 +1,158 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the invocation dependency graph."""
+
+from zenml import pipeline, step
+from zenml.execution.pipeline.dynamic.invocation_dependency_graph import (
+    InvocationDependencyGraph,
+    NodeState,
+)
+
+
+@step
+def _noop_step() -> None:
+    pass
+
+
+@pipeline(dynamic=True)
+def _noop_pipeline() -> None:
+    pass
+
+
+def _start_step(graph: InvocationDependencyGraph, node_id: str) -> None:
+    """Drive a step node from ready to running."""
+    graph.mark_node_starting(node_id)
+    graph.mark_node_running(node_id)
+
+
+def test_after_requires_success_not_just_start() -> None:
+    """An `after` dependency releases only when the upstream succeeds."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    graph.register_step_node(node_id="b", upstream_ids=["a"])
+
+    _start_step(graph, "a")
+    assert graph.get_node_state("b") == NodeState.PENDING
+
+    graph.mark_node_succeeded("a")
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_blocks_until_running() -> None:
+    """A starting (not yet running) upstream does not release a dependent."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    graph.register_step_node(node_id="b", start_upstream_ids=["a"])
+
+    graph.mark_node_starting("a")
+    # The upstream is being launched but is not running yet.
+    assert graph.get_node_state("b") == NodeState.PENDING
+
+    graph.mark_node_running("a")
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_releases_when_upstream_runs() -> None:
+    """A `start_after` dependency releases when the upstream runs."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    _, ready = graph.register_step_node(node_id="b", start_upstream_ids=["a"])
+    assert ready is False
+    assert graph.get_node_state("b") == NodeState.PENDING
+
+    graph.mark_node_starting("a")
+    became_ready = graph.mark_node_running("a")
+    assert became_ready is True
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_released_when_upstream_already_running() -> None:
+    """A `start_after` dependency on an already-running upstream is ready."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    _start_step(graph, "a")
+
+    _, ready = graph.register_step_node(node_id="b", start_upstream_ids=["a"])
+    assert ready is True
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_released_by_cached_upstream() -> None:
+    """A `start_after` dependency on a cached upstream is ready."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a", state=NodeState.SUCCEEDED)
+
+    _, ready = graph.register_step_node(node_id="b", start_upstream_ids=["a"])
+    assert ready is True
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_released_by_failed_upstream() -> None:
+    """A failed upstream counts as started for a `start_after` dependency."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    graph.register_step_node(node_id="b", start_upstream_ids=["a"])
+
+    graph.mark_node_starting("a")
+    became_ready = graph.mark_node_failed("a")
+    assert became_ready is True
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_mixed_after_and_start_after() -> None:
+    """A node with both dependency kinds waits for both to be satisfied."""
+    graph = InvocationDependencyGraph()
+    graph.register_step_node(node_id="a")
+    graph.register_step_node(node_id="c")
+    graph.register_step_node(
+        node_id="b", upstream_ids=["a"], start_upstream_ids=["c"]
+    )
+
+    _start_step(graph, "c")
+    # `c` is running, but `a` has not succeeded yet.
+    assert graph.get_node_state("b") == NodeState.PENDING
+
+    _start_step(graph, "a")
+    graph.mark_node_succeeded("a")
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_map_node_releases_when_running() -> None:
+    """A `start_after` dependency on a map node releases when it runs."""
+    graph = InvocationDependencyGraph()
+    graph.register_map_node(
+        node_id="m", step=_noop_step, inputs={}, product=False
+    )
+    graph.register_step_node(node_id="b", start_upstream_ids=["m"])
+    assert graph.get_node_state("b") == NodeState.PENDING
+
+    graph.mark_node_starting("m")
+    became_ready = graph.mark_node_running("m")
+    assert became_ready is True
+    assert graph.get_node_state("b") == NodeState.READY
+
+
+def test_start_after_child_pipeline_releases_when_running() -> None:
+    """A `start_after` dependency on a child pipeline releases when it runs."""
+    graph = InvocationDependencyGraph()
+    graph.register_child_pipeline_node(node_id="c", pipeline=_noop_pipeline)
+    graph.register_step_node(node_id="b", start_upstream_ids=["c"])
+    assert graph.get_node_state("b") == NodeState.PENDING
+    assert graph.node_has_started("c") is False
+
+    graph.mark_node_starting("c")
+    became_ready = graph.mark_node_running("c")
+    assert became_ready is True
+    assert graph.node_has_started("c") is True
+    assert graph.get_node_state("b") == NodeState.READY

--- a/tests/unit/execution/pipeline/dynamic/test_start_ordering.py
+++ b/tests/unit/execution/pipeline/dynamic/test_start_ordering.py
@@ -1,0 +1,116 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""End-to-end tests for `start_after` ordering in dynamic pipelines."""
+
+import threading
+from typing import Dict
+
+from zenml import pipeline, step
+
+_upstream_started = threading.Event()
+_upstream_finished = threading.Event()
+_dependent_ran = threading.Event()
+_observations: Dict[str, bool] = {}
+
+
+@step
+def _upstream_step() -> None:
+    _upstream_started.set()
+    # Block until the dependent has run, then finish. With a `start_after`
+    # dependency the dependent is released while we are still here.
+    _dependent_ran.wait(timeout=10)
+    _upstream_finished.set()
+
+
+@step
+def _dependent_step() -> None:
+    _upstream_started.wait(timeout=10)
+    _observations["upstream_started_when_dependent_ran"] = (
+        _upstream_started.is_set()
+    )
+    _observations["upstream_finished_when_dependent_ran"] = (
+        _upstream_finished.is_set()
+    )
+    _dependent_ran.set()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def _start_ordering_pipeline() -> None:
+    upstream = _upstream_step.submit()
+    dependent = _dependent_step.submit(start_after=upstream)
+    upstream.wait()
+    dependent.wait()
+
+
+def test_start_after_runs_concurrently_with_running_upstream() -> None:
+    """A `start_after` dependent runs while its upstream is still running."""
+    _upstream_started.clear()
+    _upstream_finished.clear()
+    _dependent_ran.clear()
+    _observations.clear()
+
+    run = _start_ordering_pipeline()
+
+    assert run.status.is_successful
+    # The dependent ran after the upstream started but before it finished, so a
+    # finish dependency (`after`) would have deadlocked or serialized instead.
+    assert _observations["upstream_started_when_dependent_ran"] is True
+    assert _observations["upstream_finished_when_dependent_ran"] is False
+
+
+_service_finished = threading.Event()
+_observer_ran = threading.Event()
+_child_observations: Dict[str, bool] = {}
+
+
+@step
+def _service_step() -> None:
+    _observer_ran.wait(timeout=10)
+    _service_finished.set()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def _service_pipeline() -> None:
+    _service_step()
+
+
+@step
+def _sync_observer_step() -> None:
+    _child_observations["service_finished_when_observed"] = (
+        _service_finished.is_set()
+    )
+    _observer_ran.set()
+
+
+@pipeline(dynamic=True, enable_cache=False)
+def _start_after_child_pipeline() -> None:
+    sub = _service_pipeline.submit()
+    # Synchronous call: the entrypoint blocks until the child pipeline has
+    # started, then runs the observer inline while the child is still running.
+    _sync_observer_step(start_after=sub)
+    sub.wait()
+
+
+def test_sync_step_start_after_child_pipeline_runs_concurrently() -> None:
+    """A sync step with `start_after` a child pipeline runs while it is up."""
+    _service_finished.clear()
+    _observer_ran.clear()
+    _child_observations.clear()
+
+    run = _start_after_child_pipeline()
+
+    assert run.status.is_successful
+    # The observer ran while the child pipeline was still running, so the sync
+    # call waited for the child to start, not to finish.
+    assert _child_observations["service_finished_when_observed"] is False


### PR DESCRIPTION
This PR adds an option to specify `start_after=...` when calling steps in dynamic pipelines. This allows specifying which steps should start before/after other steps when running them concurrently.

Breaking change:
- The `start_after` keyword is now a reserved keyword for steps. Any pipelines containing steps with a keyword argument with this name will fail from this point on.