### PR TITLE
feat: added logging and otel support to helm charts

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -114,28 +114,37 @@ If you override `podSecurityContext`, ensure that `fsGroup: 1000` is set when us
 
 ### Server Observability
 
-You can configure server log output and OpenTelemetry export through
-`server.environment`:
+You can configure server log output and OpenTelemetry export with dedicated Helm values:
 
 ```yaml
 server:
-  environment:
-    ZENML_CONSOLE_LOGGING_FORMAT: "<console|json>" # default is console
-    ZENML_LOGGING_COLORS_DISABLED: "<true|false>" # default is false
-    ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
-    ZENML_SERVER_OTEL_SERVICE_NAME: "zenml-server" # default is zenml-server
-    ZENML_SERVER_OTEL_TRACES_ENABLED: "<true|false>" # default is true
-    ZENML_SERVER_OTEL_METRICS_ENABLED: "<true|false>" # default is true
-    ZENML_SERVER_OTEL_LOGS_ENABLED: "<true|false>" # default is true
+  logging:
+    format: "console" # console, json, or a custom %-style format
+    colorsDisabled: false
+  openTelemetry:
+    endpoint: "http://otel-collector:4318"
+    serviceName: "zenml-server"
+    tracesEndpoint:
+    metricsEndpoint:
+    logsEndpoint:
+    tracesEnabled: true
+    metricsEnabled: true
+    logsEnabled: true
 ```
 
-`ZENML_CONSOLE_LOGGING_FORMAT` controls the server container stdout/stderr output. It can be set to `console`, `json`, or a valid Python `%`-style logging format string. The older `ZENML_LOGGING_FORMAT` environment variable is still supported as a deprecated alias but will be removed in a future version.
+`server.logging.format` controls the server container stdout/stderr output. It can be set to `console`, `json`, or a valid Python `%`-style logging format string. The older `ZENML_LOGGING_FORMAT` environment variable is still supported through `server.environment` as a deprecated alias but will be removed in a future version.
 
-OpenTelemetry export is configured separately with `ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT` and exports traces, metrics, and logs using OTLP/HTTP transport. Each signal is enabled by default and can be disabled individually with `ZENML_SERVER_OTEL_TRACES_ENABLED`, `ZENML_SERVER_OTEL_METRICS_ENABLED`, and `ZENML_SERVER_OTEL_LOGS_ENABLED`.
+OpenTelemetry export behavior:
 
-The standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is also supported as a fallback.
+- Export is enabled when either `server.openTelemetry.endpoint` or at least one per-signal endpoint is configured.
+- Per-signal endpoints can be configured with `server.openTelemetry.tracesEndpoint`, `metricsEndpoint`, or `logsEndpoint`.
+- If `server.openTelemetry.endpoint` is not configured, only signals with a per-signal endpoint are exported.
+- If `server.openTelemetry.endpoint` is configured, the server uses it for any signal without a per-signal endpoint by appending paths like `/v1/traces`, `/v1/metrics`, and `/v1/logs`.
+- Each signal is enabled by default and can be disabled individually with `server.openTelemetry.tracesEnabled`, `metricsEnabled`, and `logsEnabled`. OR you can set individual per-signal endpoints to enable export only for that signal type.
 
-Standard per-signal OTLP/HTTP endpoint variables such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` are supported too, along with matching `ZENML_SERVER_OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT` names.
+The service name can be configured with `server.openTelemetry.serviceName`. If not set, the server uses its default service name.
+
+You can use `server.environment` for advanced exporter settings and standard OpenTelemetry variables that are not modeled as chart values, such as `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TIMEOUT`, and `OTEL_EXPORTER_OTLP_COMPRESSION`.
 
 Standard OTLP headers, timeout, and compression variables are handled by the OpenTelemetry Python exporters. OTLP/gRPC protocol variables are not supported because the server configures OTLP/HTTP exporters directly. You can read more about the OpenTelemetry environment variables and SDK configuration [here](https://opentelemetry.io/docs/languages/sdk-configuration/).
 

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -294,6 +294,7 @@ root_url_path: {{ .ZenML.rootUrlPath | quote }}
 server_url: {{ .ZenML.serverURL | quote }}
 {{- end }}
 {{- with .ZenML.openTelemetry }}
+{{- if or .endpoint .tracesEndpoint .metricsEndpoint .logsEndpoint }}
 {{- if .endpoint }}
 otel_exporter_otlp_endpoint: {{ .endpoint | quote }}
 {{- end }}
@@ -317,6 +318,7 @@ otel_metrics_enabled: {{ .metricsEnabled | quote }}
 {{- end }}
 {{- if hasKey . "logsEnabled" }}
 otel_logs_enabled: {{ .logsEnabled | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- range $key, $value := .ZenML.secure_headers }}

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -293,6 +293,32 @@ root_url_path: {{ .ZenML.rootUrlPath | quote }}
 {{- if .ZenML.serverURL }}
 server_url: {{ .ZenML.serverURL | quote }}
 {{- end }}
+{{- with .ZenML.openTelemetry }}
+{{- if .endpoint }}
+otel_exporter_otlp_endpoint: {{ .endpoint | quote }}
+{{- end }}
+{{- if .serviceName }}
+otel_service_name: {{ .serviceName | quote }}
+{{- end }}
+{{- if .tracesEndpoint }}
+otel_exporter_otlp_traces_endpoint: {{ .tracesEndpoint | quote }}
+{{- end }}
+{{- if .metricsEndpoint }}
+otel_exporter_otlp_metrics_endpoint: {{ .metricsEndpoint | quote }}
+{{- end }}
+{{- if .logsEndpoint }}
+otel_exporter_otlp_logs_endpoint: {{ .logsEndpoint | quote }}
+{{- end }}
+{{- if hasKey . "tracesEnabled" }}
+otel_traces_enabled: {{ .tracesEnabled | quote }}
+{{- end }}
+{{- if hasKey . "metricsEnabled" }}
+otel_metrics_enabled: {{ .metricsEnabled | quote }}
+{{- end }}
+{{- if hasKey . "logsEnabled" }}
+otel_logs_enabled: {{ .logsEnabled | quote }}
+{{- end }}
+{{- end }}
 {{- range $key, $value := .ZenML.secure_headers }}
 secure_headers_{{ $key }}: {{ $value | quote }}
 {{- end }}
@@ -615,6 +641,14 @@ SSL_CERT_FILE: "/updated-certs/ca-certificates.crt"
 {{- end }}
 {{- if $server.debug }}
 ZENML_LOGGING_VERBOSITY: "DEBUG"
+{{- end }}
+{{- with $server.logging }}
+{{- if .format }}
+ZENML_CONSOLE_LOGGING_FORMAT: {{ .format | quote }}
+{{- end }}
+{{- if hasKey . "colorsDisabled" }}
+ZENML_LOGGING_COLORS_DISABLED: {{ .colorsDisabled | quote }}
+{{- end }}
 {{- end }}
 {{- if $server.analyticsOptIn }}
 ZENML_ANALYTICS_OPT_IN: "True"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1124,31 +1124,39 @@ server:
     permissions: enabled
 
 
+  # Logging settings for the ZenML server container.
+  logging:
+    # Log output format. Use "console", "json", or a custom Python logging
+    # format string in %-style format like "%(levelname)s:%(name)s:%(message)s".
+    format: console
+
+    # Disable ANSI colors in console logs.
+    colorsDisabled: false
+
+  # OpenTelemetry export settings for the ZenML server container.
+  openTelemetry:
+    # Base OTLP/HTTP collector endpoint. When set, traces, metrics, and logs
+    # use this endpoint with /v1/traces, /v1/metrics, and /v1/logs appended
+    # unless a per-signal endpoint below overrides it.
+    endpoint:
+
+    # Service name attached to exported telemetry. If not set, the server uses
+    # its default service name.
+    serviceName:
+
+    # Optional per-signal OTLP/HTTP endpoints. Without a base endpoint, only
+    # signals with a per-signal endpoint are exported.
+    tracesEndpoint:
+    metricsEndpoint:
+    logsEndpoint:
+
+    # Controls whether each telemetry signal is exported when an endpoint is
+    # configured.
+    tracesEnabled: true
+    metricsEnabled: true
+    logsEnabled: true
+
   # Extra environment variables to set in the ZenML server container.
-  #
-  # Examples:
-  #
-  #   # Controls the server stdout/stderr log format.
-  #   # Use "console" (default), "json", or a valid Python %-style format string.
-  #   ZENML_CONSOLE_LOGGING_FORMAT: "json"
-  #
-  #   # Disables ANSI color output in console logs. Default is "false".
-  #   ZENML_LOGGING_COLORS_DISABLED: "true"
-  #
-  #   # Enables server OpenTelemetry export for traces, metrics, and logs.
-  #   # The logs export to the OTel backend is independent of ZENML_CONSOLE_LOGGING_FORMAT
-  #   # Logs are exported as OTLP records with structured attributes derived from the
-  #   # underlying log record, not as console-formatted text or JSON.
-  #   ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
-  #   # Standard OTLP/HTTP endpoint env vars are also supported:
-  #   # OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
-  #   # OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel-collector:4318/v1/traces"
-  #   # OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://otel-collector:4318/v1/metrics"
-  #   # OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://otel-collector:4318/v1/logs"
-  #   ZENML_SERVER_OTEL_SERVICE_NAME: "zenml-server"
-  #   ZENML_SERVER_OTEL_TRACES_ENABLED: "true"
-  #   ZENML_SERVER_OTEL_METRICS_ENABLED: "true"
-  #   ZENML_SERVER_OTEL_LOGS_ENABLED: "true"
   environment: {}
 
   # Extra environment variables to set in the ZenML server container that

--- a/src/zenml/zen_server/otel.py
+++ b/src/zenml/zen_server/otel.py
@@ -57,7 +57,7 @@ _otel_providers: list[Any] = []
 _otel_uninstrument_callbacks: list[Callable[[], None]] = []
 
 
-def configure_otel(app: "FastAPI") -> None:
+def configure_otel(app: Optional["FastAPI"] = None) -> None:
     """Set up OpenTelemetry tracing, metrics, and log export.
 
     Reads OTel settings from ``ServerConfiguration`` (which in turn reads
@@ -66,7 +66,7 @@ def configure_otel(app: "FastAPI") -> None:
     immediately so the server runs without OTel overhead.
 
     Args:
-        app: The FastAPI application instance to instrument.
+        app: Optional FastAPI application instance to instrument.
     """
     global _otel_configured
 
@@ -122,7 +122,9 @@ def configure_otel(app: "FastAPI") -> None:
         )
         return
 
-    _instrument_libraries(app=app)
+    if app is not None:
+        _instrument_fastapi_app(app=app)
+    _instrument_requests()
     _otel_configured = True
 
     logger.info(
@@ -371,11 +373,11 @@ def instrument_sqlalchemy_store(store: "SqlZenStore") -> None:
         logger.exception("Failed to instrument SQLAlchemy with OpenTelemetry.")
 
 
-def _instrument_libraries(app: "FastAPI") -> None:
-    """Instrument supported libraries when their OTel packages are present.
+def _instrument_fastapi_app(app: "FastAPI") -> None:
+    """Instrument a FastAPI application when OTel packages are present.
 
     Args:
-        app: The FastAPI application instance to instrument.
+        app: FastAPI application instance to instrument.
     """
     try:
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -396,6 +398,9 @@ def _instrument_libraries(app: "FastAPI") -> None:
             "Install `opentelemetry-instrumentation-fastapi`."
         )
 
+
+def _instrument_requests() -> None:
+    """Instrument requests when OTel packages are present."""
     try:
         from opentelemetry.instrumentation.requests import RequestsInstrumentor
 


### PR DESCRIPTION
## Describe changes
Added logging and otel support to zenml helm chart:
```yaml
server:
  logging:
    format: "console" # console, json, or a custom %-style format
    colorsDisabled: false
  openTelemetry:
    endpoint: "http://otel-collector:4318"
    serviceName: "zenml-server"
    
    tracesEndpoint:
    metricsEndpoint:
    logsEndpoint:
    
    tracesEnabled: true
    metricsEnabled: true
    logsEnabled: true
```

Also added support to allow other micro-services to use the OTEL instrumentations without depending on FastAPI.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

