### PR TITLE
Reduce unnecessary server requests

### DIFF
--- a/.github/workflows/server-request-count.yml
+++ b/.github/workflows/server-request-count.yml
@@ -1,0 +1,142 @@
+---
+name: ZenML Server Request Count
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths: [src/zenml/**]
+  workflow_dispatch:
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  count-server-requests:
+    name: Count ZenML Server Requests
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    env:
+      ZENML_ANALYTICS_OPT_IN: false
+      PYTHONIOENCODING: utf-8
+      UV_HTTP_TIMEOUT: 600
+      AUTO_OPEN_DASHBOARD: false
+      BASE_RESULTS_FILE: base_request_counts.json
+      CURRENT_RESULTS_FILE: current_request_counts.json
+      BASE_VENV: .venv-base
+      CURRENT_VENV: .venv-current
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: '3.11'
+      - name: Install system dependencies
+        run: |
+          python -m pip install --upgrade wheel pip uv
+
+      # The measurement script is copied out of the repository so both
+      # branches run the exact same pipeline and counting logic.
+      - name: Save merge commit and measurement script
+        run: |
+          echo "MERGE_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          cp scripts/pipeline_request_count.py $RUNNER_TEMP/pipeline_request_count.py
+
+      # Count requests on the base branch with an isolated environment
+      - name: Checkout base branch
+        run: |
+          git checkout ${GITHUB_BASE_REF}
+      - name: Setup base virtual environment
+        run: |
+          python -m venv ${{ env.BASE_VENV }}
+          source ${{ env.BASE_VENV }}/bin/activate
+          pip install --upgrade pip uv
+      - name: Install ZenML in base environment
+        run: |
+          source ${{ env.BASE_VENV }}/bin/activate
+          ./scripts/install-zenml-dev.sh
+          zenml --version
+      - name: Count requests on base branch
+        run: |
+          source ${{ env.BASE_VENV }}/bin/activate
+          zenml login --local
+          python $RUNNER_TEMP/pipeline_request_count.py --output $BASE_RESULTS_FILE
+          zenml logout --local
+
+      # Delete local files so the second measurement starts with a fresh DB
+      - name: Cleanup
+        run: |
+          rm -rf ~/.config/zenml
+
+      # Count requests on the PR merge commit with an isolated environment
+      - name: Checkout merged branch
+        run: |
+          git checkout ${MERGE_SHA}
+      - name: Setup current virtual environment
+        run: |
+          python -m venv ${{ env.CURRENT_VENV }}
+          source ${{ env.CURRENT_VENV }}/bin/activate
+          pip install --upgrade pip uv
+      - name: Install ZenML in current environment
+        run: |
+          source ${{ env.CURRENT_VENV }}/bin/activate
+          ./scripts/install-zenml-dev.sh
+          zenml --version
+      - name: Count requests on merged branch
+        run: |
+          source ${{ env.CURRENT_VENV }}/bin/activate
+          zenml login --local
+          python $RUNNER_TEMP/pipeline_request_count.py --output $CURRENT_RESULTS_FILE
+          zenml logout --local
+      - name: Compare results and create report
+        id: create-report
+        run: |
+          if diff -U0 --label "${GITHUB_BASE_REF}" --label "${GITHUB_HEAD_REF}" $BASE_RESULTS_FILE $CURRENT_RESULTS_FILE > requests_diff.txt; then
+            echo "has_difference=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_difference=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "<!-- REQUEST_COUNT_REPORT -->"
+              echo "## Server requests changed"
+              echo ""
+              echo '```diff'
+              cat requests_diff.txt
+              echo '```'
+              echo ""
+              echo "cc @schustmi"
+            } > request_count_report.md
+
+            # Save the report to an environment variable for later steps
+            echo "REQUEST_COUNT_REPORT<<EOF" >> $GITHUB_ENV
+            cat request_count_report.md >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          fi
+      - name: Find existing comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad  # v4.0.0
+        if: github.event_name == 'pull_request' && steps.create-report.outputs.has_difference
+          == 'true'
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- REQUEST_COUNT_REPORT -->
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
+        if: github.event_name == 'pull_request' && steps.create-report.outputs.has_difference
+          == 'true'
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ env.REQUEST_COUNT_REPORT }}
+          edit-mode: replace
+
+      # Upload results as artifacts
+      - name: Upload request count results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: request-count-results
+          path: |-
+            ${{ env.BASE_RESULTS_FILE }}
+            ${{ env.CURRENT_RESULTS_FILE }}
+            request_count_report.md

--- a/scripts/pipeline_request_count.py
+++ b/scripts/pipeline_request_count.py
@@ -1,0 +1,118 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Count the server requests made by a minimal pipeline run."""
+
+import argparse
+import json
+import re
+from collections import Counter
+from typing import Any, Tuple
+from urllib.parse import urlparse
+
+import requests
+
+from zenml import pipeline, step
+
+UUID_REGEX = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
+@step
+def noop_step() -> None:
+    pass
+
+
+@pipeline(enable_cache=False)
+def request_count_pipeline() -> None:
+    noop_step()
+    noop_step()
+    noop_step()
+
+
+def normalize_path(path: str) -> str:
+    """Replace UUIDs in a request path with a placeholder.
+
+    Args:
+        path: Request path.
+
+    Returns:
+        Normalized path.
+    """
+    return UUID_REGEX.sub("{id}", path)
+
+
+def run_and_count(output_file: str) -> None:
+    """Run the pipeline and write per-endpoint request counts to a file.
+
+    Args:
+        output_file: Output JSON file.
+    """
+    counts: Counter[Tuple[str, str, str]] = Counter()
+    original_send = requests.Session.send
+
+    def counting_send(
+        session: requests.Session,
+        request: requests.PreparedRequest,
+        **kwargs: Any,
+    ) -> requests.Response:
+        parsed = urlparse(request.url or "")
+        key = (
+            parsed.netloc,
+            request.method or "",
+            normalize_path(parsed.path),
+        )
+        counts[key] += 1
+
+        return original_send(session, request, **kwargs)
+
+    requests.Session.send = counting_send  # type: ignore[method-assign]
+    try:
+        request_count_pipeline()
+    finally:
+        requests.Session.send = original_send  # type: ignore[method-assign]
+
+    from zenml.config.global_config import GlobalConfiguration
+
+    server_netloc = urlparse(
+        GlobalConfiguration().store_configuration.url
+    ).netloc
+    requests_by_endpoint = {
+        f"{method} {path}": count
+        for (netloc, method, path), count in sorted(counts.items())
+        if netloc == server_netloc
+    }
+    result = {
+        "total": sum(requests_by_endpoint.values()),
+        "requests": requests_by_endpoint,
+    }
+
+    with open(output_file, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print(json.dumps(result, indent=2))
+
+
+def main() -> None:
+    """Parse arguments and run the pipeline."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, help="Output JSON file")
+    args = parser.parse_args()
+
+    run_and_count(output_file=args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zenml/deployers/utils.py
+++ b/src/zenml/deployers/utils.py
@@ -375,7 +375,9 @@ def deployment_snapshot_request_from_source_snapshot(
             code_repository=source_snapshot.code_reference.code_repository.id,
         )
 
-    zenml_version = Client().zen_store.get_store_info().version
+    zenml_version = (
+        Client().zen_store.get_store_info(force_refresh=True).version
+    )
 
     # Compute the source snapshot ID:
     # - If the source snapshot has a name, we use it as the source snapshot.

--- a/src/zenml/models/v2/base/scoped.py
+++ b/src/zenml/models/v2/base/scoped.py
@@ -374,7 +374,17 @@ class ProjectScopedResponse(
         """
         from zenml.client import Client
 
-        return Client().get_project(self.project_id)
+        client = Client()
+
+        try:
+            active_project = client.active_project
+        except Exception:
+            active_project = None
+
+        if active_project is not None and active_project.id == self.project_id:
+            return active_project
+
+        return client.get_project(self.project_id)
 
 
 # ---------------------- Filter Models ----------------------

--- a/src/zenml/orchestrators/step_runner.py
+++ b/src/zenml/orchestrators/step_runner.py
@@ -737,6 +737,9 @@ class StepRunner:
         Returns:
             The IDs of the published output artifacts.
         """
+        if not output_data:
+            return {}
+
         from zenml.deployers.server import runtime
 
         step_context = get_step_context()

--- a/src/zenml/pipelines/pipeline_definition.py
+++ b/src/zenml/pipelines/pipeline_definition.py
@@ -1359,7 +1359,7 @@ To avoid this consider setting pipeline parameters only in one place (config or 
                     if not source.is_internal:
                         custom_materializer = True
 
-        stack_creator = Client().get_stack(stack.id).user_id
+        stack_creator = stack.model.user_id
         active_user = Client().active_user
         own_stack = stack_creator and stack_creator == active_user.id
 

--- a/src/zenml/stack/stack.py
+++ b/src/zenml/stack/stack.py
@@ -156,6 +156,7 @@ class Stack:
         self._name = name
         self._environment = environment or {}
         self._secrets = secrets or []
+        self._model: Optional["StackResponse"] = None
 
         self._components: Dict[StackComponentType, List["StackComponent"]] = (
             defaultdict(list)
@@ -187,6 +188,17 @@ class Stack:
 
                 for component in components:
                     self._components[component.type].append(component)
+
+    @property
+    def model(self) -> "StackResponse":
+        """The stack response model.
+
+        Returns:
+            The model of the stack.
+        """
+        if self._model is None:
+            self._model = Client().get_stack(self._id)
+        return self._model
 
     @classmethod
     def from_model(cls, stack_model: "StackResponse") -> "Stack":
@@ -242,6 +254,7 @@ class Stack:
             secrets=stack_model.secrets,
             components=stack_components,
         )
+        stack._model = stack_model
         _STACK_CACHE[key] = stack
 
         client = Client()

--- a/src/zenml/steps/step_context.py
+++ b/src/zenml/steps/step_context.py
@@ -166,20 +166,10 @@ class StepContext(context_utils.BaseContext):
             StepContextError: If the keys of the output materializers and
                 output artifacts do not match.
         """
-        from zenml.client import Client
-
         super().__init__()
-
-        try:
-            pipeline_run = Client().get_pipeline_run(pipeline_run.id)
-        except KeyError:
-            pass
         self.pipeline_run = pipeline_run
-        try:
-            step_run = Client().get_run_step(step_run.id)
-        except KeyError:
-            pass
         self.step_run = step_run
+
         self.model_version = (
             step_run.model_version or pipeline_run.model_version
         )

--- a/src/zenml/zen_stores/base_zen_store.py
+++ b/src/zenml/zen_stores/base_zen_store.py
@@ -384,8 +384,11 @@ class BaseZenStore(
 
         return active_project, active_stack
 
-    def get_store_info(self) -> ServerModel:
+    def get_store_info(self, force_refresh: bool = False) -> ServerModel:
         """Get information about the store.
+
+        Args:
+            force_refresh: Ignored, the information is always fresh.
 
         Returns:
             Information about the store.

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -578,18 +578,20 @@ class RestZenStore(BaseZenStore):
         Returns:
             Cached information about the server.
         """
-        if self._server_info is None:
-            return self.get_store_info()
-        return self._server_info
+        return self.get_store_info()
 
-    def get_store_info(self) -> ServerModel:
+    def get_store_info(self, force_refresh: bool = False) -> ServerModel:
         """Get information about the server.
+
+        Args:
+            force_refresh: Fetch the server information even if it is cached.
 
         Returns:
             Information about the server.
         """
-        body = self.get(INFO)
-        self._server_info = ServerModel.model_validate(body)
+        if self._server_info is None or force_refresh:
+            body = self.get(INFO)
+            self._server_info = ServerModel.model_validate(body)
         return self._server_info
 
     def get_deployment_id(self) -> UUID:
@@ -4880,7 +4882,7 @@ class RestZenStore(BaseZenStore):
             # NOTE: this is the best place to do this because we know that
             # the token is valid and the server is reachable.
             try:
-                server_info = self.get_store_info()
+                server_info = self.get_store_info(force_refresh=True)
             except Exception as e:
                 logger.warning(f"Failed to get server info: {e}.")
             else:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1747,8 +1747,11 @@ class SqlZenStore(BaseZenStore):
         """Purge all in-built and integration flavors from the DB and sync."""
         FlavorRegistry().register_flavors(store=self)
 
-    def get_store_info(self) -> ServerModel:
+    def get_store_info(self, force_refresh: bool = False) -> ServerModel:
         """Get information about the store.
+
+        Args:
+            force_refresh: Ignored, the information is always fresh.
 
         Returns:
             Information about the store.

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -246,8 +246,11 @@ class ZenStoreInterface(ResourcePoolsStoreInterface, ABC):
         """
 
     @abstractmethod
-    def get_store_info(self) -> ServerModel:
+    def get_store_info(self, force_refresh: bool = False) -> ServerModel:
         """Get information about the store.
+
+        Args:
+            force_refresh: Fetch the store information even if it is cached.
 
         Returns:
             Information about the store.


### PR DESCRIPTION
- Cache project when fetching via `ProjectScopedResponse`
- Cache RestZenStore store info unless explicitly requesting refresh
- Store stack response on stack object

Local orchestrator, `N` steps, no step output artifacts or tags/metadata, bare setup.
- Before `26 + 14N` requests
- After `18 + 6N` requests