### PR TITLE
Enforce admin-only permissions for service account management in non-RBAC deployments

### DIFF
--- a/src/zenml/zen_server/routers/service_accounts_endpoints.py
+++ b/src/zenml/zen_server/routers/service_accounts_endpoints.py
@@ -55,6 +55,7 @@ from zenml.zen_server.rbac.utils import (
 from zenml.zen_server.utils import (
     async_fastapi_endpoint_wrapper,
     make_dependable,
+    verify_admin_status_if_no_rbac,
     zen_store,
 )
 
@@ -97,17 +98,21 @@ def _raise_deprecated_pro_service_accounts() -> None:
 @async_fastapi_endpoint_wrapper
 def create_service_account(
     service_account: ServiceAccountRequest,
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> ServiceAccountResponse:
     """Creates a service account.
 
     Args:
         service_account: Service account to create.
+        auth_context: The authentication context.
 
     Returns:
         The created service account.
     """
     _raise_deprecated_pro_service_accounts()
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "create service account"
+    )
     return verify_permissions_and_create_entity(
         request_model=service_account,
         create_method=zen_store().create_service_account,
@@ -184,13 +189,14 @@ def list_service_accounts(
 def update_service_account(
     service_account_name_or_id: Union[str, UUID],
     service_account_update: ServiceAccountUpdate,
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> ServiceAccountResponse:
     """Updates a specific service account.
 
     Args:
         service_account_name_or_id: Name or ID of the service account.
         service_account_update: the service account to use for the update.
+        auth_context: The authentication context.
 
     Returns:
         The updated service account.
@@ -209,6 +215,9 @@ def update_service_account(
             "be updated."
         )
 
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "update service account"
+    )
     verify_permission_for_model(service_account, action=Action.UPDATE)
 
     return zen_store().update_service_account(
@@ -223,12 +232,13 @@ def update_service_account(
 @async_fastapi_endpoint_wrapper
 def delete_service_account(
     service_account_name_or_id: Union[str, UUID],
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> None:
     """Delete a specific service account.
 
     Args:
         service_account_name_or_id: Name or ID of the service account.
+        auth_context: The authentication context.
 
     Raises:
         IllegalOperationError: If the service account was created via external
@@ -243,6 +253,9 @@ def delete_service_account(
             "be deleted."
         )
 
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "delete service account"
+    )
     verify_permission_for_model(service_account, action=Action.DELETE)
 
     zen_store().delete_service_account(service_account_name_or_id)
@@ -263,7 +276,7 @@ def delete_service_account(
 def create_api_key(
     service_account_id: UUID,
     api_key: APIKeyRequest,
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> APIKeyResponse:
     """Creates an API key for a service account.
 
@@ -271,6 +284,7 @@ def create_api_key(
         service_account_id: ID of the service account for which to create the
             API key.
         api_key: API key to create.
+        auth_context: The authentication context.
 
     Returns:
         The created API key.
@@ -297,6 +311,9 @@ def create_api_key(
             "have associated API keys."
         )
 
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "create API key"
+    )
     return verify_permissions_and_create_entity(
         request_model=api_key,
         create_method=create_api_key_wrapper,
@@ -380,7 +397,7 @@ def update_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
     api_key_update: APIKeyUpdate,
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> APIKeyResponse:
     """Updates an API key for a service account.
 
@@ -389,6 +406,7 @@ def update_api_key(
             belongs.
         api_key_name_or_id: Name or ID of the API key to update.
         api_key_update: API key update.
+        auth_context: The authentication context.
 
     Returns:
         The updated API key.
@@ -406,6 +424,9 @@ def update_api_key(
             "have associated API keys."
         )
 
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "update API key"
+    )
     verify_permission_for_model(service_account, action=Action.UPDATE)
     return zen_store().update_api_key(
         service_account_id=service_account_id,
@@ -426,7 +447,7 @@ def rotate_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
     rotate_request: APIKeyRotateRequest,
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> APIKeyResponse:
     """Rotate an API key.
 
@@ -435,6 +456,7 @@ def rotate_api_key(
             belongs.
         api_key_name_or_id: Name or ID of the API key to rotate.
         rotate_request: API key rotation request.
+        auth_context: The authentication context.
 
     Returns:
         The updated API key.
@@ -452,6 +474,9 @@ def rotate_api_key(
             "have associated API keys."
         )
 
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "rotate API key"
+    )
     verify_permission_for_model(service_account, action=Action.UPDATE)
     return zen_store().rotate_api_key(
         service_account_id=service_account_id,
@@ -468,7 +493,7 @@ def rotate_api_key(
 def delete_api_key(
     service_account_id: UUID,
     api_key_name_or_id: Union[str, UUID],
-    _: AuthContext = Security(authorize),
+    auth_context: AuthContext = Security(authorize),
 ) -> None:
     """Deletes an API key.
 
@@ -476,8 +501,12 @@ def delete_api_key(
         service_account_id: ID of the service account to which the API key
             belongs.
         api_key_name_or_id: Name or ID of the API key to delete.
+        auth_context: The authentication context.
     """
     service_account = zen_store().get_service_account(service_account_id)
+    verify_admin_status_if_no_rbac(
+        auth_context.user.is_admin, "delete API key"
+    )
     verify_permission_for_model(service_account, action=Action.UPDATE)
     zen_store().delete_api_key(
         service_account_id=service_account_id,

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -667,6 +667,96 @@ class TestAdminUser:
                 user = zen_store.get_user(test_user.id)
                 assert not user.is_admin
 
+    def test_service_account_mutations_require_admin_without_rbac(self):
+        """Tests service account mutations as an admin and as a non-admin."""
+        if Client().zen_store.type == StoreType.SQL:
+            pytest.skip("SQL ZenStore does not support admin users.")
+
+        zen_store: RestZenStore = Client().zen_store
+        service_account = zen_store.create_service_account(
+            ServiceAccountRequest(
+                name=sample_name("admin_only_service_account"),
+                active=True,
+            )
+        )
+        api_key = zen_store.create_api_key(
+            service_account_id=service_account.id,
+            api_key=APIKeyRequest(name=sample_name("admin_only_api_key")),
+        )
+
+        try:
+            with UserContext(
+                password=self.default_pwd, is_admin=False
+            ) as test_user:
+                with LoginContext(
+                    user_name=test_user.name, password=self.default_pwd
+                ):
+                    non_admin_store: RestZenStore = Client().zen_store
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.create_service_account(
+                            ServiceAccountRequest(
+                                name=sample_name("denied_service_account"),
+                                active=True,
+                            )
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.update_service_account(
+                            service_account_name_or_id=service_account.id,
+                            service_account_update=ServiceAccountUpdate(
+                                description="Non-admin update should fail.",
+                            ),
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.delete_service_account(
+                            service_account.id
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.create_api_key(
+                            service_account_id=service_account.id,
+                            api_key=APIKeyRequest(
+                                name=sample_name("denied_api_key")
+                            ),
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.update_api_key(
+                            service_account_id=service_account.id,
+                            api_key_name_or_id=api_key.id,
+                            api_key_update=APIKeyUpdate(
+                                description="Non-admin update should fail.",
+                            ),
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.rotate_api_key(
+                            service_account_id=service_account.id,
+                            api_key_name_or_id=api_key.id,
+                            rotate_request=APIKeyRotateRequest(),
+                        )
+
+                    with pytest.raises(IllegalOperationError):
+                        non_admin_store.delete_api_key(
+                            service_account_id=service_account.id,
+                            api_key_name_or_id=api_key.id,
+                        )
+        finally:
+            try:
+                zen_store.delete_api_key(
+                    service_account_id=service_account.id,
+                    api_key_name_or_id=api_key.id,
+                )
+            except KeyError:
+                pass
+
+            try:
+                zen_store.delete_service_account(service_account.id)
+            except (KeyError, IllegalOperationError):
+                pass
+
 
 def test_active_user():
     """Tests the active user can be queried with .get_user()."""
@@ -2184,7 +2274,16 @@ def test_login_inactive_api_key():
             active_user = new_zen_store.get_user()
             assert active_user.id == service_account.id
 
-            new_zen_store.update_api_key(
+            with pytest.raises(IllegalOperationError):
+                new_zen_store.update_api_key(
+                    service_account_id=service_account.id,
+                    api_key_name_or_id=api_key.id,
+                    api_key_update=APIKeyUpdate(
+                        active=False,
+                    ),
+                )
+
+            zen_store.update_api_key(
                 service_account_id=service_account.id,
                 api_key_name_or_id=api_key.id,
                 api_key_update=APIKeyUpdate(
@@ -2255,7 +2354,15 @@ def test_login_inactive_service_account():
             active_user = new_zen_store.get_user()
             assert active_user.id == service_account.id
 
-            new_zen_store.update_service_account(
+            with pytest.raises(IllegalOperationError):
+                new_zen_store.update_service_account(
+                    service_account_name_or_id=service_account.id,
+                    service_account_update=ServiceAccountUpdate(
+                        active=False,
+                    ),
+                )
+
+            zen_store.update_service_account(
                 service_account_name_or_id=service_account.id,
                 service_account_update=ServiceAccountUpdate(
                     active=False,
@@ -2315,7 +2422,13 @@ def test_login_deleted_api_key():
             active_user = new_zen_store.get_user()
             assert active_user.id == service_account.id
 
-            new_zen_store.delete_api_key(
+            with pytest.raises(IllegalOperationError):
+                new_zen_store.delete_api_key(
+                    service_account_id=service_account.id,
+                    api_key_name_or_id=api_key.id,
+                )
+
+            zen_store.delete_api_key(
                 service_account_id=service_account.id,
                 api_key_name_or_id=api_key.id,
             )
@@ -2374,14 +2487,21 @@ def test_login_rotate_api_key():
         with LoginContext(api_key=rotated_api_key.key):
             new_zen_store = Client().zen_store
 
-            new_zen_store.rotate_api_key(
+            with pytest.raises(IllegalOperationError):
+                new_zen_store.rotate_api_key(
+                    service_account_id=service_account.id,
+                    api_key_name_or_id=api_key.id,
+                    rotate_request=APIKeyRotateRequest(),
+                )
+
+            zen_store.rotate_api_key(
                 service_account_id=service_account.id,
                 api_key_name_or_id=api_key.id,
                 rotate_request=APIKeyRotateRequest(),
             )
 
-            active_user = new_zen_store.get_user()
-            assert active_user.id == service_account.id
+            with pytest.raises(AuthorizationException):
+                new_zen_store.get_user()
 
 
 def test_login_rotate_api_key_retain_period():


### PR DESCRIPTION
## Describe changes
In non-RBAC enabled server deployments, we already have admin-only authorization guards for user-management (e.g. creating new user accounts, fetching other user accounts, deleting them). The same level of protection doesn't extend to service account management, allowing non-privileged users to create new long-lived account identities.

This PR fixes the same authorization class asymmetry by introducing similar guardrails in all service account and API key related endpoints.

## Breaking changes

Non-privileged user accounts in open-source ZenML server deployments without RBAC enabled will lose access to the service accounts and API keys they may have created in the past. Only admin accounts are allowed to manage them going forward. 

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

