### PR TITLE
Expire tokens after password changes and API key rotations

### DIFF
--- a/src/zenml/models/v2/core/api_key.py
+++ b/src/zenml/models/v2/core/api_key.py
@@ -293,6 +293,51 @@ class APIKeyInternalResponse(APIKeyResponse):
         default=None,
         title="The previous API key. Only set if the key was rotated.",
     )
+    key_generation: int = Field(
+        default=1,
+        title="The current API key generation.",
+    )
+
+    def is_previous_key_retained(self) -> bool:
+        """Check whether the previous API key generation is still retained.
+
+        Returns:
+            True if the previous key/generation is still in its retention
+            window.
+        """
+        if (
+            not self.active
+            or self.last_rotated is None
+            or self.retain_period_minutes <= 0
+            or self.key_generation <= 1
+        ):
+            return False
+
+        return utc_now(tz_aware=self.last_rotated) - self.last_rotated < (
+            timedelta(minutes=self.retain_period_minutes)
+        )
+
+    def is_token_generation_valid(
+        self, token_generation: Optional[int]
+    ) -> bool:
+        """Check whether an API-key-derived token generation is still valid.
+
+        Args:
+            token_generation: The API key generation embedded in the JWT.
+
+        Returns:
+            True if the token generation is still valid.
+        """
+        if token_generation is None:
+            return True
+
+        if token_generation == self.key_generation:
+            return True
+
+        return (
+            token_generation == self.key_generation - 1
+            and self.is_previous_key_retained()
+        )
 
     def verify_key(
         self,
@@ -319,19 +364,8 @@ class APIKeyInternalResponse(APIKeyResponse):
 
         # same for the previous key, if set and if it's still valid
         key_hash = None
-        if (
-            self.previous_key is not None
-            and self.last_rotated is not None
-            and self.active
-            and self.retain_period_minutes > 0
-        ):
-            # check if the previous key is still valid
-            if utc_now(
-                tz_aware=self.last_rotated
-            ) - self.last_rotated < timedelta(
-                minutes=self.retain_period_minutes
-            ):
-                key_hash = self.previous_key
+        if self.previous_key is not None and self.is_previous_key_retained():
+            key_hash = self.previous_key
         previous_result = context.verify(key, key_hash)
 
         return result or previous_result

--- a/src/zenml/models/v2/core/user.py
+++ b/src/zenml/models/v2/core/user.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Models representing users."""
 
+from datetime import datetime
 from secrets import token_hex
 from typing import (
     TYPE_CHECKING,
@@ -302,6 +303,10 @@ class UserResponseBody(BaseDatedResponseBody):
 class UserResponseMetadata(BaseResponseMetadata):
     """Response metadata for users."""
 
+    password_changed_at: Optional[datetime] = Field(
+        default=None,
+        title="The time when the user's password was last changed.",
+    )
     email: Optional[str] = Field(
         default="",
         title="The email address associated with the account. Only relevant "
@@ -403,6 +408,26 @@ class UserResponse(
             the value of the property.
         """
         return self.get_body().is_service_account
+
+    def is_token_issued_after_password_change(
+        self, issued_at: Optional[datetime]
+    ) -> bool:
+        """Check whether a token was issued after the latest password change.
+
+        Args:
+            issued_at: The time at which the token was issued.
+
+        Returns:
+            True if the token is still valid for this user account.
+        """
+        if issued_at is None or self.is_service_account:
+            return True
+
+        password_changed_at = self.get_metadata().password_changed_at
+        if not password_changed_at:
+            return True
+
+        return issued_at >= password_changed_at
 
     @property
     def is_admin(self) -> bool:

--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -101,13 +101,17 @@ class AuthContext(BaseModel):
 
 
 def _fetch_and_verify_api_key(
-    api_key_id: UUID, key_to_verify: Optional[str] = None
+    api_key_id: UUID,
+    key_to_verify: Optional[str] = None,
+    token_generation: Optional[int] = None,
 ) -> APIKeyInternalResponse:
     """Fetches an API key from the database and verifies it.
 
     Args:
         api_key_id: The API key ID.
         key_to_verify: Optional API key value to verify against the API key.
+        token_generation: Optional API key generation embedded in a JWT that
+            was derived from the API key.
 
     Returns:
         The fetched API key.
@@ -160,6 +164,14 @@ def _fetch_and_verify_api_key(
             f"{api_key.name}"
         )
         logger.exception(error)
+        raise CredentialsNotValid(error)
+
+    if not api_key.is_token_generation_valid(token_generation):
+        error = (
+            f"Authentication error: access token for API key {api_key.name} "
+            "was issued for an API key generation that is no longer valid"
+        )
+        logger.error(error)
         raise CredentialsNotValid(error)
 
     # Update the "last used" timestamp of the API key
@@ -324,12 +336,26 @@ def authenticate_credentials(
             logger.error(error)
             raise CredentialsNotValid(error)
 
+        if not user_model.is_token_issued_after_password_change(
+            decoded_token.issued_at
+        ):
+            error = (
+                f"Authentication error: access token for user "
+                f"{user_model.name} was issued before the user's password "
+                "was changed"
+            )
+            logger.error(error)
+            raise CredentialsNotValid(error)
+
         api_key_model: Optional[APIKeyInternalResponse] = None
         if decoded_token.api_key_id:
             # The API token was generated from an API key. We still have to
             # verify if the API key hasn't been deactivated or deleted in the
             # meantime.
-            api_key_model = _fetch_and_verify_api_key(decoded_token.api_key_id)
+            api_key_model = _fetch_and_verify_api_key(
+                decoded_token.api_key_id,
+                token_generation=decoded_token.api_key_generation,
+            )
 
         device_model: Optional[OAuthDeviceInternalResponse] = None
         if decoded_token.device_id:
@@ -1081,6 +1107,7 @@ def generate_access_token(
         user_id=user_id,
         device_id=device.id if device else None,
         api_key_id=api_key.id if api_key else None,
+        api_key_generation=api_key.key_generation if api_key else None,
         schedule_id=schedule_id,
         pipeline_run_id=pipeline_run_id,
         deployment_id=deployment_id,

--- a/src/zenml/zen_server/jwt.py
+++ b/src/zenml/zen_server/jwt.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """JWT utilities module for ZenML server."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
     Dict,
@@ -47,6 +47,9 @@ class JWTToken(BaseModel):
         step_run_id: The id of the step run for which the token was
             issued.
         session_id: The id of the authenticated session (used for CSRF).
+        issued_at: The time at which the token was issued.
+        api_key_generation: The API key generation for which this token was
+            issued.
         claims: The original token claims.
     """
 
@@ -57,6 +60,8 @@ class JWTToken(BaseModel):
     pipeline_run_id: Optional[UUID] = None
     deployment_id: Optional[UUID] = None
     session_id: Optional[UUID] = None
+    issued_at: Optional[datetime] = None
+    api_key_generation: Optional[int] = None
     claims: Dict[str, Any] = {}
 
     @classmethod
@@ -177,6 +182,28 @@ class JWTToken(BaseModel):
                     "UUID"
                 )
 
+        issued_at: Optional[datetime] = None
+        if "iat" in claims:
+            iat = claims.pop("iat")
+            if isinstance(iat, datetime):
+                issued_at = iat
+            elif isinstance(iat, (int, float)):
+                issued_at = datetime.utcfromtimestamp(iat)
+            else:
+                raise CredentialsNotValid(
+                    "Invalid JWT token: the iat claim is not a valid timestamp"
+                )
+
+        api_key_generation: Optional[int] = None
+        if "key_gen" in claims:
+            api_key_generation_value = claims.pop("key_gen")
+            if not isinstance(api_key_generation_value, int):
+                raise CredentialsNotValid(
+                    "Invalid JWT token: the key_gen claim is not a valid "
+                    "integer"
+                )
+            api_key_generation = api_key_generation_value
+
         return JWTToken(
             user_id=user_id,
             device_id=device_id,
@@ -185,6 +212,8 @@ class JWTToken(BaseModel):
             pipeline_run_id=pipeline_run_id,
             deployment_id=deployment_id,
             session_id=session_id,
+            issued_at=issued_at,
+            api_key_generation=api_key_generation,
             claims=claims,
         )
 
@@ -207,6 +236,10 @@ class JWTToken(BaseModel):
         claims["sub"] = str(self.user_id)
         claims["iss"] = config.get_jwt_token_issuer()
         claims["aud"] = config.get_jwt_token_audience()
+        issued_at = self.issued_at or datetime.utcnow()
+        if issued_at.tzinfo is None:
+            issued_at = issued_at.replace(tzinfo=timezone.utc)
+        claims["iat"] = issued_at.timestamp()
 
         if expires:
             claims["exp"] = expires
@@ -225,6 +258,8 @@ class JWTToken(BaseModel):
             claims["deployment_id"] = str(self.deployment_id)
         if self.session_id:
             claims["session_id"] = str(self.session_id)
+        if self.api_key_generation is not None:
+            claims["key_gen"] = self.api_key_generation
 
         return jwt.encode(
             claims,

--- a/src/zenml/zen_stores/migrations/versions/b6f2a8d9c3e1_add_token_revocation_state.py
+++ b/src/zenml/zen_stores/migrations/versions/b6f2a8d9c3e1_add_token_revocation_state.py
@@ -1,0 +1,50 @@
+"""Add token revocation state [b6f2a8d9c3e1].
+
+Revision ID: b6f2a8d9c3e1
+Revises: 0.96.1
+Create Date: 2026-07-02 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b6f2a8d9c3e1"
+down_revision = "0.96.1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("password_changed_at", sa.DateTime(), nullable=True)
+        )
+
+    with op.batch_alter_table("api_key", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("key_generation", sa.Integer(), nullable=True)
+        )
+
+    connection = op.get_bind()
+
+    meta = sa.MetaData()
+    meta.reflect(bind=connection, only=["api_key"])
+    api_key_table = sa.Table("api_key", meta)
+
+    connection.execute(sa.update(api_key_table).values(key_generation=1))
+
+    with op.batch_alter_table("api_key", schema=None) as batch_op:
+        batch_op.alter_column(
+            "key_generation", existing_type=sa.Integer, nullable=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("api_key", schema=None) as batch_op:
+        batch_op.drop_column("key_generation")
+
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_column("password_changed_at")

--- a/src/zenml/zen_stores/schemas/api_key_schemas.py
+++ b/src/zenml/zen_stores/schemas/api_key_schemas.py
@@ -56,6 +56,7 @@ class APIKeySchema(NamedSchema, table=True):
     description: str = Field(sa_column=Column(TEXT))
     key: str
     previous_key: Optional[str] = Field(default=None, nullable=True)
+    key_generation: int = Field(default=1)
     retain_period: int = Field(default=0)
     active: bool = Field(default=True)
     last_login: Optional[datetime] = None
@@ -214,6 +215,7 @@ class APIKeySchema(NamedSchema, table=True):
             id=self.id,
             name=self.name,
             previous_key=self.previous_key,
+            key_generation=self.key_generation,
             body=model.body,
             metadata=model.metadata,
         )
@@ -266,6 +268,7 @@ class APIKeySchema(NamedSchema, table=True):
         """
         self.updated = utc_now()
         self.previous_key = self.key
+        self.key_generation += 1
         self.retain_period = rotate_request.retain_period_minutes
         new_key = self._generate_jwt_secret_key()
         self.key = self._get_hashed_key(new_key)

--- a/src/zenml/zen_stores/schemas/user_schemas.py
+++ b/src/zenml/zen_stores/schemas/user_schemas.py
@@ -231,8 +231,7 @@ class UserSchema(NamedSchema, table=True):
 
             if field == "password":
                 setattr(self, field, user_update.create_hashed_password())
-                if value is not None:
-                    self.password_changed_at = utc_now()
+                self.password_changed_at = utc_now()
             elif field == "activation_token":
                 setattr(
                     self, field, user_update.create_hashed_activation_token()

--- a/src/zenml/zen_stores/schemas/user_schemas.py
+++ b/src/zenml/zen_stores/schemas/user_schemas.py
@@ -14,6 +14,7 @@
 """SQLModel implementation of user tables."""
 
 import json
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 from uuid import UUID
 
@@ -82,6 +83,9 @@ class UserSchema(NamedSchema, table=True):
     )
     active: bool
     password: Optional[str] = Field(nullable=True)
+    password_changed_at: Optional[datetime] = Field(
+        default=None, nullable=True
+    )
     activation_token: Optional[str] = Field(nullable=True)
     email_opted_in: Optional[bool] = Field(nullable=True)
     external_user_id: Optional[UUID] = Field(nullable=True)
@@ -173,6 +177,7 @@ class UserSchema(NamedSchema, table=True):
             avatar_url=model.avatar_url,
             active=model.active,
             password=model.create_hashed_password(),
+            password_changed_at=utc_now() if model.password else None,
             activation_token=model.create_hashed_activation_token(),
             external_user_id=model.external_user_id,
             email_opted_in=model.email_opted_in,
@@ -226,6 +231,8 @@ class UserSchema(NamedSchema, table=True):
 
             if field == "password":
                 setattr(self, field, user_update.create_hashed_password())
+                if value is not None:
+                    self.password_changed_at = utc_now()
             elif field == "activation_token":
                 setattr(
                     self, field, user_update.create_hashed_activation_token()
@@ -282,6 +289,9 @@ class UserSchema(NamedSchema, table=True):
         metadata = None
         if include_metadata:
             metadata = UserResponseMetadata(
+                password_changed_at=self.password_changed_at
+                if include_private
+                else None,
                 email=self.email if include_private else None,
                 external_user_id=self.external_user_id,
                 user_metadata=json.loads(self.user_metadata)

--- a/tests/integration/functional/zen_stores/test_zen_store.py
+++ b/tests/integration/functional/zen_stores/test_zen_store.py
@@ -683,6 +683,29 @@ class TestAdminUser:
                 user = zen_store.get_user(test_user.id)
                 assert not user.is_admin
 
+                new_password = "new-password"
+                new_zen_store.put(
+                    "/current-user",
+                    body=UserUpdate(
+                        name=test_user.name,
+                        old_password=self.default_pwd,
+                        password=new_password,
+                    ),
+                )
+
+                with pytest.raises(AuthorizationException):
+                    new_zen_store.get_user()
+
+            with pytest.raises(AuthorizationException):
+                with LoginContext(
+                    user_name=test_user.name, password=self.default_pwd
+                ):
+                    Client().zen_store.get_user()
+
+            with LoginContext(user_name=test_user.name, password=new_password):
+                new_zen_store = Client().zen_store
+                assert new_zen_store.get_user().id == test_user.id
+
     def test_service_account_mutations_require_admin_without_rbac(self):
         """Tests service account mutations as an admin and as a non-admin."""
         if Client().zen_store.type == StoreType.SQL:

--- a/tests/unit/zen_server/test_auth.py
+++ b/tests/unit/zen_server/test_auth.py
@@ -13,12 +13,16 @@
 #  permissions and limitations under the License.
 """Unit tests for ZenML server authentication helpers."""
 
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
 from zenml.exceptions import CredentialsNotValid
+from zenml.models import APIKeyInternalResponse, UserResponse
+from zenml.models.v2.core.api_key import APIKeyResponseMetadata
+from zenml.models.v2.core.user import UserResponseMetadata
 from zenml.zen_server import auth
 
 
@@ -36,6 +40,9 @@ class _ApiKey:
         self.verified_keys.append(key)
         return key == "valid"
 
+    def is_token_generation_valid(self, token_generation):
+        return True
+
 
 class _ZenStore:
     def __init__(self, api_key: _ApiKey):
@@ -48,6 +55,44 @@ class _ZenStore:
 
     def update_internal_api_key(self, api_key_id, _):
         self.updated_api_key_ids.append(api_key_id)
+
+
+def _api_key_model(
+    *,
+    key_generation: int,
+    last_rotated: datetime,
+    retain_period_minutes: int,
+) -> APIKeyInternalResponse:
+    return APIKeyInternalResponse.model_construct(
+        id=uuid4(),
+        name="test-key",
+        key_generation=key_generation,
+        body=SimpleNamespace(active=True),
+        metadata=APIKeyResponseMetadata(
+            description="",
+            retain_period_minutes=retain_period_minutes,
+            last_login=None,
+            last_rotated=last_rotated,
+        ),
+    )
+
+
+def _user_model(
+    *,
+    password_changed_at=None,
+    is_service_account: bool = False,
+) -> UserResponse:
+    return UserResponse.model_construct(
+        id=uuid4(),
+        name="test-user",
+        body=SimpleNamespace(is_service_account=is_service_account),
+        metadata=UserResponseMetadata(
+            password_changed_at=password_changed_at,
+            email=None,
+            external_user_id=None,
+            user_metadata={},
+        ),
+    )
 
 
 def test_fetch_and_verify_api_key_rejects_empty_key(monkeypatch):
@@ -71,3 +116,97 @@ def test_fetch_and_verify_api_key_allows_internal_skip(monkeypatch):
 
     assert api_key.verified_keys == []
     assert store.updated_api_key_ids == [api_key.id]
+
+
+def test_api_key_token_generation_allows_legacy_tokens():
+    """Ensure JWTs without a generation claim remain valid."""
+    api_key = _api_key_model(
+        key_generation=2,
+        last_rotated=datetime.utcnow(),
+        retain_period_minutes=5,
+    )
+
+    assert api_key.is_token_generation_valid(token_generation=None)
+
+
+def test_api_key_token_generation_allows_current_generation():
+    """Ensure JWTs issued for the current API key generation are valid."""
+    api_key = _api_key_model(
+        key_generation=2,
+        last_rotated=datetime.utcnow(),
+        retain_period_minutes=5,
+    )
+
+    assert api_key.is_token_generation_valid(token_generation=2)
+
+
+def test_api_key_token_generation_allows_retained_previous_generation():
+    """Ensure the previous API key generation follows the retain period."""
+    api_key = _api_key_model(
+        key_generation=2,
+        last_rotated=datetime.utcnow(),
+        retain_period_minutes=5,
+    )
+
+    assert api_key.is_token_generation_valid(token_generation=1)
+
+
+def test_api_key_token_generation_rejects_expired_previous_generation():
+    """Ensure previous-generation JWTs expire with the retain period."""
+    api_key = _api_key_model(
+        key_generation=2,
+        last_rotated=datetime.utcnow() - timedelta(minutes=6),
+        retain_period_minutes=5,
+    )
+
+    assert not api_key.is_token_generation_valid(token_generation=1)
+
+
+def test_api_key_token_generation_rejects_older_generation():
+    """Ensure only the immediately previous API key generation is retained."""
+    api_key = _api_key_model(
+        key_generation=3,
+        last_rotated=datetime.utcnow(),
+        retain_period_minutes=5,
+    )
+
+    assert not api_key.is_token_generation_valid(token_generation=1)
+
+
+def test_password_change_check_allows_legacy_tokens():
+    """Ensure JWTs without an issued-at claim remain valid."""
+    user = _user_model(password_changed_at=datetime.utcnow())
+
+    assert user.is_token_issued_after_password_change(issued_at=None)
+
+
+def test_password_change_check_rejects_stale_user_tokens():
+    """Ensure user JWTs issued before a password change are rejected."""
+    password_changed_at = datetime.utcnow()
+    user = _user_model(password_changed_at=password_changed_at)
+
+    assert not user.is_token_issued_after_password_change(
+        issued_at=password_changed_at - timedelta(seconds=1)
+    )
+
+
+def test_password_change_check_allows_fresh_user_tokens():
+    """Ensure user JWTs issued after a password change are valid."""
+    password_changed_at = datetime.utcnow()
+    user = _user_model(password_changed_at=password_changed_at)
+
+    assert user.is_token_issued_after_password_change(
+        issued_at=password_changed_at + timedelta(seconds=1)
+    )
+
+
+def test_password_change_check_skips_service_accounts():
+    """Ensure service accounts are governed by API key generation checks."""
+    password_changed_at = datetime.utcnow()
+    user = _user_model(
+        password_changed_at=password_changed_at, is_service_account=True
+    )
+
+    assert user.is_token_issued_after_password_change(
+        issued_at=password_changed_at - timedelta(seconds=1)
+    )

--- a/tests/unit/zen_server/test_jwt.py
+++ b/tests/unit/zen_server/test_jwt.py
@@ -40,6 +40,8 @@ def test_encode_decode_works():
     user_id = uuid.uuid4()
     device_id = uuid.uuid4()
     api_key_id = uuid.uuid4()
+    api_key_generation = 3
+    issued_at = datetime.utcnow()
     schedule_id = uuid.uuid4()
     pipeline_run_id = uuid.uuid4()
     claims = {
@@ -51,19 +53,33 @@ def test_encode_decode_works():
         user_id=user_id,
         device_id=device_id,
         api_key_id=api_key_id,
+        api_key_generation=api_key_generation,
+        issued_at=issued_at,
         schedule_id=schedule_id,
         pipeline_run_id=pipeline_run_id,
         claims=claims,
     )
 
     encoded_token = token.encode()
+    raw_claims = jwt.decode(
+        encoded_token,
+        server_config().jwt_secret_key,
+        algorithms=[server_config().jwt_token_algorithm],
+        audience=server_config().get_jwt_token_audience(),
+        issuer=server_config().get_jwt_token_issuer(),
+    )
     decoded_token = JWTToken.decode_token(encoded_token)
 
+    assert raw_claims["key_gen"] == api_key_generation
+    assert "api_key_generation" not in raw_claims
+    assert isinstance(raw_claims["iat"], float)
     assert decoded_token.user_id == user_id
     assert decoded_token.device_id == device_id
     assert decoded_token.api_key_id == api_key_id
+    assert decoded_token.api_key_generation == api_key_generation
     assert decoded_token.schedule_id == schedule_id
     assert decoded_token.pipeline_run_id == pipeline_run_id
+    assert decoded_token.issued_at == issued_at
     # Check that the configured custom claims are included in the decoded claims
     assert decoded_token.claims["foo"] == "bar"
     assert decoded_token.claims["baz"] == "qux"


### PR DESCRIPTION
## Describe changes
This fixes stale session reuse after user passwords are changed or API keys are rotated.

The change adds token revocation state without tracking every issued token individually:

- User accounts now store `password_changed_at`.
- JWTs now include an `iat` claim with subsecond precision.
- User tokens issued before `password_changed_at` are rejected.
- API keys now track a `key_generation`.
- JWTs derived from API keys include a compact `key_gen` claim.
- API-key tokens are accepted only for the current key generation, or the immediately previous generation while the configured retain period is still active.
- Legacy tokens without `iat` / `key_gen` remain valid.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

