### PR TITLE
Misc query improvements

### DIFF
--- a/src/zenml/models/v2/base/filter.py
+++ b/src/zenml/models/v2/base/filter.py
@@ -538,7 +538,6 @@ class UUIDFilter(StrFilter):
             A list of query conditions.
         """
         import sqlalchemy
-        from sqlalchemy_utils.functions import cast_if
 
         from zenml.utils import uuid_utils
 
@@ -557,9 +556,9 @@ class UUIDFilter(StrFilter):
             assert isinstance(self.value, (str, UUID))
             return column != uuid_utils.to_uuid(self.value)
 
-        # For all other operations, cast and handle the column as string
+        # For all other operations, handle the column as a string
         return super().generate_query_conditions_from_column(
-            column=cast_if(column, sqlalchemy.String)
+            column=sqlalchemy.type_coerce(column, sqlalchemy.String)
         )
 
 

--- a/src/zenml/models/v2/base/scoped.py
+++ b/src/zenml/models/v2/base/scoped.py
@@ -463,38 +463,6 @@ class TaggableFilter(BaseFilter):
         "tags",
     ]
 
-    def apply_filter(
-        self,
-        query: AnyQuery,
-        table: Type["AnySchema"],
-    ) -> AnyQuery:
-        """Applies the filter to a query.
-
-        Args:
-            query: The query to which to apply the filter.
-            table: The query table.
-
-        Returns:
-            The query with filter applied.
-        """
-        from zenml.models.v2.base.filter import VALUELESS_FILTER_OPS
-        from zenml.zen_stores.schemas import TagResourceSchema, TagSchema
-
-        query = super().apply_filter(query=query, table=table)
-
-        tag_values = [self.tags] if isinstance(self.tags, str) else self.tags
-
-        if tag_values and any(
-            self._resolve_operator(tag)[1] not in VALUELESS_FILTER_OPS
-            for tag in tag_values
-        ):
-            query = query.join(
-                TagResourceSchema,
-                TagResourceSchema.resource_id == getattr(table, "id"),
-            ).join(TagSchema, TagSchema.id == TagResourceSchema.tag_id)
-
-        return query
-
     def get_custom_filters(
         self, table: Type["AnySchema"]
     ) -> List["ColumnElement[bool]"]:


### PR DESCRIPTION
- Tag filters now use EXISTS subqueries only, dropping a redundant join that forced a DISTINCT (and row multiplication) on every tag-filtered list.
- UUID filters (startswith/contains/endswith/etc.) no longer wrap the ID column in a CAST, so id LIKE 'prefix%' uses the primary-key index instead of a full scan.