### PR TITLE
Remove placeholder data on queue full errors

### DIFF
--- a/src/zenml/zen_server/pipeline_execution/utils.py
+++ b/src/zenml/zen_server/pipeline_execution/utils.py
@@ -352,13 +352,18 @@ def run_snapshot(
         try:
             snapshot_run_dispatcher().submit(execution_request)
         except SnapshotRunQueueFullError:
-            zen_store().update_run(
-                run_id=execution_request.run_id,
-                run_update=PipelineRunUpdate(
-                    status=ExecutionStatus.FAILED,
-                    status_reason="Snapshot execution queue is full.",
-                ),
-            )
+            try:
+                zen_store().delete_run(run_id=execution_request.run_id)
+                if create_new_snapshot:
+                    zen_store().delete_snapshot(
+                        snapshot_id=execution_request.snapshot_id
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to clean up snapshot run %s after queue "
+                    "rejection.",
+                    execution_request.run_id,
+                )
             raise
         except Exception as exc:
             logger.exception(

--- a/tests/unit/zen_server/test_pipeline_execution_utils.py
+++ b/tests/unit/zen_server/test_pipeline_execution_utils.py
@@ -178,10 +178,11 @@ def test_synchronous_snapshot_run_executes_without_redispatch(
     assert failed_update.status == ExecutionStatus.FAILED
 
 
-def test_queue_rejection_marks_run_failed_and_retains_prepared_state(
-    monkeypatch,
+@pytest.mark.parametrize("create_new_snapshot", [True, False])
+def test_queue_rejection_removes_prepared_state(
+    monkeypatch, create_new_snapshot: bool
 ) -> None:
-    """Queue backpressure retains prepared state for visibility."""
+    """Queue backpressure only removes state created by the request."""
     source_snapshot = SimpleNamespace(id=uuid4())
     target_snapshot = SimpleNamespace(id=uuid4())
     placeholder_run = SimpleNamespace(id=uuid4())
@@ -210,13 +211,17 @@ def test_queue_rejection_marks_run_failed_and_retains_prepared_state(
         utils.run_snapshot(
             snapshot=source_snapshot,
             auth_context=MagicMock(),
+            create_new_snapshot=create_new_snapshot,
         )
 
-    failed_update = store.update_run.call_args_list[-1].kwargs["run_update"]
-    assert failed_update.status == ExecutionStatus.FAILED
-    assert failed_update.status_reason == "Snapshot execution queue is full."
-    store.delete_run.assert_not_called()
-    store.delete_snapshot.assert_not_called()
+    store.delete_run.assert_called_once_with(run_id=placeholder_run.id)
+    if create_new_snapshot:
+        store.delete_snapshot.assert_called_once_with(
+            snapshot_id=target_snapshot.id
+        )
+    else:
+        store.delete_snapshot.assert_not_called()
+    store.update_run.assert_called_once()
     usage.assert_called_once_with(
         feature=utils.RUN_TEMPLATE_TRIGGERS_FEATURE_NAME,
         resource_id=placeholder_run.id,


### PR DESCRIPTION
## Describe changes

Deletes placeholder on queue full error. This handles the scenario of generating multiple retried failed runs when the queue is full.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

