### PR TITLE
Validate custom flavors at loading time

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -2568,9 +2568,9 @@ class Client(metaclass=ClientMetaClass):
         """
         from zenml.stack.flavor import validate_flavor_source
 
-        flavor = validate_flavor_source(
+        _, flavor = validate_flavor_source(
             source=source, component_type=component_type
-        )()
+        )
 
         if len(flavor.config_schema) > TEXT_FIELD_MAX_LENGTH:
             raise ValueError(

--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -149,6 +149,7 @@ class Flavor:
             _, flavor = validate_flavor_source(
                 source=flavor_model.source,
                 component_type=flavor_model.type,
+                validate_component_classes=False,
             )
         except (TypeError, ValueError) as err:
             if flavor_model.is_custom:
@@ -272,12 +273,15 @@ class Flavor:
 def validate_flavor_source(
     source: str,
     component_type: StackComponentType,
+    validate_component_classes: bool = True,
 ) -> Tuple[Type["Flavor"], "Flavor"]:
     """Import and instantiate a Flavor class from a source path.
 
     Args:
         source: source path of the implementation
         component_type: the type of the stack component
+        validate_component_classes: whether to validate the flavor's
+            implementation and config classes.
 
     Returns:
         the imported flavor class and an instance of it.
@@ -315,6 +319,14 @@ def validate_flavor_source(
             f"instantiated: {e}"
         ) from e
 
+    if flavor.type != component_type:  # noqa
+        raise TypeError(
+            f"The source points to a {flavor.type}, not a {component_type}."
+        )
+
+    if not validate_component_classes:
+        return flavor_class, flavor
+
     try:
         impl_class = flavor.implementation_class
     except (ModuleNotFoundError, ImportError, NotImplementedError) as e:
@@ -327,12 +339,6 @@ def validate_flavor_source(
         raise TypeError(
             f"The implementation class '{impl_class.__name__}' of a flavor "
             f"needs to be a subclass of the ZenML StackComponent."
-        )
-
-    if flavor.type != component_type:  # noqa
-        raise TypeError(
-            f"The source points to a {impl_class.type}, not a "  # noqa
-            f"{component_type}."
         )
 
     try:

--- a/src/zenml/stack/flavor.py
+++ b/src/zenml/stack/flavor.py
@@ -15,7 +15,7 @@
 
 import os
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Type, cast
+from typing import Any, Dict, Optional, Tuple, Type
 
 from zenml.enums import StackComponentType
 from zenml.exceptions import CustomFlavorImportError
@@ -146,10 +146,13 @@ class Flavor:
             The loaded flavor.
         """
         try:
-            flavor = source_utils.load(flavor_model.source)()
-        except (ModuleNotFoundError, ImportError, NotImplementedError) as err:
+            _, flavor = validate_flavor_source(
+                source=flavor_model.source,
+                component_type=flavor_model.type,
+            )
+        except (TypeError, ValueError) as err:
             if flavor_model.is_custom:
-                flavor_module, _ = flavor_model.source.rsplit(".", maxsplit=1)
+                flavor_module, _, _ = flavor_model.source.rpartition(".")
                 expected_file_path = os.path.join(
                     source_utils.get_source_root(),
                     flavor_module.replace(".", os.path.sep),
@@ -161,12 +164,12 @@ class Flavor:
                     "a library, make sure it is installed. If "
                     "it is a local code file, make sure it exists at "
                     f"`{expected_file_path}.py`."
-                )
+                ) from err
             else:
                 raise ImportError(
                     f"Couldn't import flavor {flavor_model.name}: {err}"
-                )
-        return cast(Flavor, flavor)
+                ) from err
+        return flavor
 
     def to_model(
         self,
@@ -267,16 +270,17 @@ class Flavor:
 
 
 def validate_flavor_source(
-    source: str, component_type: StackComponentType
-) -> Type["Flavor"]:
-    """Import a StackComponent class from a given source and validate its type.
+    source: str,
+    component_type: StackComponentType,
+) -> Tuple[Type["Flavor"], "Flavor"]:
+    """Import and instantiate a Flavor class from a source path.
 
     Args:
         source: source path of the implementation
         component_type: the type of the stack component
 
     Returns:
-        the imported class
+        the imported flavor class and an instance of it.
 
     Raises:
         ValueError: If ZenML cannot find the given module path
@@ -287,14 +291,13 @@ def validate_flavor_source(
         StackComponent,
         StackComponentConfig,
     )
-    from zenml.utils import source_utils
 
     try:
         flavor_class = source_utils.load(source)
     except (ValueError, AttributeError, ImportError) as e:
         raise ValueError(
             f"ZenML can not import the flavor class '{source}': {e}"
-        )
+        ) from e
 
     if not (
         isinstance(flavor_class, type) and issubclass(flavor_class, Flavor)
@@ -304,14 +307,21 @@ def validate_flavor_source(
             f"Flavor."
         )
 
-    flavor = flavor_class()
+    try:
+        flavor = flavor_class()
+    except (ModuleNotFoundError, ImportError, NotImplementedError) as e:
+        raise ValueError(
+            f"The flavor class '{flavor_class.__name__}' can not be "
+            f"instantiated: {e}"
+        ) from e
+
     try:
         impl_class = flavor.implementation_class
     except (ModuleNotFoundError, ImportError, NotImplementedError) as e:
         raise ValueError(
             f"The implementation class defined within the "
             f"'{flavor_class.__name__}' can not be imported: {e}"
-        )
+        ) from e
 
     if not issubclass(impl_class, StackComponent):
         raise TypeError(
@@ -331,7 +341,7 @@ def validate_flavor_source(
         raise ValueError(
             f"The config class defined within the "
             f"'{flavor_class.__name__}' can not be imported: {e}"
-        )
+        ) from e
 
     if not issubclass(conf_class, StackComponentConfig):
         raise TypeError(
@@ -339,4 +349,4 @@ def validate_flavor_source(
             f"needs to be a subclass of the ZenML StackComponentConfig."
         )
 
-    return flavor_class
+    return flavor_class, flavor

--- a/tests/unit/test_flavor.py
+++ b/tests/unit/test_flavor.py
@@ -70,6 +70,20 @@ class AriaOrchestratorFlavor(BaseOrchestratorFlavor):
         return self.generate_default_docs_url()
 
 
+class MissingImplementationFlavor(BaseOrchestratorFlavor):
+    @property
+    def name(self) -> str:
+        return "missing_implementation"
+
+    @property
+    def config_class(self) -> Type[AriaOrchestratorConfig]:
+        return AriaOrchestratorConfig
+
+    @property
+    def implementation_class(self) -> Type["LocalOrchestrator"]:
+        raise ImportError("No module named 'missing_dependency'")
+
+
 _ZERO_ARG_CALLABLE_WAS_CALLED = False
 
 
@@ -165,4 +179,22 @@ def test_flavor_from_model_raises_custom_import_error():
     with pytest.raises(CustomFlavorImportError):
         Flavor.from_model(
             _flavor_response(source="not_a_real_module.NotARealFlavor")
+        )
+
+
+def test_flavor_from_model_skips_implementation_class_validation():
+    """Tests that flavor hydration does not require optional dependencies."""
+    flavor = Flavor.from_model(
+        _flavor_response(source=f"{__name__}.MissingImplementationFlavor")
+    )
+
+    assert isinstance(flavor, MissingImplementationFlavor)
+
+
+def test_validate_flavor_source_validates_implementation_class_by_default():
+    """Tests that explicit flavor source validation still validates classes."""
+    with pytest.raises(ValueError, match="missing_dependency"):
+        validate_flavor_source(
+            source=f"{__name__}.MissingImplementationFlavor",
+            component_type=StackComponentType.ORCHESTRATOR,
         )

--- a/tests/unit/test_flavor.py
+++ b/tests/unit/test_flavor.py
@@ -11,14 +11,26 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+from datetime import datetime
 from typing import Optional, Type
+from uuid import uuid4
+
+import pytest
 
 from zenml import __version__ as zenml_version
+from zenml.enums import StackComponentType
+from zenml.exceptions import CustomFlavorImportError
+from zenml.models import (
+    FlavorResponse,
+    FlavorResponseBody,
+    FlavorResponseMetadata,
+)
 from zenml.orchestrators.base_orchestrator import (
     BaseOrchestratorConfig,
     BaseOrchestratorFlavor,
 )
 from zenml.orchestrators.local.local_orchestrator import LocalOrchestrator
+from zenml.stack.flavor import Flavor, validate_flavor_source
 
 
 class AriaOrchestratorConfig(BaseOrchestratorConfig):
@@ -58,6 +70,43 @@ class AriaOrchestratorFlavor(BaseOrchestratorFlavor):
         return self.generate_default_docs_url()
 
 
+_ZERO_ARG_CALLABLE_WAS_CALLED = False
+
+
+def _zero_arg_callable() -> AriaOrchestratorFlavor:
+    global _ZERO_ARG_CALLABLE_WAS_CALLED
+    _ZERO_ARG_CALLABLE_WAS_CALLED = True
+    return AriaOrchestratorFlavor()
+
+
+def _flavor_response(source: str, is_custom: bool = True) -> FlavorResponse:
+    now = datetime.utcnow()
+    return FlavorResponse(
+        id=uuid4(),
+        name="aria",
+        body=FlavorResponseBody(
+            user_id=uuid4(),
+            type=StackComponentType.ORCHESTRATOR,
+            display_name="Aria",
+            integration=None,
+            source=source,
+            logo_url=None,
+            is_custom=is_custom,
+            created=now,
+            updated=now,
+        ),
+        metadata=FlavorResponseMetadata(
+            config_schema={},
+            connector_type=None,
+            connector_resource_type=None,
+            connector_resource_id_attr=None,
+            docs_url=None,
+            sdk_docs_url=None,
+        ),
+        resources=None,
+    )
+
+
 def test_sdk_docs_url():
     """Tests that SDK Docs URLs are correct."""
     assert AriaOrchestratorFlavor().sdk_docs_url == (
@@ -85,3 +134,35 @@ def test_integration_sdk_docs_url():
         f"#zenml.integrations.kubernetes.flavors.KubernetesOrchestratorConfig"
     )
     assert flavor.sdk_docs_url == expected_url
+
+
+def test_validate_flavor_source_returns_class_and_instance():
+    """Tests that flavor validation returns both the class and an instance."""
+    flavor_class, flavor = validate_flavor_source(
+        source=f"{__name__}.AriaOrchestratorFlavor",
+        component_type=StackComponentType.ORCHESTRATOR,
+    )
+
+    assert flavor_class is AriaOrchestratorFlavor
+    assert isinstance(flavor, AriaOrchestratorFlavor)
+
+
+def test_flavor_from_model_does_not_call_non_flavor_source():
+    """Tests that flavor hydration rejects callables without invoking them."""
+    global _ZERO_ARG_CALLABLE_WAS_CALLED
+    _ZERO_ARG_CALLABLE_WAS_CALLED = False
+
+    with pytest.raises(CustomFlavorImportError):
+        Flavor.from_model(
+            _flavor_response(source=f"{__name__}._zero_arg_callable")
+        )
+
+    assert _ZERO_ARG_CALLABLE_WAS_CALLED is False
+
+
+def test_flavor_from_model_raises_custom_import_error():
+    """Tests that custom flavor import errors are raised during validation."""
+    with pytest.raises(CustomFlavorImportError):
+        Flavor.from_model(
+            _flavor_response(source="not_a_real_module.NotARealFlavor")
+        )


### PR DESCRIPTION
## Describe changes

Fixes unsafe flavor hydration by validating flavor sources before instantiating them.

`Flavor.from_model()` now uses `validate_flavor_source()` instead of directly calling `source_utils.load(... )()`. This ensures the resolved source points to a `Flavor` subclass before instantiation, preventing arbitrary zero-argument callables from being invoked during server-side hydration.

Previously, `Flavor.from_model()` loaded and immediately called the source stored in a flavor model. A crafted flavor source could point to any importable zero-argument callable, causing it to be invoked during stack component hydration. This change validates the loaded object first and only instantiates valid ZenML flavor classes.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

