### PR TITLE
Fix duplicated word in service connector login output

### DIFF
--- a/docs/book/component-guide/container-registries/aws.md
+++ b/docs/book/component-guide/container-registries/aws.md
@@ -190,7 +190,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'aws-us-east-1' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'aws-us-east-1' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 {% endhint %}

--- a/docs/book/component-guide/container-registries/azure.md
+++ b/docs/book/component-guide/container-registries/azure.md
@@ -177,7 +177,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'azure-demo' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'azure-demo' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 {% endhint %}

--- a/docs/book/component-guide/container-registries/default.md
+++ b/docs/book/component-guide/container-registries/default.md
@@ -161,7 +161,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'dockerhub' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'dockerhub' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 {% endhint %}

--- a/docs/book/component-guide/container-registries/gcp.md
+++ b/docs/book/component-guide/container-registries/gcp.md
@@ -197,7 +197,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'gcp-zenml-core' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'gcp-zenml-core' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 {% endhint %}

--- a/docs/book/component-guide/service-connectors/connector-types/aws-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/aws-service-connector.md
@@ -1252,7 +1252,7 @@ zenml service-connector login aws-session-token --resource-type kubernetes-clust
 Cluster "arn:aws:eks:us-east-1:715803424590:cluster/zenhacks-cluster" set.
 Context "arn:aws:eks:us-east-1:715803424590:cluster/zenhacks-cluster" modified.
 Updated local kubeconfig with the cluster details. The current kubectl context was set to 'arn:aws:eks:us-east-1:715803424590:cluster/zenhacks-cluster'.
-The 'aws-session-token' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'aws-session-token' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 ```
 {% endcode %}
 
@@ -1297,7 +1297,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'aws-session-token' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'aws-session-token' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 
@@ -1337,7 +1337,7 @@ zenml service-connector login aws-session-token --resource-type aws-generic
 {% code title="Example Command Output" %}
 ```
 Configured local AWS SDK profile 'zenml-c0f8e857'.
-The 'aws-session-token' AWS Service Connector connector was used to successfully configure the local Generic AWS resource client/SDK.
+The 'aws-session-token' AWS Service Connector was used to successfully configure the local Generic AWS resource client/SDK.
 ```
 {% endcode %}
 

--- a/docs/book/component-guide/service-connectors/connector-types/azure-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/azure-service-connector.md
@@ -473,7 +473,7 @@ zenml service-connector login azure-service-principal --resource-type kubernetes
 ```
 ⠙ Attempting to configure local client using service connector 'azure-service-principal'...
 Updated local kubeconfig with the cluster details. The current kubectl context was set to 'demo-zenml-terraform-cluster'.
-The 'azure-service-principal' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'azure-service-principal' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 ```
 {% endcode %}
 
@@ -520,7 +520,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'azure-service-principal' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'azure-service-principal' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 
@@ -560,7 +560,7 @@ zenml service-connector login azure-service-principal --resource-type azure-gene
 {% code title="Example Command Output" %}
 ```
 Updated the local Azure CLI configuration with the connector's service principal credentials.
-The 'azure-service-principal' Azure Service Connector connector was used to successfully configure the local Generic Azure resource client/SDK.
+The 'azure-service-principal' Azure Service Connector was used to successfully configure the local Generic Azure resource client/SDK.
 ```
 {% endcode %}
 

--- a/docs/book/component-guide/service-connectors/connector-types/docker-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/docker-service-connector.md
@@ -83,7 +83,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'dockerhub' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'dockerhub' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 

--- a/docs/book/component-guide/service-connectors/connector-types/gcp-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/gcp-service-connector.md
@@ -988,7 +988,7 @@ zenml service-connector login gcp-user-account --resource-type kubernetes-cluste
 ⠴ Attempting to configure local client using service connector 'gcp-user-account'...
 Context "gke_zenml-core_zenml-test-cluster" modified.
 Updated local kubeconfig with the cluster details. The current kubectl context was set to 'gke_zenml-core_zenml-test-cluster'.
-The 'gcp-user-account' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'gcp-user-account' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 ```
 {% endcode %}
 
@@ -1035,7 +1035,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'gcp-user-account' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'gcp-user-account' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 ```
 {% endcode %}
 
@@ -1075,7 +1075,7 @@ zenml service-connector login gcp-user-account --resource-type gcp-generic
 {% code title="Example Command Output" %}
 ```
 Updated the local gcloud default application credentials file at '/home/user/.config/gcloud/application_default_credentials.json'
-The 'gcp-user-account' GCP Service Connector connector was used to successfully configure the local Generic GCP resource client/SDK.
+The 'gcp-user-account' GCP Service Connector was used to successfully configure the local Generic GCP resource client/SDK.
 ```
 {% endcode %}
 

--- a/docs/book/component-guide/service-connectors/connector-types/kubernetes-service-connector.md
+++ b/docs/book/component-guide/service-connectors/connector-types/kubernetes-service-connector.md
@@ -138,7 +138,7 @@ Cluster "35.185.95.223" set.
 ⠇ Attempting to configure local client using service connector 'kube-auto'...
 ⠏ Attempting to configure local client using service connector 'kube-auto'...
 Updated local kubeconfig with the cluster details. The current kubectl context was set to '35.185.95.223'.
-The 'kube-auto' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'kube-auto' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 ```
 {% endcode %}
 

--- a/docs/book/component-guide/service-connectors/service-connectors-guide.md
+++ b/docs/book/component-guide/service-connectors/service-connectors-guide.md
@@ -1413,7 +1413,7 @@ zenml service-connector login gcp-user-multi --resource-type kubernetes-cluster 
 $ zenml service-connector login gcp-user-multi --resource-type kubernetes-cluster --resource-id zenml-test-cluster
 ⠇ Attempting to configure local client using service connector 'gcp-user-multi'...
 Updated local kubeconfig with the cluster details. The current kubectl context was set to 'gke_zenml-core_zenml-test-cluster'.
-The 'gcp-user-multi' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'gcp-user-multi' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 
 # Verify that the local kubectl client is now configured to access the remote Kubernetes cluster
 $ kubectl cluster-info
@@ -1433,7 +1433,7 @@ zenml service-connector login aws-multi-type --resource-type kubernetes-cluster 
 $ zenml service-connector login aws-multi-type --resource-type kubernetes-cluster --resource-id zenhacks-cluster
 ⠏ Attempting to configure local client using service connector 'aws-multi-type'...
 Updated local kubeconfig with the cluster details. The current kubectl context was set to 'arn:aws:eks:us-east-1:715803424590:cluster/zenhacks-cluster'.
-The 'aws-multi-type' Kubernetes Service Connector connector was used to successfully configure the local Kubernetes cluster client/SDK.
+The 'aws-multi-type' Kubernetes Service Connector was used to successfully configure the local Kubernetes cluster client/SDK.
 
 # Verify that the local kubectl client is now configured to access the remote Kubernetes cluster
 $ kubectl cluster-info
@@ -1471,7 +1471,7 @@ WARNING! Your password will be stored unencrypted in /home/stefan/.docker/config
 Configure a credential helper to remove this warning. See
 https://docs.docker.com/engine/reference/commandline/login/#credentials-store
 
-The 'aws-session-token' Docker Service Connector connector was used to successfully configure the local Docker/OCI container registry client/SDK.
+The 'aws-session-token' Docker Service Connector was used to successfully configure the local Docker/OCI container registry client/SDK.
 
 # Verify that the local Docker client is now configured to access the remote Docker container registry
 $ docker pull 715803424590.dkr.ecr.us-east-1.amazonaws.com/zenml-server

--- a/src/zenml/cli/service_connectors.py
+++ b/src/zenml/cli/service_connectors.py
@@ -1933,7 +1933,7 @@ def login_service_connector(
         assert resource_type is not None
         resource_name = spec.resource_type_dict[resource_type].name
         cli_utils.declare(
-            f"The '{name_id_or_prefix}' {spec.name} connector was used to "
+            f"The '{name_id_or_prefix}' {spec.name} was used to "
             f"successfully configure the local {resource_name} client/SDK."
         )
 


### PR DESCRIPTION
## Describe changes
`zenml service-connector login` printed "connector" twice, e.g. "The 'aws-us-east-1' AWS Service Connector connector was used to successfully configure the local S3 bucket client/SDK". The connector type name already ends in "Connector", so the extra word was redundant.

Removed the duplicate word and updated the docs pages that showed the old output.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
