### PR TITLE
Fix configuration of docker credentials for building/pushing container images

### DIFF
--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -21,11 +21,6 @@ jobs:
         run: |
           BRANCH="${GITHUB_REF_NAME}"
           echo ::set-output name=VERSION::${BRANCH#release/}
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '14'
-      - run: npm install
-      - run: npm install html-minifier -g
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -60,13 +60,6 @@ rules:
       - validate-changelog.yml:37  # step output
       - notify-changelog.yml:27  # inputs.release_tag is workflow_dispatch input (authorized users only)
 
-  # Detect cache poisoning vulnerabilities
-  # Ignores: Low-confidence findings for protected publish workflows
-  cache-poisoning:
-    ignore:
-      - publish_api_docs.yml:24  # Protected release branch, docs only (setup-node caching)
-      - publish_api_docs.yml:27  # Protected release branch, docs only
-
   # Detect malformed conditionals
   unsound-condition: {}
 

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -96,6 +96,14 @@ install_zenml() {
     
     # install ZenML in editable mode
     uv pip install $PIP_ARGS $upgrade_args -e ".[server,otel,templates,terraform,secrets-aws,secrets-gcp,secrets-azure,secrets-hashicorp,s3fs,gcsfs,adlfs,dev,connectors-aws,connectors-gcp,connectors-azure,azureml,sagemaker,vertex]"
+
+    # `docstring_parser_fork` (required by pydoclint) ships under the same
+    # `docstring_parser/` namespace as the upstream `docstring-parser` package.
+    # Some integration dependencies pull in upstream `docstring-parser`, which
+    # then overwrites the fork's files on disk and breaks `pydoclint` with an
+    # `ImportError: cannot import name 'DocstringYields'`. Force-reinstall the
+    # fork last so its files win the namespace collision.
+    uv pip install $PIP_ARGS --force-reinstall --no-deps "docstring_parser_fork"
     
     echo "✅ ZenML installation completed"
 }

--- a/src/zenml/container_engines/base.py
+++ b/src/zenml/container_engines/base.py
@@ -72,20 +72,24 @@ class ContainerEngine(ABC):
         """
 
     def login_registry(
-        self, container_registry: "BaseContainerRegistry"
+        self, container_registry: "BaseContainerRegistry", **kwargs: Any
     ) -> None:
         """Authenticate the container engine with the container registry credentials.
 
         Args:
             container_registry: Container registry to authenticate with.
+            kwargs: Additional keyword arguments.
         """
         credentials = container_registry.credentials
         if credentials:
             username, password = credentials
+            registry_uri = container_registry.config.uri
+            base_registry_uri = registry_uri.split("/")[0]
             self.login(
                 username=username,
                 password=password,
-                registry=container_registry.config.uri,
+                registry=base_registry_uri,
+                **kwargs,
             )
 
     @abstractmethod

--- a/src/zenml/container_engines/docker_engine.py
+++ b/src/zenml/container_engines/docker_engine.py
@@ -238,6 +238,7 @@ class DockerContainerEngine(ContainerEngine):
         username: str,
         password: str,
         registry: str,
+        **kwargs: Any,
     ) -> None:
         """Authenticate the Docker client with the container registry credentials.
 
@@ -245,17 +246,20 @@ class DockerContainerEngine(ContainerEngine):
             username: Registry username.
             password: Registry password or token.
             registry: Registry host or URI.
+            **kwargs: Additional keyword arguments.
         """
-        self.login_client(
-            username=username,
-            password=password,
-            registry=registry,
-        )
-        self.login_cli(
-            username=username,
-            password=password,
-            registry=registry,
-        )
+        if kwargs.get("use_subprocess", False):
+            self.login_cli(
+                username=username,
+                password=password,
+                registry=registry,
+            )
+        else:
+            self.login_client(
+                username=username,
+                password=password,
+                registry=registry,
+            )
 
     def build(
         self,
@@ -278,7 +282,7 @@ class DockerContainerEngine(ContainerEngine):
             None
         """
         if container_registry:
-            self.login_registry(container_registry)
+            self.login_registry(container_registry, **kwargs)
 
         if kwargs.get("use_subprocess", False):
             self._build_cli(image_name, build_context, docker_build_options)
@@ -365,7 +369,6 @@ class DockerContainerEngine(ContainerEngine):
         ):
             self.login_registry(container_registry)
             container_registry.prepare_image_push(image_name)
-
         logger.info("Pushing Docker image `%s`.", image_name)
         output_stream = self.client.images.push(image_name, stream=True)
         aux_info = self.process_docker_stream(output_stream)

--- a/src/zenml/container_engines/docker_engine.py
+++ b/src/zenml/container_engines/docker_engine.py
@@ -254,12 +254,12 @@ class DockerContainerEngine(ContainerEngine):
                 password=password,
                 registry=registry,
             )
-        else:
-            self.login_client(
-                username=username,
-                password=password,
-                registry=registry,
-            )
+
+        self.login_client(
+            username=username,
+            password=password,
+            registry=registry,
+        )
 
     def build(
         self,


### PR DESCRIPTION
## Describe changes

Fixes https://github.com/zenml-io/zenml-jetbrains/issues/50

This PR addresses a couple of things related to how zenml configures credentials for Docker as part of the process of building and pushing container images:

1. configuring credentials for the docker python client was done incorrectly. The URL extracted from the container registry used in combination with username/password credentials was never actually used by the python client because of a registry URI mismatch. For example:

* the registry URI expected by the docker python client (hostname only, similar to the one used by the local docker CLI/SDK): ` europe-west3-docker.pkg.dev`
* the actual URI configured for the python client via `self.client.login` in the `DockerContainerEngine` class contained the entire repository path: `europe-west3-docker.pkg.dev/zenml-core/zenml-f0a1916fb0ad/zenml:super_simple_pipeline-orchestrator`

This caused the docker python client to completely ignore the configured credentials and rely on those lifted from the local docker SDK configuration. In the past, this lead to all sorts of problems involving expired, missing or incorrect credentials, which is why we decided a long time ago to always configure the local docker CLI/SDK credentials at the same time as the python client (see point 2).

2. the local docker CLI/SDK credentials are always configured in addition to those for the python client. This can overwrite the credentials that the user stored there previously. It is also completely unnecessary unless the "use_subprocess" option is used in the local image builder.

The solutions to these issues are:

1. using the proper hostname when configuring credentials for the docker python client.
2. stop configuring credentials for the local docker CLI/SDK unless absolutely necessary (i.e. only when the "use_subprocess" option is set).


## Side changes

* fix the zenml development install script to include the `docstring_parser_fork` fix even if no integrations are installed
* remove unused `npm install html-minifier` from github actions to address zizmor vulnerability

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

