### PR TITLE
Fix dict parameter overrides when invoking deployments

### DIFF
--- a/src/zenml/deployers/utils.py
+++ b/src/zenml/deployers/utils.py
@@ -352,7 +352,7 @@ def deployment_snapshot_request_from_source_snapshot(
         }
 
         step_config = pydantic_utils.update_model(
-            step.step_config_overrides, step_update
+            step.step_config_overrides, step_update, recursive=False
         )
         merged_step_config = step_config.apply_pipeline_configuration(
             pipeline_configuration,

--- a/tests/integration/functional/deployers/test_deployment_utils.py
+++ b/tests/integration/functional/deployers/test_deployment_utils.py
@@ -1,0 +1,62 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Functional tests for deployment snapshot request creation."""
+
+from typing import Annotated, Dict, List
+
+from zenml import pipeline, step
+from zenml.client import Client
+from zenml.deployers.utils import (
+    deployment_snapshot_request_from_source_snapshot,
+)
+
+
+@step(enable_cache=False)
+def _echo_parameters(
+    mapping: Dict[str, int], items: List[int]
+) -> Annotated[Dict[str, int], "mapping"]:
+    return mapping
+
+
+@pipeline(enable_cache=False)
+def _parametrized_pipeline(
+    mapping: Dict[str, int] = {"default": 1},
+    items: List[int] = [1, 2, 3],
+) -> Dict[str, int]:
+    return _echo_parameters(mapping=mapping, items=items)
+
+
+def test_deployment_parameters_replace_dict_defaults(
+    clean_client: Client,
+) -> None:
+    """Deployment parameters replace defaults instead of merging into them.
+
+    A dict-valued parameter used to be merged recursively with its compiled
+    default when building the invocation snapshot, leaking stale default keys
+    into the value the step actually executed with. The provided value must
+    replace the default wholesale, matching how the parameter behaves in a
+    batch run.
+    """
+    run = _parametrized_pipeline()
+    source_snapshot = clean_client.get_pipeline_run(run.id).snapshot
+
+    request = deployment_snapshot_request_from_source_snapshot(
+        source_snapshot=source_snapshot,
+        run_name=None,
+        deployment_parameters={"mapping": {"override": 5}},
+    )
+
+    step_config = next(iter(request.step_configurations.values()))
+    assert step_config.config.parameters["mapping"] == {"override": 5}
+    assert step_config.config.parameters["items"] == [1, 2, 3]


### PR DESCRIPTION
## Describe changes
Dict-valued pipeline parameters passed to a deployment `/invoke` were recursively merged with their compiled defaults instead of replacing them, so default keys leaked into the value a step actually ran with (e.g. sending `{"b": 5}` ran with `{"a": 1, "b": 5}`). The run still reported success, hiding the wrong result. Scalar and list parameters were replaced correctly, so only dicts were affected.

Deployment parameters now replace their defaults, matching how the same parameter behaves in a batch run.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
