### PR TITLE
Support secret references in secret strings

### DIFF
--- a/src/zenml/utils/secret_utils.py
+++ b/src/zenml/utils/secret_utils.py
@@ -51,6 +51,9 @@ def is_secret_reference(value: Any) -> bool:
     Returns:
         `True` if the value is a secret reference, `False` otherwise.
     """
+    if isinstance(value, SecretStr):
+        value = value.get_secret_value()
+
     if not isinstance(value, str):
         return False
 
@@ -69,7 +72,9 @@ class SecretReference(NamedTuple):
     key: str
 
 
-def parse_secret_reference(reference: str) -> SecretReference:
+def parse_secret_reference(
+    reference: Union[str, SecretStr],
+) -> SecretReference:
     """Parses a secret reference.
 
     This function assumes the input string is a valid secret reference and
@@ -82,6 +87,9 @@ def parse_secret_reference(reference: str) -> SecretReference:
     Returns:
         The parsed secret reference.
     """
+    if isinstance(reference, SecretStr):
+        reference = reference.get_secret_value()
+
     reference = reference[2:]
     reference = reference[:-2]
 

--- a/tests/unit/config/test_secret_reference_mixin.py
+++ b/tests/unit/config/test_secret_reference_mixin.py
@@ -15,7 +15,7 @@ import json
 from contextlib import ExitStack as does_not_raise
 
 import pytest
-from pydantic import field_validator
+from pydantic import SecretStr, field_validator
 
 from zenml.client import Client
 from zenml.config.secret_reference_mixin import SecretReferenceMixin
@@ -26,6 +26,12 @@ class MixinSubclass(SecretReferenceMixin):
     """Secret reference mixin subclass."""
 
     value: str
+
+
+class SecretStrMixinSubclass(SecretReferenceMixin):
+    """Secret reference mixin subclass with a `SecretStr` field."""
+
+    value: SecretStr
 
 
 def test_secret_references_are_not_allowed_for_clear_text_fields():
@@ -99,3 +105,27 @@ def test_secret_reference_resolving(clean_client: Client):
 
     with does_not_raise():
         _ = obj.value
+
+
+def test_secret_str_field_detects_required_secrets():
+    """Tests that secret references in a `SecretStr` field are detected."""
+    assert SecretStrMixinSubclass(value="plain text").required_secrets == set()
+
+    secrets = SecretStrMixinSubclass(value="{{name.key}}").required_secrets
+    assert len(secrets) == 1
+    secret_ref = secrets.pop()
+    assert secret_ref.name == "name"
+    assert secret_ref.key == "key"
+
+
+def test_secret_str_field_reference_resolving(clean_client: Client):
+    """Tests secret resolving for a `SecretStr` field."""
+    obj = SecretStrMixinSubclass(value="{{secret.key}}")
+
+    with pytest.raises(KeyError):
+        _ = obj.value
+
+    clean_client.create_secret("secret", values=dict(key="resolved_value"))
+
+    with does_not_raise():
+        assert obj.value == "resolved_value"

--- a/tests/unit/utils/test_secret_utils.py
+++ b/tests/unit/utils/test_secret_utils.py
@@ -14,7 +14,7 @@
 
 from hypothesis import given
 from hypothesis.strategies import from_regex
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 from zenml.utils import secret_utils
 
@@ -39,6 +39,13 @@ def test_is_secret_reference(name, key):
 
 
 @given(name=strategy, key=strategy)
+def test_is_secret_reference_unwraps_secret_str(name, key):
+    """Check that secret reference detection unwraps `SecretStr` values."""
+    assert secret_utils.is_secret_reference(SecretStr(f"{{{{{name}.{key}}}}}"))
+    assert not secret_utils.is_secret_reference(SecretStr("plain text"))
+
+
+@given(name=strategy, key=strategy)
 def test_secret_reference_parsing(name, key):
     """Tests that secret reference parsing works correctly."""
     for value in [
@@ -49,6 +56,16 @@ def test_secret_reference_parsing(name, key):
         ref = secret_utils.parse_secret_reference(value)
         assert ref.name == name
         assert ref.key == key
+
+
+@given(name=strategy, key=strategy)
+def test_secret_reference_parsing_unwraps_secret_str(name, key):
+    """Tests that secret reference parsing unwraps `SecretStr` values."""
+    ref = secret_utils.parse_secret_reference(
+        SecretStr(f"{{{{{name}.{key}}}}}")
+    )
+    assert ref.name == name
+    assert ref.key == key
 
 
 def test_secret_field():


### PR DESCRIPTION
This PR makes secret references work inside `SecretStr`-typed fields. Previously a value like `{{ my_secret.my_key }}` stored in a `SecretStr` field was never detected as a reference and therefore not resolved.