### PR TITLE
Out of stack deployers

### DIFF
--- a/docs/book/component-guide/deployers/README.md
+++ b/docs/book/component-guide/deployers/README.md
@@ -13,7 +13,7 @@ A deployed pipeline becomes a web service that can be invoked multiple times in 
 
 ### When to use it?
 
-Deployers are optional components in the ZenML stack. They are useful in the following scenarios:
+Deployers are optional stack components. They are useful in the following scenarios:
 
 - **Real-time Pipeline Execution**: Execute pipelines on-demand through HTTP requests rather than scheduled batch runs
 - **Interactive Workflows**: Build applications that need immediate pipeline responses
@@ -25,7 +25,7 @@ Use deployers when you need request-response patterns, and orchestrators for sch
 
 ### Deployer Flavors
 
-Out of the box, ZenML comes with a `local` deployer already part of the default stack that deploys pipelines on your local machine in the form of background processes. Additional Deployers are provided by integrations:
+Out of the box, ZenML comes with a built-in `default` local deployer that deploys pipelines on your local machine in the form of background processes and is used whenever you don't select another deployer at deploy time. Additional Deployers are provided by integrations:
 
 | Deployer                           | Flavor    | Integration   | Notes                                                                        |
 |------------------------------------|-----------|---------------|------------------------------------------------------------------------------|
@@ -44,24 +44,24 @@ zenml deployer flavor list
 
 ### How to use it
 
-You don't need to directly interact with the ZenML deployer stack component in your code. As long as the deployer that you want to use is part of your active [ZenML stack](../../user-guide/production-guide/understand-stacks.md), you can simply deploy a pipeline or snapshot using the ZenML CLI or the ZenML SDK. The resulting deployment can be managed using the ZenML CLI or the ZenML SDK.
+You don't need to directly interact with the ZenML deployer stack component in your code. Once you have registered the deployer that you want to use, you can select it explicitly at deploy time and deploy a pipeline or snapshot using the ZenML CLI or the ZenML SDK. If you don't select a deployer, ZenML falls back to the immutable `default` (local) deployer. The resulting deployment can be managed using the ZenML CLI or the ZenML SDK.
 
 Examples:
 
-* just use the default stack - it has a default local deployer that will deploy the pipeline on your local machine in the form of a background process:
+* just use the built-in `default` local deployer - omit the deployer at deploy time and the pipeline is deployed on your local machine in the form of a background process:
 
 ```bash
-zenml stack set default
+zenml pipeline deploy --name my_deployment my_module.my_pipeline
 ```
 
-* or set up a new stack with a deployer in it:
+* or register a deployer and select it explicitly at deploy time:
 
 ```bash
-zenml deployer register docker --flavor=local
-zenml stack register docker_deployment -a default -o default -D docker --set
+zenml deployer register docker --flavor=docker
+zenml pipeline deploy --name my_deployment -D docker my_module.my_pipeline
 ```
 
-* deploy a pipeline with the ZenML SDK:
+* deploy a pipeline with the ZenML SDK, selecting the deployer with the `deployer` argument (omit it to use the `default` local deployer):
 
 ```python
 from zenml import pipeline
@@ -76,14 +76,14 @@ def my_pipeline(name: str = "John") -> str:
 
 if __name__ == "__main__":
     # Deploy the pipeline `my_pipeline` as a deployment named `my_deployment`
-    deployment = my_pipeline.deploy(deployment_name="my_deployment")
+    deployment = my_pipeline.deploy(deployment_name="my_deployment", deployer="docker")
     print(f"Deployment URL: {deployment.url}")
 ```
 
 * deploy the same pipeline with the CLI:
 
 ```bash
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D docker my_module.my_pipeline
 ```
 
 * send a request to the deployment with the ZenML CLI:

--- a/docs/book/component-guide/deployers/aws-app-runner.md
+++ b/docs/book/component-guide/deployers/aws-app-runner.md
@@ -122,14 +122,9 @@ zenml deployer register <DEPLOYER_NAME> \
     --connector <CONNECTOR_NAME>
 ```
 
-### Configuring the stack
+### Using the deployer
 
-With the deployer registered, it can be used in the active stack:
-
-```shell
-# Register and activate a stack with the new deployer
-zenml stack register <STACK_NAME> -D <DEPLOYER_NAME> ... --set
-```
+With the deployer registered, select it explicitly at deploy time with the `-D`/`--deployer` option. The active stack still supplies the image builder and container registry used to build the deployment image.
 
 {% hint style="info" %}
 ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE_NAME>` and use it to deploy your pipeline as an App Runner service. The container registry must be Amazon ECR (private) or ECR Public. Check out [this page](https://docs.zenml.io/how-to/customize-docker-builds/) if you want to learn more about how ZenML builds these images and how you can customize them.
@@ -138,7 +133,7 @@ ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE
 You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the AWS App Runner deployer:
 
 ```shell
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D <DEPLOYER_NAME> my_module.my_pipeline
 ```
 
 ### Additional configuration

--- a/docs/book/component-guide/deployers/docker.md
+++ b/docs/book/component-guide/deployers/docker.md
@@ -20,23 +20,37 @@ To use the Docker deployer, you only need to have [Docker](https://www.docker.co
 
 ## How to use it
 
-To use the Docker deployer, you can register it and use it in your active stack:
+To use the Docker deployer, register it and then select it at deploy time:
 
 ```shell
 zenml deployer register docker --flavor=docker
-
-# Register and activate a stack with the new deployer
-zenml stack register docker-deployer -D docker -o default -a default --set
 ```
 {% hint style="info" %}
 ZenML will build a local Docker image called `zenml:<PIPELINE_NAME>` and use it to deploy your pipeline as a Docker container. Check out [this page](https://docs.zenml.io/how-to/customize-docker-builds/) if you want to learn more about how ZenML builds these images and how you can customize them.
 {% endhint %}
 
-You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the Docker deployer:
+You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the Docker deployer by selecting it with the `-D`/`--deployer` option:
 
 ```shell
-zenml pipeline deploy my_module.my_pipeline
+zenml pipeline deploy -D docker my_module.my_pipeline
 ```
+
+{% hint style="warning" %}
+**Local artifact stores are not supported with the Docker deployer.** By default, ZenML uploads your pipeline code to the artifact store and the deployment container downloads it on startup. A Docker container cannot reach a local artifact store, so the download fails and the container cannot import your pipeline (you will see a `ModuleNotFoundError` for your pipeline module). Use one of the following instead:
+
+* a [remote artifact store](https://docs.zenml.io/stacks/artifact-stores/) or a [code repository](https://docs.zenml.io/user-guides/production-guide/connect-code-repository) that the container can access, or
+* include the code in the image so nothing needs to be downloaded at runtime:
+
+```python
+from zenml.config import DockerSettings
+
+docker_settings = DockerSettings(
+    allow_including_files_in_images=True,
+    allow_download_from_artifact_store=False,
+    allow_download_from_code_repository=False,
+)
+```
+{% endhint %}
 
 ### Additional configuration
 

--- a/docs/book/component-guide/deployers/gcp-cloud-run.md
+++ b/docs/book/component-guide/deployers/gcp-cloud-run.md
@@ -98,14 +98,9 @@ zenml deployer register <DEPLOYER_NAME> \
     --connector <CONNECTOR_NAME>
 ```
 
-### Configuring the stack
+### Using the deployer
 
-With the deployer registered, it can be used in the active stack:
-
-```shell
-# Register and activate a stack with the new deployer
-zenml stack register <STACK_NAME> -D <DEPLOYER_NAME> ... --set
-```
+With the deployer registered, select it explicitly at deploy time with the `-D`/`--deployer` option. The active stack still supplies the image builder and container registry used to build the deployment image.
 
 {% hint style="info" %}
 ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE_NAME>` and use it to deploy your pipeline as a Cloud Run service. Check out [this page](https://docs.zenml.io/how-to/customize-docker-builds/) if you want to learn more about how ZenML builds these images and how you can customize them.
@@ -114,7 +109,7 @@ ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE
 You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the GCP Cloud Run deployer:
 
 ```shell
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D <DEPLOYER_NAME> my_module.my_pipeline
 ```
 
 ### Additional configuration

--- a/docs/book/component-guide/deployers/huggingface.md
+++ b/docs/book/component-guide/deployers/huggingface.md
@@ -70,14 +70,9 @@ zenml deployer register <DEPLOYER_NAME> \
     --token='{{hf_token.token}}'
 ```
 
-### Configuring the stack
+### Using the deployer
 
-With the deployer registered, it can be used in the active stack:
-
-```shell
-# Register and activate a stack with the new deployer
-zenml stack register <STACK_NAME> -D <DEPLOYER_NAME> ... --set
-```
+With the deployer registered, select it explicitly at deploy time with the `-D`/`--deployer` option. The active stack still supplies the image builder and container registry used to build the deployment image.
 
 {% hint style="info" %}
 ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE_NAME>` which will be referenced in a Dockerfile deployed to your Hugging Face Space. Check out [this page](https://docs.zenml.io/how-to/customize-docker-builds/) if you want to learn more about how ZenML builds these images and how you can customize them.
@@ -86,7 +81,7 @@ ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE
 You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the Hugging Face deployer:
 
 ```shell
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D <DEPLOYER_NAME> my_module.my_pipeline
 ```
 
 ### Additional configuration

--- a/docs/book/component-guide/deployers/kubernetes.md
+++ b/docs/book/component-guide/deployers/kubernetes.md
@@ -108,14 +108,9 @@ zenml deployer register <DEPLOYER_NAME> \
 
 This uses the service account token mounted into the pod running ZenML.
 
-### Configuring the stack
+### Using the deployer
 
-With the deployer registered, you can use it in your active stack:
-
-```shell
-# Register and activate a stack with the new deployer
-zenml stack register <STACK_NAME> -D <DEPLOYER_NAME> ... --set
-```
+With the deployer registered, select it explicitly at deploy time with the `-D`/`--deployer` option. The active stack still supplies the image builder and container registry used to build the deployment image.
 
 {% hint style="info" %}
 ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE_NAME>` and use it to deploy your pipeline as a Kubernetes Deployment with a Service. Check out [this page](https://docs.zenml.io/how-to/customize-docker-builds/) if you want to learn more about how ZenML builds these images and how you can customize them.
@@ -124,7 +119,7 @@ ZenML will build a Docker image called `<CONTAINER_REGISTRY_URI>/zenml:<PIPELINE
 You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the Kubernetes deployer:
 
 ```shell
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D <DEPLOYER_NAME> my_module.my_pipeline
 ```
 
 ## Advanced configuration

--- a/docs/book/component-guide/deployers/local.md
+++ b/docs/book/component-guide/deployers/local.md
@@ -8,7 +8,7 @@ The local deployer is a [deployer](./) flavor that comes built-in with ZenML and
 
 ### When to use it
 
-The local deployer is part of your default stack when you're first getting started with ZenML. Due to it running locally on your machine, it requires no additional setup and is easy to use and debug.
+The local deployer is the built-in `default` deployer that ZenML uses when you don't select another deployer at deploy time, so it's ideal when you're first getting started with ZenML. Due to it running locally on your machine, it requires no additional setup and is easy to use and debug.
 
 You should use the local deployer if:
 
@@ -21,20 +21,20 @@ The local deployer comes with ZenML and works without any additional setup.
 
 ### How to use it
 
-To use the local deployer, you can register it and use it in your active stack:
+To use the local deployer, register it and then select it at deploy time:
 
 ```shell
 zenml deployer register <DEPLOYER_NAME> --flavor=local
-
-# Register and activate a stack with the new deployer
-zenml stack register <STACK_NAME> -D <DEPLOYER_NAME> ... --set
 ```
 
-You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the local deployer:
+You can now [deploy any ZenML pipeline](https://docs.zenml.io/concepts/deployment) using the local deployer by selecting it with the `-D`/`--deployer` option:
 
 ```shell
-zenml pipeline deploy --name my_deployment my_module.my_pipeline
+zenml pipeline deploy --name my_deployment -D <DEPLOYER_NAME> my_module.my_pipeline
 ```
+
+If you omit the `-D`/`--deployer` option, ZenML uses the built-in `default` local deployer.
+
 ### Additional configuration
 
 For additional configuration of the Local deployer, you can pass the following `LocalDeployerSettings` attributes defined in the `zenml.deployers.local.local_deployer` module when configuring the deployer or defining or deploying your pipeline:

--- a/src/zenml/cli/deployment.py
+++ b/src/zenml/cli/deployment.py
@@ -188,6 +188,16 @@ def describe_deployment(
     help="The name or ID of the pipeline to which the snapshot belongs.",
 )
 @click.option(
+    "--deployer",
+    "-D",
+    "deployer",
+    type=str,
+    required=False,
+    default=None,
+    help="Name or ID of the deployer to use. Ignored when re-provisioning an "
+    "existing deployment, which keeps its stored deployer.",
+)
+@click.option(
     "--overtake",
     "-o",
     "overtake",
@@ -211,6 +221,7 @@ def provision_deployment(
     deployment_name_or_id: str,
     snapshot_name_or_id: Optional[str] = None,
     pipeline_name_or_id: Optional[str] = None,
+    deployer: Optional[str] = None,
     overtake: bool = False,
     timeout: Optional[int] = None,
 ) -> None:
@@ -221,6 +232,8 @@ def provision_deployment(
         snapshot_name_or_id: The ID or name of the pipeline snapshot to use.
         pipeline_name_or_id: The name or ID of the pipeline to which the
             snapshot belongs.
+        deployer: Name or ID of the deployer to use. Ignored when
+            re-provisioning an existing deployment.
         overtake: If True, provision the deployment with the given name
             even if it is owned by a different user.
         timeout: The maximum time in seconds to wait for the deployment
@@ -259,6 +272,7 @@ def provision_deployment(
             deployment = Client().provision_deployment(
                 name_id_or_prefix=deployment_name_or_id,
                 snapshot_id=snapshot_id,
+                deployer=deployer,
                 timeout=timeout,
             )
         except KeyError as e:

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -25,7 +25,6 @@ from zenml.cli.cli import TagGroup, cli
 from zenml.cli.utils import OutputFormat, fetch_snapshot, list_options
 from zenml.client import Client
 from zenml.console import console
-from zenml.deployers.base_deployer import BaseDeployer
 from zenml.enums import (
     CliCategories,
     ExecutionStatus,
@@ -347,6 +346,16 @@ def run_pipeline(
     help="Name or ID of the stack to deploy on.",
 )
 @click.option(
+    "--deployer",
+    "-D",
+    "deployer",
+    type=str,
+    required=False,
+    default=None,
+    help="Name or ID of the deployer to use. Defaults to the `default` "
+    "deployer.",
+)
+@click.option(
     "--build",
     "-b",
     "build_path_or_id",
@@ -403,6 +412,7 @@ def deploy_pipeline(
     deployment_name: Optional[str] = None,
     config_path: Optional[str] = None,
     stack_name_or_id: Optional[str] = None,
+    deployer: Optional[str] = None,
     build_path_or_id: Optional[str] = None,
     prevent_build_reuse: bool = False,
     update: bool = False,
@@ -418,6 +428,8 @@ def deploy_pipeline(
         config_path: Path to pipeline configuration file.
         stack_name_or_id: Name or ID of the stack on which the pipeline should
             be deployed.
+        deployer: Name or ID of the deployer to use. Defaults to the `default`
+            deployer.
         build_path_or_id: ID of file path of the build to use for the pipeline
             deployment.
         prevent_build_reuse: If True, prevents automatic reusing of previous
@@ -493,7 +505,9 @@ def deploy_pipeline(
                     return
 
         deployment = pipeline_instance.deploy(
-            deployment_name=deployment_name, timeout=timeout
+            deployment_name=deployment_name,
+            deployer=deployer,
+            timeout=timeout,
         )
 
         cli_utils.pretty_print_deployment(deployment, show_secret=False)
@@ -506,9 +520,8 @@ def deploy_pipeline(
             )
 
         if attach:
-            deployer = BaseDeployer.get_active_deployer()
-            for log in deployer.get_deployment_logs(
-                deployment_name_or_id=deployment.id,
+            for log in client.get_deployment_logs(
+                deployment.id,
                 follow=True,
             ):
                 print(log)
@@ -1631,11 +1644,10 @@ def create_pipeline_snapshot(
             "* run this snapshot from the dashboard or by calling "
             f"`zenml pipeline snapshot run {snapshot.id}`"
         )
-    if snapshot.deployable:
-        options.append(
-            "* deploy this snapshot by calling "
-            f"`zenml pipeline snapshot deploy {snapshot.id}`"
-        )
+    options.append(
+        "* deploy this snapshot by calling "
+        f"`zenml pipeline snapshot deploy {snapshot.id}`"
+    )
 
     if options:
         cli_utils.declare("You can now:")
@@ -1705,6 +1717,16 @@ def run_snapshot(
     "raised, unless the --update or --overtake flag is used.",
 )
 @click.option(
+    "--deployer",
+    "-D",
+    "deployer",
+    type=str,
+    required=False,
+    default=None,
+    help="Name or ID of the deployer to use. Defaults to the `default` "
+    "deployer. Ignored when re-provisioning an existing deployment.",
+)
+@click.option(
     "--update",
     "-u",
     "update",
@@ -1736,6 +1758,7 @@ def deploy_snapshot(
     snapshot_name_or_id: str,
     pipeline_name_or_id: Optional[str] = None,
     deployment_name_or_id: Optional[str] = None,
+    deployer: Optional[str] = None,
     update: bool = False,
     overtake: bool = False,
     timeout: Optional[int] = None,
@@ -1747,6 +1770,8 @@ def deploy_snapshot(
         pipeline_name_or_id: The name or ID of the pipeline.
         deployment_name_or_id: Name or ID of the deployment to use for the
             pipeline.
+        deployer: Name or ID of the deployer to use. Defaults to the `default`
+            deployer. Ignored when re-provisioning an existing deployment.
         update: If True, update the deployment with the same name if it
             already exists.
         overtake: If True, update the deployment with the same name if
@@ -1808,6 +1833,7 @@ def deploy_snapshot(
             deployment = Client().provision_deployment(
                 name_id_or_prefix=deployment_name_or_id,
                 snapshot_id=snapshot.id,
+                deployer=deployer,
                 timeout=timeout,
             )
         except KeyError as e:
@@ -1835,7 +1861,6 @@ def deploy_snapshot(
         "pipeline",
         "is_dynamic",
         "runnable",
-        "deployable",
     ],
 )
 def list_pipeline_snapshots(

--- a/src/zenml/cli/stack.py
+++ b/src/zenml/cli/stack.py
@@ -202,14 +202,6 @@ def stack() -> None:
     required=False,
 )
 @click.option(
-    "-D",
-    "--deployer",
-    "deployer",
-    help="Name of the deployer for this stack.",
-    type=str,
-    required=False,
-)
-@click.option(
     "-l",
     "--log_store",
     "log_store",
@@ -279,7 +271,6 @@ def register_stack(
     annotator: Optional[str] = None,
     data_validator: Optional[str] = None,
     image_builder: Optional[str] = None,
-    deployer: Optional[str] = None,
     log_store: Optional[str] = None,
     sandbox: Tuple[str, ...] = (),
     set_stack: bool = False,
@@ -304,7 +295,6 @@ def register_stack(
         annotator: Name of the annotator for this stack.
         data_validator: Name of the data validator for this stack.
         image_builder: Name of the new image builder for this stack.
-        deployer: Name of the deployer for this stack.
         log_store: Name of the log store for this stack.
         sandbox: Names of sandboxes for this stack.
         set_stack: Immediately set this stack as active.
@@ -554,7 +544,6 @@ def register_stack(
             (StackComponentType.MODEL_DEPLOYER, model_deployer),
             (StackComponentType.MODEL_REGISTRY, model_registry),
             (StackComponentType.CONTAINER_REGISTRY, container_registry),
-            (StackComponentType.DEPLOYER, deployer),
         ]:
             if component_name_ and component_type_ not in components:
                 components[component_type_] = [
@@ -746,14 +735,6 @@ def register_stack(
     required=False,
 )
 @click.option(
-    "-D",
-    "--deployer",
-    "deployer",
-    help="Name of the deployer for this stack.",
-    type=str,
-    required=False,
-)
-@click.option(
     "-l",
     "--log_store",
     "log_store",
@@ -812,7 +793,6 @@ def update_stack(
     data_validator: Optional[str] = None,
     image_builder: Optional[str] = None,
     model_registry: Optional[str] = None,
-    deployer: Optional[str] = None,
     log_store: Optional[str] = None,
     sandbox: Tuple[str, ...] = (),
     secrets: List[str] = [],
@@ -836,7 +816,6 @@ def update_stack(
         data_validator: Name of the new data validator for this stack.
         image_builder: Name of the new image builder for this stack.
         model_registry: Name of the new model registry for this stack.
-        deployer: Name of the new deployer for this stack.
         log_store: Name of the log store for this stack.
         sandbox: Names of sandboxes for this stack.
         secrets: Secrets to attach to the stack.
@@ -883,8 +862,6 @@ def update_stack(
             updates[StackComponentType.ORCHESTRATOR] = [orchestrator]
         if step_operator:
             updates[StackComponentType.STEP_OPERATOR] = list(step_operator)
-        if deployer:
-            updates[StackComponentType.DEPLOYER] = [deployer]
         if log_store:
             updates[StackComponentType.LOG_STORE] = [log_store]
         if sandbox:
@@ -995,14 +972,6 @@ def update_stack(
     required=False,
 )
 @click.option(
-    "-D",
-    "--deployer",
-    "deployer_flag",
-    help="Include this to remove the deployer from this stack.",
-    is_flag=True,
-    required=False,
-)
-@click.option(
     "-l",
     "--log_store",
     "log_store_flag",
@@ -1030,7 +999,6 @@ def remove_stack_component(
     data_validator_flag: Optional[bool] = False,
     image_builder_flag: Optional[bool] = False,
     model_registry_flag: Optional[str] = None,
-    deployer_flag: Optional[bool] = False,
     log_store_flag: Optional[bool] = False,
     sandbox_flag: Optional[bool] = False,
 ) -> None:
@@ -1050,7 +1018,6 @@ def remove_stack_component(
         data_validator_flag: To remove the data validator from this stack.
         image_builder_flag: To remove the image builder from this stack.
         model_registry_flag: To remove the model registry from this stack.
-        deployer_flag: To remove the deployer from this stack.
         log_store_flag: To remove the log store from this stack.
         sandbox_flag: To remove the sandbox from this stack.
     """
@@ -1088,9 +1055,6 @@ def remove_stack_component(
 
         if image_builder_flag:
             stack_component_update[StackComponentType.IMAGE_BUILDER] = []
-
-        if deployer_flag:
-            stack_component_update[StackComponentType.DEPLOYER] = []
 
         if log_store_flag:
             stack_component_update[StackComponentType.LOG_STORE] = []
@@ -1270,7 +1234,6 @@ def rename_stack(
         "user",
         "artifact_store",
         "orchestrator",
-        "deployer",
     ],
 )
 @click.pass_context

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -231,6 +231,7 @@ from zenml.utils.pagination_utils import depaginate
 from zenml.utils.uuid_utils import is_valid_uuid
 
 if TYPE_CHECKING:
+    from zenml.deployers.base_deployer import BaseDeployer
     from zenml.metadata.metadata_types import MetadataType, MetadataTypeEnum
     from zenml.orchestrators import BaseOrchestrator
     from zenml.service_connectors.service_connector import ServiceConnector
@@ -3121,7 +3122,6 @@ class Client(metaclass=ClientMetaClass):
         schedule_id: UUIDFilterOption = None,
         source_snapshot_id: UUIDFilterOption = None,
         runnable: Optional[bool] = None,
-        deployable: Optional[bool] = None,
         deployed: Optional[bool] = None,
         tags: StringFilterOption = None,
         hydrate: bool = False,
@@ -3148,7 +3148,6 @@ class Client(metaclass=ClientMetaClass):
             schedule_id: The ID of the schedule to filter by.
             source_snapshot_id: The ID of the source snapshot to filter by.
             runnable: Whether the snapshot is runnable.
-            deployable: Whether the snapshot is deployable.
             deployed: Whether the snapshot is deployed.
             tags: Filter by tags.
             hydrate: Flag deciding whether to hydrate the output model(s)
@@ -3176,7 +3175,6 @@ class Client(metaclass=ClientMetaClass):
             schedule_id=schedule_id,
             source_snapshot_id=source_snapshot_id,
             runnable=runnable,
-            deployable=deployable,
             deployed=deployed,
             tags=tags,
             trigger_id=trigger_id,
@@ -3633,6 +3631,7 @@ class Client(metaclass=ClientMetaClass):
         name_id_or_prefix: Union[str, UUID],
         project: Optional[Union[str, UUID]] = None,
         snapshot_id: Optional[Union[str, UUID]] = None,
+        deployer: Union[str, UUID, "BaseDeployer", None] = None,
         timeout: Optional[int] = None,
     ) -> DeploymentResponse:
         """Provision a deployment.
@@ -3643,6 +3642,10 @@ class Client(metaclass=ClientMetaClass):
             snapshot_id: The ID of the snapshot to use. If not provided,
                 the previous snapshot configured for the deployment will be
                 used.
+            deployer: The deployer to use. Can be a deployer instance, a name
+                or ID. Ignored when re-provisioning an existing deployment,
+                which keeps its stored deployer. If not provided for a new
+                deployment, the `default` deployer is used.
             timeout: The maximum time in seconds to wait for the pipeline
                 deployment to be provisioned.
 
@@ -3676,7 +3679,7 @@ class Client(metaclass=ClientMetaClass):
                 raise
 
         stack = Client().active_stack
-        deployer: Optional[BaseDeployer] = None
+        resolved_deployer: Optional[BaseDeployer] = None
 
         if snapshot_id:
             snapshot = self.get_snapshot(
@@ -3698,18 +3701,19 @@ class Client(metaclass=ClientMetaClass):
                 )
             snapshot = deployment.snapshot
 
-            if deployment.deployer:
-                try:
-                    deployer = cast(
-                        BaseDeployer,
-                        StackComponent.from_model(deployment.deployer),
-                    )
-                except ImportError:
-                    raise NotImplementedError(
-                        f"Deployer '{deployment.deployer.name}' could "
-                        f"not be instantiated. This is likely because the "
-                        f"deployer's dependencies are not installed."
-                    )
+        # An existing deployment keeps the deployer it was provisioned with.
+        if deployment and deployment.deployer:
+            try:
+                resolved_deployer = cast(
+                    BaseDeployer,
+                    StackComponent.from_model(deployment.deployer),
+                )
+            except ImportError:
+                raise NotImplementedError(
+                    f"Deployer '{deployment.deployer.name}' could "
+                    f"not be instantiated. This is likely because the "
+                    f"deployer's dependencies are not installed."
+                )
 
         if snapshot.stack and snapshot.stack.id != stack.id:
             # We really need to use the original stack for which the deployment
@@ -3717,19 +3721,11 @@ class Client(metaclass=ClientMetaClass):
             # might not have the correct dependencies installed.
             stack = Stack.from_model(snapshot.stack)
 
-        if not deployer:
-            if stack.deployer:
-                deployer = stack.deployer
-            else:
-                raise ValueError(
-                    f"No deployer was found in the deployment's stack "
-                    f"'{stack.name}' or in your active stack. Please add a "
-                    "deployer to your stack to be able to provision a "
-                    "deployment."
-                )
+        if not resolved_deployer:
+            resolved_deployer = BaseDeployer.get_deployer(deployer)
 
         # Provision the endpoint through the deployer
-        deployment = deployer.provision_deployment(
+        deployment = resolved_deployer.provision_deployment(
             snapshot=snapshot,
             stack=stack,
             deployment_name_or_id=deployment_name_or_id,

--- a/src/zenml/config/compiler.py
+++ b/src/zenml/config/compiler.py
@@ -375,13 +375,8 @@ class Compiler:
 
         used_by_orchestrator = stack.orchestrator.flavor != "local"
         used_by_step_operator = stack.step_operator is not None
-        used_by_deployer = (
-            stack.deployer is not None and stack.deployer.flavor != "local"
-        )
 
-        if not (
-            used_by_orchestrator or used_by_step_operator or used_by_deployer
-        ):
+        if not (used_by_orchestrator or used_by_step_operator):
             WARNING_CONTROLLER.info(
                 warning_code=WarningCodes.ZML002, message=warning_message
             )

--- a/src/zenml/deployers/__init__.py
+++ b/src/zenml/deployers/__init__.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Deployers are stack components responsible for deploying pipelines as HTTP services.
+"""Deployers are components responsible for deploying pipelines as HTTP services.
 
 Deploying pipelines is the process of hosting and running machine-learning
 pipelines as part of a managed web service and providing access to pipeline
@@ -19,15 +19,14 @@ execution through an API endpoint like HTTP or GRPC. Once deployed, you can send
 execution requests to the pipeline through the web service's API and receive
 responses containing the pipeline results or execution status.
 
-Add a deployer to your ZenML stack to be able to provision pipelines deployments
-that transform your ML pipelines into long-running HTTP services
-for real-time, on-demand execution instead of traditional batch processing.
+Register a deployer and select it explicitly at deploy time to transform your
+ML pipelines into long-running HTTP services for real-time, on-demand execution
+instead of traditional batch processing.
 
-When present in a stack, the deployer also acts as a registry for pipeline
-endpoints that are deployed with ZenML. You can use the deployer to list all
-deployments that are currently provisioned for online execution or filtered
-according to a particular snapshot or configuration, or to delete an external
-deployment managed through ZenML.
+The deployer also acts as a registry for pipeline endpoints that are deployed
+with ZenML. You can use the deployer to list all deployments that are currently
+provisioned for online execution or filtered according to a particular snapshot
+or configuration, or to delete an external deployment managed through ZenML.
 """
 
 from zenml.deployers.base_deployer import (

--- a/src/zenml/deployers/base_deployer.py
+++ b/src/zenml/deployers/base_deployer.py
@@ -234,9 +234,9 @@ class BaseDeployer(StackComponent, ABC):
 
     def _prepare_deployment_build(
         self,
-        deployment: DeploymentResponse,
         snapshot: PipelineSnapshotResponse,
         stack: "Stack",
+        local_code_available: bool = False,
     ) -> Optional[UUID]:
         """Build the image required to provision the deployment.
 
@@ -244,9 +244,10 @@ class BaseDeployer(StackComponent, ABC):
         this to build the deployer image at deploy time.
 
         Args:
-            deployment: The deployment to build the image for.
             snapshot: The pipeline snapshot to deploy.
             stack: The stack supplying the image builder and container registry.
+            local_code_available: Whether the local code can be built into the
+                image, set only when deploying directly from local code.
 
         Returns:
             The ID of the build to attach to the deployment, or None if no
@@ -466,6 +467,7 @@ class BaseDeployer(StackComponent, ABC):
         deployment_name_or_id: Union[str, UUID],
         replace: bool = True,
         timeout: Optional[int] = None,
+        local_code_available: bool = False,
     ) -> DeploymentResponse:
         """Provision a deployment.
 
@@ -488,6 +490,9 @@ class BaseDeployer(StackComponent, ABC):
             timeout: The maximum time in seconds to wait for the pipeline
                 deployment to be provisioned. If provided, will override the
                 deployer's default timeout.
+            local_code_available: Whether the local code can be built into the
+                deployer image, set only when deploying directly from local
+                code.
 
         Raises:
             DeploymentAlreadyExistsError: if the deployment already
@@ -626,7 +631,9 @@ class BaseDeployer(StackComponent, ABC):
             build_id: Optional[UUID] = existing_build_id
         else:
             build_id = self._prepare_deployment_build(
-                deployment=deployment, snapshot=snapshot, stack=stack
+                snapshot=snapshot,
+                stack=stack,
+                local_code_available=local_code_available,
             )
 
         if build_id is not None and build_id != deployment.build_id:

--- a/src/zenml/deployers/base_deployer.py
+++ b/src/zenml/deployers/base_deployer.py
@@ -232,26 +232,20 @@ class BaseDeployer(StackComponent, ABC):
                 "component\n"
             )
 
-    def _prepare_deployment_build(
+    def _validate_snapshot_deployable(
         self,
         snapshot: PipelineSnapshotResponse,
         stack: "Stack",
-        local_code_available: bool = False,
-    ) -> Optional[UUID]:
-        """Build the image required to provision the deployment.
+    ) -> None:
+        """Validate that the snapshot can be deployed by this deployer.
 
-        The base deployer requires no image. Containerized deployers override
-        this to build the deployer image at deploy time.
+        The base deployer requires no image, so any snapshot is deployable.
+        Containerized deployers override this to require a serving image that
+        was built for this deployer.
 
         Args:
             snapshot: The pipeline snapshot to deploy.
-            stack: The stack supplying the image builder and container registry.
-            local_code_available: Whether the local code can be built into the
-                image, set only when deploying directly from local code.
-
-        Returns:
-            The ID of the build to attach to the deployment, or None if no
-            build is required.
+            stack: The stack the snapshot will be deployed on.
         """
         return None
 
@@ -467,7 +461,6 @@ class BaseDeployer(StackComponent, ABC):
         deployment_name_or_id: Union[str, UUID],
         replace: bool = True,
         timeout: Optional[int] = None,
-        local_code_available: bool = False,
     ) -> DeploymentResponse:
         """Provision a deployment.
 
@@ -490,9 +483,6 @@ class BaseDeployer(StackComponent, ABC):
             timeout: The maximum time in seconds to wait for the pipeline
                 deployment to be provisioned. If provided, will override the
                 deployer's default timeout.
-            local_code_available: Whether the local code can be built into the
-                deployer image, set only when deploying directly from local
-                code.
 
         Raises:
             DeploymentAlreadyExistsError: if the deployment already
@@ -542,19 +532,15 @@ class BaseDeployer(StackComponent, ABC):
                 "a different snapshot."
             )
 
-        # Track the build and snapshot already stored on the deployment (if
-        # any) so the deployer image can be reused on an unchanged re-provision.
-        existing_build_id: Optional[UUID] = None
-        existing_snapshot_id: Optional[UUID] = None
+        # The snapshot must already carry a serving image built for this
+        # deployer. The image is built when the snapshot is created, never here.
+        self._validate_snapshot_deployable(snapshot=snapshot, stack=stack)
 
         try:
             # Get the existing deployment
             deployment = client.get_deployment(
                 deployment_name_or_id, project=snapshot.project_id
             )
-
-            existing_build_id = deployment.build_id
-            existing_snapshot_id = deployment.snapshot_id
 
             self._check_snapshot_already_deployed(snapshot, deployment.id)
 
@@ -620,28 +606,6 @@ class BaseDeployer(StackComponent, ABC):
             deployment = client.zen_store.update_deployment(
                 deployment.id,
                 deployment_update,
-            )
-
-        # Build the deployer image at deploy time. Reuse the existing build
-        # when the same snapshot is being re-provisioned.
-        if (
-            existing_build_id is not None
-            and existing_snapshot_id == snapshot.id
-        ):
-            build_id: Optional[UUID] = existing_build_id
-        else:
-            build_id = self._prepare_deployment_build(
-                snapshot=snapshot,
-                stack=stack,
-                local_code_available=local_code_available,
-            )
-
-        if build_id is not None and build_id != deployment.build_id:
-            # `update_deployment` returns the deployment with its resources
-            # hydrated, so `get_image(deployment)` resolves the deployer image
-            # from the attached build.
-            deployment = client.zen_store.update_deployment(
-                deployment.id, DeploymentUpdate(build_id=build_id)
             )
 
         logger.info(

--- a/src/zenml/deployers/base_deployer.py
+++ b/src/zenml/deployers/base_deployer.py
@@ -67,6 +67,7 @@ from zenml.stack.stack_component import StackComponentConfig
 from zenml.utils.uuid_utils import is_valid_uuid
 
 if TYPE_CHECKING:
+    from zenml.models import ComponentResponse
     from zenml.stack import Stack
 
 logger = get_logger(__name__)
@@ -115,31 +116,40 @@ class BaseDeployer(StackComponent, ABC):
         return cast(BaseDeployerConfig, self._config)
 
     @classmethod
-    def get_active_deployer(cls) -> "BaseDeployer":
-        """Get the deployer registered in the active stack.
+    def get_deployer(
+        cls,
+        deployer: Union[
+            str, UUID, "BaseDeployer", "ComponentResponse", None
+        ] = None,
+    ) -> "BaseDeployer":
+        """Resolve a deployer instance.
+
+        Args:
+            deployer: The deployer to resolve. Can be a deployer instance, a
+                component model, a name or ID, or None to fall back to the
+                `default` deployer.
 
         Returns:
-            The deployer registered in the active stack.
-
-        Raises:
-            TypeError: if a deployer is not part of the
-                active stack.
+            The resolved deployer instance.
         """
+        from zenml.models import ComponentResponse
+
+        if isinstance(deployer, BaseDeployer):
+            return deployer
+
         client = Client()
-        deployer = client.active_stack.deployer
-        if not deployer or not isinstance(deployer, cls):
-            raise TypeError(
-                "The active stack needs to have a deployer "
-                "component registered to be able to deploy pipelines. "
-                "You can create a new stack with a deployer component "
-                "or update your active stack to add this component, e.g.:\n\n"
-                "  `zenml deployer register ...`\n"
-                "  `zenml stack register <STACK-NAME> -D ...`\n"
-                "  or:\n"
-                "  `zenml stack update -D ...`\n\n"
+        if isinstance(deployer, ComponentResponse):
+            component = deployer
+        elif deployer is not None:
+            component = client.get_stack_component(
+                StackComponentType.DEPLOYER, deployer
+            )
+        else:
+            component = client.get_stack_component(
+                StackComponentType.DEPLOYER, "default"
             )
 
-        return deployer
+        return cast(BaseDeployer, StackComponent.from_model(component))
 
     def _update_deployment(
         self,
@@ -222,33 +232,27 @@ class BaseDeployer(StackComponent, ABC):
                 "component\n"
             )
 
-    def _check_deployment_snapshot(
-        self, snapshot: Optional[PipelineSnapshotResponse] = None
-    ) -> None:
-        """Check if the snapshot was created for this deployer.
+    def _prepare_deployment_build(
+        self,
+        deployment: DeploymentResponse,
+        snapshot: PipelineSnapshotResponse,
+        stack: "Stack",
+    ) -> Optional[UUID]:
+        """Build the image required to provision the deployment.
+
+        The base deployer requires no image. Containerized deployers override
+        this to build the deployer image at deploy time.
 
         Args:
-            snapshot: The pipeline snapshot to check.
+            deployment: The deployment to build the image for.
+            snapshot: The pipeline snapshot to deploy.
+            stack: The stack supplying the image builder and container registry.
 
-        Raises:
-            DeploymentSnapshotMismatchError: if the pipeline snapshot is
-                not built for this deployer.
+        Returns:
+            The ID of the build to attach to the deployment, or None if no
+            build is required.
         """
-        if not snapshot:
-            return
-
-        if snapshot.stack and snapshot.stack.components.get(
-            StackComponentType.DEPLOYER
-        ):
-            deployer = snapshot.stack.components[StackComponentType.DEPLOYER][
-                0
-            ]
-            if deployer.id != self.id:
-                raise DeploymentSnapshotMismatchError(
-                    f"The pipeline snapshot with ID '{snapshot.id}' "
-                    f"was not created for the deployer {self.name}. This will "
-                    "lead to unexpected behavior and is not allowed."
-                )
+        return None
 
     def _check_snapshot_already_deployed(
         self,
@@ -533,11 +537,19 @@ class BaseDeployer(StackComponent, ABC):
                 "a different snapshot."
             )
 
+        # Track the build and snapshot already stored on the deployment (if
+        # any) so the deployer image can be reused on an unchanged re-provision.
+        existing_build_id: Optional[UUID] = None
+        existing_snapshot_id: Optional[UUID] = None
+
         try:
             # Get the existing deployment
             deployment = client.get_deployment(
                 deployment_name_or_id, project=snapshot.project_id
             )
+
+            existing_build_id = deployment.build_id
+            existing_snapshot_id = deployment.snapshot_id
 
             self._check_snapshot_already_deployed(snapshot, deployment.id)
 
@@ -581,7 +593,6 @@ class BaseDeployer(StackComponent, ABC):
                 )
 
             self._check_deployment_deployer(deployment)
-            self._check_deployment_snapshot(snapshot)
 
             deployment_update = DeploymentUpdate(
                 snapshot_id=snapshot.id,
@@ -604,6 +615,26 @@ class BaseDeployer(StackComponent, ABC):
             deployment = client.zen_store.update_deployment(
                 deployment.id,
                 deployment_update,
+            )
+
+        # Build the deployer image at deploy time. Reuse the existing build
+        # when the same snapshot is being re-provisioned.
+        if (
+            existing_build_id is not None
+            and existing_snapshot_id == snapshot.id
+        ):
+            build_id: Optional[UUID] = existing_build_id
+        else:
+            build_id = self._prepare_deployment_build(
+                deployment=deployment, snapshot=snapshot, stack=stack
+            )
+
+        if build_id is not None and build_id != deployment.build_id:
+            # `update_deployment` returns the deployment with its resources
+            # hydrated, so `get_image(deployment)` resolves the deployer image
+            # from the attached build.
+            deployment = client.zen_store.update_deployment(
+                deployment.id, DeploymentUpdate(build_id=build_id)
             )
 
         logger.info(

--- a/src/zenml/deployers/containerized_deployer.py
+++ b/src/zenml/deployers/containerized_deployer.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Optional,
     Set,
+    cast,
 )
 from uuid import UUID
 
@@ -29,6 +30,7 @@ from zenml.constants import (
     DEPLOYER_DOCKER_IMAGE_KEY,
 )
 from zenml.deployers.base_deployer import BaseDeployer
+from zenml.deployers.exceptions import DeployerError
 from zenml.deployers.utils import load_deployment_requirements
 from zenml.logger import get_logger
 from zenml.models import (
@@ -70,25 +72,74 @@ class ContainerizedDeployer(BaseDeployer, ABC):
 
     def _prepare_deployment_build(
         self,
-        deployment: DeploymentResponse,
         snapshot: PipelineSnapshotResponse,
         stack: "Stack",
+        local_code_available: bool = False,
     ) -> Optional[UUID]:
         """Build the deployer image for the deployment.
 
+        The deployer image is built through the same machinery as any other
+        pipeline image. The code is built into the image from the local code
+        when deploying directly from local code, otherwise the image is
+        code-free and the running container downloads the code from the
+        snapshot.
+
         Args:
-            deployment: The deployment to build the image for.
             snapshot: The pipeline snapshot to deploy.
             stack: The stack supplying the image builder and container registry.
+            local_code_available: Whether the local code can be built into the
+                image, set only when deploying directly from local code.
+
+        Raises:
+            DeployerError: If the deployment has no code to run.
 
         Returns:
             The ID of the build containing the deployer image, or None if no
             build is required.
         """
-        from zenml.pipelines.build_utils import create_deployer_build
+        from zenml.pipelines.build_utils import build_required_images
+        from zenml.utils import code_repository_utils
 
-        build = create_deployer_build(
-            snapshot=snapshot, stack=stack, deployer=self
+        assert snapshot.stack is not None
+
+        snapshot_base = cast(PipelineSnapshotBase, snapshot)
+        required_builds = self.get_docker_builds(snapshot_base)
+        if not required_builds:
+            return None
+
+        code_repository = None
+        if local_code_available:
+            local_repo = code_repository_utils.find_active_code_repository()
+            if local_repo and not local_repo.has_local_changes:
+                code_repository = local_repo.code_repository
+
+        if required_builds[0].should_include_files(
+            code_repository=code_repository
+        ):
+            if not local_code_available:
+                raise DeployerError(
+                    "The pipeline code must be built into the deployer image, "
+                    "but there is no local code to build from. Deploy from "
+                    "local code, or use a snapshot whose code is uploaded to "
+                    "the artifact store or tracked in a code repository."
+                )
+        elif not snapshot.code_path and not snapshot.code_reference:
+            raise DeployerError(
+                "The deployer image does not contain the pipeline code and the "
+                "snapshot has no code to download at runtime. Use a snapshot "
+                "whose code is uploaded to the artifact store or tracked in a "
+                "code repository."
+            )
+
+        stack.ensure_image_builder()
+        build = build_required_images(
+            snapshot=snapshot_base,
+            stack=stack,
+            stack_model=snapshot.stack,
+            required_builds=required_builds,
+            project_id=snapshot.project_id,
+            pipeline_id=snapshot.pipeline.id,
+            code_repository=code_repository,
         )
         return build.id if build else None
 

--- a/src/zenml/deployers/containerized_deployer.py
+++ b/src/zenml/deployers/containerized_deployer.py
@@ -17,11 +17,9 @@ from abc import ABC
 from typing import (
     TYPE_CHECKING,
     List,
-    Optional,
     Set,
     cast,
 )
-from uuid import UUID
 
 import zenml
 from zenml.config.build_configuration import BuildConfiguration
@@ -52,6 +50,8 @@ class ContainerizedDeployer(BaseDeployer, ABC):
     def get_image(deployment: DeploymentResponse) -> str:
         """Get the docker image used to deploy a deployment.
 
+        The serving image lives on the deployment's snapshot.
+
         Args:
             deployment: The deployment to get the image for.
 
@@ -59,89 +59,79 @@ class ContainerizedDeployer(BaseDeployer, ABC):
             The docker image used to deploy the deployment.
 
         Raises:
-            RuntimeError: if the deployment does not have a build or if the
-                deployer image is not in the build.
+            RuntimeError: if the snapshot has no build or the build has no
+                deployer image.
         """
-        if deployment.build is None:
-            raise RuntimeError("Deployment does not have a build.")
-        if DEPLOYER_DOCKER_IMAGE_KEY not in deployment.build.images:
-            raise RuntimeError(
-                "Deployment build does not have a deployer image."
-            )
-        return deployment.build.images[DEPLOYER_DOCKER_IMAGE_KEY].image
+        from zenml.client import Client
 
-    def _prepare_deployment_build(
+        if deployment.snapshot is None:
+            raise RuntimeError("Deployment does not have a snapshot.")
+
+        build = (
+            Client().get_snapshot(deployment.snapshot.id, hydrate=True).build
+        )
+        if build is None:
+            raise RuntimeError("Deployment snapshot does not have a build.")
+        if DEPLOYER_DOCKER_IMAGE_KEY not in build.images:
+            raise RuntimeError(
+                "Deployment snapshot build does not have a deployer image."
+            )
+        return build.images[DEPLOYER_DOCKER_IMAGE_KEY].image
+
+    def _validate_snapshot_deployable(
         self,
         snapshot: PipelineSnapshotResponse,
         stack: "Stack",
-        local_code_available: bool = False,
-    ) -> Optional[UUID]:
-        """Build the deployer image for the deployment.
+    ) -> None:
+        """Require a serving image in the snapshot built for this deployer.
 
-        The deployer image is built through the same machinery as any other
-        pipeline image. The code is built into the image from the local code
-        when deploying directly from local code, otherwise the image is
-        code-free and the running container downloads the code from the
-        snapshot.
+        The serving image is deployer-specific (it carries the deployer's
+        requirements), so a snapshot can only be deployed by the deployer its
+        image was built for. The match is checked against the stored image
+        settings checksum, which the deployer's requirements feed into.
 
         Args:
             snapshot: The pipeline snapshot to deploy.
-            stack: The stack supplying the image builder and container registry.
-            local_code_available: Whether the local code can be built into the
-                image, set only when deploying directly from local code.
+            stack: The stack the snapshot will be deployed on.
 
         Raises:
-            DeployerError: If the deployment has no code to run.
-
-        Returns:
-            The ID of the build containing the deployer image, or None if no
-            build is required.
+            DeployerError: If the snapshot has no serving image, or its image
+                was built for a different deployer.
         """
-        from zenml.pipelines.build_utils import build_required_images
-        from zenml.utils import code_repository_utils
-
-        assert snapshot.stack is not None
-
         snapshot_base = cast(PipelineSnapshotBase, snapshot)
         required_builds = self.get_docker_builds(snapshot_base)
         if not required_builds:
-            return None
+            return
 
-        code_repository = None
-        if local_code_available:
-            local_repo = code_repository_utils.find_active_code_repository()
-            if local_repo and not local_repo.has_local_changes:
-                code_repository = local_repo.code_repository
-
-        if required_builds[0].should_include_files(
-            code_repository=code_repository
+        if (
+            not snapshot.build
+            or DEPLOYER_DOCKER_IMAGE_KEY not in snapshot.build.images
         ):
-            if not local_code_available:
-                raise DeployerError(
-                    "The pipeline code must be built into the deployer image, "
-                    "but there is no local code to build from. Deploy from "
-                    "local code, or use a snapshot whose code is uploaded to "
-                    "the artifact store or tracked in a code repository."
-                )
-        elif not snapshot.code_path and not snapshot.code_reference:
             raise DeployerError(
-                "The deployer image does not contain the pipeline code and the "
-                "snapshot has no code to download at runtime. Use a snapshot "
-                "whose code is uploaded to the artifact store or tracked in a "
-                "code repository."
+                "The snapshot does not contain a serving image. Deploy the "
+                "pipeline with `pipeline.deploy(...)` to build one."
             )
 
-        stack.ensure_image_builder()
-        build = build_required_images(
-            snapshot=snapshot_base,
-            stack=stack,
-            stack_model=snapshot.stack,
-            required_builds=required_builds,
-            project_id=snapshot.project_id,
-            pipeline_id=snapshot.pipeline.id,
-            code_repository=code_repository,
+        code_repository = None
+        if snapshot.code_reference:
+            from zenml.code_repositories import BaseCodeRepository
+
+            code_repository = BaseCodeRepository.from_model(
+                snapshot.code_reference.code_repository
+            )
+
+        expected_checksum = required_builds[0].compute_settings_checksum(
+            stack, code_repository=code_repository
         )
-        return build.id if build else None
+        actual_checksum = snapshot.build.get_settings_checksum(
+            DEPLOYER_DOCKER_IMAGE_KEY
+        )
+        if expected_checksum != actual_checksum:
+            raise DeployerError(
+                "The snapshot's serving image was not built for the deployer "
+                f"'{self.name}'. Deploy with the deployer the snapshot was "
+                "built for, or build a new snapshot with `pipeline.deploy(...)`."
+            )
 
     @property
     def requirements(self) -> Set[str]:
@@ -185,8 +175,8 @@ class ContainerizedDeployer(BaseDeployer, ABC):
         }
 
         # The deployer is no longer part of the stack, so its own requirements
-        # are not picked up by `stack.requirements()` during the deploy-time
-        # build. Inject them here (e.g. the `zenml[local]` extra that provides
+        # are not picked up by `stack.requirements()` when the serving image is
+        # built. Inject them here (e.g. the `zenml[local]` extra that provides
         # the DB drivers needed for a direct database connection).
         if docker_settings.install_stack_requirements:
             deployer_requirements = sorted(self.requirements)

--- a/src/zenml/deployers/containerized_deployer.py
+++ b/src/zenml/deployers/containerized_deployer.py
@@ -15,9 +15,12 @@
 
 from abc import ABC
 from typing import (
+    TYPE_CHECKING,
     List,
+    Optional,
     Set,
 )
+from uuid import UUID
 
 import zenml
 from zenml.config.build_configuration import BuildConfiguration
@@ -29,9 +32,13 @@ from zenml.deployers.base_deployer import BaseDeployer
 from zenml.deployers.utils import load_deployment_requirements
 from zenml.logger import get_logger
 from zenml.models import (
+    DeploymentResponse,
     PipelineSnapshotBase,
     PipelineSnapshotResponse,
 )
+
+if TYPE_CHECKING:
+    from zenml.stack import Stack
 
 logger = get_logger(__name__)
 
@@ -40,26 +47,50 @@ class ContainerizedDeployer(BaseDeployer, ABC):
     """Base class for all containerized deployers."""
 
     @staticmethod
-    def get_image(snapshot: PipelineSnapshotResponse) -> str:
-        """Get the docker image used to deploy a pipeline snapshot.
+    def get_image(deployment: DeploymentResponse) -> str:
+        """Get the docker image used to deploy a deployment.
 
         Args:
-            snapshot: The pipeline snapshot to get the image for.
+            deployment: The deployment to get the image for.
 
         Returns:
-            The docker image used to deploy the pipeline snapshot.
+            The docker image used to deploy the deployment.
 
         Raises:
-            RuntimeError: if the pipeline snapshot does not have a build or
-                if the deployer image is not in the build.
+            RuntimeError: if the deployment does not have a build or if the
+                deployer image is not in the build.
         """
-        if snapshot.build is None:
-            raise RuntimeError("Pipeline snapshot does not have a build. ")
-        if DEPLOYER_DOCKER_IMAGE_KEY not in snapshot.build.images:
+        if deployment.build is None:
+            raise RuntimeError("Deployment does not have a build.")
+        if DEPLOYER_DOCKER_IMAGE_KEY not in deployment.build.images:
             raise RuntimeError(
-                "Pipeline snapshot build does not have a deployer image. "
+                "Deployment build does not have a deployer image."
             )
-        return snapshot.build.images[DEPLOYER_DOCKER_IMAGE_KEY].image
+        return deployment.build.images[DEPLOYER_DOCKER_IMAGE_KEY].image
+
+    def _prepare_deployment_build(
+        self,
+        deployment: DeploymentResponse,
+        snapshot: PipelineSnapshotResponse,
+        stack: "Stack",
+    ) -> Optional[UUID]:
+        """Build the deployer image for the deployment.
+
+        Args:
+            deployment: The deployment to build the image for.
+            snapshot: The pipeline snapshot to deploy.
+            stack: The stack supplying the image builder and container registry.
+
+        Returns:
+            The ID of the build containing the deployer image, or None if no
+            build is required.
+        """
+        from zenml.pipelines.build_utils import create_deployer_build
+
+        build = create_deployer_build(
+            snapshot=snapshot, stack=stack, deployer=self
+        )
+        return build.id if build else None
 
     @property
     def requirements(self) -> Set[str]:
@@ -98,12 +129,25 @@ class ContainerizedDeployer(BaseDeployer, ABC):
         deployment_requirements = load_deployment_requirements(
             deployment_settings
         )
+        extra_requirements_files = {
+            ".zenml_deployment_requirements": deployment_requirements,
+        }
+
+        # The deployer is no longer part of the stack, so its own requirements
+        # are not picked up by `stack.requirements()` during the deploy-time
+        # build. Inject them here (e.g. the `zenml[local]` extra that provides
+        # the DB drivers needed for a direct database connection).
+        if docker_settings.install_stack_requirements:
+            deployer_requirements = sorted(self.requirements)
+            if deployer_requirements:
+                extra_requirements_files[".zenml_deployer_requirements"] = (
+                    deployer_requirements
+                )
+
         return [
             BuildConfiguration(
                 key=DEPLOYER_DOCKER_IMAGE_KEY,
-                settings=snapshot.pipeline_configuration.docker_settings,
-                extra_requirements_files={
-                    ".zenml_deployment_requirements": deployment_requirements,
-                },
+                settings=docker_settings,
+                extra_requirements_files=extra_requirements_files,
             )
         ]

--- a/src/zenml/deployers/docker/docker_deployer.py
+++ b/src/zenml/deployers/docker/docker_deployer.py
@@ -355,7 +355,7 @@ class DockerDeployer(ContainerizedDeployer):
             f"Starting container for deployment '{deployment.name}'..."
         )
 
-        image = self.get_image(deployment.snapshot)
+        image = self.get_image(deployment)
 
         try:
             self.docker_client.images.get(image)

--- a/src/zenml/integrations/aws/deployers/aws_deployer.py
+++ b/src/zenml/integrations/aws/deployers/aws_deployer.py
@@ -1255,7 +1255,7 @@ class AWSDeployer(ContainerizedDeployer):
         )
 
         existing_service = self._get_app_runner_service(deployment)
-        image = self.get_image(snapshot)
+        image = self.get_image(deployment)
         region = self.region
 
         if existing_service and self._requires_service_replacement(

--- a/src/zenml/integrations/gcp/deployers/gcp_deployer.py
+++ b/src/zenml/integrations/gcp/deployers/gcp_deployer.py
@@ -1038,7 +1038,7 @@ class GCPDeployer(ContainerizedDeployer, GoogleCredentialsMixin):
                         f"deployment '{deployment.name}': {e}"
                     )
 
-        image = self.get_image(snapshot)
+        image = self.get_image(deployment)
 
         entrypoint = DeploymentEntrypointConfiguration.get_entrypoint_command()
         arguments = DeploymentEntrypointConfiguration.get_entrypoint_arguments(

--- a/src/zenml/integrations/huggingface/deployers/huggingface_deployer.py
+++ b/src/zenml/integrations/huggingface/deployers/huggingface_deployer.py
@@ -281,7 +281,7 @@ class HuggingFaceDeployer(ContainerizedDeployer):
 
         api = self._get_hf_api()
         space_id = self._get_space_id(deployment)
-        image = self.get_image(deployment.snapshot)
+        image = self.get_image(deployment)
 
         # Handle space_id mismatch (e.g., renamed deployment or changed prefix)
         old_space_id = deployment.deployment_metadata.get("space_id")

--- a/src/zenml/integrations/kubernetes/deployers/kubernetes_deployer.py
+++ b/src/zenml/integrations/kubernetes/deployers/kubernetes_deployer.py
@@ -784,7 +784,7 @@ class KubernetesDeployer(ContainerizedDeployer):
         if settings.labels:
             labels.update(**settings.labels)
 
-        image = self.get_image(snapshot)
+        image = self.get_image(deployment)
 
         return _DeploymentCtx(
             settings=settings,

--- a/src/zenml/models/v2/core/deployment.py
+++ b/src/zenml/models/v2/core/deployment.py
@@ -51,7 +51,6 @@ if TYPE_CHECKING:
         CuratedVisualizationResponse,
     )
     from zenml.models.v2.core.pipeline import PipelineResponse
-    from zenml.models.v2.core.pipeline_build import PipelineBuildResponse
     from zenml.models.v2.core.pipeline_snapshot import (
         PipelineSnapshotResponse,
     )
@@ -116,10 +115,6 @@ class DeploymentUpdate(BaseUpdate):
     snapshot_id: Optional[UUID] = Field(
         default=None,
         title="New pipeline snapshot ID.",
-    )
-    build_id: Optional[UUID] = Field(
-        default=None,
-        title="New build ID.",
     )
     url: Optional[str] = Field(
         default=None,
@@ -206,11 +201,6 @@ class DeploymentResponseResources(ProjectScopedResponseResources):
         default=None,
         title="The deployer.",
         description="The deployer component managing this deployment.",
-    )
-    build: Optional["PipelineBuildResponse"] = Field(
-        default=None,
-        title="The build.",
-        description="The build containing the deployer image.",
     )
     pipeline: Optional["PipelineResponse"] = Field(
         default=None,
@@ -313,15 +303,6 @@ class DeploymentResponse(
         return self.get_resources().deployer
 
     @property
-    def build(self) -> Optional["PipelineBuildResponse"]:
-        """The build.
-
-        Returns:
-            The build.
-        """
-        return self.get_resources().build
-
-    @property
     def pipeline(self) -> Optional["PipelineResponse"]:
         """The pipeline.
 
@@ -378,18 +359,6 @@ class DeploymentResponse(
         deployer = self.get_resources().deployer
         if deployer:
             return deployer.id
-        return None
-
-    @property
-    def build_id(self) -> Optional[UUID]:
-        """The build ID.
-
-        Returns:
-            The build ID.
-        """
-        build = self.get_resources().build
-        if build:
-            return build.id
         return None
 
 

--- a/src/zenml/models/v2/core/deployment.py
+++ b/src/zenml/models/v2/core/deployment.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         CuratedVisualizationResponse,
     )
     from zenml.models.v2.core.pipeline import PipelineResponse
+    from zenml.models.v2.core.pipeline_build import PipelineBuildResponse
     from zenml.models.v2.core.pipeline_snapshot import (
         PipelineSnapshotResponse,
     )
@@ -115,6 +116,10 @@ class DeploymentUpdate(BaseUpdate):
     snapshot_id: Optional[UUID] = Field(
         default=None,
         title="New pipeline snapshot ID.",
+    )
+    build_id: Optional[UUID] = Field(
+        default=None,
+        title="New build ID.",
     )
     url: Optional[str] = Field(
         default=None,
@@ -201,6 +206,11 @@ class DeploymentResponseResources(ProjectScopedResponseResources):
         default=None,
         title="The deployer.",
         description="The deployer component managing this deployment.",
+    )
+    build: Optional["PipelineBuildResponse"] = Field(
+        default=None,
+        title="The build.",
+        description="The build containing the deployer image.",
     )
     pipeline: Optional["PipelineResponse"] = Field(
         default=None,
@@ -303,6 +313,15 @@ class DeploymentResponse(
         return self.get_resources().deployer
 
     @property
+    def build(self) -> Optional["PipelineBuildResponse"]:
+        """The build.
+
+        Returns:
+            The build.
+        """
+        return self.get_resources().build
+
+    @property
     def pipeline(self) -> Optional["PipelineResponse"]:
         """The pipeline.
 
@@ -359,6 +378,18 @@ class DeploymentResponse(
         deployer = self.get_resources().deployer
         if deployer:
             return deployer.id
+        return None
+
+    @property
+    def build_id(self) -> Optional[UUID]:
+        """The build ID.
+
+        Returns:
+            The build ID.
+        """
+        build = self.get_resources().build
+        if build:
+            return build.id
         return None
 
 

--- a/src/zenml/models/v2/core/pipeline_snapshot.py
+++ b/src/zenml/models/v2/core/pipeline_snapshot.py
@@ -33,7 +33,7 @@ from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
 from zenml.config.pipeline_spec import PipelineSpec
 from zenml.config.step_configurations import Step
 from zenml.constants import STR_FIELD_MAX_LENGTH, TEXT_FIELD_MAX_LENGTH
-from zenml.enums import ExecutionStatus, StackComponentType
+from zenml.enums import ExecutionStatus
 from zenml.models.v2.base.base import BaseUpdate, BaseZenModel
 from zenml.models.v2.base.filter import (
     StringFilterOption,
@@ -235,9 +235,6 @@ class PipelineSnapshotResponseBody(ProjectScopedResponseBody):
     runnable: bool = Field(
         title="If a run can be started from the snapshot.",
     )
-    deployable: bool = Field(
-        title="If the snapshot can be deployed.",
-    )
     is_dynamic: bool = Field(
         title="Whether this is a snapshot of a dynamic pipeline.",
     )
@@ -388,15 +385,6 @@ class PipelineSnapshotResponse(
             the value of the property.
         """
         return self.get_body().runnable
-
-    @property
-    def deployable(self) -> bool:
-        """The `deployable` property.
-
-        Returns:
-            the value of the property.
-        """
-        return self.get_body().deployable
 
     @property
     def is_dynamic(self) -> bool:
@@ -646,7 +634,6 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
         "pipeline",
         "stack",
         "runnable",
-        "deployable",
         "deployed",
         "trigger_id",
     ]
@@ -666,7 +653,6 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
         *TaggableFilter.API_SINGLE_INPUT_PARAMS,
         "named_only",
         "runnable",
-        "deployable",
         "deployed",
         "trigger_id",
     ]
@@ -708,10 +694,6 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
         default=None,
         description="Whether the snapshot is runnable.",
     )
-    deployable: Optional[bool] = Field(
-        default=None,
-        description="Whether the snapshot is deployable.",
-    )
     deployed: Optional[bool] = Field(
         default=None,
         description="Whether the snapshot is deployed.",
@@ -739,8 +721,6 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
             PipelineBuildSchema,
             PipelineSchema,
             PipelineSnapshotSchema,
-            StackComponentSchema,
-            StackCompositionSchema,
             StackSchema,
         )
 
@@ -795,30 +775,6 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
             )
 
             custom_filters.append(runnable_filter)
-
-        if self.deployable is True:
-            deployer_exists = (
-                select(StackComponentSchema.id)
-                .where(
-                    StackComponentSchema.type
-                    == StackComponentType.DEPLOYER.value
-                )
-                .where(
-                    StackCompositionSchema.component_id
-                    == StackComponentSchema.id
-                )
-                .where(
-                    StackCompositionSchema.stack_id
-                    == PipelineSnapshotSchema.stack_id
-                )
-                .exists()
-            )
-            deployable_filter = and_(
-                col(PipelineSnapshotSchema.build_id).is_not(None),
-                deployer_exists,
-            )
-
-            custom_filters.append(deployable_filter)
 
         if self.deployed is not None:
             deployment_exists = (

--- a/src/zenml/pipelines/build_utils.py
+++ b/src/zenml/pipelines/build_utils.py
@@ -22,7 +22,6 @@ from typing import (
     List,
     Optional,
     Union,
-    cast,
 )
 from uuid import UUID
 
@@ -49,8 +48,7 @@ if TYPE_CHECKING:
     from zenml.code_repositories import LocalRepositoryContext
     from zenml.config.build_configuration import BuildConfiguration
     from zenml.config.docker_settings import DockerSettings
-    from zenml.deployers.base_deployer import BaseDeployer
-    from zenml.models import PipelineSnapshotResponse
+    from zenml.stack import StackComponent
 
 logger = get_logger(__name__)
 
@@ -203,6 +201,7 @@ def reuse_or_create_pipeline_build(
     pipeline_id: Optional[UUID] = None,
     build: Union["UUID", "PipelineBuildBase", None] = None,
     code_repository: Optional["BaseCodeRepository"] = None,
+    additional_build_component: Optional["StackComponent"] = None,
 ) -> Optional["PipelineBuildResponse"]:
     """Loads or creates a pipeline build.
 
@@ -217,6 +216,9 @@ def reuse_or_create_pipeline_build(
             be created.
         code_repository: If provided, this code repository can be used to
             download code inside the container images.
+        additional_build_component: A component whose images are built in
+            addition to the active stack's images. Build reuse is skipped
+            when this is set.
 
     Returns:
         The build response.
@@ -224,6 +226,7 @@ def reuse_or_create_pipeline_build(
     if not build:
         if (
             allow_build_reuse
+            and additional_build_component is None
             and not should_prevent_build_reuse(snapshot=snapshot)
             and not requires_included_code(
                 snapshot=snapshot, code_repository=code_repository
@@ -256,6 +259,7 @@ def reuse_or_create_pipeline_build(
             snapshot=snapshot,
             pipeline_id=pipeline_id,
             code_repository=code_repository,
+            additional_build_component=additional_build_component,
         )
 
     if isinstance(build, UUID):
@@ -345,6 +349,7 @@ def create_pipeline_build(
     snapshot: "PipelineSnapshotBase",
     pipeline_id: Optional[UUID] = None,
     code_repository: Optional["BaseCodeRepository"] = None,
+    additional_build_component: Optional["StackComponent"] = None,
 ) -> Optional["PipelineBuildResponse"]:
     """Builds images and registers the output in the server.
 
@@ -353,6 +358,8 @@ def create_pipeline_build(
         pipeline_id: The ID of the pipeline.
         code_repository: If provided, this code repository will be used to
             download inside the build images.
+        additional_build_component: A component whose images are built in
+            addition to the active stack's images.
 
     Returns:
         The build output.
@@ -364,6 +371,12 @@ def create_pipeline_build(
     pruned_snapshot = prune_snapshot_before_build(snapshot)
 
     required_builds = stack.get_docker_builds(snapshot=pruned_snapshot)
+    if additional_build_component is not None:
+        required_builds = required_builds + (
+            additional_build_component.get_docker_builds(
+                snapshot=pruned_snapshot
+            )
+        )
 
     if not required_builds:
         logger.debug("No docker builds required.")

--- a/src/zenml/pipelines/build_utils.py
+++ b/src/zenml/pipelines/build_utils.py
@@ -22,6 +22,7 @@ from typing import (
     List,
     Optional,
     Union,
+    cast,
 )
 from uuid import UUID
 
@@ -48,6 +49,8 @@ if TYPE_CHECKING:
     from zenml.code_repositories import LocalRepositoryContext
     from zenml.config.build_configuration import BuildConfiguration
     from zenml.config.docker_settings import DockerSettings
+    from zenml.deployers.base_deployer import BaseDeployer
+    from zenml.models import PipelineSnapshotResponse
 
 logger = get_logger(__name__)
 
@@ -353,13 +356,9 @@ def create_pipeline_build(
 
     Returns:
         The build output.
-
-    Raises:
-        RuntimeError: If multiple builds with the same key but different
-            settings were specified.
     """
     client = Client()
-    stack_model = Client().active_stack_model
+    stack_model = client.active_stack_model
     stack = client.active_stack
 
     pruned_snapshot = prune_snapshot_before_build(snapshot)
@@ -369,6 +368,47 @@ def create_pipeline_build(
     if not required_builds:
         logger.debug("No docker builds required.")
         return None
+
+    return build_required_images(
+        snapshot=snapshot,
+        stack=stack,
+        stack_model=stack_model,
+        required_builds=required_builds,
+        project_id=client.active_project.id,
+        pipeline_id=pipeline_id,
+        code_repository=code_repository,
+    )
+
+
+def build_required_images(
+    snapshot: "PipelineSnapshotBase",
+    stack: "Stack",
+    stack_model: "StackResponse",
+    required_builds: List["BuildConfiguration"],
+    project_id: UUID,
+    pipeline_id: Optional[UUID] = None,
+    code_repository: Optional["BaseCodeRepository"] = None,
+) -> "PipelineBuildResponse":
+    """Build a list of Docker images and register the output in the server.
+
+    Args:
+        snapshot: The pipeline snapshot.
+        stack: The stack used to build the images.
+        stack_model: The stack model referenced by the created build.
+        required_builds: The build configurations to build.
+        project_id: The project referenced by the created build.
+        pipeline_id: The ID of the pipeline.
+        code_repository: If provided, this code repository will be used to
+            download inside the build images.
+
+    Returns:
+        The build output.
+
+    Raises:
+        RuntimeError: If multiple builds with the same key but different
+            settings were specified.
+    """
+    client = Client()
 
     logger.info(
         "Building Docker image(s) for pipeline `%s`.",
@@ -470,7 +510,7 @@ def create_pipeline_build(
     )
     stack_checksum = compute_stack_checksum(stack=stack_model)
     build_request = PipelineBuildRequest(
-        project=client.active_project.id,
+        project=project_id,
         stack=stack_model.id,
         pipeline=pipeline_id,
         is_local=is_local,
@@ -483,6 +523,56 @@ def create_pipeline_build(
         duration=duration,
     )
     return client.zen_store.create_build(build_request)
+
+
+def create_deployer_build(
+    snapshot: "PipelineSnapshotResponse",
+    stack: "Stack",
+    deployer: "BaseDeployer",
+) -> Optional["PipelineBuildResponse"]:
+    """Build the deployer image for a snapshot at deploy time.
+
+    Args:
+        snapshot: The pipeline snapshot to deploy.
+        stack: The stack supplying the image builder and container registry.
+        deployer: The deployer defining the required builds.
+
+    Returns:
+        The build containing the deployer image, or None if no build is
+        required.
+    """
+    from zenml.utils import code_repository_utils
+
+    assert snapshot.stack is not None
+
+    # The build machinery is typed against `PipelineSnapshotBase`. A deploy-time
+    # snapshot is a `PipelineSnapshotResponse`, which exposes the same
+    # pipeline configuration the build machinery reads.
+    snapshot_base = cast(PipelineSnapshotBase, snapshot)
+
+    required_builds = deployer.get_docker_builds(snapshot_base)
+    if not required_builds:
+        logger.debug("No deployer docker builds required.")
+        return None
+
+    # Building the deployer image requires an image builder even when the
+    # stack's orchestrator is local.
+    stack.ensure_image_builder()
+
+    local_repo = code_repository_utils.find_active_code_repository()
+    code_repository = verify_local_repository_context(
+        snapshot=snapshot_base, local_repo_context=local_repo
+    )
+
+    return build_required_images(
+        snapshot=snapshot_base,
+        stack=stack,
+        stack_model=snapshot.stack,
+        required_builds=required_builds,
+        project_id=snapshot.project_id,
+        pipeline_id=snapshot.pipeline.id,
+        code_repository=code_repository,
+    )
 
 
 def compute_build_checksum(
@@ -756,6 +846,27 @@ def should_upload_code(
     if build.contains_code:
         return False
 
+    return requires_runtime_code_download(
+        snapshot=snapshot,
+        can_download_from_code_repository=can_download_from_code_repository,
+    )
+
+
+def requires_runtime_code_download(
+    snapshot: PipelineSnapshotBase,
+    can_download_from_code_repository: bool,
+) -> bool:
+    """Checks whether any step downloads its code from the artifact store.
+
+    Args:
+        snapshot: The snapshot.
+        can_download_from_code_repository: Whether the code can be downloaded
+            from a code repository.
+
+    Returns:
+        Whether the code must be uploaded so it can be downloaded from the
+        artifact store at runtime.
+    """
     for docker_settings in get_docker_settings(snapshot=snapshot):
         if (
             can_download_from_code_repository

--- a/src/zenml/pipelines/build_utils.py
+++ b/src/zenml/pipelines/build_utils.py
@@ -525,56 +525,6 @@ def build_required_images(
     return client.zen_store.create_build(build_request)
 
 
-def create_deployer_build(
-    snapshot: "PipelineSnapshotResponse",
-    stack: "Stack",
-    deployer: "BaseDeployer",
-) -> Optional["PipelineBuildResponse"]:
-    """Build the deployer image for a snapshot at deploy time.
-
-    Args:
-        snapshot: The pipeline snapshot to deploy.
-        stack: The stack supplying the image builder and container registry.
-        deployer: The deployer defining the required builds.
-
-    Returns:
-        The build containing the deployer image, or None if no build is
-        required.
-    """
-    from zenml.utils import code_repository_utils
-
-    assert snapshot.stack is not None
-
-    # The build machinery is typed against `PipelineSnapshotBase`. A deploy-time
-    # snapshot is a `PipelineSnapshotResponse`, which exposes the same
-    # pipeline configuration the build machinery reads.
-    snapshot_base = cast(PipelineSnapshotBase, snapshot)
-
-    required_builds = deployer.get_docker_builds(snapshot_base)
-    if not required_builds:
-        logger.debug("No deployer docker builds required.")
-        return None
-
-    # Building the deployer image requires an image builder even when the
-    # stack's orchestrator is local.
-    stack.ensure_image_builder()
-
-    local_repo = code_repository_utils.find_active_code_repository()
-    code_repository = verify_local_repository_context(
-        snapshot=snapshot_base, local_repo_context=local_repo
-    )
-
-    return build_required_images(
-        snapshot=snapshot_base,
-        stack=stack,
-        stack_model=snapshot.stack,
-        required_builds=required_builds,
-        project_id=snapshot.project_id,
-        pipeline_id=snapshot.pipeline.id,
-        code_repository=code_repository,
-    )
-
-
 def compute_build_checksum(
     items: List["BuildConfiguration"],
     stack: "Stack",

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -898,12 +898,25 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         from zenml.deployers.base_deployer import BaseDeployer
 
         self.prepare(*args, **kwargs)
-        # Deployment serves the pipeline in-process, so the orchestrator image
-        # is not needed. The deployer image is built later at deploy time.
-        snapshot = self._create_snapshot(skip_build=True, **self._run_args)
+
+        docker_settings = self.configuration.docker_settings
+        local_repo = code_repository_utils.find_active_code_repository()
+        downloads_from_code_repository = (
+            local_repo is not None
+            and not local_repo.has_local_changes
+            and docker_settings.allow_download_from_code_repository
+        )
+        upload_code = (
+            not docker_settings.local_project_install_command
+            and docker_settings.allow_download_from_artifact_store
+            and not downloads_from_code_repository
+        )
+
+        snapshot = self._create_snapshot(
+            skip_build=True, upload_code=upload_code, **self._run_args
+        )
 
         stack = Client().active_stack
-
         stack.prepare_pipeline_submission(snapshot=snapshot)
 
         resolved_deployer = BaseDeployer.get_deployer(deployer)
@@ -912,6 +925,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             stack=stack,
             deployment_name_or_id=deployment_name,
             timeout=timeout,
+            local_code_available=True,
         )
 
     def _create_snapshot(
@@ -934,6 +948,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         prevent_build_reuse: bool = False,
         skip_schedule_registration: bool = False,
         skip_build: bool = False,
+        upload_code: Optional[bool] = None,
         **snapshot_request_kwargs: Any,
     ) -> PipelineSnapshotResponse:
         """Create a pipeline snapshot.
@@ -962,10 +977,9 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             prevent_build_reuse: DEPRECATED: Use
                 `DockerSettings.prevent_build_reuse` instead.
             skip_schedule_registration: Whether to skip schedule registration.
-            skip_build: Whether to skip building the pipeline images. Used when
-                deploying, where the pipeline is served in-process and the
-                orchestrator image is not needed. Code is still uploaded so the
-                deployer image can download it at runtime.
+            skip_build: Whether to skip building the pipeline images.
+            upload_code: Whether to upload the code. If None, it is decided
+                automatically from the build and the Docker settings.
             **snapshot_request_kwargs: Additional keyword arguments to pass to
                 the snapshot request.
 
@@ -1057,14 +1071,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             )
 
         if skip_build:
-            # When deploying, the orchestrator image is not needed, but the
-            # code is still uploaded if a runtime download from the artifact
-            # store is configured, so the deployer image can fetch it.
             build_model = None
-            upload_code = build_utils.requires_runtime_code_download(
-                snapshot=snapshot,
-                can_download_from_code_repository=can_download_from_code_repository,
-            )
         else:
             build_model = build_utils.reuse_or_create_pipeline_build(
                 snapshot=snapshot,
@@ -1073,6 +1080,8 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 build=build,
                 code_repository=code_repository,
             )
+
+        if upload_code is None:
             upload_code = build_utils.should_upload_code(
                 snapshot=snapshot,
                 build=build_model,

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -112,6 +112,7 @@ if TYPE_CHECKING:
     from zenml.config.cache_policy import CachePolicyOrString
     from zenml.config.retry_config import StepRetryConfig
     from zenml.config.source import Source
+    from zenml.deployers.base_deployer import BaseDeployer
     from zenml.enums import ExecutionMode
     from zenml.model.lazy_load import ModelVersionDataLazyLoader
     from zenml.model.model import Model
@@ -875,6 +876,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
     def deploy(
         self,
         deployment_name: str,
+        deployer: Union[str, "UUID", "BaseDeployer", None] = None,
         timeout: Optional[int] = None,
         *args: Any,
         **kwargs: Any,
@@ -883,6 +885,8 @@ To avoid this consider setting pipeline parameters only in one place (config or 
 
         Args:
             deployment_name: The name to use for the deployment.
+            deployer: The deployer to use. Can be a deployer instance, a name
+                or ID. If not provided, the `default` deployer is used.
             timeout: The maximum time in seconds to wait for the pipeline to be
                 deployed.
             *args: Pipeline entrypoint input arguments.
@@ -891,15 +895,22 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         Returns:
             The deployment response.
         """
+        from zenml.deployers.base_deployer import BaseDeployer
+
         self.prepare(*args, **kwargs)
-        snapshot = self._create_snapshot(**self._run_args)
+        # Deployment serves the pipeline in-process, so the orchestrator image
+        # is not needed. The deployer image is built later at deploy time.
+        snapshot = self._create_snapshot(skip_build=True, **self._run_args)
 
         stack = Client().active_stack
 
         stack.prepare_pipeline_submission(snapshot=snapshot)
-        return stack.deploy_pipeline(
+
+        resolved_deployer = BaseDeployer.get_deployer(deployer)
+        return resolved_deployer.provision_deployment(
             snapshot=snapshot,
-            deployment_name=deployment_name,
+            stack=stack,
+            deployment_name_or_id=deployment_name,
             timeout=timeout,
         )
 
@@ -922,6 +933,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         config_path: Optional[str] = None,
         prevent_build_reuse: bool = False,
         skip_schedule_registration: bool = False,
+        skip_build: bool = False,
         **snapshot_request_kwargs: Any,
     ) -> PipelineSnapshotResponse:
         """Create a pipeline snapshot.
@@ -950,6 +962,10 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             prevent_build_reuse: DEPRECATED: Use
                 `DockerSettings.prevent_build_reuse` instead.
             skip_schedule_registration: Whether to skip schedule registration.
+            skip_build: Whether to skip building the pipeline images. Used when
+                deploying, where the pipeline is served in-process and the
+                orchestrator image is not needed. Code is still uploaded so the
+                deployer image can download it at runtime.
             **snapshot_request_kwargs: Additional keyword arguments to pass to
                 the snapshot request.
 
@@ -1040,13 +1056,28 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 "`DockerSettings.prevent_build_reuse` instead."
             )
 
-        build_model = build_utils.reuse_or_create_pipeline_build(
-            snapshot=snapshot,
-            pipeline_id=pipeline_id,
-            allow_build_reuse=not prevent_build_reuse,
-            build=build,
-            code_repository=code_repository,
-        )
+        if skip_build:
+            # When deploying, the orchestrator image is not needed, but the
+            # code is still uploaded if a runtime download from the artifact
+            # store is configured, so the deployer image can fetch it.
+            build_model = None
+            upload_code = build_utils.requires_runtime_code_download(
+                snapshot=snapshot,
+                can_download_from_code_repository=can_download_from_code_repository,
+            )
+        else:
+            build_model = build_utils.reuse_or_create_pipeline_build(
+                snapshot=snapshot,
+                pipeline_id=pipeline_id,
+                allow_build_reuse=not prevent_build_reuse,
+                build=build,
+                code_repository=code_repository,
+            )
+            upload_code = build_utils.should_upload_code(
+                snapshot=snapshot,
+                build=build_model,
+                can_download_from_code_repository=can_download_from_code_repository,
+            )
         build_id = build_model.id if build_model else None
 
         code_reference = None
@@ -1065,11 +1096,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             )
 
         code_path = None
-        if build_utils.should_upload_code(
-            snapshot=snapshot,
-            build=build_model,
-            can_download_from_code_repository=can_download_from_code_repository,
-        ):
+        if upload_code:
             source_root = source_utils.get_source_root()
             code_archive = code_utils.CodeArchive(root=source_root)
             logger.info(

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -117,6 +117,7 @@ if TYPE_CHECKING:
     from zenml.model.lazy_load import ModelVersionDataLazyLoader
     from zenml.model.model import Model
     from zenml.models import ArtifactVersionResponse
+    from zenml.stack import StackComponent
     from zenml.types import HookSpecification, InitHookSpecification
 
     StepConfigurationUpdateOrDict = Union[
@@ -899,33 +900,19 @@ To avoid this consider setting pipeline parameters only in one place (config or 
 
         self.prepare(*args, **kwargs)
 
-        docker_settings = self.configuration.docker_settings
-        local_repo = code_repository_utils.find_active_code_repository()
-        downloads_from_code_repository = (
-            local_repo is not None
-            and not local_repo.has_local_changes
-            and docker_settings.allow_download_from_code_repository
-        )
-        upload_code = (
-            not docker_settings.local_project_install_command
-            and docker_settings.allow_download_from_artifact_store
-            and not downloads_from_code_repository
-        )
-
+        resolved_deployer = BaseDeployer.get_deployer(deployer)
         snapshot = self._create_snapshot(
-            skip_build=True, upload_code=upload_code, **self._run_args
+            additional_build_component=resolved_deployer, **self._run_args
         )
 
         stack = Client().active_stack
         stack.prepare_pipeline_submission(snapshot=snapshot)
 
-        resolved_deployer = BaseDeployer.get_deployer(deployer)
         return resolved_deployer.provision_deployment(
             snapshot=snapshot,
             stack=stack,
             deployment_name_or_id=deployment_name,
             timeout=timeout,
-            local_code_available=True,
         )
 
     def _create_snapshot(
@@ -947,8 +934,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
         config_path: Optional[str] = None,
         prevent_build_reuse: bool = False,
         skip_schedule_registration: bool = False,
-        skip_build: bool = False,
-        upload_code: Optional[bool] = None,
+        additional_build_component: Optional["StackComponent"] = None,
         **snapshot_request_kwargs: Any,
     ) -> PipelineSnapshotResponse:
         """Create a pipeline snapshot.
@@ -977,9 +963,8 @@ To avoid this consider setting pipeline parameters only in one place (config or 
             prevent_build_reuse: DEPRECATED: Use
                 `DockerSettings.prevent_build_reuse` instead.
             skip_schedule_registration: Whether to skip schedule registration.
-            skip_build: Whether to skip building the pipeline images.
-            upload_code: Whether to upload the code. If None, it is decided
-                automatically from the build and the Docker settings.
+            additional_build_component: A component whose images are built into
+                the snapshot in addition to the active stack's images.
             **snapshot_request_kwargs: Additional keyword arguments to pass to
                 the snapshot request.
 
@@ -1070,23 +1055,20 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                 "`DockerSettings.prevent_build_reuse` instead."
             )
 
-        if skip_build:
-            build_model = None
-        else:
-            build_model = build_utils.reuse_or_create_pipeline_build(
-                snapshot=snapshot,
-                pipeline_id=pipeline_id,
-                allow_build_reuse=not prevent_build_reuse,
-                build=build,
-                code_repository=code_repository,
-            )
+        build_model = build_utils.reuse_or_create_pipeline_build(
+            snapshot=snapshot,
+            pipeline_id=pipeline_id,
+            allow_build_reuse=not prevent_build_reuse,
+            build=build,
+            code_repository=code_repository,
+            additional_build_component=additional_build_component,
+        )
 
-        if upload_code is None:
-            upload_code = build_utils.should_upload_code(
-                snapshot=snapshot,
-                build=build_model,
-                can_download_from_code_repository=can_download_from_code_repository,
-            )
+        upload_code = build_utils.should_upload_code(
+            snapshot=snapshot,
+            build=build_model,
+            can_download_from_code_repository=can_download_from_code_repository,
+        )
         build_id = build_model.id if build_model else None
 
         code_reference = None

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -237,6 +237,7 @@ class Stack:
             secrets=stack_model.secrets,
             components=stack_components,
         )
+        stack.ensure_image_builder()
         _STACK_CACHE[key] = stack
 
         client = Client()
@@ -1314,25 +1315,14 @@ class Stack:
         self._validate_secrets(raise_exception=fail_if_secrets_missing)
 
     def validate_image_builder(self) -> None:
-        """Validates that the stack has an image builder if required.
-
-        If the stack requires an image builder, but none is specified, a
-        local image builder will be created and assigned to the stack to
-        ensure backwards compatibility.
-        """
-        requires_image_builder = (
-            self.orchestrator.flavor != "local"
-            or self.step_operator
-            or (self.model_deployer and self.model_deployer.flavor != "mlflow")
-        )
-        if requires_image_builder:
-            self.ensure_image_builder()
+        """Assign a temporary local image builder if none is configured."""
+        self.ensure_image_builder()
 
     def ensure_image_builder(self) -> None:
         """Assign a temporary local image builder if none is configured.
 
-        Building images (e.g. the deployer image at deploy time) requires an
-        image builder even when the stack's orchestrator is local.
+        Building images (e.g. the deployer image) requires an image builder
+        even when the stack's orchestrator is local.
         """
         skip_default_image_builder = handle_bool_env_var(
             ENV_ZENML_SKIP_IMAGE_BUILDER_DEFAULT, default=False

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -62,7 +62,6 @@ if TYPE_CHECKING:
     from zenml.config.step_run_info import StepRunInfo
     from zenml.container_registries import BaseContainerRegistry
     from zenml.data_validators import BaseDataValidator
-    from zenml.deployers import BaseDeployer
     from zenml.experiment_trackers.base_experiment_tracker import (
         BaseExperimentTracker,
     )
@@ -72,7 +71,6 @@ if TYPE_CHECKING:
     from zenml.model_deployers import BaseModelDeployer
     from zenml.model_registries import BaseModelRegistry
     from zenml.models import (
-        DeploymentResponse,
         PipelineRunResponse,
         PipelineSnapshotBase,
         PipelineSnapshotResponse,
@@ -122,7 +120,6 @@ class Stack:
         data_validator: Optional["BaseDataValidator"] = None,
         image_builder: Optional["BaseImageBuilder"] = None,
         model_registry: Optional["BaseModelRegistry"] = None,
-        deployer: Optional["BaseDeployer"] = None,
         log_store: Optional["BaseLogStore"] = None,
         sandbox: Optional[Union["BaseSandbox", List["BaseSandbox"]]] = None,
     ):
@@ -147,7 +144,6 @@ class Stack:
             data_validator: Data validator component of the stack.
             image_builder: Image builder component of the stack.
             model_registry: Model registry component of the stack.
-            deployer: Deployer component of the stack.
             log_store: Log store component of the stack.
             sandbox: Sandbox component(s) of the stack. Repeatable; a single
                 component or a list of components.
@@ -174,7 +170,6 @@ class Stack:
             data_validator,
             image_builder,
             model_registry,
-            deployer,
             log_store,
             sandbox,
         ]:
@@ -291,7 +286,6 @@ class Stack:
         from zenml.artifact_stores import BaseArtifactStore
         from zenml.container_registries import BaseContainerRegistry
         from zenml.data_validators import BaseDataValidator
-        from zenml.deployers import BaseDeployer
         from zenml.experiment_trackers import BaseExperimentTracker
         from zenml.feature_stores import BaseFeatureStore
         from zenml.image_builders import BaseImageBuilder
@@ -388,10 +382,6 @@ class Stack:
         ):
             _raise_type_error(model_registry, BaseModelRegistry)
 
-        deployer = components.get(StackComponentType.DEPLOYER)
-        if deployer is not None and not isinstance(deployer, BaseDeployer):
-            _raise_type_error(deployer, BaseDeployer)
-
         log_store = components.get(StackComponentType.LOG_STORE)
         if log_store is not None and not isinstance(log_store, BaseLogStore):
             _raise_type_error(log_store, BaseLogStore)
@@ -417,7 +407,6 @@ class Stack:
             data_validator=data_validator,
             image_builder=image_builder,
             model_registry=model_registry,
-            deployer=deployer,
             log_store=log_store,
             sandbox=sandbox,
         )
@@ -457,7 +446,6 @@ class Stack:
         from zenml.artifact_stores import BaseArtifactStore
         from zenml.container_registries import BaseContainerRegistry
         from zenml.data_validators import BaseDataValidator
-        from zenml.deployers import BaseDeployer
         from zenml.experiment_trackers import BaseExperimentTracker
         from zenml.feature_stores import BaseFeatureStore
         from zenml.image_builders import BaseImageBuilder
@@ -597,14 +585,6 @@ class Stack:
             if not isinstance(model_registry[0], BaseModelRegistry):
                 _raise_type_error(model_registry[0], BaseModelRegistry)
 
-        # Deployer
-        deployer = components.get(StackComponentType.DEPLOYER)
-        if deployer:
-            if len(deployer) > 1:
-                raise TypeError("Multiple deployers are not supported.")
-            if not isinstance(deployer[0], BaseDeployer):
-                _raise_type_error(deployer[0], BaseDeployer)
-
         # Log Store
         log_store = components.get(StackComponentType.LOG_STORE)
         if log_store:
@@ -671,9 +651,6 @@ class Stack:
             model_registry=cast(
                 Optional["BaseModelRegistry"],
                 model_registry[0] if model_registry else None,
-            ),
-            deployer=cast(
-                Optional["BaseDeployer"], deployer[0] if deployer else None
             ),
             log_store=cast(
                 Optional["BaseLogStore"], log_store[0] if log_store else None
@@ -1001,18 +978,6 @@ class Stack:
         return cast(
             "BaseModelRegistry",
             self._get_default_component(StackComponentType.MODEL_REGISTRY),
-        )
-
-    @property
-    def deployer(self) -> Optional["BaseDeployer"]:
-        """The deployer of the stack.
-
-        Returns:
-            The deployer of the stack.
-        """
-        return cast(
-            "BaseDeployer",
-            self._get_default_component(StackComponentType.DEPLOYER),
         )
 
     @property
@@ -1358,44 +1323,48 @@ class Stack:
         requires_image_builder = (
             self.orchestrator.flavor != "local"
             or self.step_operator
-            or self.deployer
             or (self.model_deployer and self.model_deployer.flavor != "mlflow")
         )
+        if requires_image_builder:
+            self.ensure_image_builder()
+
+    def ensure_image_builder(self) -> None:
+        """Assign a temporary local image builder if none is configured.
+
+        Building images (e.g. the deployer image at deploy time) requires an
+        image builder even when the stack's orchestrator is local.
+        """
         skip_default_image_builder = handle_bool_env_var(
             ENV_ZENML_SKIP_IMAGE_BUILDER_DEFAULT, default=False
         )
-        if (
-            requires_image_builder
-            and not skip_default_image_builder
-            and not self.image_builder
-        ):
-            from uuid import uuid4
+        if skip_default_image_builder or self.image_builder:
+            return
 
-            from zenml.image_builders import (
-                LocalImageBuilder,
-                LocalImageBuilderConfig,
-                LocalImageBuilderFlavor,
-            )
+        from uuid import uuid4
 
-            flavor = LocalImageBuilderFlavor()
+        from zenml.image_builders import (
+            LocalImageBuilder,
+            LocalImageBuilderConfig,
+            LocalImageBuilderFlavor,
+        )
 
-            now = utc_now()
-            image_builder = LocalImageBuilder(
-                id=uuid4(),
-                name="temporary_default",
-                flavor=flavor.name,
-                type=flavor.type,
-                config=LocalImageBuilderConfig(),
-                environment={},
-                user=Client().active_user.id,
-                created=now,
-                updated=now,
-                secrets=[],
-            )
+        flavor = LocalImageBuilderFlavor()
 
-            self._components[StackComponentType.IMAGE_BUILDER] = [
-                image_builder
-            ]
+        now = utc_now()
+        image_builder = LocalImageBuilder(
+            id=uuid4(),
+            name="temporary_default",
+            flavor=flavor.name,
+            type=flavor.type,
+            config=LocalImageBuilderConfig(),
+            environment={},
+            user=Client().active_user.id,
+            created=now,
+            updated=now,
+            secrets=[],
+        )
+
+        self._components[StackComponentType.IMAGE_BUILDER] = [image_builder]
 
     def validate_log_store(self) -> None:
         """Validates that the stack has a log store."""
@@ -1465,39 +1434,6 @@ class Stack:
         """
         self.orchestrator.run(
             snapshot=snapshot, stack=self, placeholder_run=placeholder_run
-        )
-
-    def deploy_pipeline(
-        self,
-        snapshot: "PipelineSnapshotResponse",
-        deployment_name: str,
-        timeout: Optional[int] = None,
-    ) -> "DeploymentResponse":
-        """Deploys a pipeline on this stack.
-
-        Args:
-            snapshot: The pipeline snapshot.
-            deployment_name: The name to use for the deployment.
-            timeout: The maximum time in seconds to wait for the pipeline to be
-                deployed.
-
-        Returns:
-            The deployment response.
-
-        Raises:
-            RuntimeError: If the stack does not have a deployer.
-        """
-        if not self.deployer:
-            raise RuntimeError(
-                "The stack does not have a deployer. Please add a "
-                "deployer to the stack in order to deploy a pipeline."
-            )
-
-        return self.deployer.provision_deployment(
-            snapshot=snapshot,
-            stack=self,
-            deployment_name_or_id=deployment_name,
-            timeout=timeout,
         )
 
     def _get_active_components_for_step(

--- a/src/zenml/zen_stores/migrations/versions/d7ebd154242a_detach_deployer_from_stack.py
+++ b/src/zenml/zen_stores/migrations/versions/d7ebd154242a_detach_deployer_from_stack.py
@@ -1,0 +1,67 @@
+"""detach deployer from stack [d7ebd154242a].
+
+Revision ID: d7ebd154242a
+Revises: c1d964b6075c
+Create Date: 2026-06-29 10:25:33.000930
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d7ebd154242a"
+down_revision = "c1d964b6075c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("build_id", sa.Uuid(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_deployment_build_id_pipeline_build",
+            "pipeline_build",
+            ["build_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    # Detach every deployer from every stack while keeping the deployer
+    # components themselves. Deployers are selected explicitly at deploy time
+    # and are no longer part of the stack aggregation.
+    connection = op.get_bind()
+
+    meta = sa.MetaData()
+    meta.reflect(
+        bind=connection,
+        only=("stack_component", "stack_composition"),
+    )
+
+    component_table = sa.Table("stack_component", meta)
+    composition_table = sa.Table("stack_composition", meta)
+
+    deployer_ids = connection.execute(
+        sa.select(component_table.c.id).where(
+            component_table.c.type == "deployer"
+        )
+    ).fetchall()
+
+    if deployer_ids:
+        connection.execute(
+            sa.delete(composition_table).where(
+                composition_table.c.component_id.in_(
+                    [row[0] for row in deployer_ids]
+                )
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("deployment", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_deployment_build_id_pipeline_build", type_="foreignkey"
+        )
+        batch_op.drop_column("build_id")

--- a/src/zenml/zen_stores/migrations/versions/d7ebd154242a_detach_deployer_from_stack.py
+++ b/src/zenml/zen_stores/migrations/versions/d7ebd154242a_detach_deployer_from_stack.py
@@ -18,16 +18,6 @@ depends_on = None
 
 def upgrade() -> None:
     """Upgrade database schema and/or data, creating a new revision."""
-    with op.batch_alter_table("deployment", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("build_id", sa.Uuid(), nullable=True))
-        batch_op.create_foreign_key(
-            "fk_deployment_build_id_pipeline_build",
-            "pipeline_build",
-            ["build_id"],
-            ["id"],
-            ondelete="SET NULL",
-        )
-
     # Detach every deployer from every stack while keeping the deployer
     # components themselves. Deployers are selected explicitly at deploy time
     # and are no longer part of the stack aggregation.
@@ -60,8 +50,5 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade database schema and/or data back to the previous revision."""
-    with op.batch_alter_table("deployment", schema=None) as batch_op:
-        batch_op.drop_constraint(
-            "fk_deployment_build_id_pipeline_build", type_="foreignkey"
-        )
-        batch_op.drop_column("build_id")
+    # The deployer-stack detachment is a data migration and is not reversed.
+    pass

--- a/src/zenml/zen_stores/schemas/deployment_schemas.py
+++ b/src/zenml/zen_stores/schemas/deployment_schemas.py
@@ -41,6 +41,7 @@ from zenml.models.v2.core.deployment import (
 from zenml.utils.time_utils import utc_now
 from zenml.zen_stores.schemas.base_schemas import NamedSchema
 from zenml.zen_stores.schemas.component_schemas import StackComponentSchema
+from zenml.zen_stores.schemas.pipeline_build_schemas import PipelineBuildSchema
 from zenml.zen_stores.schemas.pipeline_snapshot_schemas import (
     PipelineSnapshotSchema,
 )
@@ -130,6 +131,16 @@ class DeploymentSchema(NamedSchema, table=True):
     )
     deployer: Optional["StackComponentSchema"] = Relationship()
 
+    build_id: Optional[UUID] = build_foreign_key_field(
+        source=__tablename__,
+        target=PipelineBuildSchema.__tablename__,
+        source_column="build_id",
+        target_column="id",
+        ondelete="SET NULL",
+        nullable=True,
+    )
+    build: Optional["PipelineBuildSchema"] = Relationship()
+
     tags: List["TagSchema"] = Relationship(
         sa_relationship_kwargs=dict(
             primaryjoin=f"and_(foreign(TagResourceSchema.resource_type)=='{TaggableResourceTypes.DEPLOYMENT.value}', foreign(TagResourceSchema.resource_id)==DeploymentSchema.id)",
@@ -179,6 +190,7 @@ class DeploymentSchema(NamedSchema, table=True):
                 [
                     selectinload(jl_arg(DeploymentSchema.user)),
                     selectinload(jl_arg(DeploymentSchema.deployer)),
+                    selectinload(jl_arg(DeploymentSchema.build)),
                     selectinload(jl_arg(DeploymentSchema.snapshot)).joinedload(
                         jl_arg(PipelineSnapshotSchema.pipeline)
                     ),
@@ -241,6 +253,7 @@ class DeploymentSchema(NamedSchema, table=True):
                 tags=[tag.to_model() for tag in self.tags],
                 snapshot=self.snapshot.to_model() if self.snapshot else None,
                 deployer=self.deployer.to_model() if self.deployer else None,
+                build=self.build.to_model() if self.build else None,
                 pipeline=self.snapshot.pipeline.to_model()
                 if self.snapshot and self.snapshot.pipeline
                 else None,

--- a/src/zenml/zen_stores/schemas/deployment_schemas.py
+++ b/src/zenml/zen_stores/schemas/deployment_schemas.py
@@ -41,7 +41,6 @@ from zenml.models.v2.core.deployment import (
 from zenml.utils.time_utils import utc_now
 from zenml.zen_stores.schemas.base_schemas import NamedSchema
 from zenml.zen_stores.schemas.component_schemas import StackComponentSchema
-from zenml.zen_stores.schemas.pipeline_build_schemas import PipelineBuildSchema
 from zenml.zen_stores.schemas.pipeline_snapshot_schemas import (
     PipelineSnapshotSchema,
 )
@@ -131,16 +130,6 @@ class DeploymentSchema(NamedSchema, table=True):
     )
     deployer: Optional["StackComponentSchema"] = Relationship()
 
-    build_id: Optional[UUID] = build_foreign_key_field(
-        source=__tablename__,
-        target=PipelineBuildSchema.__tablename__,
-        source_column="build_id",
-        target_column="id",
-        ondelete="SET NULL",
-        nullable=True,
-    )
-    build: Optional["PipelineBuildSchema"] = Relationship()
-
     tags: List["TagSchema"] = Relationship(
         sa_relationship_kwargs=dict(
             primaryjoin=f"and_(foreign(TagResourceSchema.resource_type)=='{TaggableResourceTypes.DEPLOYMENT.value}', foreign(TagResourceSchema.resource_id)==DeploymentSchema.id)",
@@ -190,7 +179,6 @@ class DeploymentSchema(NamedSchema, table=True):
                 [
                     selectinload(jl_arg(DeploymentSchema.user)),
                     selectinload(jl_arg(DeploymentSchema.deployer)),
-                    selectinload(jl_arg(DeploymentSchema.build)),
                     selectinload(jl_arg(DeploymentSchema.snapshot)).joinedload(
                         jl_arg(PipelineSnapshotSchema.pipeline)
                     ),
@@ -253,7 +241,6 @@ class DeploymentSchema(NamedSchema, table=True):
                 tags=[tag.to_model() for tag in self.tags],
                 snapshot=self.snapshot.to_model() if self.snapshot else None,
                 deployer=self.deployer.to_model() if self.deployer else None,
-                build=self.build.to_model() if self.build else None,
                 pipeline=self.snapshot.pipeline.to_model()
                 if self.snapshot and self.snapshot.pipeline
                 else None,

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -521,17 +521,12 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
         Returns:
             The response.
         """
-        deployable = False
-        if self.build and self.stack and self.stack.has_deployer:
-            deployable = True
-
         body = PipelineSnapshotResponseBody(
             user_id=self.user_id,
             project_id=self.project_id,
             created=self.created,
             updated=self.updated,
             runnable=self.is_runnable,
-            deployable=deployable,
             is_dynamic=self.is_dynamic,
         )
         metadata = None

--- a/src/zenml/zen_stores/schemas/stack_schemas.py
+++ b/src/zenml/zen_stores/schemas/stack_schemas.py
@@ -20,9 +20,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy import UniqueConstraint
-from sqlalchemy.orm import joinedload, object_session
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.base import ExecutableOption
-from sqlmodel import Field, Relationship, SQLModel, select
+from sqlmodel import Field, Relationship, SQLModel
 
 from zenml.enums import SecretResourceTypes, StackComponentType
 from zenml.models import (
@@ -150,41 +150,6 @@ class StackSchema(NamedSchema, table=True):
             overlaps="secrets",
         ),
     )
-
-    @property
-    def has_deployer(self) -> bool:
-        """If the stack has a deployer component.
-
-        Returns:
-            If the stack has a deployer component.
-
-        Raises:
-            RuntimeError: if the stack has no DB session.
-        """
-        from zenml.zen_stores.schemas import (
-            StackComponentSchema,
-            StackCompositionSchema,
-        )
-
-        if session := object_session(self):
-            query = (
-                select(StackComponentSchema.id)
-                .where(
-                    StackComponentSchema.type
-                    == StackComponentType.DEPLOYER.value
-                )
-                .where(
-                    StackCompositionSchema.component_id
-                    == StackComponentSchema.id
-                )
-                .where(StackCompositionSchema.stack_id == self.id)
-            )
-
-            return session.execute(query).first() is not None
-        else:
-            raise RuntimeError(
-                "Missing DB session to check if stack has a deployer component."
-            )
 
     @classmethod
     def from_request(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -11219,7 +11219,8 @@ class SqlZenStore(BaseZenStore):
         """Create the default stack components and stack.
 
         The default stack contains a local orchestrator and a local artifact
-        store.
+        store. The `default` local deployer is also created as a standalone
+        component, but it is not part of the default stack.
 
         Returns:
             The model of the created default stack.
@@ -11240,10 +11241,14 @@ class SqlZenStore(BaseZenStore):
                 ),
             )
 
-            deployer = self.create_stack_component(
+            # The `default` deployer is created as a standalone, immutable
+            # component. It is selected explicitly at deploy time and is no
+            # longer part of the default stack, but it must always exist as the
+            # fallback for `BaseDeployer.get_deployer`.
+            self.create_stack_component(
                 # Use `DefaultComponentRequest` instead of
                 # `ComponentRequest` here to force the `create_stack_component`
-                # call to use `None` for the user, meaning the orchestrator
+                # call to use `None` for the user, meaning the deployer
                 # is owned by the server, which for RBAC indicates that
                 # everyone can read it
                 component=DefaultComponentRequest(
@@ -11269,8 +11274,7 @@ class SqlZenStore(BaseZenStore):
             )
 
             components = {
-                c.type: [c.id]
-                for c in [orchestrator, deployer, artifact_store]
+                c.type: [c.id] for c in [orchestrator, artifact_store]
             }
 
             # Use `DefaultStackRequest` instead of `StackRequest` here to force

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -646,7 +646,6 @@ def sample_snapshot_response_model(
             created=datetime.now(),
             updated=datetime.now(),
             runnable=True,
-            deployable=True,
             is_dynamic=False,
         ),
         metadata=PipelineSnapshotResponseMetadata(

--- a/tests/unit/deployers/test_containerized_deployer.py
+++ b/tests/unit/deployers/test_containerized_deployer.py
@@ -1,0 +1,49 @@
+#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the containerized deployer."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from zenml.constants import DEPLOYER_DOCKER_IMAGE_KEY
+from zenml.deployers.containerized_deployer import ContainerizedDeployer
+
+
+def test_get_image_reads_from_deployment_build():
+    """The deployer image is read from the build attached to the deployment."""
+    deployment = MagicMock()
+    deployment.build.images = {
+        DEPLOYER_DOCKER_IMAGE_KEY: MagicMock(image="my-deployer-image")
+    }
+
+    assert ContainerizedDeployer.get_image(deployment) == "my-deployer-image"
+
+
+def test_get_image_raises_without_build():
+    """get_image raises when the deployment has no build."""
+    deployment = MagicMock()
+    deployment.build = None
+
+    with pytest.raises(RuntimeError):
+        ContainerizedDeployer.get_image(deployment)
+
+
+def test_get_image_raises_without_deployer_image():
+    """get_image raises when the build has no deployer image."""
+    deployment = MagicMock()
+    deployment.build.images = {}
+
+    with pytest.raises(RuntimeError):
+        ContainerizedDeployer.get_image(deployment)

--- a/tests/unit/deployers/test_containerized_deployer.py
+++ b/tests/unit/deployers/test_containerized_deployer.py
@@ -17,8 +17,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from zenml.config import DockerSettings
+from zenml.config.build_configuration import BuildConfiguration
 from zenml.constants import DEPLOYER_DOCKER_IMAGE_KEY
 from zenml.deployers.containerized_deployer import ContainerizedDeployer
+from zenml.deployers.exceptions import DeployerError
 
 
 def test_get_image_reads_from_deployment_build():
@@ -47,3 +50,46 @@ def test_get_image_raises_without_deployer_image():
 
     with pytest.raises(RuntimeError):
         ContainerizedDeployer.get_image(deployment)
+
+
+def _deployer_builds(**docker_flags):
+    return [
+        BuildConfiguration(
+            key=DEPLOYER_DOCKER_IMAGE_KEY,
+            settings=DockerSettings(**docker_flags),
+        )
+    ]
+
+
+def test_prepare_build_refuses_bake_without_local_code():
+    """An existing snapshot that must bake code can't deploy without local code."""
+    deployer = MagicMock()
+    deployer.get_docker_builds.return_value = _deployer_builds(
+        allow_download_from_artifact_store=False,
+        allow_download_from_code_repository=False,
+        allow_including_files_in_images=True,
+    )
+    snapshot = MagicMock(code_path=None, code_reference=None)
+
+    with pytest.raises(DeployerError, match="no local code"):
+        ContainerizedDeployer._prepare_deployment_build(
+            deployer,
+            snapshot=snapshot,
+            stack=MagicMock(),
+            local_code_available=False,
+        )
+
+
+def test_prepare_build_refuses_code_free_image_without_code_source():
+    """A code-free deployer image needs the snapshot to carry downloadable code."""
+    deployer = MagicMock()
+    deployer.get_docker_builds.return_value = _deployer_builds()
+    snapshot = MagicMock(code_path=None, code_reference=None)
+
+    with pytest.raises(DeployerError, match="no code to download"):
+        ContainerizedDeployer._prepare_deployment_build(
+            deployer,
+            snapshot=snapshot,
+            stack=MagicMock(),
+            local_code_available=False,
+        )

--- a/tests/unit/deployers/test_containerized_deployer.py
+++ b/tests/unit/deployers/test_containerized_deployer.py
@@ -13,83 +13,115 @@
 #  permissions and limitations under the License.
 """Unit tests for the containerized deployer."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from zenml.config import DockerSettings
-from zenml.config.build_configuration import BuildConfiguration
 from zenml.constants import DEPLOYER_DOCKER_IMAGE_KEY
 from zenml.deployers.containerized_deployer import ContainerizedDeployer
 from zenml.deployers.exceptions import DeployerError
 
 
-def test_get_image_reads_from_deployment_build():
-    """The deployer image is read from the build attached to the deployment."""
-    deployment = MagicMock()
-    deployment.build.images = {
-        DEPLOYER_DOCKER_IMAGE_KEY: MagicMock(image="my-deployer-image")
-    }
+def _snapshot_with_image(image: str) -> MagicMock:
+    snapshot = MagicMock()
+    snapshot.build.images = {DEPLOYER_DOCKER_IMAGE_KEY: MagicMock(image=image)}
+    return snapshot
 
-    assert ContainerizedDeployer.get_image(deployment) == "my-deployer-image"
+
+def test_get_image_reads_from_snapshot_build():
+    """The serving image is read from the deployment's snapshot build."""
+    deployment = MagicMock()
+    snapshot = _snapshot_with_image("my-deployer-image")
+
+    with patch("zenml.client.Client") as mock_client:
+        mock_client.return_value.get_snapshot.return_value = snapshot
+        assert (
+            ContainerizedDeployer.get_image(deployment) == "my-deployer-image"
+        )
 
 
 def test_get_image_raises_without_build():
-    """get_image raises when the deployment has no build."""
+    """get_image raises when the snapshot has no build."""
     deployment = MagicMock()
-    deployment.build = None
+    snapshot = MagicMock()
+    snapshot.build = None
 
-    with pytest.raises(RuntimeError):
-        ContainerizedDeployer.get_image(deployment)
+    with patch("zenml.client.Client") as mock_client:
+        mock_client.return_value.get_snapshot.return_value = snapshot
+        with pytest.raises(RuntimeError):
+            ContainerizedDeployer.get_image(deployment)
 
 
 def test_get_image_raises_without_deployer_image():
     """get_image raises when the build has no deployer image."""
     deployment = MagicMock()
-    deployment.build.images = {}
+    snapshot = MagicMock()
+    snapshot.build.images = {}
 
-    with pytest.raises(RuntimeError):
-        ContainerizedDeployer.get_image(deployment)
-
-
-def _deployer_builds(**docker_flags):
-    return [
-        BuildConfiguration(
-            key=DEPLOYER_DOCKER_IMAGE_KEY,
-            settings=DockerSettings(**docker_flags),
-        )
-    ]
+    with patch("zenml.client.Client") as mock_client:
+        mock_client.return_value.get_snapshot.return_value = snapshot
+        with pytest.raises(RuntimeError):
+            ContainerizedDeployer.get_image(deployment)
 
 
-def test_prepare_build_refuses_bake_without_local_code():
-    """An existing snapshot that must bake code can't deploy without local code."""
+def _deployer_with_checksum(checksum: str) -> MagicMock:
+    build_config = MagicMock()
+    build_config.compute_settings_checksum.return_value = checksum
     deployer = MagicMock()
-    deployer.get_docker_builds.return_value = _deployer_builds(
-        allow_download_from_artifact_store=False,
-        allow_download_from_code_repository=False,
-        allow_including_files_in_images=True,
+    deployer.get_docker_builds.return_value = [build_config]
+    deployer.name = "docker"
+    return deployer
+
+
+def test_validate_skips_when_no_image_required():
+    """A deployer that needs no image accepts any snapshot."""
+    deployer = MagicMock()
+    deployer.get_docker_builds.return_value = []
+
+    assert (
+        ContainerizedDeployer._validate_snapshot_deployable(
+            deployer, snapshot=MagicMock(), stack=MagicMock()
+        )
+        is None
     )
-    snapshot = MagicMock(code_path=None, code_reference=None)
 
-    with pytest.raises(DeployerError, match="no local code"):
-        ContainerizedDeployer._prepare_deployment_build(
-            deployer,
-            snapshot=snapshot,
-            stack=MagicMock(),
-            local_code_available=False,
+
+def test_validate_rejects_snapshot_without_serving_image():
+    """A snapshot with no serving image is not deployable."""
+    deployer = _deployer_with_checksum("whatever")
+    snapshot = MagicMock(build=None)
+
+    with pytest.raises(
+        DeployerError, match="does not contain a serving image"
+    ):
+        ContainerizedDeployer._validate_snapshot_deployable(
+            deployer, snapshot=snapshot, stack=MagicMock()
         )
 
 
-def test_prepare_build_refuses_code_free_image_without_code_source():
-    """A code-free deployer image needs the snapshot to carry downloadable code."""
-    deployer = MagicMock()
-    deployer.get_docker_builds.return_value = _deployer_builds()
-    snapshot = MagicMock(code_path=None, code_reference=None)
+def test_validate_rejects_image_built_for_a_different_deployer():
+    """A serving image whose checksum differs is rejected."""
+    deployer = _deployer_with_checksum("expected")
+    snapshot = MagicMock(code_reference=None)
+    snapshot.build.images = {DEPLOYER_DOCKER_IMAGE_KEY: MagicMock()}
+    snapshot.build.get_settings_checksum.return_value = "different"
 
-    with pytest.raises(DeployerError, match="no code to download"):
-        ContainerizedDeployer._prepare_deployment_build(
-            deployer,
-            snapshot=snapshot,
-            stack=MagicMock(),
-            local_code_available=False,
+    with pytest.raises(DeployerError, match="not built for the deployer"):
+        ContainerizedDeployer._validate_snapshot_deployable(
+            deployer, snapshot=snapshot, stack=MagicMock()
         )
+
+
+def test_validate_accepts_matching_serving_image():
+    """A serving image whose checksum matches is accepted."""
+    deployer = _deployer_with_checksum("match")
+    snapshot = MagicMock(code_reference=None)
+    snapshot.build.images = {DEPLOYER_DOCKER_IMAGE_KEY: MagicMock()}
+    snapshot.build.get_settings_checksum.return_value = "match"
+
+    assert (
+        ContainerizedDeployer._validate_snapshot_deployable(
+            deployer, snapshot=snapshot, stack=MagicMock()
+        )
+        is None
+    )

--- a/tests/unit/stack/test_stack.py
+++ b/tests/unit/stack/test_stack.py
@@ -113,6 +113,30 @@ def test_stack_returns_all_its_components(
     )
 
 
+def test_stack_does_not_accept_or_return_a_deployer(
+    local_orchestrator, local_artifact_store
+):
+    """Tests that the deployer is no longer part of the stack aggregation."""
+    stack = Stack(
+        id=uuid4(),
+        name="",
+        orchestrator=local_orchestrator,
+        artifact_store=local_artifact_store,
+    )
+
+    assert not hasattr(stack, "deployer")
+    assert StackComponentType.DEPLOYER not in stack._components
+
+    with pytest.raises(TypeError):
+        Stack(
+            id=uuid4(),
+            name="",
+            orchestrator=local_orchestrator,
+            artifact_store=local_artifact_store,
+            deployer=local_orchestrator,
+        )
+
+
 def test_stack_requirements(stack_with_mock_components):
     """Tests that the stack returns the requirements of all its components."""
     stack_with_mock_components.orchestrator.requirements = {"one_requirement"}


### PR DESCRIPTION
### Implementation decisions:
- Images for a deployment are built at deploy time, from scratch. What this means:
  - Deploying from the server is not possible (wasn't previously possible, but now it is much harder to enable)
  - The build that already happened for a snapshot is not reused. In theory, we could start an image with the snapshot image as a base. We could also store the image built for a deployer in the snapshot build, and fetch it from there. Would need to be in a way that allows deploying the same snapshot multiple times though.

### Breaking changes
- `PipelineSnapshotResponse.is_deployable` has been removed