### PR TITLE
Fix truncated dashboard URLs in CLI output

### DIFF
--- a/src/zenml/cli/deployment.py
+++ b/src/zenml/cli/deployment.py
@@ -273,7 +273,7 @@ def provision_deployment(
             if dashboard_url:
                 cli_utils.declare(
                     f"\nView in ZenML Cloud: [link]{dashboard_url}[/link]",
-                    no_wrap=True,
+                    soft_wrap=True,
                 )
 
 

--- a/src/zenml/cli/pipeline.py
+++ b/src/zenml/cli/pipeline.py
@@ -502,7 +502,7 @@ def deploy_pipeline(
         if dashboard_url:
             cli_utils.declare(
                 f"\nView in the ZenML UI: [link]{dashboard_url}[/link]",
-                no_wrap=True,
+                soft_wrap=True,
             )
 
         if attach:
@@ -1822,7 +1822,7 @@ def deploy_snapshot(
             if dashboard_url:
                 cli_utils.declare(
                     f"\nView in the ZenML UI: [link]{dashboard_url}[/link]",
-                    no_wrap=True,
+                    soft_wrap=True,
                 )
 
 

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -2592,11 +2592,11 @@ def pretty_print_deployment(
 
         declare(
             f"\n[bold]Endpoint URL:[/bold] [link]{deployment.url}[/link]",
-            no_wrap=True,
+            soft_wrap=True,
         )
         declare(
             f"[bold]Swagger URL:[/bold] [link]{deployment.url.rstrip('/')}/docs[/link]",
-            no_wrap=True,
+            soft_wrap=True,
         )
 
         # Auth key handling with proper security

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -1,4 +1,5 @@
 import io
+from types import SimpleNamespace
 
 import pytest
 from rich.console import Console
@@ -29,3 +30,40 @@ def test_print_page_info_does_not_render_backticks(
     )
     assert "`" not in rendered_output
     assert "[cyan]" not in rendered_output
+
+
+def test_pretty_print_deployment_does_not_truncate_endpoint_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = io.StringIO()
+    test_console = Console(
+        file=output,
+        force_terminal=False,
+        theme=zenml_custom_theme,
+        width=80,
+    )
+    monkeypatch.setattr(cli_utils, "console", test_console)
+    monkeypatch.setattr(
+        cli_utils, "get_deployment_invocation_example", lambda deployment: {}
+    )
+
+    # The endpoint URL is deliberately wider than the console. It must be
+    # printed in full on its own line rather than cropped to the terminal
+    # width, which is what no_wrap=True would do.
+    url = "https://example.com/deployments/" + "d" * 64
+    deployment = SimpleNamespace(
+        name="my-deployment",
+        status="running",
+        snapshot=None,
+        url=url,
+        auth_key=None,
+    )
+
+    cli_utils.pretty_print_deployment(deployment)
+
+    endpoint_line = next(
+        line
+        for line in output.getvalue().splitlines()
+        if "Endpoint URL" in line
+    )
+    assert url in endpoint_line


### PR DESCRIPTION
## Describe changes

The deployment and pipeline CLI commands printed dashboard and deployment URLs with `no_wrap=True`. That flag makes Rich crop whatever overflows the console width instead of wrapping it, so when a URL was wider than the terminal (or `COLUMNS` was set) the trailing characters were silently dropped, leaving a broken "View in the ZenML UI" link that couldn't be opened.

I switched these prints to `soft_wrap=True`, which disables cropping so the full URL is always emitted and the terminal handles the overflow. This covers the `deployment` and `pipeline` deploy/snapshot commands as well as the endpoint and Swagger URLs shown by `pretty_print_deployment`, and adds a regression test that renders a link wider than the console and asserts it isn't truncated.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources (CLI output only — no docs/dashboard/template/project changes required):
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [x] Dashboard: Needs to be communicated to the frontend team.
  - [x] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [x] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
