### PR TITLE
Bump FastAPI version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,10 @@ local = [
 ]
 server = [
     "zenml[local,native-schedules]",  # Includes all the DB dependencies
-    "fastapi>=0.120.1,<0.121.0",
+    "fastapi>=0.138.0,<0.139.0",
     "uvicorn[standard]>=0.17.5",
     "python-multipart~=0.0.9",
     "pyjwt[crypto]>=2.13.0,<2.14.0",
-    "fastapi-utils",
     "orjson>=3.11.6,<3.12.0",
     "Jinja2",
     "ipinfo>=4.4.3",
@@ -154,6 +153,10 @@ dev = [
     "zizmor>=1.0.0",
     "coverage[toml]>=7.6.1,<8.0.0",
     "pytest>=9.0.3,<10.0.0",
+    # starlette's TestClient imports httpx on 0.46.0 through 1.1.x and httpx2
+    # on 1.2.0 and newer.
+    "httpx>=0.23.0,<1.0.0",
+    "httpx2>=2.5.0,<3.0.0",
     "beautifulsoup4>=4.12.0,<5.0.0",
     "mypy==1.18.1",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ server = [
     "uvicorn[standard]>=0.17.5",
     "python-multipart~=0.0.9",
     "pyjwt[crypto]>=2.13.0,<2.14.0",
-    "orjson>=3.11.6,<3.12.0",
     "Jinja2",
     "ipinfo>=4.4.3",
     "secure~=1.0.1",

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -30,7 +30,7 @@ from typing import Any, AsyncGenerator, List
 from anyio import to_thread
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.responses import (
@@ -215,7 +215,6 @@ app = FastAPI(
     title="ZenML",
     version=zenml.__version__,
     root_path=server_config().root_url_path,
-    default_response_class=ORJSONResponse,
     lifespan=lifespan,
 )
 
@@ -231,9 +230,7 @@ configure_otel(app)
 # Customize the default request validation handler that comes with FastAPI
 # to return a JSON response that matches the ZenML API spec.
 @app.exception_handler(RequestValidationError)
-def validation_exception_handler(
-    request: Any, exc: Exception
-) -> ORJSONResponse:
+def validation_exception_handler(request: Any, exc: Exception) -> JSONResponse:
     """Custom validation exception handler.
 
     Args:
@@ -243,7 +240,7 @@ def validation_exception_handler(
     Returns:
         The error response formatted using the ZenML API conventions.
     """
-    return ORJSONResponse(error_detail(exc, ValueError), status_code=422)
+    return JSONResponse(error_detail(exc, ValueError), status_code=422)
 
 
 DASHBOARD_REDIRECT_URL = None

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -23,8 +23,9 @@ To run this file locally, execute:
 import logging
 import os
 from asyncio.log import logger
+from contextlib import asynccontextmanager
 from genericpath import isfile
-from typing import Any, List
+from typing import Any, AsyncGenerator, List
 
 from anyio import to_thread
 from fastapi import FastAPI, HTTPException, Request
@@ -156,43 +157,16 @@ def _configure_uvicorn_logging() -> None:
         _uvicorn_logger.propagate = True
 
 
-app = FastAPI(
-    title="ZenML",
-    version=zenml.__version__,
-    root_path=server_config().root_url_path,
-    default_response_class=ORJSONResponse,
-)
-
-add_middlewares(app)
-
-# suppress uvicorn access logs
-_configure_uvicorn_logging()
-
-# Configure OpenTelemetry
-configure_otel(app)
-
-
-# Customize the default request validation handler that comes with FastAPI
-# to return a JSON response that matches the ZenML API spec.
-@app.exception_handler(RequestValidationError)
-def validation_exception_handler(
-    request: Any, exc: Exception
-) -> ORJSONResponse:
-    """Custom validation exception handler.
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Manage the ZenML server application lifespan.
 
     Args:
-        request: The request.
-        exc: The exception.
+        app: The FastAPI application instance.
 
-    Returns:
-        The error response formatted using the ZenML API conventions.
+    Yields:
+        None: Control is handed back to FastAPI once initialization completes.
     """
-    return ORJSONResponse(error_detail(exc, ValueError), status_code=422)
-
-
-@app.on_event("startup")
-async def initialize() -> None:
-    """Initialize the ZenML server."""
     cfg = server_config()
     # Set the maximum number of worker threads
     to_thread.current_default_thread_limiter().total_tokens = (
@@ -225,10 +199,8 @@ async def initialize() -> None:
 
     await register_event_handlers()
 
+    yield
 
-@app.on_event("shutdown")
-async def shutdown() -> None:
-    """Shutdown the ZenML server."""
     if logger.isEnabledFor(logging.DEBUG):
         stop_event_loop_lag_monitor()
     shutdown_otel()
@@ -237,6 +209,41 @@ async def shutdown() -> None:
     await shutdown_streaming()
     await cleanup_request_manager()
     cleanup_artifact_store_cache()
+
+
+app = FastAPI(
+    title="ZenML",
+    version=zenml.__version__,
+    root_path=server_config().root_url_path,
+    default_response_class=ORJSONResponse,
+    lifespan=lifespan,
+)
+
+add_middlewares(app)
+
+# suppress uvicorn access logs
+_configure_uvicorn_logging()
+
+# Configure OpenTelemetry
+configure_otel(app)
+
+
+# Customize the default request validation handler that comes with FastAPI
+# to return a JSON response that matches the ZenML API spec.
+@app.exception_handler(RequestValidationError)
+def validation_exception_handler(
+    request: Any, exc: Exception
+) -> ORJSONResponse:
+    """Custom validation exception handler.
+
+    Args:
+        request: The request.
+        exc: The exception.
+
+    Returns:
+        The error response formatted using the ZenML API conventions.
+    """
+    return ORJSONResponse(error_detail(exc, ValueError), status_code=422)
 
 
 DASHBOARD_REDIRECT_URL = None
@@ -301,9 +308,7 @@ async def dashboard(request: Request) -> Any:
 
     if not os.path.isfile(os.path.join(dashboard_directory(), "index.html")):
         raise HTTPException(status_code=404)
-    return templates.TemplateResponse(
-        name="index.html", context={"request": request}
-    )
+    return templates.TemplateResponse(request=request, name="index.html")
 
 
 app.include_router(artifact_endpoint.artifact_router)
@@ -425,6 +430,4 @@ async def catch_all(request: Request, file_path: str) -> Any:
 
     # everything else is directed to the index.html file that hosts the
     # single-page application
-    return templates.TemplateResponse(
-        name="index.html", context={"request": request}
-    )
+    return templates.TemplateResponse(request=request, name="index.html")


### PR DESCRIPTION
- Bumps FastAPI version to `0.138.0`. This also increases the lower bound of `starlette` to `0.46.0`, which fixes some CVEs present in previous releases.
- Removes unused `fastapi_utils` install.
- Fixes three deprecations. Both those changes work with all supported fastapi/starlette versions.
  - Convert `app.on_event("startup")` and `app.on_event("shutdown")` to a lifespan context manager
  - Pass `request` as first parameter to `TemplateResponse`
  - `ORJSONResponse` was deprecated. Instead, FastAPI now uses the pydantic rust-based serializer which is even quicker than using `ORJSONResponse`. One case that got slower, but not noticeably: During error handling, pydantic is not used and instead it falls back to a regular JSONResponse. This however is for very small payloads and does not really matter. As a consequence of this, the `orjson` dependency has been removed.