### PR TITLE
Add dependency audit release waivers

### DIFF
--- a/.github/dependency-audit-waivers.json
+++ b/.github/dependency-audit-waivers.json
@@ -1,0 +1,18 @@
+{
+  "waivers": [
+    {
+      "package": "starlette",
+      "advisories": [
+        "CVE-2026-48818",
+        "GHSA-wqp7-x3pw-xc5r",
+        "PYSEC-2026-249",
+        "CVE-2026-54283",
+        "GHSA-82w8-qh3p-5jfq"
+      ],
+      "allowed_contexts": ["release-pr"],
+      "expires_on": "2026-07-31",
+      "owner": "server-team",
+      "reason": "Starlette fixes require a FastAPI range bump. FastAPI upgrades affect ZenML server compatibility and need a dedicated test plan outside release prep."
+    }
+  ]
+}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -6,12 +6,15 @@ on:
     paths:
       - pyproject.toml
       - scripts/dependency_audit_severity_gate.py
+      - .github/dependency-audit-waivers.json
       - .github/workflows/dependency-audit.yml
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main, develop]
     paths:
       - pyproject.toml
       - scripts/dependency_audit_severity_gate.py
+      - .github/dependency-audit-waivers.json
       - .github/workflows/dependency-audit.yml
   # Weekly safety net to catch newly disclosed vulnerabilities
   schedule:
@@ -34,9 +37,12 @@ jobs:
     outputs:
       audit_error: ${{ steps.classify.outputs.audit_error }}
       blocking_count: ${{ steps.classify.outputs.blocking_count }}
+      waived_blocking_count: ${{ steps.classify.outputs.waived_blocking_count }}
       nonblocking_count: ${{ steps.classify.outputs.nonblocking_count }}
       unknown_count: ${{ steps.classify.outputs.unknown_count }}
+      has_waived_blocking: ${{ steps.classify.outputs.has_waived_blocking }}
       has_nonblocking: ${{ steps.classify.outputs.has_nonblocking }}
+      waiver_context: ${{ steps.waiver-context.outputs.waiver_context }}
     env:
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
@@ -72,6 +78,22 @@ jobs:
           # zenml removes only its own dist-info and leaves every dependency
           # installed, so the audit still covers the full dependency set.
           uv pip uninstall --python .venv-audit-target/bin/python zenml
+      - name: Determine dependency audit waiver context
+        id: waiver-context
+        run: |
+          if [[ "$IS_RELEASE_PR" == "true" ]]; then
+            echo "waiver_context=release-pr" >> "$GITHUB_OUTPUT"
+          else
+            echo "waiver_context=" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          IS_RELEASE_PR: >-
+            ${{
+              github.event_name == 'pull_request' &&
+              startsWith(github.head_ref, 'misc/prepare-release-') &&
+              contains(github.event.pull_request.labels.*.name, 'release') &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            }}
       - name: Audit installed dependencies with pip-audit
         id: pip-audit
         run: |
@@ -99,11 +121,15 @@ jobs:
             --classified-json dependency-audit-reports/classified.json \
             --summary-md dependency-audit-reports/summary.md \
             --nonblocking-issue-md dependency-audit-reports/nonblocking-issue.md \
+            --waivers-json .github/dependency-audit-waivers.json \
+            --waiver-context "$WAIVER_CONTEXT" \
+            --waived-discord-md dependency-audit-reports/waived-discord.md \
             --github-output "$GITHUB_OUTPUT" \
             --github-token "$ADVISORY_GITHUB_TOKEN"
         env:
           ADVISORY_GITHUB_TOKEN: ${{ github.event_name != 'pull_request' && github.token || '' }}
           PIP_AUDIT_EXIT_CODE: ${{ steps.pip-audit.outputs.exit_code }}
+          WAIVER_CONTEXT: ${{ steps.waiver-context.outputs.waiver_context }}
       - name: Append dependency audit summary
         if: always()
         run: |
@@ -153,6 +179,46 @@ jobs:
           AUDIT_CLASSIFY_RESULT: ${{ needs.audit-classify.result }}
           AUDIT_ERROR: ${{ needs.audit-classify.outputs.audit_error }}
           BLOCKING_COUNT: ${{ needs.audit-classify.outputs.blocking_count }}
+  notify-waived-release-findings:
+    name: Notify waived release dependency findings
+    runs-on: ubuntu-latest
+    needs: audit-classify
+    if: >-
+      github.repository == 'zenml-io/zenml' &&
+      needs.audit-classify.result == 'success' &&
+      needs.audit-classify.outputs.waiver_context == 'release-pr' &&
+      needs.audit-classify.outputs.has_waived_blocking == 'true'
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Download dependency audit reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: dependency-audit-reports
+          path: dependency-audit-reports
+      - name: Build Discord message
+        id: build_message
+        shell: bash
+        run: |
+          DELIMITER="GH_OUTPUT_DELIMITER_$$"
+          {
+            echo "message<<${DELIMITER}"
+            if [[ -f dependency-audit-reports/waived-discord.md ]]; then
+              sed -e 's/\r$//' dependency-audit-reports/waived-discord.md
+            else
+              echo "**Dependency Audit Waiver Used**"
+              echo
+              echo "Failed to generate waived finding summary."
+            fi
+            echo "${DELIMITER}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Send Discord notification for waived findings
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554  # master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SRE }}
+        with:
+          args: ${{ steps.build_message.outputs.message }}
   update-nonblocking-tracking-issue:
     name: Update medium/low dependency tracking issue
     runs-on: ubuntu-latest

--- a/scripts/dependency_audit_severity_gate.py
+++ b/scripts/dependency_audit_severity_gate.py
@@ -16,6 +16,7 @@ import re
 import sys
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+from datetime import date
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -73,6 +74,20 @@ class Finding:
     unknown_reason: str | None = None
     ghsa_id: str | None = None
     cve_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AdvisoryWaiver:
+    """A temporary waiver for specific advisories in specific CI contexts."""
+
+    package: str
+    normalized_package: str
+    advisories: list[str]
+    normalized_advisories: list[str]
+    allowed_contexts: list[str]
+    expires_on: date
+    owner: str
+    reason: str
 
 
 class GitHubAdvisoryClient:
@@ -222,10 +237,15 @@ class GitHubAdvisoryClient:
 def classify_audit(
     audit_data: dict[str, Any],
     client: GitHubAdvisoryClient,
+    waivers: list[AdvisoryWaiver] | None = None,
+    waiver_context: str = "",
+    today: date | None = None,
     audit_error: bool = False,
     audit_error_message: str = "",
 ) -> dict[str, Any]:
     """Classify a parsed pip-audit JSON document."""
+    waivers = waivers or []
+    today = today or date.today()
     malformed_messages = _collect_malformed_audit_messages(audit_data)
     if malformed_messages:
         audit_error = True
@@ -245,7 +265,12 @@ def classify_audit(
             audit_error_message,
             _skipped_dependency_error_message(skipped_dependencies),
         )
-    blocking = [finding for finding in findings if finding.blocking]
+    blocking, waived_blocking = _split_blocking_findings(
+        findings,
+        waivers,
+        waiver_context,
+        today,
+    )
     nonblocking = [finding for finding in findings if not finding.blocking]
     unknown_count = sum(
         1 for finding in findings if finding.severity == "unknown"
@@ -257,6 +282,7 @@ def classify_audit(
         "counts": {
             "total": len(findings),
             "blocking": len(blocking),
+            "waived_blocking": len(waived_blocking),
             "nonblocking": len(nonblocking),
             "unknown": unknown_count,
             "skipped": len(skipped_dependencies),
@@ -266,6 +292,7 @@ def classify_audit(
         ],
         "findings": [asdict(finding) for finding in findings],
         "blocking": [asdict(finding) for finding in blocking],
+        "waived_blocking": waived_blocking,
         "nonblocking": [asdict(finding) for finding in nonblocking],
     }
 
@@ -283,6 +310,7 @@ def render_summary(report: dict[str, Any]) -> str:
         "| Bucket | Count |",
         "| --- | ---: |",
         f"| Blocking (`critical`, `high`, `unknown`) | {counts['blocking']} |",
+        f"| Waived blocking | {counts.get('waived_blocking', 0)} |",
         f"| Non-blocking (`medium`, `low`) | {counts['nonblocking']} |",
         f"| Unknown severity | {counts['unknown']} |",
         f"| Skipped/unauditable dependencies | {counts.get('skipped', 0)} |",
@@ -314,6 +342,12 @@ def render_summary(report: dict[str, Any]) -> str:
     )
     lines.extend(
         _render_finding_sections(report["blocking"], "Blocking findings")
+    )
+    lines.extend(
+        _render_waived_finding_sections(
+            report.get("waived_blocking", []),
+            "Waived blocking findings",
+        )
     )
     lines.extend(
         _render_finding_sections(
@@ -377,6 +411,45 @@ def render_tracking_issue_body(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def render_waived_discord_message(
+    report: dict[str, Any],
+    run_url: str | None,
+) -> str:
+    """Render a concise Discord message for release-only waived findings."""
+    waived_findings = report.get("waived_blocking", [])
+    if not waived_findings:
+        return "No waived blocking dependency audit findings were found.\n"
+
+    lines = [
+        "**Dependency Audit Waiver Used**",
+        "",
+        "A release PR used temporary waivers for blocking dependency findings.",
+        "",
+        "**Waived findings:**",
+    ]
+    for finding in waived_findings:
+        waiver = finding.get("waiver", {})
+        lines.append(
+            "- "
+            f"{finding['package']} {finding['installed_version']} — "
+            f"{finding['advisory_id']} — {finding['severity']} "
+            f"(expires {waiver.get('expires_on', 'unknown')})"
+        )
+    reasons = sorted(
+        {
+            str(finding.get("waiver", {}).get("reason", "")).strip()
+            for finding in waived_findings
+            if str(finding.get("waiver", {}).get("reason", "")).strip()
+        }
+    )
+    if reasons:
+        lines.extend(["", "**Reason:**"])
+        lines.extend(f"- {reason}" for reason in reasons)
+    if run_url:
+        lines.extend(["", f"**Details:** {run_url}"])
+    return "\n".join(lines).rstrip() + "\n"
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -386,6 +459,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--classified-json", required=True, type=Path)
     parser.add_argument("--summary-md", required=True, type=Path)
     parser.add_argument("--nonblocking-issue-md", required=True, type=Path)
+    parser.add_argument("--waivers-json", type=Path)
+    parser.add_argument("--waiver-context", default="")
+    parser.add_argument("--waived-discord-md", type=Path)
+    parser.add_argument("--today", type=_parse_iso_date)
     parser.add_argument("--github-output", type=Path)
     parser.add_argument(
         "--github-token", default=os.environ.get("GITHUB_TOKEN")
@@ -402,6 +479,13 @@ def main(argv: list[str] | None = None) -> int:
     """Run the severity gate helper."""
     args = parse_args(argv or sys.argv[1:])
     audit_data, audit_error, audit_error_message = _load_audit_data(args)
+    waivers, waiver_error_message = _load_waivers(args.waivers_json)
+    if waiver_error_message:
+        audit_error = True
+        audit_error_message = _append_audit_error_message(
+            audit_error_message,
+            waiver_error_message,
+        )
     client = GitHubAdvisoryClient(
         token=args.github_token,
         api_url=args.github_api_url,
@@ -409,6 +493,9 @@ def main(argv: list[str] | None = None) -> int:
     report = classify_audit(
         audit_data,
         client,
+        waivers=waivers,
+        waiver_context=args.waiver_context,
+        today=args.today,
         audit_error=audit_error,
         audit_error_message=audit_error_message,
     )
@@ -418,6 +505,11 @@ def main(argv: list[str] | None = None) -> int:
         args.nonblocking_issue_md,
         render_tracking_issue_body(report, args.run_url),
     )
+    if args.waived_discord_md:
+        _write_text(
+            args.waived_discord_md,
+            render_waived_discord_message(report, args.run_url),
+        )
     _write_json(args.classified_json, report)
     if args.github_output:
         _write_github_outputs(args.github_output, report)
@@ -455,6 +547,98 @@ def _load_audit_data(
     return data, audit_error, " ".join(error_parts)
 
 
+def _load_waivers(
+    waivers_json: Path | None,
+) -> tuple[list[AdvisoryWaiver], str]:
+    """Load explicit advisory waivers from JSON."""
+    if waivers_json is None or not waivers_json.exists():
+        return [], ""
+    try:
+        data = json.loads(waivers_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [], f"Invalid dependency audit waiver JSON: {exc}"
+    if not isinstance(data, dict):
+        return (
+            [],
+            "Invalid dependency audit waiver JSON: root was not an object.",
+        )
+    raw_waivers = data.get("waivers", [])
+    if not isinstance(raw_waivers, list):
+        return (
+            [],
+            "Invalid dependency audit waiver JSON: waivers was not a list.",
+        )
+
+    waivers: list[AdvisoryWaiver] = []
+    errors: list[str] = []
+    for index, raw_waiver in enumerate(raw_waivers):
+        waiver, error = _parse_waiver(raw_waiver, index)
+        if error:
+            errors.append(error)
+            continue
+        waivers.append(waiver)
+    return waivers, " ".join(errors)
+
+
+def _parse_waiver(
+    raw_waiver: Any,
+    index: int,
+) -> tuple[AdvisoryWaiver | None, str]:
+    """Parse one waiver entry and return a validation error if malformed."""
+    if not isinstance(raw_waiver, dict):
+        return None, f"waiver entry {index} was not an object."
+
+    package = str(raw_waiver.get("package") or "").strip()
+    advisories = _string_list(raw_waiver.get("advisories", []))
+    allowed_contexts = _string_list(raw_waiver.get("allowed_contexts", []))
+    expires_on_raw = str(raw_waiver.get("expires_on") or "").strip()
+    owner = str(raw_waiver.get("owner") or "").strip()
+    reason = str(raw_waiver.get("reason") or "").strip()
+
+    missing = []
+    if not package:
+        missing.append("package")
+    if not advisories:
+        missing.append("advisories")
+    if not allowed_contexts:
+        missing.append("allowed_contexts")
+    if not expires_on_raw:
+        missing.append("expires_on")
+    if not owner:
+        missing.append("owner")
+    if not reason:
+        missing.append("reason")
+    if missing:
+        return (
+            None,
+            f"waiver entry {index} is missing required fields: "
+            + ", ".join(missing)
+            + ".",
+        )
+
+    try:
+        expires_on = _parse_iso_date(expires_on_raw)
+    except argparse.ArgumentTypeError as exc:
+        return None, f"waiver entry {index} has invalid expires_on: {exc}"
+
+    return (
+        AdvisoryWaiver(
+            package=package,
+            normalized_package=_normalize_package_name(package),
+            advisories=advisories,
+            normalized_advisories=[
+                _normalize_advisory_identifier(advisory)
+                for advisory in advisories
+            ],
+            allowed_contexts=allowed_contexts,
+            expires_on=expires_on,
+            owner=owner,
+            reason=reason,
+        ),
+        "",
+    )
+
+
 def _iter_skipped_dependencies(
     audit_data: dict[str, Any],
 ) -> list[SkippedDependency]:
@@ -486,6 +670,75 @@ def _iter_skipped_dependencies(
             dependency.installed_version,
         ),
     )
+
+
+def _split_blocking_findings(
+    findings: list[Finding],
+    waivers: list[AdvisoryWaiver],
+    waiver_context: str,
+    today: date,
+) -> tuple[list[Finding], list[dict[str, Any]]]:
+    """Split blocking findings into unwaived and explicitly waived groups."""
+    blocking: list[Finding] = []
+    waived_blocking: list[dict[str, Any]] = []
+    for finding in findings:
+        if not finding.blocking:
+            continue
+        waiver = _matching_waiver(finding, waivers, waiver_context, today)
+        if waiver is None:
+            blocking.append(finding)
+            continue
+        waived_finding = asdict(finding)
+        waived_finding["waiver"] = _waiver_report_dict(waiver)
+        waived_blocking.append(waived_finding)
+    return blocking, waived_blocking
+
+
+def _matching_waiver(
+    finding: Finding,
+    waivers: list[AdvisoryWaiver],
+    waiver_context: str,
+    today: date,
+) -> AdvisoryWaiver | None:
+    """Return the active waiver that covers a finding, if one exists."""
+    if not waiver_context:
+        return None
+    finding_identifiers = set(_finding_advisory_identifiers(finding))
+    for waiver in waivers:
+        if waiver_context not in waiver.allowed_contexts:
+            continue
+        if waiver.expires_on < today:
+            continue
+        if waiver.normalized_package != finding.normalized_package:
+            continue
+        if finding_identifiers.intersection(waiver.normalized_advisories):
+            return waiver
+    return None
+
+
+def _finding_advisory_identifiers(finding: Finding) -> list[str]:
+    """Return all advisory identifiers that can match a waiver."""
+    identifiers = [finding.advisory_id, *finding.aliases]
+    if finding.ghsa_id:
+        identifiers.append(finding.ghsa_id)
+    if finding.cve_id:
+        identifiers.append(finding.cve_id)
+    return [
+        _normalize_advisory_identifier(identifier)
+        for identifier in identifiers
+    ]
+
+
+def _waiver_report_dict(waiver: AdvisoryWaiver) -> dict[str, Any]:
+    """Serialize waiver details included in audit artifacts."""
+    return {
+        "package": waiver.package,
+        "advisories": waiver.advisories,
+        "allowed_contexts": waiver.allowed_contexts,
+        "expires_on": waiver.expires_on.isoformat(),
+        "owner": waiver.owner,
+        "reason": waiver.reason,
+    }
 
 
 def _iter_raw_findings(audit_data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -739,6 +992,16 @@ def _first_cve_identifier(identifiers: list[str]) -> str | None:
     return None
 
 
+def _parse_iso_date(value: str) -> date:
+    """Parse an ISO date used by waiver expiry checks."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"expected YYYY-MM-DD, got {value!r}"
+        ) from exc
+
+
 def _normalize_ghsa_id(identifier: Any) -> str | None:
     if not identifier:
         return None
@@ -751,10 +1014,16 @@ def _normalize_cve_id(identifier: Any) -> str | None:
     return str(identifier).upper()
 
 
+def _normalize_advisory_identifier(identifier: str) -> str:
+    """Normalize advisory IDs so waivers can match IDs or aliases."""
+    return identifier.strip().upper()
+
+
 def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
-    return [str(item) for item in value if item]
+    strings = [str(item).strip() for item in value if item]
+    return [item for item in strings if item]
 
 
 def _normalize_package_name(name: str) -> str:
@@ -783,6 +1052,11 @@ def _summary_status_line(report: dict[str, Any]) -> str:
         return "❌ The audit result was unusable and the final gate will fail."
     if counts["blocking"]:
         return "❌ Blocking dependency vulnerabilities were found."
+    if counts.get("waived_blocking", 0):
+        return (
+            "⚠️ Blocking dependency vulnerabilities were waived for this "
+            "workflow context."
+        )
     if counts["nonblocking"]:
         return "⚠️ Only medium/low dependency vulnerabilities were found."
     return "✅ No dependency vulnerabilities were found."
@@ -852,20 +1126,57 @@ def _render_finding_sections(
     return lines
 
 
+def _render_waived_finding_sections(
+    findings: list[dict[str, Any]],
+    title: str,
+) -> list[str]:
+    """Render waived blocking findings and the waiver metadata."""
+    lines = [f"## {title}", ""]
+    if not findings:
+        lines.extend(["None.", ""])
+        return lines
+
+    lines.extend(
+        [
+            "These findings are still blocking-severity vulnerabilities, but "
+            "the final gate allows them in this workflow context because an "
+            "explicit, unexpired waiver matched the package and advisory.",
+            "",
+            "| Package | Installed | Advisory | Severity | Expires | Owner | Reason |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for finding in findings:
+        waiver = finding.get("waiver", {})
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _markdown_escape(finding["package"]),
+                    _markdown_escape(finding["installed_version"]),
+                    _advisory_cell(finding),
+                    _markdown_escape(finding["severity"]),
+                    _markdown_escape(str(waiver.get("expires_on", ""))),
+                    _markdown_escape(str(waiver.get("owner", ""))),
+                    _markdown_escape(str(waiver.get("reason", ""))),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return lines
+
+
 def _finding_table_row(
     finding: dict[str, Any],
     include_reason: bool = False,
 ) -> str:
-    aliases = ", ".join(finding.get("aliases", []))
-    advisory = _markdown_escape(finding["advisory_id"])
-    if aliases:
-        advisory = f"{advisory}<br>{_markdown_escape(aliases)}"
     fix_versions = ", ".join(finding.get("fix_versions", [])) or "None listed"
     cells = [
         _markdown_escape(finding["severity"]),
         _markdown_escape(finding["package"]),
         _markdown_escape(finding["installed_version"]),
-        advisory,
+        _advisory_cell(finding),
         _markdown_escape(fix_versions),
     ]
     if include_reason:
@@ -877,6 +1188,15 @@ def _finding_table_row(
         )
         cells.append(_markdown_escape(reason))
     return "| " + " | ".join(cells) + " |"
+
+
+def _advisory_cell(finding: dict[str, Any]) -> str:
+    """Render the advisory ID and aliases for summary tables."""
+    aliases = ", ".join(finding.get("aliases", []))
+    advisory = _markdown_escape(finding["advisory_id"])
+    if aliases:
+        return f"{advisory}<br>{_markdown_escape(aliases)}"
+    return advisory
 
 
 def _markdown_escape(value: str) -> str:
@@ -910,9 +1230,13 @@ def _write_github_outputs(path: Path, report: dict[str, Any]) -> None:
     outputs = {
         "audit_error": str(report["audit_error"]).lower(),
         "blocking_count": str(counts["blocking"]),
+        "waived_blocking_count": str(counts.get("waived_blocking", 0)),
         "nonblocking_count": str(counts["nonblocking"]),
         "unknown_count": str(counts["unknown"]),
         "skipped_count": str(counts.get("skipped", 0)),
+        "has_waived_blocking": str(
+            counts.get("waived_blocking", 0) > 0
+        ).lower(),
         "has_nonblocking": str(counts["nonblocking"] > 0).lower(),
     }
     with path.open("a", encoding="utf-8") as output_file:

--- a/tests/unit/scripts/test_dependency_audit_severity_gate.py
+++ b/tests/unit/scripts/test_dependency_audit_severity_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 from typing import Any
 from urllib.error import URLError
 
@@ -82,9 +83,40 @@ def install_fake_github_api(
 def classify(
     data: dict[str, Any],
     token: str | None = "token",
+    waivers: list[gate.AdvisoryWaiver] | None = None,
+    waiver_context: str = "",
+    today: date | None = None,
 ) -> dict[str, Any]:
     """Classify fixture audit data through the real helper path."""
-    return gate.classify_audit(data, gate.GitHubAdvisoryClient(token=token))
+    return gate.classify_audit(
+        data,
+        gate.GitHubAdvisoryClient(token=token),
+        waivers=waivers,
+        waiver_context=waiver_context,
+        today=today,
+    )
+
+
+def waiver(
+    package: str,
+    advisories: list[str],
+    allowed_contexts: list[str] | None = None,
+    expires_on: date = date(2026, 7, 31),
+) -> gate.AdvisoryWaiver:
+    """Build an advisory waiver fixture."""
+    return gate.AdvisoryWaiver(
+        package=package,
+        normalized_package=gate._normalize_package_name(package),
+        advisories=advisories,
+        normalized_advisories=[
+            gate._normalize_advisory_identifier(advisory)
+            for advisory in advisories
+        ],
+        allowed_contexts=allowed_contexts or ["release-pr"],
+        expires_on=expires_on,
+        owner="server-team",
+        reason="Needs a dedicated compatibility upgrade.",
+    )
 
 
 def test_no_vulnerabilities_pass_without_findings() -> None:
@@ -94,6 +126,7 @@ def test_no_vulnerabilities_pass_without_findings() -> None:
     assert report["counts"] == {
         "total": 0,
         "blocking": 0,
+        "waived_blocking": 0,
         "nonblocking": 0,
         "unknown": 0,
         "skipped": 0,
@@ -391,6 +424,100 @@ def test_high_and_critical_findings_are_blocking(
     }
 
 
+def test_matching_waiver_allows_blocking_finding_in_release_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release PR waivers should move exact findings out of blocking."""
+    install_fake_github_api(
+        monkeypatch,
+        {
+            "https://api.github.com/advisories/GHSA-HIGH-1111-2222": {
+                "ghsa_id": "GHSA-high-1111-2222",
+                "severity": "high",
+            }
+        },
+    )
+
+    report = classify(
+        audit_data(
+            (
+                "package-a",
+                "1.0.0",
+                vulnerability("PYSEC-1", ["GHSA-high-1111-2222"]),
+            )
+        ),
+        waivers=[waiver("package-a", ["GHSA-HIGH-1111-2222"])],
+        waiver_context="release-pr",
+        today=date(2026, 7, 2),
+    )
+
+    assert report["counts"]["blocking"] == 0
+    assert report["counts"]["waived_blocking"] == 1
+    assert report["waived_blocking"][0]["package"] == "package-a"
+    assert report["waived_blocking"][0]["waiver"]["expires_on"] == "2026-07-31"
+    assert "Waived blocking findings" in gate.render_summary(report)
+
+
+def test_waiver_does_not_apply_outside_allowed_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Feature PRs should still fail on advisories waived for release PRs."""
+    install_fake_github_api(
+        monkeypatch,
+        {
+            "https://api.github.com/advisories/GHSA-HIGH-1111-2222": {
+                "ghsa_id": "GHSA-high-1111-2222",
+                "severity": "high",
+            }
+        },
+    )
+
+    report = classify(
+        audit_data(
+            ("package-a", "1.0.0", vulnerability("GHSA-high-1111-2222"))
+        ),
+        waivers=[waiver("package-a", ["GHSA-HIGH-1111-2222"])],
+        waiver_context="feature-pr",
+        today=date(2026, 7, 2),
+    )
+
+    assert report["counts"]["blocking"] == 1
+    assert report["counts"]["waived_blocking"] == 0
+
+
+def test_expired_waiver_does_not_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expired waivers should not keep CI green."""
+    install_fake_github_api(
+        monkeypatch,
+        {
+            "https://api.github.com/advisories/GHSA-HIGH-1111-2222": {
+                "ghsa_id": "GHSA-high-1111-2222",
+                "severity": "high",
+            }
+        },
+    )
+
+    report = classify(
+        audit_data(
+            ("package-a", "1.0.0", vulnerability("GHSA-high-1111-2222"))
+        ),
+        waivers=[
+            waiver(
+                "package-a",
+                ["GHSA-HIGH-1111-2222"],
+                expires_on=date(2026, 7, 1),
+            )
+        ],
+        waiver_context="release-pr",
+        today=date(2026, 7, 2),
+    )
+
+    assert report["counts"]["blocking"] == 1
+    assert report["counts"]["waived_blocking"] == 0
+
+
 def test_unmapped_advisory_becomes_unknown_and_blocks() -> None:
     """PYSEC/OSV-only findings should block when no GHSA/CVE is present."""
     report = classify(
@@ -674,3 +801,95 @@ def test_main_writes_compact_outputs(
     assert "Only medium/low" in summary_md.read_text(encoding="utf-8")
     assert "has_nonblocking=true" in github_output.read_text(encoding="utf-8")
     assert "blocking_count=0" in github_output.read_text(encoding="utf-8")
+    assert "has_waived_blocking=false" in github_output.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_main_applies_release_waiver_and_writes_discord_message(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI should expose waived blocking findings for release PR alerts."""
+    install_fake_github_api(
+        monkeypatch,
+        {
+            "https://api.github.com/advisories/GHSA-HIGH-1111-2222": {
+                "ghsa_id": "GHSA-high-1111-2222",
+                "severity": "high",
+            }
+        },
+    )
+    audit_json = tmp_path / "pip-audit.json"
+    classified_json = tmp_path / "classified.json"
+    summary_md = tmp_path / "summary.md"
+    issue_md = tmp_path / "issue.md"
+    waivers_json = tmp_path / "waivers.json"
+    discord_md = tmp_path / "discord.md"
+    github_output = tmp_path / "github-output.txt"
+    audit_json.write_text(
+        json.dumps(
+            audit_data(
+                (
+                    "package-a",
+                    "1.0.0",
+                    vulnerability("PYSEC-1", ["GHSA-high-1111-2222"]),
+                )
+            )
+        ),
+        encoding="utf-8",
+    )
+    waivers_json.write_text(
+        json.dumps(
+            {
+                "waivers": [
+                    {
+                        "package": "package-a",
+                        "advisories": ["GHSA-HIGH-1111-2222"],
+                        "allowed_contexts": ["release-pr"],
+                        "expires_on": "2026-07-31",
+                        "owner": "server-team",
+                        "reason": "Needs a dedicated compatibility upgrade.",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = gate.main(
+        [
+            "--audit-json",
+            str(audit_json),
+            "--pip-audit-exit-code",
+            "1",
+            "--classified-json",
+            str(classified_json),
+            "--summary-md",
+            str(summary_md),
+            "--nonblocking-issue-md",
+            str(issue_md),
+            "--waivers-json",
+            str(waivers_json),
+            "--waiver-context",
+            "release-pr",
+            "--waived-discord-md",
+            str(discord_md),
+            "--today",
+            "2026-07-02",
+            "--github-output",
+            str(github_output),
+        ]
+    )
+
+    classified = json.loads(classified_json.read_text(encoding="utf-8"))
+    output = github_output.read_text(encoding="utf-8")
+    discord = discord_md.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert classified["counts"]["blocking"] == 0
+    assert classified["counts"]["waived_blocking"] == 1
+    assert "blocking_count=0" in output
+    assert "waived_blocking_count=1" in output
+    assert "has_waived_blocking=true" in output
+    assert "Dependency Audit Waiver Used" in discord
+    assert "package-a 1.0.0" in discord


### PR DESCRIPTION
## What this changes

Adds explicit, time-limited advisory waivers to the dependency audit workflow so release PRs can proceed when a blocking vulnerability is acknowledged but cannot safely be fixed during release prep.

Concretely:
- adds `.github/dependency-audit-waivers.json` with temporary Starlette advisory waivers expiring on `2026-07-31`
- teaches `scripts/dependency_audit_severity_gate.py` to classify matching findings as `waived_blocking` instead of `blocking`
- applies waivers only in the `release-pr` context
- sends a Discord notification only when a release PR actually uses waived findings
- reruns the workflow when the `release` label is added or removed, so waiver eligibility is recalculated

## Why

The current audit failure is caused by Starlette advisories whose fixes require a FastAPI range bump. That bump is risky enough for ZenML server users that it should happen in a dedicated, tested dependency PR rather than during release prep.

This keeps normal PRs strict while giving release PRs an explicit, expiring exception with visibility.

## Verification

- `uv run --extra dev --extra local --extra server pytest tests/unit/scripts/test_dependency_audit_severity_gate.py --no-provision -q`
- `uv run --extra dev --extra local --extra server bash scripts/format.sh`
- Smoke checked against downloaded release audit report from `/Users/strickvl/Desktop/dependency-audit-reports/pip-audit.json`:
  - normal context: `blocking=2`, `waived_blocking=0`
  - `release-pr` context: `blocking=0`, `waived_blocking=2`
