### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ ZenML is used by thousands of companies to run their AI workflows. Here are some
 
 ```bash
 # Install ZenML with server capabilities
+
+[![Listed on TakoAPI](https://takoapi.com/api/badge/zenml-io-zenml)](https://takoapi.com/agents/zenml-io-zenml)
+
 pip install "zenml[server]"  # pip install zenml will install a slimmer client
 
 # Initialize your ZenML repository


### PR DESCRIPTION
Hi! 👋 **zenml** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/zenml-io-zenml

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building zenml! 🙏