### PR TITLE
Don't include dockerignore in build context archive

### DIFF
--- a/src/zenml/image_builders/build_context.py
+++ b/src/zenml/image_builders/build_context.py
@@ -120,6 +120,11 @@ class BuildContext(Archivable):
             return {
                 archive_path: os.path.join(self._root, archive_path)
                 for archive_path in archive_paths
+                # The patterns are already applied at this point. Keeping the
+                # dockerignore would make some image builders re-apply them
+                # which would exclude anything in `self.extra_files` if the
+                # dockerignore contains patterns that match any of them.
+                if archive_path != ".dockerignore"
             }
         else:
             return {}

--- a/tests/unit/image_builders/test_build_context.py
+++ b/tests/unit/image_builders/test_build_context.py
@@ -78,7 +78,6 @@ def test_build_context_includes_and_excludes(tmp_path):
     build_context.dockerignore_file == str(default_dockerignore)
     assert build_context._get_exclude_patterns() == ["*", "!/.zen"]
     assert build_context.get_files() == {
-        ".dockerignore": str(default_dockerignore),
         ".zen": str(root / ".zen"),
         os.path.join(".zen", "config.yaml"): str(zen_repo),
     }


### PR DESCRIPTION
This PR fixes image builds on remote image builders (AWS CodeBuild, GCP Cloud Build, Kaniko) when the build context root contains a `.dockerignore` whose patterns match the ZenML-generated files, e.g. an allowlist-style file starting with `*`.

Fixes #5030 