### PR TITLE
Trim Codex agent instructions

### DIFF
--- a/.agents/skills/zenml-repo-workflows/SKILL.md
+++ b/.agents/skills/zenml-repo-workflows/SKILL.md
@@ -1,0 +1,568 @@
+---
+name: zenml-repo-workflows
+description: Use for ZenML repo work involving tests, PRs, migrations, docs, integrations, models, orchestrators, server, or storage.
+---
+
+# ZenML Repo Workflows
+
+Use this skill when work in the ZenML repository needs more detail than the
+always-loaded `AGENTS.md` files provide. The root guide keeps safety rules,
+universal conventions, and the most common commands in memory. This skill keeps
+the longer recipes, examples, and subsystem checklists.
+
+## Moved Content Index
+
+Former root headings covered here:
+
+- Code Style & Quality Standards
+- Commenting policy
+- Formatting and Linting
+- Python Standards
+- Util Function Placement
+- Private Methods and API Stability
+- FastAPI Agent Profile
+- FastAPI Project Structure
+- Prefer typing over dynamic attribute checks
+- Error Handling & Validation
+- Testing Requirements
+- Dependencies & Runtime Constraints
+- Development Workflow
+- Prerequisites
+- Documentation Access via MCP
+- Environment Variables
+- Branch Management
+- Making Changes
+- Security Guidelines
+- Database and Migration Guidelines
+- Migration Testing Workflow
+- Commit Message Guidelines
+- When Implementing Features
+- When Fixing Bugs
+- Pull Request Guidelines
+- Continuous Integration
+- Core Concepts
+- Important Terminology
+- Pipeline Architecture
+- Key Abstractions
+- Cross-Cutting Architecture Areas
+- Common Tasks
+- Adding New Integrations
+- Modifying Core Functionality
+- Expert Tips
+- Summary Checklist for PR Reviewers
+- Documentation Guidelines
+- Structure
+- Format and Style
+- Content Standards
+
+## Development Workflow
+
+### Setup
+
+- Install ZenML in development mode with dev dependencies.
+- ZenML recommends `uv` for Python package installation because it resolves
+  dependencies more quickly and reliably than plain `pip`.
+- Useful development environment variables:
+  - `ZENML_DEBUG=true`
+  - `ZENML_LOGGING_VERBOSITY=INFO`
+  - `ZENML_ANALYTICS_OPT_IN=false`
+  - `MLSTACKS_ANALYTICS_OPT_OUT=true`
+  - `AUTO_OPEN_DASHBOARD=false`
+  - `ZENML_ENABLE_RICH_TRACEBACK=false`
+  - `TOKENIZERS_PARALLELISM=false`
+
+### Formatting, Linting, and Tests
+
+- Format before committing: `bash scripts/format.sh`.
+- Check quality: `bash scripts/lint.sh`.
+- The lint script runs Ruff, pydoclint on `src/zenml tests/harness`, yamlfix,
+  zizmor, unused import/variable checks, Ruff formatting checks, and mypy.
+- Full mypy is slow on the whole codebase. For focused work, run mypy on the
+  changed file or package.
+- Run targeted pytest files or tests for the component you changed. Avoid the
+  full local test suite unless there is a specific reason.
+- Some coverage workflows use `bash scripts/test-coverage-xml.sh`, but that does
+  not run every test.
+
+### Branches and PRs
+
+- `develop` is the primary working branch. PRs should target `develop`.
+- `main` is only updated during the release process.
+- PR titles should be human-readable and concise. Avoid prefixes like `feat:`.
+- PR descriptions should explain what changed, why it was needed, important
+  implementation decisions, and anything reviewers should inspect carefully.
+- Every PR needs exactly one release-notes label:
+  - `release-notes` for user-facing features, API changes, important fixes, or
+    changes users should know about.
+  - `no-release-notes` for internal work, CI fixes, refactors, minor docs-only
+    changes, or maintenance work.
+
+### Continuous Integration
+
+ZenML uses a two-tier CI setup:
+
+- Fast CI runs on all PRs and covers basic tests, linting, and type checking.
+- Full CI includes integration tests and broader coverage.
+- The `run-slow-ci` label triggers full CI. Maintainers add it when required.
+- If changes touch integrations or core behavior, mention in the PR that full
+  CI should run.
+- For GitHub Actions debugging, check whether logs have expired before deep
+  investigation. If logs are expired, inspect current workflow files and recent
+  runs instead.
+
+## Code Style Details
+
+### Comments
+
+Use comments to explain intent, trade-offs, invariants, and edge cases. Prefer
+clear names and small functions over comments that restate the code.
+
+Good comments answer questions such as:
+
+- Why is this constraint here?
+- What edge case is being protected?
+- Which external API behavior forced this shape?
+- What invariant must future edits preserve?
+
+Avoid:
+
+- Change-tracking comments such as "updated from previous version".
+- Comments that repeat the line below them.
+- Multi-line banner comments grouping classes or functions.
+
+### Python
+
+- Use Python 3.10+ compatible code.
+- Follow Google Python style for docstrings.
+- Type hint function parameters and return values.
+- Use descriptive names.
+- Keep functions manageable. A 50-line target is useful, though not absolute.
+- Prefer functional style where it fits the existing code.
+
+### Helper Placement
+
+Put a helper on a class when it only makes sense in that class context or when
+subclasses call it frequently. Use a utility module for generic behavior shared
+across unrelated modules.
+
+Example: `BaseOrchestrator.requires_resources_in_orchestration_environment`
+could be a global helper, but it lives on `BaseOrchestrator` because
+orchestrator subclasses call it often and the behavior is part of orchestrator
+execution decisions.
+
+Useful utility locations:
+
+- `src/zenml/utils/`
+- `src/zenml/orchestrators/utils.py`
+- `src/zenml/orchestrators/step_run_utils.py`
+- `src/zenml/orchestrators/publish_utils.py`
+
+### Private Methods and API Stability
+
+Symbols with a leading underscore are private and should only be called from
+inside their class or module.
+
+When changing a non-underscore symbol, check whether it is exported from
+`zenml.__init__`. Root exports and public methods on those exports are public
+API and generally require deprecation before breaking changes.
+
+Internal non-underscore code that is not exported at the root can usually be
+changed without deprecation, but update all internal usages.
+
+Integrations should avoid ZenML private methods because future external
+integration packages will not be protected by in-repo mypy checks.
+
+### Prefer Typing Over Dynamic Attribute Checks
+
+Prefer `Protocol`, ABCs, `Union` with `isinstance` narrowing, or typed adapters
+over `getattr`/`hasattr` for capability checks. Use dynamic attribute checks
+only when the object is truly untyped, and isolate that behavior in a small
+typed helper.
+
+## FastAPI and Server Work
+
+ZenML OSS FastAPI work expects strong FastAPI, SQLModel, SQLAlchemy 2.0, and
+Pydantic v2 judgment.
+
+Preferred patterns:
+
+- Extend existing service or repository classes when behavior belongs there.
+- Keep shared state in FastAPI dependency injection or the application factory.
+- Use synchronous `def` route handlers in OSS Codex contributions.
+- Use descriptive lower_snake_case paths and named exports.
+- Co-locate Pydantic request/response models with consuming routes.
+- Keep reusable behavior in service or repository modules accessed through
+  dependency injection.
+- Start routes, dependencies, and services with guard clauses.
+- Avoid redundant `else` blocks after returns.
+- Raise `HTTPException` with precise status codes for expected failures.
+- Let middleware translate unexpected failures into consistent JSON responses
+  with logging and metrics.
+- Define inputs and outputs with Pydantic models so validation and docs stay in
+  sync.
+
+Import rule: code outside `src/zenml/zen_server/` must not import from
+`zen_server/`. Client-side code should use `Client` and shared models from
+`src/zenml/models/`.
+
+## Database and Migrations
+
+ZenML uses SQLModel and SQLAlchemy. Avoid raw SQL unless it is genuinely needed.
+
+Database schema changes require Alembic migrations.
+
+Migration rules:
+
+- Create descriptive migrations, e.g. `alembic revision -m "Add X to Y table"`.
+- Test upgrade paths with `alembic upgrade head`.
+- Downgrade testing is optional because ZenML generally does not support
+  downgrades.
+- Never modify existing migrations that are already on `main` or `develop`.
+- Consider rolling-deployment compatibility.
+- Include schema changes and data migrations when both are needed.
+- Run `scripts/check-alembic-branches.sh` to verify migration consistency.
+
+Migration testing workflow:
+
+1. Check out `develop` or the relevant old release.
+2. Populate the database from that version.
+3. Switch to the feature branch.
+4. Run `alembic upgrade head`.
+
+Useful MySQL query for foreign key dependency tracing:
+
+```sql
+SELECT
+  kcu.CONSTRAINT_NAME AS fk_name,
+  kcu.TABLE_SCHEMA AS referencing_schema,
+  kcu.TABLE_NAME AS referencing_table,
+  kcu.COLUMN_NAME AS referencing_column,
+  kcu.REFERENCED_TABLE_SCHEMA AS referenced_schema,
+  kcu.REFERENCED_TABLE_NAME AS referenced_table,
+  kcu.REFERENCED_COLUMN_NAME AS referenced_column,
+  rc.UPDATE_RULE,
+  rc.DELETE_RULE
+FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+  ON rc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
+ AND rc.CONSTRAINT_NAME  = kcu.CONSTRAINT_NAME
+WHERE kcu.REFERENCED_TABLE_SCHEMA = '<DB_NAME>'
+  AND kcu.REFERENCED_TABLE_NAME IN ('table1', 'table2')
+ORDER BY kcu.TABLE_NAME, kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
+```
+
+Use it before adding cascade behavior, dropping columns/tables, debugging FK
+failures, or auditing existing delete rules.
+
+## Documentation Work
+
+Documentation content lives in `docs/book/`. Generated docs directories such as
+`docs/mkdocs/` and `docs/site/` are not edit targets.
+
+GitBook URLs follow the table of contents, not direct file paths. Pro docs under
+`docs/book/getting-started/zenml-pro/` are served under
+`https://docs.zenml.io/pro/...`.
+
+When adding or removing docs pages, update the relevant `toc.md`. Assets belong
+in a `.gitbook` folder beside the relevant `toc.md`.
+
+Before committing docs changes with absolute URLs:
+
+1. Check whether the URL exists.
+2. Compare with existing working links in the same section.
+3. Inspect the relevant `toc.md` to understand the public URL.
+
+Link checking:
+
+- `scripts/check_broken_links.py` and `scripts/check_relative_links.py` check
+  relative markdown links.
+- Lychee covers local files, images, HTML links, and external URLs.
+- Local full docs check: `lychee --no-progress 'docs/book/**/*.md'`.
+- Offline local links only: `lychee --offline --no-progress 'docs/book/**/*.md'`.
+
+## Domain Models
+
+Models live under `src/zenml/models`.
+
+Core concepts:
+
+- Requests, Updates, and typed Responses use Body, Metadata, and Resources.
+- Filters provide typed operations, scoping, sorting, and pagination.
+- Domain models must stay aligned with ORM schemas.
+- Canonical Cursor rules live in `.cursor/rules/zenml-domain-models.mdc` and
+  `.cursor/rules/zenml-orm-schema.mdc`.
+
+Common base patterns:
+
+- `BaseRequest` -> `{Entity}Request`
+- `BaseUpdate` -> `{Entity}Update`
+- `BaseResponse[Body, Metadata, Resources]`
+- `BaseFilter`, `UserScopedFilter`, `ProjectScopedFilter`, `TaggableFilter`
+
+Adding a new entity usually means implementing Request, ResponseBody,
+ResponseMetadata, ResponseResources, Response, and Filter classes. Choose the
+narrowest scope that matches ownership semantics.
+
+### Filter Field Coupling
+
+When adding a field to a filter model, update three locations:
+
+1. The filter model field.
+2. The corresponding `Client` list method signature.
+3. The filter model instantiation inside that client method.
+
+If the field should not become a CLI option, add it to `CLI_EXCLUDE_FIELDS`.
+
+Test the new filter through the CLI, for example:
+
+```bash
+zenml pipeline runs list --new_field=some_value
+```
+
+Relationship-backed filter fields can also require custom ORM join behavior in
+the store layer.
+
+### Model Compatibility
+
+Usually safe:
+
+- Adding optional properties.
+
+Risky or breaking:
+
+- Deleting properties.
+- Renaming properties.
+- Making required fields optional in a way older code cannot tolerate.
+- Changing property types.
+
+Safe evolution pattern: add optional fields, deprecate before removal, use
+defaults when adding required behavior, and consider versioned responses for
+major changes.
+
+## CLI Work
+
+Important files:
+
+- `src/zenml/cli/utils.py` for `list_options`.
+- `src/zenml/cli/pipeline.py` for pipeline, run, legacy schedule, and
+  replay/resume commands.
+- `src/zenml/cli/trigger.py` for native trigger commands.
+- `src/zenml/cli/resource_pool.py` and `resource_request.py` for resource pool
+  and queue inspection commands.
+- `src/zenml/cli/stack.py` for stack management.
+- `src/zenml/cli/base.py` for core CLI setup and common decorators.
+
+List commands use `@list_options(FilterModel)` to generate options from filter
+model fields, then pass them to explicit client method parameters. If a field is
+missing from the client method, the CLI can raise:
+
+```text
+TypeError: list_pipeline_runs() got an unexpected keyword argument 'new_field'
+```
+
+Scheduling command families:
+
+- `zenml pipeline schedule ...` for legacy schedule records.
+- `zenml trigger schedule ...` for native schedule triggers.
+- `zenml trigger platform-event ...` for platform event triggers.
+
+Resource pools use both management commands and request/queue inspection
+commands. Check `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and
+`ResourceRequest*` models when editing this area.
+
+Import rules:
+
+- Do not import integration libraries at module level in CLI files.
+- Do not import from `zen_server/` in CLI code.
+- Do not import SQL schemas directly from `zen_stores/`; use `Client`.
+
+## Integrations
+
+The most important integration rule: flavor files must not import integration
+libraries at module level.
+
+Flavor files live at `src/zenml/integrations/*/flavors/*.py`. They are imported
+for component discovery, so optional third-party libraries must only be imported
+inside methods or under `TYPE_CHECKING`.
+
+Correct pattern:
+
+```python
+from typing import TYPE_CHECKING, Type
+
+from zenml.orchestrators import BaseOrchestratorConfig
+from zenml.orchestrators.base_orchestrator import BaseOrchestratorFlavor
+
+if TYPE_CHECKING:
+    from zenml.integrations.aws.orchestrators import SagemakerOrchestrator
+
+
+class SagemakerOrchestratorFlavor(BaseOrchestratorFlavor):
+    @property
+    def implementation_class(self) -> Type["SagemakerOrchestrator"]:
+        from zenml.integrations.aws.orchestrators import SagemakerOrchestrator
+
+        return SagemakerOrchestrator
+```
+
+Integration package shape:
+
+```text
+src/zenml/integrations/<name>/
+├── __init__.py
+├── flavors/
+├── orchestrators/
+├── step_operators/
+├── materializers/
+└── ...
+```
+
+Step operators should implement the async-first lifecycle:
+
+- `submit(...)`
+- `get_status(...)`
+- `wait(...)`
+- `cancel(...)`
+
+`StepLauncher` calls `submit()` plus `wait()` by default and falls back to
+legacy `launch()` only for backwards compatibility. Store backend job IDs in run
+metadata immediately after submission.
+
+Dependency updates:
+
+- Prefer inclusive lower bounds and exclusive upper bounds.
+- Check Python version compatibility.
+- Test locally with realistic integration scenarios.
+- Treat dropping support for an old version as breaking.
+- Mention breaking dependency changes in release notes.
+
+## Orchestrators
+
+Key files:
+
+- `base_orchestrator.py`
+- `containerized_orchestrator.py`
+- `utils.py`
+- `step_launcher.py`
+- `step_runner.py`
+- `cache_utils.py`, `input_utils.py`, `publish_utils.py`
+
+Main submission methods:
+
+- `submit_pipeline(...)` for static pipelines.
+- `submit_dynamic_pipeline(...)` for dynamic pipelines.
+- Isolated-step APIs for dynamic pipeline support:
+  - `submit_isolated_step(...)`
+  - `get_isolated_step_status(...)`
+  - `wait_for_isolated_step(...)`
+  - `stop_isolated_step(...)`
+
+`BaseOrchestrator.run(...)` already prunes steps skipped by replay or
+client-side caching before submission. Integration orchestrators should not
+re-implement that pruning.
+
+### `get_orchestrator_run_id`
+
+This method must return an ID that is unique per backend run and stable for all
+steps in the same ZenML pipeline run.
+
+Static pipelines often start directly with the first step. The first step uses
+the orchestrator run ID to create the ZenML run, and downstream steps use the
+same ID to find it.
+
+Dynamic pipelines have an initial orchestration container. Use an ID that is
+stable for retries of that orchestration environment.
+
+Kubernetes is special because it has an orchestration container even for static
+pipelines. Prefer the configured Kubernetes run ID for static pipelines and the
+parent Kubernetes job name for dynamic pipelines, falling back only when the job
+lookup fails.
+
+Implementation checklist:
+
+- Inherit from `ContainerizedOrchestrator` if steps run in containers.
+- Implement `get_orchestrator_run_id()` correctly.
+- Implement `submit_pipeline()` for static pipelines.
+- Implement `submit_dynamic_pipeline()` when supporting dynamic pipelines.
+- Add isolated-step methods when needed.
+- Handle scheduling hooks when the backend supports scheduling.
+- Respect CPU, memory, GPU, and other resource settings.
+- Return `SubmissionResult` with `wait_for_completion` for synchronous
+  execution.
+- Use `self.get_image(deployment, step_name)`.
+- Use `orchestrator_utils.get_step_entrypoint_command(...)`.
+
+## ORM Schemas and Zen Stores
+
+ORM schemas live under `src/zenml/zen_stores/schemas`.
+
+Rules:
+
+- Use SQLModel declarative table classes.
+- Prefer `BaseSchema` or `NamedSchema`.
+- Keep fields aligned with domain models.
+- Schema changes usually require migrations.
+- Export new schemas from `src/zenml/zen_stores/schemas/__init__.py`.
+- General string column limit is about 250 characters because of MySQL.
+
+Foreign keys:
+
+- Use `schema_utils.build_foreign_key_field`.
+- Define relationships on both sides with matching `back_populates`.
+- For many-to-many relationships, use a link model with composite primary keys.
+
+Conversions:
+
+- Provide `to_model`.
+- Provide `from_request` or `from_model` where appropriate.
+- Provide `update` or `update_from_model`.
+- Include related resources only when requested by flags.
+- Refresh `updated` on mutations.
+
+Eager-loading rules:
+
+- Collections use `selectinload`; `joinedload` on collections multiplies rows.
+- Single-valued relationships use `joinedload` for get paths when the related
+  row usually exists.
+- Keep `selectinload` for nullable FKs that are usually empty.
+
+Import rule: code outside `zen_stores/` should not import SQL-related code
+directly from this directory. Use `Client`, or `client.zen_store` when lower
+level access is truly needed.
+
+## Cross-Area Change Checklist
+
+Some features span many layers. When touching these, trace the whole path:
+
+- Dynamic pipelines and nested child pipelines:
+  - `src/zenml/execution/pipeline/dynamic/`
+  - `src/zenml/pipelines/dynamic/`
+  - orchestrators and `step_launcher.py`
+  - pipeline run models, schemas, migrations, tests, and docs
+- Triggers:
+  - `src/zenml/triggers/`
+  - trigger models, schemas, CLI, client, server endpoints, docs
+- Resource pools and requests:
+  - `src/zenml/models/v2/core/resource_pool*.py`
+  - `resource_request.py`
+  - `src/zenml/zen_stores/resource_pools/`
+  - CLI, store behavior, Pro/backend scheduling behavior
+- Container engines:
+  - use `src/zenml/container_engines/` instead of direct Docker-specific calls
+
+## Review Checklist
+
+- Integration PRs: no library imports in flavor files.
+- Orchestrator PRs: `get_orchestrator_run_id` is unique per run and stable for
+  all steps in that run.
+- Filter model changes: matching client method signature and body are updated.
+- Private method changes: all internal usages are updated.
+- Import checks: no `zen_server` imports outside `zen_server`.
+- Import checks: no direct SQL imports outside `zen_stores`.
+- Model changes: adding properties is usually OK; deleting, renaming, or
+  incompatible type changes are risky.
+- Dependency bumps: dropping old version support is breaking.
+- Scheduling changes: update both legacy schedule and trigger stacks where
+  relevant.
+- Step operator changes: check `BaseStepOperator`, `StepLauncher`, and at least
+  one concrete integration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,466 +1,141 @@
 # ZenML Codex Agent Guidelines
 
-This document provides guidance for Codex agents working with the ZenML codebase. ZenML is an extensible, open-source MLOps framework for creating production-ready ML pipelines.
+ZenML is an extensible open-source MLOps framework for creating production-ready
+ML pipelines. This root guide contains rules that must be loaded for every
+Codex session in this repository. For detailed workflows, examples, and
+subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Project Structure
 
-- `/src/zenml/` - Core source code
-- `/tests/` - Test suite (unit, integration)
-- `/docs/` - Documentation
-- `/examples/` - Example projects
-- `/scripts/` - Development utilities
-
-Use filesystem navigation tools to explore the codebase structure as needed.
-
-## Code Style & Quality Standards
-
-- **Use US English spelling** in all code, comments, docstrings, and documentation (e.g., "initialize", "stabilize", "color"). CI enforces this via `typos` (configured in `.typos.toml`).
-
-### Commenting policy — explain why, not what
-- Use comments to document intent, trade‑offs, constraints, invariants, and tricky edge cases—i.e., why the code is this way—rather than narrating changes. Prefer self‑explanatory code; add comments only where extra context is needed. Write for a reader 6+ months later.
-- Use for: complex logic/algorithms, non‑obvious design decisions, business rules/constraints, API purpose/contracts, edge cases.
-- Avoid: change‑tracking comments ("Updated from previous version", "New implementation", "Changed to use X instead of Y", "Refactored this section").
-- Avoid simple explanatory comments, where it is already clear from the code itself.
-- Avoid useless one-line comments interleaved with code that restate the obvious. Prefer clear names and small functions.
-
-  ```python
-  # Bad
-  i = 0  # initialize i
-  i += 1  # increment
-
-  # Good
-  index = 0
-  index += 1
-  ```
-
-- Do not use multi-line banner comments to group classes/functions in a module. Prefer a concise module-level docstring or separate modules.
-
-  ```python
-  # Bad
-  """
-  ===== Handlers =====
-  """
-  class FileHandler: ...
-  class RemoteHandler: ...
-
-  # Good (module-level docstring at top)
-  """
-  Handlers used by the logging subsystem (file and remote variants).
-  """
-  class FileHandler: ...
-  class RemoteHandler: ...
-  ```
-
-### Formatting and Linting
-- Format code with: `bash scripts/format.sh` (requires Python environment with dev dependencies)
-  - Run this before every commit to ensure proper formatting
-  - Automatically fixes and formats code using ruff and yamlfix
-- Check code quality with: `bash scripts/lint.sh`
-  - Unlike format.sh, this doesn't auto-fix issues
-  - Runs Ruff, pydoclint (on `src/zenml tests/harness`), yamlfix, zizmor, unused import/variable checks, Ruff formatting checks, and mypy
-  - Note: Full mypy check is slow on the entire codebase
-  - For faster checks, run mypy directly on specific files: `mypy src/zenml/path/to/file.py`
-- The primary code style is enforced by ruff, configured in `pyproject.toml`
-- YAML formatting uses yamlfix: `yamlfix .github -v`
-
-### Python Standards
-- Use Python 3.10+ compatible code
-- Follow Google Python style for docstrings
-- Type hint all function parameters and return values
-- Use descriptive variable names and documentation
-- Keep function size manageable (aim for < 50 lines) though there are exceptions
-
-### Util Function Placement
-
-When deciding whether to place a helper function in a utils file or on a class, follow these guidelines:
-
-1. **If a method only makes sense within the context of a class** → Put it on the class
-2. **If a static/util method is heavily used by subclasses** → Put it on the parent class
-
-**Rationale for placing methods on classes:**
-- Saves imports for users and subclasses
-- Subclasses can simply call `self.something()` instead of finding and importing from a util file
-- Keeps related functionality co-located
-
-**Example:** `requires_resources_in_orchestration_environment` in `base_orchestrator.py:495-514`
-
-```python
-# This is a @staticmethod on BaseOrchestrator, not a standalone util
-@staticmethod
-def requires_resources_in_orchestration_environment(step: "Step") -> bool:
-    """Checks if the orchestrator should run this step on special resources."""
-    if step.config.step_operator:
-        return False
-    return not step.config.resource_settings.empty
-```
-
-This method could be a global util, but it's placed on the class because:
-- All orchestrator subclasses frequently need it
-- Subclasses can call `self.requires_resources_in_orchestration_environment(step)` without imports
-- It's conceptually tied to orchestrator behavior
-
-**When to use utils files:**
-- Truly generic functions used across unrelated modules
-- Functions that don't logically belong to any class
-- Pure utility functions (string manipulation, date formatting, etc.)
-
-**Key utils locations:**
-- `src/zenml/utils/` — General utilities
-- `src/zenml/orchestrators/utils.py` — Orchestrator-specific utilities
-- `src/zenml/orchestrators/step_run_utils.py` — Step execution utilities
-- `src/zenml/orchestrators/publish_utils.py` — Status/metadata publishing
-
-### Private Methods and API Stability
-
-Methods and functions starting with `_` (underscore) are **private** and should NOT be called from outside their class or module.
-
-**The rule:**
-- `_method()` on a class → only call from within that class
-- `_function()` in a utils module → only call from within that module
-- This isn't always consistently applied in the codebase, but it's the intended convention
-
-**Backwards compatibility — case-by-case judgment:**
-
-There are no strict written rules; evaluate each change individually:
-
-| Symbol type | Part of public API? | Breaking change if modified? |
-|-------------|---------------------|------------------------------|
-| Classes/functions exported in `zenml.__init__` | ✅ Definitely public | ⚠️ Yes — requires deprecation |
-| Public methods on those classes | ✅ Public | ⚠️ Yes — requires deprecation |
-| Internal methods deep in the codebase (no underscore) | ❌ Not intended for users | ✅ No — update all internal usages |
-| `_private_method()` | ❌ No | ✅ No — can change freely |
-
-**When changing any non-underscore method:**
-1. Check if the class/function is exported in `zenml.__init__` — if so, it's public API
-2. Search for usages **within the ZenML codebase** (grep/find references)
-3. Update all internal usages
-4. For truly internal code not exported at the root, no deprecation needed
-
-**Best practice for integrations (future-proofing):**
-
-> ⚠️ **Integrations should avoid using ZenML private methods**
-
-This is primarily a future concern: when integrations eventually move out of the main ZenML repo (external packages), mypy won't detect if a private method they depend on was changed, leading to silent breakage. Even while integrations live in-repo, using only public APIs is good practice and prepares for this transition.
-
-```python
-# Bad - integration code using private method
-from zenml.orchestrators.base_orchestrator import BaseOrchestrator
-
-class MyOrchestrator(BaseOrchestrator):
-    def submit_pipeline(self, ...):
-        self._some_private_helper()  # ❌ Don't do this
-
-# Good - use only public methods or reimplement logic
-class MyOrchestrator(BaseOrchestrator):
-    def submit_pipeline(self, ...):
-        self.public_method()  # ✅ Safe
-```
-
-### FastAPI Agent Profile
-- ZenML OSS FastAPI work expects senior-level API expertise covering FastAPI, SQLModel, SQLAlchemy 2.0, and modern Pydantic v2 features.
-- Default to object-oriented patterns—extend existing service classes or create cohesive new ones instead of scattering helpers or global functions.
-- Keep shared state inside FastAPI dependency injection or the application factory; never introduce new global variables outside initialization.
-- Use descriptive auxiliary-verb-prefixed names and keep directories/files in lower_snake_case (for example `routers/user_routes.py`, `services/user_service.py`).
-- Apply the Receive an Object, Return an Object (RORO) pattern for all public interfaces so inputs/outputs remain self-describing.
-
-### FastAPI Project Structure
-- Every FastAPI package must expose a router entry point plus clearly separated sub-routes, utilities, static resources, and types (Pydantic models or schemas).
-- Favor named exports for routers, dependencies, and helper utilities to keep imports explicit and observable during reviews.
-- Co-locate Pydantic models with their consuming routes and keep reusable business logic inside service or repository modules referenced via dependency injection.
-- Name directories/files with descriptive verbs or nouns that express behavior (e.g., `routers/register_user.py`, `services/create_invitation.py`) to keep navigation predictable.
-
-#### Prefer typing over dynamic attribute checks
-- Don't use getattr/hasattr for capability checks when static typing can express the contract
-- Prefer Protocols/ABCs for required methods, Unions with isinstance narrowing, or typed adapters around dynamic third-party objects
-- Only use getattr/hasattr when the object is truly untyped and can't be reasonably typed; isolate in a small helper with a typed public surface
-
-Examples:
-```python
-# Bad
-if hasattr(handler, "close"):
-    handler.close()
-
-# Good: structural typing
-from typing import Protocol
-
-class Closable(Protocol):
-    def close(self) -> None: ...
-
-def shutdown(h: Closable) -> None:
-    h.close()
-
-# Good: union + narrowing
-from typing import Union
-
-class FileHandler:
-    def close(self) -> None: ...
-
-class RemoteHandler:
-    def shutdown(self) -> None: ...
-
-def stop(h: Union[FileHandler, RemoteHandler]) -> None:
-    if isinstance(h, FileHandler):
-        h.close()
-    else:
-        h.shutdown()
-```
-
-### Error Handling & Validation
-- Start each route, dependency, or service with guard clauses that validate payloads and dependencies; prefer early returns over nested branches and keep the happy path last.
-- Avoid redundant `else` blocks after a return; handle error cases up front with clear log messages and user-safe responses.
-- Use custom exception classes or error factories so FastAPI middleware can translate them into consistent JSON payloads.
-- Raise `HTTPException` (with precise status codes and detail messages) for expected client/server errors, and rely on middleware for unexpected failures plus centralized logging and metrics.
-- Define inputs/outputs with Pydantic models to make validation explicit and keep documentation in sync automatically.
-
-### Testing Requirements
-- Most new code requires test coverage
-  - Key exceptions are when the code involves integrations with external
-    services. (in those cases we generally test things extensively locally and
-    in the CI. So the developer might have to run things or set things up
-    locally first.)
-- Tests live in the `/tests/` folder with structure loosely mirroring the main codebase
-- Unit tests go in `/tests/unit/`
-- Integration tests go in `/tests/integration/`
-
-#### Running Tests
-- Do NOT try to run the entire test suite locally - many tests require special environments
-- Run targeted tests for the specific components you've changed:
-  - `pytest tests/unit/path/to/test_file.py`
-  - `pytest tests/unit/path/to/test_file.py::test_specific_function`
-- For full coverage, use CI (see CI section below)
-- Some tests use: `bash scripts/test-coverage-xml.sh` (but this won't run all tests)
-
-## Dependencies & Runtime Constraints
-- Target the FastAPI + Pydantic v2 + SQLAlchemy 2.0 + SQLModel stack defined for ZenML OSS; confirm new third-party additions align with `pyproject.toml`.
-- The current ZenML OSS runtime disallows async I/O in Codex contributions even though FastAPI supports it; implement synchronous `def` route handlers and coordinate background tasks via dependencies or workers rather than `async def`.
-- Document minimum supported versions when touching dependency-heavy modules and prefer dependency injection over module-level singletons for stateful clients.
-- Cache static or frequently accessed data through in-memory stores (for example, dependency-scoped caches) and lazy-load heavyweight resources to optimize cold-start performance.
-- Use middleware hooks for logging, error monitoring, and performance profiling so route handlers stay focused on business logic.
-
-## Development Workflow
-
-### Prerequisites
-- Set up a Python environment with ZenML dev dependencies
-- Install ZenML in development mode: `pip install -e ".[dev]"`
-- Most scripts require these dependencies to be available
-- ZenML recommends using `uv` for Python package installation in local environments
-  - `uv` is also used in CI workflows
-  - It resolves dependencies more quickly and reliably than pip
-  - It can resolve dependency conflicts that pip sometimes struggles with or takes a long time to resolve
-
-### Documentation Access via MCP
-ZenML documentation is available via a built-in GitBook MCP server: https://docs.zenml.io/~gitbook/mcp. IDE agents like Cursor and Claude Code can add this as an HTTP MCP server named 'ZenML Docs' to answer questions directly from the docs while you code. This enables live, source-of-truth lookups with fewer hallucinations and faster feature discovery. Note that the MCP server indexes the latest released docs, not the develop branch. For full setup details and examples, see docs/book/reference/llms-txt.md.
-
-### Environment Variables
-- Several environment variables are useful during ZenML development:
-  - `ZENML_DEBUG=true`: Enables verbose debug logging
-  - `ZENML_LOGGING_VERBOSITY=INFO`: Controls logging verbosity
-  - `ZENML_ANALYTICS_OPT_IN=false`: Disables analytics during development
-  - `MLSTACKS_ANALYTICS_OPT_OUT=true`: Disables MLStacks analytics
-  - `AUTO_OPEN_DASHBOARD=false`: Prevents automatic dashboard opening
-  - `ZENML_ENABLE_RICH_TRACEBACK=false`: Disables rich traceback formatting
-  - `TOKENIZERS_PARALLELISM=false`: Avoids tokenizers parallelism warnings
-
-### Branch Management
-- **IMPORTANT**: `develop` is our primary working branch, NOT `main`
-- Always branch off `develop` for all changes
-- All PRs should target the `develop` branch
-- The `main` branch is only updated during the release process
-- If working on a feature branch that's already based on `develop`, you may need to branch off that feature branch for related changes
-
-### Making Changes
-1. Run `bash scripts/format.sh` before every commit
-2. Run targeted tests to verify changes (see above)
-3. Update documentation for user-facing changes (or ensure that nothing was broken)
-
-### Security Guidelines
-- **NEVER** commit secrets, API keys, tokens, or passwords
-- Use environment variables or ZenML's secret management for sensitive data
-- Review changes for accidental credential exposure before committing
-- If you accidentally commit secrets, notify the team immediately
-- Follow the principle of least privilege when implementing access controls
-- Validate and sanitize all user inputs
-
-### Database and Migration Guidelines
-- Database schema changes require Alembic migrations
-- ZenML uses **SQLModel** (SQLAlchemy-based) — no raw SQL unless absolutely necessary
-- Create migrations with descriptive names: `alembic revision -m "Add X to Y table"`
-- Test the upgrade path with `alembic upgrade head`; downgrade testing is optional because ZenML does not generally support downgrades
-- Never modify existing migrations that are already on main/develop branches
-- Always consider backward compatibility for rolling deployments
-- Include both schema changes and data migrations when needed
-- Run `scripts/check-alembic-branches.sh` to verify migration consistency
-
-#### Migration Testing Workflow
-When testing database migrations locally:
-1. Check out `develop` branch (or relevant old release)
-2. Populate the database from that version (create runs, stacks, etc.)
-3. Switch to your current branch
-4. Test whether the migration works with `alembic upgrade head`
-
-This ensures migrations handle existing data correctly. CI does basic migration testing, but local testing with realistic data is recommended for complex migrations.
-
-### Commit Message Guidelines
-- Write clear, descriptive commit messages explaining the "why" not just the "what"
-- First line should be a concise summary (50 chars or less)
-- Use imperative mood: "Add feature" not "Added feature"
-- Reference issue numbers when applicable: "Fix user auth bug (#1234)"
-- For multi-line messages, add a blank line after the summary
-- Example:
-  ```
-  Add retry logic to artifact upload
-  
-  Previously, artifact uploads would fail immediately on network errors.
-  This adds exponential backoff retry logic to handle transient failures.
-  
-  Fixes #1234
-  ```
-
-### When Implementing Features
-- Study existing similar implementations first
-- Follow the established patterns in the codebase
-- Keep backward compatibility in mind
-- Add appropriate error handling
-- Document public APIs thoroughly
-
-### When Fixing Bugs
-- Add regression tests that would have caught the bug
-- Understand root cause before implementing fix
-- Document the fix in commit messages
-
-### Pull Request Guidelines
-- Use human-readable names for PRs (no prefixes like "feat:" or "doc:")
-- Keep PR titles concise but descriptive
-- Write comprehensive PR descriptions:
-  - Clearly explain what the changes do
-  - Mention why the changes are needed
-  - Detail any important implementation decisions
-  - Note any areas that need special reviewer attention
-- Detailed PR descriptions help both reviewers and release note creation
-- Use appropriate PR tags where applicable:
-  - `internal`: For changes relevant only to ZenML team members
-  - `documentation`: For changes related to documentation
-  - `bug`: For bug fixes
-  - `dependencies`: For dependency updates
-  - `enhancement`: For new features or improvements
-- **REQUIRED: Release Notes Labels** - Every PR must have exactly one of these labels:
-  - `release-notes`: For user-facing features, significant updates, or changes that should appear in the changelog. Use this for new features, important bug fixes affecting users, API changes, or anything users should know about.
-  - `no-release-notes`: For internal changes, CI fixes, refactoring, minor bug fixes, documentation-only changes, or anything that doesn't need to be surfaced to users.
-  - The CI will block merging if neither label is present. When in doubt, use `no-release-notes` for internal/maintenance work.
-
-### Continuous Integration
-- ZenML uses a two-tier CI approach:
-  - **Fast CI**: Runs automatically on all PRs (basic tests, linting, type checking)
-  - **Full CI**: Includes integration tests and more extensive test coverage
-- The `run-slow-ci` label triggers full CI testing
-- Full CI is required before merging - maintainers will add the label if needed
-- If your changes touch integrations or core functionality, mention in the PR that full CI should be run
-- CI failures will show in the PR checks - review logs to understand any issues
-
-## Core Concepts
-
-### Important Terminology
-- The term "model" has multiple distinct meanings in the codebase:
-  1. **Pydantic models**: Data structures used throughout the codebase (like `PipelineModel`)
-  2. **ML models**: Actual machine learning models (PyTorch, sklearn, etc.)
-  3. **ZenML models**: Namespaces that group artifacts, metadata, and other resources related to an ML model
-- Be careful with these terms when reading/writing code to avoid confusion
-
-### Pipeline Architecture
-- Pipelines are collections of steps
-- Steps produce and consume artifacts
-- Artifacts are serialized/deserialized by materializers
-- Pipelines are executed by orchestrators
-- Stack components provide functionality like storage, orchestration, etc.
-
-### Key Abstractions
-- `StackComponent` - Base for stack components
-- `Pipeline` - Pipeline definition
-- `BaseStep` - Step implementation
-- `BaseMaterializer` - Artifact serialization
-- `BaseOrchestrator` - Pipeline execution
-- `BaseStepOperator` - Remote step execution (submit/status/wait/cancel lifecycle)
-
-### Cross-Cutting Architecture Areas
-Some ZenML features span many layers. When working in these areas, follow the full chain instead of editing only the file where the immediate change appears:
-
-- `src/zenml/execution/pipeline/dynamic/` and `src/zenml/pipelines/dynamic/` contain dynamic pipeline execution, including nested child pipelines. Changes here often need matching updates in orchestrators, pipeline run models/schemas, migrations, tests, and docs.
-- `src/zenml/triggers/` and `src/zenml/models/v2/core/triggers.py` contain the trigger architecture, including schedule triggers and platform event triggers. Keep CLI, client, server, model, schema, and docs layers aligned when touching triggers.
-- `src/zenml/models/v2/core/resource_pool*.py`, `resource_request.py`, and `src/zenml/zen_stores/resource_pools/` contain resource pool and resource request functionality. These features coordinate API models, store behavior, CLI commands, and Pro/backend integrations.
-- `src/zenml/container_engines/` contains the client-side container engine abstraction for Docker and Podman. Prefer this abstraction over calling Docker-specific helpers directly when local OCI tooling is involved.
-
-## Common Tasks
-
-### Adding New Integrations
-1. Create integration package in `/src/zenml/integrations/`
-2. Implement required abstractions and register flavors
-3. Add tests in `/tests/integration/` (usually `/tests/integration/integrations/` for integration-specific tests)
-4. Add documentation in `/docs/book/component-guide/`
-
-### Modifying Core Functionality
-1. Understand the impact on existing components
-2. Maintain backward compatibility where possible
-3. Add comprehensive test coverage
-4. Update type hints and documentation
-
-## Task Planning Approach
-
-When tackling complex tasks:
-1. Break down the task into smaller sub-tasks
-2. Research existing implementations in the codebase
-3. Plan approach before implementation
-4. Test incrementally as you implement
-5. Document design decisions in code comments
-
-## Expert Tips
-
-- ZenML follows a plugin architecture - study how components are registered
-- API stability is important - don't break public interfaces
-- Review similar PRs for implementation patterns
-- Pipeline execution is complex - test thoroughly when modifying
-- Centralize FastAPI request logging, tracing, and unexpected error handling inside middleware so route handlers stay lean.
-- Evaluate latency/throughput for every new endpoint; cache static data, lazy-load heavyweight resources, and document serialization trade-offs to protect performance budgets.
-
-### Summary Checklist for PR Reviewers
-
-Quick reference for common review concerns. Detailed explanations live in the nested AGENTS.md files.
-
-- [ ] **Integration PRs:** No library imports in flavor files (`integrations/AGENTS.md`)
-- [ ] **Orchestrator PRs:** Verify `get_orchestrator_run_id` is unique per run but same for all steps (`orchestrators/AGENTS.md`)
-- [ ] **Filter model changes:** Check corresponding client method is updated (`models/AGENTS.md`)
-- [ ] **Private method changes:** Check all internal usages (see "Private Methods" above)
-- [ ] **Import checking:** No `zen_server` imports from outside `zen_server` (`zen_server/AGENTS.md`)
-- [ ] **Import checking:** No direct SQL imports from outside `zen_stores` (`zen_stores/schemas/AGENTS.md`)
-- [ ] **Model changes:** Adding properties OK, deleting/making optional is breaking (`models/AGENTS.md`)
-- [ ] **Dependency bumps:** If dropping old version support, it's a breaking change (`integrations/AGENTS.md`)
-- [ ] **Scheduling changes:** Must span both legacy schedule and trigger stacks (CLI + client + server + models + schemas)
-- [ ] **Step operator changes:** Check `BaseStepOperator`, `StepLauncher`, and at least one concrete integration
-
-## Documentation Guidelines
-
-### Structure
-- Documentation files live in `docs/book/`
-- Multiple sections each have their own `toc.md` file for navigation
-- Assets (images, etc.) belong in a `.gitbook` folder at the same level as the relevant `toc.md`
-- When adding or removing pages, update the appropriate `toc.md` file
-
-### Format and Style
-- ZenML uses GitBook for documentation
-- Include metadata fields at the top of documentation pages (follow existing patterns)
-- Documentation should be readable and conversational
-- Use consistent formatting with existing documentation
-- Avoid overusing bullet points or other formatting elements
-- Prioritize readability and clarity over excessive structure
-- Include appropriate cross-references to related documentation
-
-### Content Standards
-- Clear, concise language
-- Code examples for APIs
-- Explanation of concepts
-- Usage patterns and best practices
-- Match tone and style with existing documentation
-
----
-
-*This document is maintained to help Codex agents work effectively with the
-ZenML codebase. For human contributors, see CONTRIBUTING.md.*
+- `src/zenml/` - Core source code.
+- `tests/` - Unit and integration tests.
+- `docs/book/` - Source documentation.
+- `examples/` - Example projects.
+- `scripts/` - Development utilities.
+
+## Always-Loaded Rules
+
+- Use US English spelling in code, comments, docstrings, and documentation.
+- Use Python 3.10+ compatible code.
+- Type hint function parameters and return values.
+- Follow Google Python style for docstrings.
+- Prefer clear names and small functions over explanatory comments.
+- Comments should explain intent, trade-offs, constraints, invariants, and
+  tricky edge cases. Avoid comments that restate obvious code.
+- Do not use multi-line banner comments to group classes or functions.
+- Prefer typed contracts over `getattr`/`hasattr` capability checks when static
+  typing can express the requirement.
+- Private methods and functions with a leading underscore should not be called
+  outside their class or module.
+- Integrations should avoid using ZenML private methods because externalized
+  integrations will not be protected by in-repo type checks.
+
+## Common Commands
+
+- Format before committing: `bash scripts/format.sh`.
+- Check quality: `bash scripts/lint.sh`.
+- Run targeted tests only: `pytest tests/unit/path/to/test_file.py` or
+  `pytest tests/unit/path/to/test_file.py::test_specific_function`.
+- Do NOT run the entire local test suite by default; many tests need special
+  environments.
+- If you make changes after running tests, rerun the relevant tests.
+
+## Branches, Git, and PRs
+
+- `develop` is the primary working branch, not `main`.
+- Always branch off `develop` for new work.
+- PRs should target `develop`.
+- `main` is only updated during releases.
+- Use targeted `git add`; do not stage unrelated files.
+- Never add anything from `design/` to git history.
+- PR titles should be concise and human-readable, without prefixes like
+  `feat:`.
+- Every PR must have exactly one release-notes label:
+  `release-notes` or `no-release-notes`.
+- When pushing new commits to an open PR, check whether the PR description needs
+  updating.
+
+## Security
+
+- NEVER commit secrets, API keys, tokens, passwords, or credentials.
+- Use environment variables or ZenML secret management for sensitive data.
+- Validate and sanitize user inputs.
+- If secrets are accidentally committed, notify the team immediately.
+
+## Architecture and API Safety
+
+- Check whether a class or function is exported in `zenml.__init__` before
+  changing a public-looking interface.
+- Public APIs need backward-compatible evolution or deprecation.
+- For internal non-underscore methods, search for usages and update all
+  internal callers.
+- The term "model" can mean Pydantic models, machine learning models, or ZenML
+  model namespaces. Be explicit when writing or reviewing.
+- When changing cross-cutting features, trace the full path through CLI,
+  client, server, models, schemas, migrations, tests, and docs.
+
+## FastAPI and Runtime Rules
+
+- ZenML OSS FastAPI work expects FastAPI, SQLModel, SQLAlchemy 2.0, and
+  Pydantic v2 patterns.
+- Implement synchronous `def` route handlers for OSS Codex contributions.
+- Keep shared state inside FastAPI dependency injection or the application
+  factory; never introduce fresh global variables outside initialization.
+- Start routes, dependencies, and services with guard clauses.
+- Raise `HTTPException` with precise status codes for expected errors.
+- Use Pydantic models for route inputs and outputs.
+- Code outside `src/zenml/zen_server/` should NEVER import from `zen_server/`.
+
+## Database and Storage Rules
+
+- ZenML uses SQLModel and SQLAlchemy; no raw SQL unless absolutely necessary.
+- Database schema changes require Alembic migrations.
+- Never modify existing migrations that are already on `main` or `develop`.
+- Always consider backward compatibility for rolling deployments.
+- Test migration upgrade paths with `alembic upgrade head` for meaningful
+  schema changes.
+- Code outside `zen_stores/` should not import SQL-related code directly from
+  `zen_stores`; use `Client` or, rarely, `client.zen_store`.
+
+## Subsystem Pointers
+
+Load `.agents/skills/zenml-repo-workflows/SKILL.md` for detailed guidance on
+tests, PRs, migrations, docs, integrations, models, orchestrators, FastAPI,
+server code, and storage.
+
+Directory-specific reminders:
+
+- `docs/book/AGENTS.md` - documentation source, GitBook links, and docs checks.
+- `src/zenml/cli/AGENTS.md` - CLI import rules and filter/client coupling.
+- `src/zenml/integrations/AGENTS.md` - integration flavor import rules.
+- `src/zenml/models/AGENTS.md` - domain model compatibility and filter fields.
+- `src/zenml/orchestrators/AGENTS.md` - orchestrator IDs and dynamic pipelines.
+- `src/zenml/zen_server/AGENTS.md` - server import boundary and endpoint shape.
+- `src/zenml/zen_stores/migrations/AGENTS.md` - Alembic migration guidance.
+- `src/zenml/zen_stores/schemas/AGENTS.md` - ORM schema and SQL import rules.
+
+## Reviewer Checklist
+
+- Integration PRs: no top-level integration-library imports in flavor files.
+- Orchestrator PRs: `get_orchestrator_run_id` is unique per run and stable for
+  all steps in that run.
+- Filter model changes: matching client method signature and body are updated.
+- Private method changes: all internal usages are updated.
+- Import checks: no `zen_server` imports outside `zen_server`.
+- Import checks: no direct SQL imports outside `zen_stores`.
+- Model changes: adding properties is usually OK; deleting, renaming, or
+  incompatible type changes are risky.
+- Dependency bumps: dropping old version support is breaking.
+- Scheduling changes: check both legacy schedule and trigger stacks.
+- Step operator changes: check `BaseStepOperator`, `StepLauncher`, and at least
+  one concrete integration.
+
+## Documentation Rules
+
+- Documentation source files live in `docs/book/`.
+- Do not edit generated docs directories such as `docs/mkdocs/` or
+  `docs/site/`.
+- When adding or removing docs pages, update the relevant `toc.md`.
+- Assets belong in a `.gitbook` folder beside the relevant `toc.md`.
+
+For human contributors, see `CONTRIBUTING.md`.

--- a/docs/book/AGENTS.md
+++ b/docs/book/AGENTS.md
@@ -1,84 +1,38 @@
-# Documentation Guidelines for AI Agents
+# Documentation Agent Guidelines
 
-This file provides guidance for AI agents working with ZenML documentation.
+This file applies when Codex starts in `docs/book/` or below. For detailed
+GitBook URL examples, link-checking notes, and docs workflow recipes, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Source of Truth
 
-`docs/book/` is the source of truth for documentation content. Other docs directories (`docs/mkdocs/`, `docs/site/`) contain generated output — do not edit those directly. Changes to docs may also interact with the API docs buildability check in CI (fast CI).
-
-## GitBook URL Structure
-
-ZenML uses GitBook for documentation. The URL structure does **not** directly mirror the file system structure.
-
-### Key Rules
-
-1. **Pro docs live under `/pro/`**: Files in `docs/book/getting-started/zenml-pro/` are served at `https://docs.zenml.io/pro/...`
-
-2. **URLs follow TOC hierarchy, not file paths**: The `toc.md` file determines the URL structure. Child pages are nested under their parent's URL path.
-
-   Example from `zenml-pro/toc.md`:
-   ```text
-   ## Deployments
-   * Scenarios        -> scenarios.md
-     * SaaS           -> saas-deployment.md
-     * Self-hosted    -> self-hosted-deployment.md
-   ```
-
-   This creates:
-   - `scenarios.md` → `https://docs.zenml.io/pro/deployments/scenarios`
-   - `self-hosted-deployment.md` → `https://docs.zenml.io/pro/deployments/scenarios/self-hosted-deployment`
-
-   Note: `self-hosted-deployment.md` is nested under `scenarios/` in the URL because it's a child of Scenarios in the TOC.
-
-3. **Cross-section links require absolute URLs**: When linking from OSS docs to Pro docs (or vice versa), use absolute `https://docs.zenml.io/...` URLs. Relative links only work reliably within the same TOC section.
-
-### Common URL Patterns
-
-| File Location | URL |
-|--------------|-----|
-| `docs/book/getting-started/zenml-pro/README.md` | `https://docs.zenml.io/pro` |
-| `docs/book/getting-started/zenml-pro/workspaces.md` | `https://docs.zenml.io/pro/core-concepts/workspaces` |
-| `docs/book/getting-started/zenml-pro/roles.md` | `https://docs.zenml.io/pro/access-management/roles` |
-| `docs/book/how-to/secrets/secrets.md` | `https://docs.zenml.io/how-to/secrets/secrets` |
-
-### Verifying URLs
-
-Before committing documentation changes with absolute URLs:
-1. Check if the URL exists by fetching it (WebFetch tool or browser)
-2. Look at existing working links in the codebase for the same section
-3. Consult the relevant `toc.md` file to understand the hierarchy
-
-### Link Checking
-
-**CI checks** (`scripts/check_broken_links.py`, `scripts/check_relative_links.py`):
-- Check relative markdown links resolve to existing files
-- Do **not** check images, `.gitbook` paths, HTML `<a href>` links, or external URLs
-
-**Lychee** (`lychee.toml` config at repo root):
-- Comprehensive link checker that covers local files, images, HTML links, and external URLs
-- Run locally: `lychee --no-progress 'docs/book/**/*.md'`
-- Run offline (local links only, fast): `lychee --offline --no-progress 'docs/book/**/*.md'`
-- Known false positives (bot-blocked sites, placeholder URLs) are excluded in `lychee.toml`
-- If you see 404 errors for `docs.zenml.io` URLs, the URL structure likely changed (common after docs reorganizations) and needs updating
+- `docs/book/` is the source of truth for documentation content.
+- Other docs directories such as `docs/mkdocs/` and `docs/site/` contain
+  generated output; do not edit those directly.
+- Docs changes can affect the API docs buildability check in fast CI.
 
 ## Structure
-- Documentation files live in `docs/book/`
-- Multiple sections each have their own `toc.md` file for navigation
-- Assets (images, etc.) belong in a `.gitbook` folder at the same level as the relevant `toc.md`
-- When adding or removing pages, update the appropriate `toc.md` file
 
-## Format and Style
-- ZenML uses GitBook for documentation
-- Include metadata fields at the top of documentation pages (follow existing patterns)
-- Documentation should be readable and conversational
-- Use consistent formatting with existing documentation
-- Avoid overusing bullet points or other formatting elements
-- Prioritize readability and clarity over excessive structure
-- Include appropriate cross-references to related documentation
+- Multiple docs sections have their own `toc.md`; update the relevant `toc.md`
+  when adding, moving, or removing pages.
+- Assets belong in a `.gitbook` folder at the same level as the relevant
+  `toc.md`.
+- GitBook URLs follow TOC hierarchy, not filesystem paths.
+- Use absolute `https://docs.zenml.io/...` links when linking across major docs
+  sections such as OSS docs and Pro docs.
 
-## Content Standards
-- Clear, concise language
-- Code examples for APIs
-- Explanation of concepts
-- Usage patterns and best practices
-- Match tone and style with existing documentation
+## Style
+
+- Include metadata fields at the top of pages when existing nearby pages do so.
+- Match the tone and structure of nearby documentation.
+- Prioritize readable prose over dense bullet lists.
+- Include code examples, cross-references, and usage guidance where they help
+  users complete the task.
+
+## Verification
+
+- For changed relative markdown links, run the relevant local link checks.
+- For absolute docs URLs, check the current URL or inspect the relevant
+  `toc.md`.
+- Use Lychee when the change affects many links:
+  `lychee --offline --no-progress 'docs/book/**/*.md'`.

--- a/src/zenml/cli/AGENTS.md
+++ b/src/zenml/cli/AGENTS.md
@@ -1,105 +1,44 @@
-# ZenML CLI — Agent Guidelines
+# ZenML CLI Agent Guidelines
 
-Guidance for agents working with ZenML CLI code.
+This file applies when Codex starts in `src/zenml/cli/` or below. For detailed
+CLI examples and command-family notes, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `utils.py` | CLI utilities including `list_options` decorator |
-| `pipeline.py` | Pipeline, run, legacy schedule, and replay/resume management commands |
-| `trigger.py` | Native trigger commands, including schedule triggers and platform event triggers |
-| `resource_pool.py` | Resource pool commands and resource pool subject policies |
-| `resource_request.py` | Resource request / queue inspection commands |
-| `stack.py` | Stack management commands |
-| `base.py` | Core CLI setup and common decorators |
+- `utils.py` - CLI helpers, including `list_options`.
+- `pipeline.py` - pipeline, run, legacy schedule, and replay/resume commands.
+- `trigger.py` - native schedule and platform-event trigger commands.
+- `resource_pool.py` and `resource_request.py` - resource pool management and
+  queue/request inspection commands.
+- `stack.py` - stack management.
+- `base.py` - core CLI setup and common decorators.
 
-## Adding or Modifying List Commands
+## Filter and Client Coupling
 
-List commands (e.g., `zenml pipeline runs list`) use the `@list_options(FilterModel)` decorator to auto-generate CLI options from filter model fields.
+List commands often use `@list_options(FilterModel)` to generate CLI options
+from filter fields, then pass those options to explicit `Client` method
+parameters.
 
-**Critical:** When adding new filter fields, you must update multiple locations or the CLI will break. See the detailed checklist in:
+When adding a filter field, update all matching client method signatures and
+filter model construction sites. If the field should not be a CLI option, add
+it to `CLI_EXCLUDE_FIELDS` on the filter model.
 
-→ `src/zenml/models/AGENTS.md` § "Adding New Filter Fields — CLI-Client Coupling"
+Failure story: the CLI exposes `--new-field`, passes `new_field` to
+`Client.list_pipeline_runs`, and the client method does not accept it. The user
+gets `TypeError: list_pipeline_runs() got an unexpected keyword argument`.
 
-### Quick Summary
+## Import Rules
 
-The `@list_options` decorator auto-generates CLI options from filter model fields, but passes them to client methods that have explicit parameter lists. If a filter model field isn't also a client method parameter, users get:
-```
-TypeError: list_pipeline_runs() got an unexpected keyword argument 'new_field'
-```
+- Never import integration libraries at module level in CLI files.
+- Do not import from `zen_server/` in CLI code.
+- Do not import SQL schemas directly from `zen_stores/`; use `Client`.
+- Keep heavy optional imports inside the command that needs them.
 
-## CLI Patterns
+## Command Families
 
-### List Command Structure
-```python
-@entity.command("list")
-@list_options(EntityFilter)  # Auto-generates --field options
-def list_entities(**kwargs: Any) -> None:
-    client = Client()
-    entities = client.list_entities(**kwargs)  # kwargs passed to client
-```
-
-### Excluding Fields from CLI
-Add to `CLI_EXCLUDE_FIELDS` in the filter model (not here in CLI code):
-```python
-# In src/zenml/models/v2/core/<entity>.py
-class EntityFilter(...):
-    CLI_EXCLUDE_FIELDS = [..., "internal_field"]
-```
-
-## Scheduling Command Families
-
-There are now separate scheduling/trigger command families in the CLI:
-
-- `zenml pipeline schedule ...` — Legacy schedule records (CRUD on `ScheduleResponse`)
-- `zenml trigger schedule ...` — Native schedule triggers in the trigger architecture
-- `zenml trigger platform-event ...` — Platform event triggers and their supported events
-
-When modifying scheduling or trigger CLI code, be explicit about which stack you are changing. The trigger CLI lives in `cli/trigger.py`, while legacy schedule commands live in `cli/pipeline.py`. Trigger changes usually span CLI, client, server endpoints, models, schemas, and docs.
-
-## Resource Pool Command Family
-
-Resource pools have their own CLI surfaces in `cli/resource_pool.py` and `cli/resource_request.py`. When changing resource pool behavior, check both the management commands (create/update/list/delete, policy attach/detach/list) and request/queue inspection commands. These commands are coupled to `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and `ResourceRequest*` models.
-
-## Import Considerations
-
-### Core ZenML Imports
-
-The CLI does import most of ZenML core when used, because it needs to import models which import many other modules. This is acceptable because:
-- ZenML itself is not that large
-- Core imports are fast and always available
-- The real problem is integration libraries (see below)
-
-### Integration Imports — NEVER at Module Level
-
-Never import integration libraries at module level in CLI files. Integrations may not be installed, and module-level imports would break the entire CLI.
-
-```python
-# Bad - breaks CLI if sklearn not installed
-from sklearn import metrics
-
-# Good - import inside function when needed
-def some_command():
-    from sklearn import metrics
-```
-
-**Why this matters especially for CLI:**
-- Integration libraries can be massive (Evidently, Great Expectations = millions of lines of code)
-- Users expect `zenml --help` to work instantly, not after loading heavy dependencies
-- A single bad import can break the entire CLI for all users
-
-### Server and SQL Imports
-
-The CLI should also avoid importing from:
-- `zen_server/` — Server dependencies are optional
-- `zen_stores/` schemas directly — Use the Client abstraction instead
-
-```python
-# Bad
-from zenml.zen_stores.schemas import PipelineSchema
-
-# Good
-from zenml.client import Client
-client = Client()
-```
+- Legacy schedules: `zenml pipeline schedule ...` in `pipeline.py`.
+- Native schedule triggers: `zenml trigger schedule ...` in `trigger.py`.
+- Platform event triggers: `zenml trigger platform-event ...` in `trigger.py`.
+- Resource pool behavior often spans CLI commands, models, store methods, and
+  Pro/backend scheduling behavior.

--- a/src/zenml/integrations/AGENTS.md
+++ b/src/zenml/integrations/AGENTS.md
@@ -1,200 +1,62 @@
-# ZenML Integrations — Agent Guidelines
+# ZenML Integrations Agent Guidelines
 
-Guidance for agents working with ZenML integration code.
+This file applies when Codex starts in `src/zenml/integrations/` or below. For
+detailed examples, dependency update guidance, and step-operator notes, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
-## ⚠️ CRITICAL: Integration Flavor Import Rule
+## Critical Flavor Import Rule
 
-**This is the #1 review concern for integration PRs.** Getting this wrong can break all of ZenML.
+NEVER import integration libraries at the top level in flavor files.
 
-### The Rule
+Flavor files live at `src/zenml/integrations/*/flavors/*.py`. They are imported
+by the ZenML server and client for stack component discovery. Optional
+dependencies such as `boto3`, `sagemaker`, or `kubernetes` may not be installed.
+A module-level import can break all of ZenML, not just that integration.
 
-**NEVER import integration libraries at the top level in flavor files.**
+Allowed in flavor files:
 
-Flavor files are located at: `src/zenml/integrations/*/flavors/*.py`
+- Standard library imports.
+- Pydantic and ZenML core imports.
+- Integration type imports inside `if TYPE_CHECKING:`.
+- Implementation imports inside the `implementation_class` property or another
+  method that only runs when the component is used.
 
-### Why This Matters
+Not allowed in flavor files:
 
-1. **Server-side imports**: Flavor files are imported by the ZenML server and client to discover available stack components
-2. **Optional dependencies**: Integration libraries (boto3, sagemaker, kubernetes, etc.) are optional—users only install what they need
-3. **Cascading failures**: If a flavor file imports an uninstalled library at module level, importing that module fails, which can break the entire ZenML installation—not just that integration
+- Top-level imports of the integration library.
+- Top-level imports from implementation modules that themselves import the
+  integration library.
+- Config fields typed directly with third-party integration classes.
 
-### ✅ Correct Pattern
+## Package Shape
 
-```python
-# src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
+Each integration usually has:
 
-from typing import TYPE_CHECKING, Optional, Type
-from pydantic import Field
+- `__init__.py` for integration registration.
+- `flavors/` for flavor definitions.
+- Implementation folders such as `orchestrators/`, `step_operators/`, and
+  `materializers/`.
 
-from zenml.orchestrators import BaseOrchestratorConfig
-from zenml.orchestrators.base_orchestrator import BaseOrchestratorFlavor
+## Step Operators
 
-# Use TYPE_CHECKING for type hints only—never executed at runtime
-if TYPE_CHECKING:
-    from zenml.integrations.aws.orchestrators import SagemakerOrchestrator
+New step operator integrations should implement the async-first lifecycle:
 
+- `submit(...)`
+- `get_status(...)`
+- `wait(...)`
+- `cancel(...)`
 
-class SagemakerOrchestratorConfig(BaseOrchestratorConfig):
-    """Config for the Sagemaker orchestrator."""
-    execution_role: str = Field(...)
-    # ... other fields using only stdlib/zenml types
+Store backend job IDs in run metadata immediately after submission so status,
+cancel, and wait can work reliably.
 
+## Dependencies
 
-class SagemakerOrchestratorFlavor(BaseOrchestratorFlavor):
-    
-    @property
-    def config_class(self) -> Type[SagemakerOrchestratorConfig]:
-        return SagemakerOrchestratorConfig
-    
-    @property
-    def implementation_class(self) -> Type["SagemakerOrchestrator"]:
-        # Import INSIDE the method—only executed when actually needed
-        from zenml.integrations.aws.orchestrators import SagemakerOrchestrator
-        return SagemakerOrchestrator
-```
+- Prefer inclusive lower bounds and exclusive upper bounds.
+- Test realistic integration scenarios locally when changing dependencies.
+- Dropping support for an older dependency version is a breaking change.
 
-### ❌ Incorrect Pattern
+## Import Boundaries
 
-```python
-# src/zenml/integrations/aws/flavors/sagemaker_orchestrator_flavor.py
-
-# BAD: Top-level import of integration library
-import sagemaker  # ← This breaks ZenML if sagemaker isn't installed!
-from sagemaker.processing import Processor  # ← Also bad
-
-# BAD: Even indirect imports that pull in the integration library
-from zenml.integrations.aws.orchestrators import SagemakerOrchestrator  # ← Bad at top level
-
-
-class SagemakerOrchestratorConfig(BaseOrchestratorConfig):
-    # BAD: Using integration library types in config fields
-    processor: sagemaker.processing.Processor  # ← Requires import at top
-```
-
-### Key Points
-
-| Location | Integration imports allowed? |
-|----------|------------------------------|
-| `flavors/*.py` | ❌ Never at top level; only in `TYPE_CHECKING` blocks or inside methods |
-| `orchestrators/*.py`, `step_operators/*.py`, etc. | ✅ Yes—these are only imported when the integration is used |
-| Config classes in flavor files | ❌ Only use stdlib types, Pydantic types, or ZenML core types |
-| `implementation_class` property | ✅ Import inside the property method body |
-
-### Review Checklist for Integration PRs
-
-When reviewing or creating integration code:
-
-- [ ] No top-level imports of the integration library in `flavors/*.py`
-- [ ] Implementation class imports are inside the `implementation_class` property
-- [ ] Config fields only use stdlib/Pydantic/ZenML types, not integration library types
-- [ ] Any type hints for integration classes are protected by `if TYPE_CHECKING:`
-
-## Integration Package Structure
-
-Each integration follows this structure:
-
-```
-src/zenml/integrations/<name>/
-├── __init__.py           # Integration registration
-├── flavors/              # Flavor definitions (NO integration library imports!)
-│   ├── __init__.py
-│   └── *_flavor.py
-├── orchestrators/        # Actual implementations (integration imports OK here)
-│   └── *.py
-├── step_operators/
-│   └── *.py
-├── materializers/
-│   └── *.py
-└── ...
-```
-
-## Step Operator Contract
-
-Step operators now use an async-first lifecycle instead of the legacy `launch()` method:
-
-- `submit(...)` — Submit the step for remote execution (non-blocking)
-- `get_status(...)` — Check current execution status
-- `wait(...)` — Block until the step completes (polls `get_status` internally)
-- `cancel(...)` — Cancel a running step
-
-The `StepLauncher` calls `submit()` + `wait()` by default, falling back to the legacy `launch()` only for backwards compatibility. New step operator integrations should implement the async contract. Store the backend job ID in run metadata immediately after submission so that status/cancel/wait can work. See `integrations/runai/step_operators/runai_step_operator.py` for a reference implementation.
-
-## Adding New Integrations
-
-1. Create the integration package structure
-2. Register the integration in `__init__.py`
-3. Implement flavors (respecting the import rule above)
-4. Implement the actual stack components
-5. Add tests in `/tests/integration/`
-6. Add documentation in `/docs/book/component-guide/`
-
-## Dependency Updates
-
-When updating integration dependencies in `pyproject.toml`:
-
-1. **Check compatibility**: Ensure the new version works with supported Python versions (3.10+)
-2. **Test locally**: Run integration tests with the new dependency version
-3. **Update bounds carefully**: Prefer inclusive lower bounds and exclusive upper bounds (`>=1.0.0,<2.0.0`)
-4. **Document breaking changes**: If the update requires code changes, mention this in the PR
-5. **Consider transitive dependencies**: Major version bumps may affect other integrations
-
-### Breaking Changes
-
-A dependency update is a **breaking change** if you bump to a new version **and no longer support the old one**. This affects users who may be pinned to older versions.
-
-| Scenario | Breaking? | Action Required |
-|----------|-----------|-----------------|
-| Add support for new version (keep old) | ❌ No | Just update upper bound |
-| Bump minimum version | ⚠️ Yes | Document in changelog, consider deprecation period |
-| Drop support for old version | ⚠️ Yes | Major version considerations, migration guide |
-
-### CI Coverage for Dependency Conflicts
-
-Most dependency incompatibility issues are caught automatically by CI:
-
-- **Cross-integration conflicts**: If a new version conflicts with another integration's dependencies, CI will break
-- **Python version compatibility**: CI tests across supported Python versions
-- **Transitive dependency issues**: Dependency resolution failures surface in CI
-
-This safety net helps catch issues before merge, but doesn't replace local testing with realistic integration scenarios.
-
-### Version Constraint Guidelines
-
-```toml
-# Good: Clear bounds
-"sagemaker>=2.117.0,<3.0.0"
-
-# Avoid: Unbounded upper versions (can break unexpectedly)
-"sagemaker>=2.117.0"
-
-# Avoid: Overly tight constraints
-"sagemaker==2.117.0"
-```
-
-## General Import Restrictions
-
-Beyond the flavor file rule, integrations should also respect these import boundaries:
-
-### Never Import From
-
-| Directory | Why |
-|-----------|-----|
-| `zen_server/` | Server dependencies are optional; not installed on client machines |
-| `zen_stores/` (schemas directly) | SQL dependencies may not be installed; use `Client` instead |
-
-### Correct Pattern for Store Access
-
-```python
-# ❌ Bad - direct SQL import
-from zenml.zen_stores.schemas import ArtifactSchema
-
-# ✅ Good - use the Client
-from zenml.client import Client
-client = Client()
-artifacts = client.list_artifacts()
-
-# ✅ If you need store access (rare, and only in implementation files)
-client.zen_store.get_artifact(artifact_id)
-```
-
-This ensures proper dependency checking and clear error messages when dependencies are missing.
+- Integrations should not import from `zen_server/`.
+- Integrations should not import SQL schemas directly from `zen_stores/`; use
+  `Client` or `client.zen_store` only when lower-level access is truly needed.

--- a/src/zenml/models/AGENTS.md
+++ b/src/zenml/models/AGENTS.md
@@ -1,298 +1,57 @@
-# ZenML Domain Models — Concise Guide
-
-Compact reference for understanding, adding, or modifying ZenML domain models. For the canonical, detailed rules, see:
-- .cursor/rules/zenml-domain-models.mdc
-- Also keep models aligned with ORM schemas; see .cursor/rules/zenml-orm-schema.mdc
-
-Models live under: src/zenml/models
-
-## Core Concepts
-
-- Layered model hierarchy: Requests, Updates, and typed Responses using a tripartite structure (Body, Metadata, Resources).
-- Layered filter hierarchy: typed filter operations, scoping, sorting, pagination.
-- Scoping variants: global (base), user-scoped, project-scoped.
-- Strong typing and generics for response composition.
-- Keep domain models and ORM schemas strictly in sync (names and types).
-
-## Base Hierarchies
-
-Model base:
-- BaseZenModel: common root (analytics tracking, YAML serialization).
-- BaseRequest → {Entity}Request (UserScopedRequest, ProjectScopedRequest as needed).
-- BaseUpdate → {Entity}Update (omit if entity is immutable).
-- BaseResponse[Body, Metadata, Resources]
-  - BaseResponseBody → BaseDatedResponseBody
-    - UserScopedResponseBody, ProjectScopedResponseBody
-  - BaseResponseMetadata
-    - UserScopedResponseMetadata, ProjectScopedResponseMetadata
-  - BaseResponseResources
-    - UserScopedResponseResources, ProjectScopedResponseResources
-  - BaseIdentifiedResponse[DatedBody, Metadata, Resources]
-    - UserScopedResponse[…]
-      - ProjectScopedResponse[…]
-
-Filter base:
-- BaseFilter: core filtering, sorting, pagination.
-- Filter (ABC) specializations: BoolFilter, StrFilter → UUIDFilter, NumericFilter, DatetimeFilter.
-- UserScopedFilter → ProjectScopedFilter.
-- TaggableFilter for entities that support tagging.
-- FilterGenerator: creates appropriate filter instances.
-
-Response generics:
-- Body extends BaseResponseBody
-- Metadata extends BaseResponseMetadata
-- Resources extends BaseResponseResources
-
-## Cross-Layer Entity Families
-
-Some model families are coordination points between API models, ORM schemas, store methods, client methods, CLI commands, server endpoints, migrations, and docs. When touching these, trace the whole path instead of changing only the model file:
-
-- **Triggers:** `Trigger*`, `ScheduleTrigger*`, `PlatformEventTrigger*`, dispatch status/error models, and supported-event helpers. These back `zenml trigger ...` commands and trigger endpoints.
-- **Resource pools:** `ResourcePool*`, `ResourcePoolSubjectPolicy*`, and `ResourceRequest*` models. These back resource pool commands, queue/request inspection, store interfaces, and Pro/backend scheduling behavior.
-- **Run wait conditions:** `RunWaitCondition*` models coordinate pause/resume and wait-condition behavior for pipeline runs.
-- **Nested child pipelines:** `PipelineRun*` includes parent/child/root run fields such as `parent_run_id`, `child_key`, and `root_run_id`. Keep these aligned with ORM schemas, migrations, filters, client list methods, and dynamic pipeline tests.
-
-## Domain Model Types
-
-1) Request ({Entity}Request)
-- For creation. Inherit BaseRequest or scoped variants.
-- Include all mandatory fields and input validation.
-- Examples: name, has_custom_name, tags.
-
-2) Response ({Entity}Response)
-- Retrieval representation with Body/Metadata/Resources.
-- Hydration via get_hydrated_version(); provide property accessors.
-- May include analytics hooks and helper methods.
-
-3) Update ({Entity}Update)
-- For partial modifications; inherit BaseUpdate.
-- Fields are Optional and restricted to mutable attributes.
-- If the entity is immutable, omit the Update model.
-
-4) Filter ({Entity}Filter)
-- For querying; inherit BaseFilter or scoped variants (+ TaggableFilter if applicable).
-- Declare filterable fields, sorting options, and query-building logic.
-- Operations are type-specific (equals, not_equals, contains, startswith, gt, lt, etc.) and combinable (AND/OR).
-
-## Hydration Pattern
-
-Responses split into:
-- Body: essential attributes (BaseResponseBody / BaseDatedResponseBody).
-- Metadata: relationships/auxiliary info (BaseResponseMetadata). Optional; requires hydrated response.
-- Resources: related/computed/dynamic data (BaseResponseResources).
-
-Key methods:
-- hydrate(), get_hydrated_version()
-- get_body(), get_metadata(), get_resources()
-
-## Scoping
-
-- UserScoped*: associates entities with a user (base for project scope).
-- ProjectScoped*: associates entities with both a user and a project.
-
-For each scope, define matching types:
-- *ScopedRequest, *ScopedResponseBody, *ScopedResponseMetadata, *ScopedResponseResources, *ScopedFilter
-
-Select the narrowest scope that matches ownership semantics.
-
-## Filtering
-
-- Use BaseFilter / UserScopedFilter / ProjectScopedFilter (+ TaggableFilter if needed).
-- Provide:
-  - Declared filter fields with type-appropriate filters.
-  - Supported sorts and any exclusions.
-  - Scope-aware query rules.
-- Use FilterGenerator where dynamic filter construction is needed.
-
-## Naming and File Structure
-
-- Class names:
-  - Request: {Entity}Request
-  - Response: {Entity}Response
-  - Update: {Entity}Update
-  - Filter: {Entity}Filter
-  - Body: {Entity}ResponseBody
-  - Metadata: {Entity}ResponseMetadata
-  - Resources: {Entity}ResponseResources
-- Files:
-  - One entity per file, snake_case filename.
-  - Place under appropriate subdirectory (e.g., core/, base/, misc/).
-
-## Minimal New Entity Skeleton
-
-```python
-class NewEntityRequest(ProjectScopedRequest):
-    # Required creation fields and validation
-
-class NewEntityResponseBody(ProjectScopedResponseBody):
-    # Core attributes
-
-class NewEntityResponseMetadata(ProjectScopedResponseMetadata):
-    # Optional relationships / metadata
-
-class NewEntityResponseResources(ProjectScopedResponseResources):
-    # Optional computed / dynamic data
-
-class NewEntityResponse(
-    ProjectScopedResponse[
-        NewEntityResponseBody,
-        NewEntityResponseMetadata,
-        NewEntityResponseResources,
-    ]
-):
-    # Optional: hydration overrides, convenience accessors
-    # def get_hydrated_version(self) -> "NewEntityResponse": ...
-
-class NewEntityFilter(ProjectScopedFilter):
-    # Filter fields, supported operations, sorting options
-```
-
-## Implementation Checklist
-
-- Scope
-  - Choose global vs user vs project; select matching *Scoped base classes.
-- Classes
-  - Implement Request, ResponseBody, ResponseMetadata, ResponseResources, Response, Filter.
-- Fields
-  - Use Pydantic Field with clear title/description and precise typing.
-  - Carefully separate mandatory vs Optional.
-  - Keep names/types aligned with ORM schemas.
-- Methods
-  - Implement/override get_hydrated_version() if needed.
-  - Add convenience properties and helper constructors (e.g., from_response()) when useful.
-- Filtering
-  - Define filterable fields, supported operations, sort keys, and exclusions.
-  - Apply scope-specific query rules; combine filters with AND/OR as appropriate.
-- Documentation
-  - Add descriptive docstrings; remember these models back the REST API.
-- Sync
-  - Keep this guide and the canonical MDC rules synchronized.
-
-Remember: Consistency, type-safety, and parity with the ORM schema are critical for stable API and internal behavior.
-
-## ⚠️ Adding New Filter Fields — CLI-Client Coupling
-
-When adding a field to a filter model (e.g., `PipelineRunFilter`), **you must update THREE locations** or the CLI will break at runtime.
-
-### Why This Matters
-
-The CLI uses `@list_options(FilterModel)` (in `src/zenml/cli/utils.py`) to auto-generate CLI options from filter model fields. These options are passed as `**kwargs` to client methods, but client methods have **explicit parameter lists** that must match. If they don't match, users get:
-```
-TypeError: list_pipeline_runs() got an unexpected keyword argument 'new_field'
-```
-
-This error only occurs at runtime when the CLI option is used—there's no mypy or test coverage to catch it.
-
-**Note:** Relationship-backed filter fields (e.g., `trigger_id` on pipeline runs) may also require custom ORM join logic in the store layer, not just client signature updates.
-
-### Three-Location Update Checklist
-
-When adding a new filter field:
-
-1. **Filter Model** (`src/zenml/models/v2/core/<entity>.py`)
-   ```python
-   class PipelineRunFilter(...):
-       new_field: Optional[str] = Field(default=None, description="...")
-   ```
-
-2. **Client Method Signature** (`src/zenml/client.py`)
-   ```python
-   def list_pipeline_runs(
-       self,
-       # ... existing params ...
-       new_field: Optional[str] = None,  # ← ADD THIS
-   ) -> Page[PipelineRunResponse]:
-   ```
-
-3. **Client Method Body** — filter model instantiation inside the same method:
-   ```python
-   runs_filter_model = PipelineRunFilter(
-       # ... existing params ...
-       new_field=new_field,  # ← ADD THIS
-   )
-   ```
-
-### Optional: Exclude from CLI
-
-If the field should NOT be a CLI option, add it to `CLI_EXCLUDE_FIELDS`:
-```python
-class PipelineRunFilter(...):
-    CLI_EXCLUDE_FIELDS = [
-        *ProjectScopedFilter.CLI_EXCLUDE_FIELDS,
-        "new_field",  # Not exposed in CLI
-    ]
-```
-
-### Testing
-
-Always test the new filter via CLI after adding:
-```bash
-zenml pipeline runs list --new_field=some_value
-```
-
-### Related Files
-
-| Component | Location |
-|-----------|----------|
-| Filter models | `src/zenml/models/v2/core/*.py`, `src/zenml/models/v2/base/scoped.py` |
-| list_options decorator | `src/zenml/cli/utils.py:2798` |
-| Client list methods | `src/zenml/client.py` |
-| CLI commands | `src/zenml/cli/*.py` |
-
-## Model Changes and Backwards Compatibility
-
-When modifying domain models, be aware of server/client compatibility implications:
-
-| Change Type | Compatibility Impact |
-|-------------|---------------------|
-| **Adding new properties** | Usually NOT a problem (extras are now allowed in Pydantic) |
-| **Deleting properties** | ⚠️ PROBLEMATIC — breaks server/client compatibility |
-| **Making required→optional** | ⚠️ PROBLEMATIC — similar to deletion |
-| **Renaming properties** | ⚠️ PROBLEMATIC — equivalent to delete + add |
-| **Changing property types** | ⚠️ PROBLEMATIC — may break serialization |
-
-### Why This Matters
-
-ZenML clients and servers may run different versions. When a newer server sends a response with a deleted field, older clients expecting that field will break. Similarly, when an older client sends a request missing a newly-required field, the server will reject it.
-
-### Safe Evolution Pattern
-
-1. **Add new optional fields** — always safe
-2. **Deprecate before removing** — mark fields as deprecated, keep them for 2+ minor versions
-3. **Use default values** — when adding required fields, provide sensible defaults
-4. **Version responses** — for major changes, consider response versioning
-
----
-
-## Client Method Patterns
-
-When adding or modifying client methods in `src/zenml/client.py`, follow existing patterns:
-
-### Get Methods
-```python
-def get_pipeline(self, name_id_or_prefix: Union[str, UUID]) -> PipelineResponse:
-    """Get a pipeline by name, ID, or prefix."""
-    # If it looks like a UUID, fetch directly
-    # If it's a name, list + filter to find it
-    # Follow what other get_* methods do
-```
-
-### List Methods
-```python
-def list_pipelines(
-    self,
-    # All filter model fields as explicit parameters
-    name: Optional[str] = None,
-    size: int = PAGE_SIZE_DEFAULT,
-    # ... etc
-) -> Page[PipelineResponse]:
-    """List pipelines with filtering."""
-    filter_model = PipelineFilter(name=name, ...)
-    return self.zen_store.list_pipelines(filter_model)
-```
-
-### Key Conventions
-- **Get by name or ID**: Most `get_*` methods accept either a name or UUID
-- **Explicit parameters**: List methods have explicit parameters matching filter fields (see CLI coupling above)
-- **Consistent return types**: Get returns single Response, List returns `Page[Response]`
-- **Follow existing patterns**: When in doubt, look at similar methods in the same file
+# ZenML Domain Models Agent Guidelines
+
+This file applies when Codex starts in `src/zenml/models/` or below. For
+detailed model hierarchy notes and examples, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
+
+Models live under `src/zenml/models`. Keep them aligned with ORM schemas and
+store behavior.
+
+## Core Patterns
+
+- Requests represent creation payloads.
+- Updates represent partial modification payloads.
+- Responses use Body, Metadata, and Resources.
+- Filters define query fields, operations, sorting, scoping, and pagination.
+- Choose the narrowest scope that matches ownership semantics: global, user, or
+  project.
+
+## Cross-Layer Families
+
+Trace the full path when touching:
+
+- Triggers and schedule/platform event trigger models.
+- Resource pools, subject policies, and resource requests.
+- Run wait conditions.
+- Nested child pipeline run fields such as `parent_run_id`, `child_key`, and
+  `root_run_id`.
+
+These often require aligned changes in CLI, client methods, server endpoints,
+schemas, migrations, tests, and docs.
+
+## Filter Field Checklist
+
+When adding a filter field, update:
+
+1. The filter model.
+2. The corresponding `Client` list method signature.
+3. The filter model instantiation inside that client method.
+
+If the field should not be exposed by CLI, add it to `CLI_EXCLUDE_FIELDS`.
+Relationship-backed filters may also need custom ORM join logic in the store
+layer.
+
+## Compatibility
+
+Usually safe:
+
+- Adding optional properties.
+
+Risky or breaking:
+
+- Deleting properties.
+- Renaming properties.
+- Making required fields optional in a way older code cannot tolerate.
+- Changing property types incompatibly.
+
+Use deprecation periods and defaults when evolving public model responses.

--- a/src/zenml/orchestrators/AGENTS.md
+++ b/src/zenml/orchestrators/AGENTS.md
@@ -1,216 +1,54 @@
-# ZenML Orchestrators — Agent Guidelines
+# ZenML Orchestrators Agent Guidelines
 
-Guidance for agents implementing or modifying ZenML orchestrators.
+This file applies when Codex starts in `src/zenml/orchestrators/` or below. For
+detailed examples and implementation recipes, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `base_orchestrator.py` | Base class with abstract methods to implement |
-| `containerized_orchestrator.py` | Base for orchestrators that run steps in containers |
-| `utils.py` | Shared orchestrator utilities |
-| `step_launcher.py` | Step execution launcher, including step-operator and isolated-step paths |
-| `step_runner.py` | Runtime step execution logic |
-| `cache_utils.py`, `input_utils.py`, `publish_utils.py` | Shared cache/input/status and metadata helpers |
+- `base_orchestrator.py` - base class and abstract methods.
+- `containerized_orchestrator.py` - base for containerized orchestrators.
+- `step_launcher.py` - step-operator and isolated-step execution paths.
+- `step_runner.py` - runtime step execution logic.
+- `utils.py`, `cache_utils.py`, `input_utils.py`, `publish_utils.py` - shared
+  orchestration helpers.
 
-## Methods to Implement
+## Submission Methods
 
-When implementing a custom orchestrator, there are two main submission methods:
+- `submit_pipeline(...)` submits static pipelines where the DAG is known.
+- `submit_dynamic_pipeline(...)` submits dynamic pipelines where the DAG can
+  change during execution.
+- Dynamic pipeline support may also need isolated-step APIs:
+  `submit_isolated_step`, `get_isolated_step_status`,
+  `wait_for_isolated_step`, and `stop_isolated_step`.
 
-### 1. `submit_pipeline` (line ~188)
+`BaseOrchestrator.run(...)` already removes steps skipped by replay or
+client-side caching before submission. Do not re-implement that pruning inside
+integration orchestrators.
 
-For **static pipelines** where the DAG is known at submission time.
+## `get_orchestrator_run_id`
 
-```python
-def submit_pipeline(
-    self,
-    snapshot: "PipelineSnapshotResponse",
-    stack: "Stack",
-    base_environment: Dict[str, str],
-    step_environments: Dict[str, Dict[str, str]],
-    placeholder_run: Optional["PipelineRunResponse"] = None,
-) -> Optional[SubmissionResult]:
-    """Submit the pipeline to your orchestration backend."""
-```
+This method must return a value that is:
 
-### 2. `submit_dynamic_pipeline` (line ~218)
+- Unique across backend runs.
+- The same for all steps in one ZenML pipeline run.
+- Stable across retries of the same dynamic orchestration environment.
 
-For **dynamic pipelines** where the DAG can change during execution.
+Do not return a fixed string or a value that changes between steps. If dynamic
+pipelines are supported, handle the orchestration-container case explicitly.
 
-```python
-def submit_dynamic_pipeline(
-    self,
-    snapshot: "PipelineSnapshotResponse",
-    stack: "Stack",
-    environment: Dict[str, str],
-    placeholder_run: Optional["PipelineRunResponse"] = None,
-) -> Optional[SubmissionResult]:
-    """Submit a dynamic pipeline to your orchestration backend."""
-```
+Kubernetes is special because it has an orchestration container even for static
+pipelines. Prefer the configured Kubernetes run ID for static runs and the
+parent Kubernetes job name for dynamic runs, falling back only when needed.
 
-Both methods ask you to submit the pipeline to your orchestration backend (e.g., starting a job in Vertex, starting a pipeline in SageMaker).
+## Dynamic Child Pipelines
 
-### 3. Isolated-Step APIs (for dynamic pipelines)
+When changing dynamic pipeline behavior, check:
 
-When implementing dynamic pipeline support, orchestrators can also override these methods to manage individual step execution:
+- `src/zenml/execution/pipeline/dynamic/`
+- `src/zenml/pipelines/dynamic/`
+- `src/zenml/orchestrators/step_launcher.py`
+- pipeline run models, schemas, migrations, tests, and docs.
 
-- `submit_isolated_step(...)` — Submit a single step as an isolated job
-- `get_isolated_step_status(...)` — Check the status of a submitted step
-- `wait_for_isolated_step(...)` — Block until a step completes
-- `stop_isolated_step(...)` — Cancel a running step
-
-These are used by the `StepLauncher` when running steps via step operators or in dynamic pipeline contexts. See the Kubernetes orchestrator for a reference implementation.
-
-### Replay/Cache-Aware Snapshots
-
-`BaseOrchestrator.run(...)` now prunes the pipeline snapshot before submission: steps skipped by replay or resolved by client-side caching are removed before your `submit_pipeline`/`submit_dynamic_pipeline` method is called. Do not re-implement replay or caching pruning inside integration orchestrators.
-
----
-
-### Nested Child Pipelines
-
-Dynamic pipelines can now call other dynamic pipelines as child pipelines. A child pipeline may create its own pipeline run with `parent_run_id`, `child_key`, and `root_run_id` links back to the parent run. Inline child pipelines execute their steps inside the parent run instead.
-
-When changing dynamic pipeline or orchestrator behavior, check the full chain:
-- Dynamic execution: `src/zenml/execution/pipeline/dynamic/`
-- Dynamic pipeline public API: `src/zenml/pipelines/dynamic/`
-- Parent/child run models and schemas: `PipelineRun*` models, `pipeline_run_schemas.py`, and migrations
-- Step launching: `src/zenml/orchestrators/step_launcher.py`
-- Tests: `tests/unit/execution/pipeline/dynamic/test_child_pipelines.py`
-- Docs: `docs/book/how-to/steps-pipelines/dynamic_pipelines.md`
-
-Concrete failure story: the parent dynamic run launches a child pipeline, then resumes or retries. If the child key or orchestration run ID changes unexpectedly, ZenML can fail to find the existing child run and may start duplicate work. Keep child identifiers stable across replay/resume/retry paths.
-
----
-
-## ⚠️ The Tricky Method: `get_orchestrator_run_id`
-
-**Location:** `base_orchestrator.py:173`
-
-This is where most implementers get confused, despite the docstring documentation.
-
-```python
-@abstractmethod
-def get_orchestrator_run_id(self) -> str:
-    """Returns the run id of the active orchestrator run.
-
-    Important: This needs to be a unique ID and return the same value for
-    all steps of a pipeline run.
-    """
-```
-
-### Static Pipeline Case
-
-**Key requirements:**
-1. Must return the **same value** for all steps in a pipeline run
-2. Must be **unique across runs** (can't return a fixed string)
-
-**Why this is tricky:**
-- In static pipelines, there's typically no orchestration container that gets spun up first
-- For orchestrators like SageMaker, execution immediately starts with the first step
-- No step knows in advance what the ZenML pipeline run ID is supposed to be (the run doesn't exist yet when steps start)
-- The `get_orchestrator_run_id` allows the first step to create the run, and all downstream steps to find it
-
-**How to get the ID:**
-- Most orchestration backends expose a run ID as an environment variable
-- Example: SageMaker has `TRAINING_JOB_ARN` or reads from `/opt/ml/config/processingjobconfig.json`
-- This ID is unique for each run of the backend pipeline
-
-**Size constraints:** Limited to ~250 characters due to MySQL database column limit, but any ID from orchestration backends should fit.
-
-### Dynamic Pipeline Case
-
-**Key differences:**
-- There's always one initial container that gets spun up first: the "orchestration container"
-- This container creates the pipeline run
-- The ID needs to be unique for the orchestration environment and stable for retries of that same orchestration environment
-- It does NOT need to be unique across all step containers that get spun up later
-
-**What to use:**
-- **Kubernetes:** Prefer the parent Kubernetes job name for the orchestration pod; fall back to the pod name only if the job lookup fails
-- **SageMaker:** The job ID of the orchestration container
-
-### Orchestration Exception: Kubernetes
-
-Kubernetes is special because it **does** spin up an orchestration container first, even for static pipelines. This means:
-- The Kubernetes orchestrator first checks for `ENV_ZENML_KUBERNETES_RUN_ID` (set for static pipelines)
-- For dynamic pipelines, it tries to use the parent Kubernetes job name so retries of the orchestration pod resolve to the same run ID
-- It falls back to `socket.gethostname()` only if the job-name lookup fails
-
----
-
-## Reference Implementations
-
-Study these implementations when building your own orchestrator:
-
-### Kubernetes (recommended starting point)
-**File:** `src/zenml/integrations/kubernetes/orchestrators/kubernetes_orchestrator.py:1080`
-
-```python
-def get_orchestrator_run_id(self) -> str:
-    try:
-        return os.environ[ENV_ZENML_KUBERNETES_RUN_ID]
-    except KeyError:
-        # Dynamic pipeline: use parent job name for retry stability,
-        # falling back to pod name if the lookup fails.
-        pod_name = socket.gethostname()
-        return get_parent_job_name(...) or pod_name
-```
-
-### SageMaker (complex example)
-**File:** `src/zenml/integrations/aws/orchestrators/sagemaker_orchestrator.py:270`
-
-```python
-def get_orchestrator_run_id(self) -> str:
-    # Check multiple environment variables
-    for env in [ENV_ZENML_SAGEMAKER_RUN_ID, "TRAINING_JOB_ARN"]:
-        if env in os.environ:
-            return os.environ[env]
-    
-    # Fall back to processing job config file
-    config_file_path = "/opt/ml/config/processingjobconfig.json"
-    if os.path.exists(config_file_path):
-        with open(config_file_path, "r") as f:
-            # Read job name from config...
-```
-
-### Vertex AI
-**File:** `src/zenml/integrations/gcp/orchestrators/vertex_orchestrator.py:1004`
-
-```python
-def get_orchestrator_run_id(self) -> str:
-    try:
-        return os.environ[ENV_ZENML_VERTEX_RUN_ID]
-    except KeyError:
-        raise RuntimeError(
-            f"Unable to read run id from environment variable {ENV_ZENML_VERTEX_RUN_ID}."
-        )
-```
-
----
-
-## Implementation Checklist
-
-When implementing a new orchestrator:
-
-- [ ] Inherit from `ContainerizedOrchestrator` if your orchestrator runs steps in containers
-- [ ] Implement `get_orchestrator_run_id()` following the static/dynamic patterns above
-- [ ] Implement `submit_pipeline()` for static pipelines
-- [ ] Optionally implement `submit_dynamic_pipeline()` for dynamic pipeline support
-- [ ] Optionally implement `submit_isolated_step()` / `get_isolated_step_status()` / `wait_for_isolated_step()` for dynamic pipelines with step operators
-- [ ] Handle scheduling if your backend supports it (see `update_schedule`/`delete_schedule` hooks)
-- [ ] Handle resource settings from step configurations appropriately (CPU, memory, GPU, etc.)
-- [ ] Return `SubmissionResult` with `wait_for_completion` for synchronous execution
-- [ ] Use `self.get_image(deployment, step_name)` to get the Docker image for each step
-- [ ] Use `orchestrator_utils.get_step_entrypoint_command(...)` for step container commands, so command steps can override the default ZenML step entrypoint
-
-## Common Pitfalls
-
-1. **Returning a non-unique ID**: Don't return a fixed string or timestamp that could collide across runs
-2. **Different IDs for different steps**: All steps in a run MUST get the same ID
-3. **Forgetting the dynamic case**: If you support dynamic pipelines, handle the fallback
-4. **Not setting environment variables**: The entrypoint needs your run ID to be discoverable
-
-## Additional Resources
-
-- Custom orchestrator documentation: `docs/book/component-guide/orchestrators/custom.md`
+If a child key or backend run ID changes during retry/resume, ZenML can fail to
+find the existing child run and start duplicate work.

--- a/src/zenml/zen_server/AGENTS.md
+++ b/src/zenml/zen_server/AGENTS.md
@@ -1,80 +1,40 @@
-# ZenML Server — Agent Guidelines
+# ZenML Server Agent Guidelines
 
-Guidance for agents working with ZenML server code.
+This file applies when Codex starts in `src/zenml/zen_server/` or below. For
+detailed FastAPI guidance, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
-## ⚠️ CRITICAL: Import Boundary
+## Critical Import Boundary
 
-**Rule:** Code outside `zen_server/` should **NEVER** import from `zen_server/`
+Code outside `src/zenml/zen_server/` should NEVER import from `zen_server/`.
 
-```
-src/zenml/zen_server/   ← Server code (this directory)
-src/zenml/...           ← Client code (everything else)
-```
+Server dependencies such as FastAPI and uvicorn are optional in many client
+installations. If client code imports server code, it can fail on machines that
+do not have server dependencies installed.
 
-### Why This Matters
+Allowed:
 
-1. **Optional installation**: The ZenML server is not installed on client machines in most deployments
-2. **Optional dependencies**: Server-specific dependencies (FastAPI, uvicorn, etc.) are only installed when users want to run a local server
-3. **Import failures**: If client code imports from `zen_server/`, it will fail on machines without server dependencies
+- Server code importing within `zen_server/`.
+- Client-side code using shared models from `src/zenml/models/`.
+- Client-side code using the `Client` abstraction for server communication.
 
-### What This Means
+## Endpoint Pattern
 
-| From | Can import from `zen_server/`? |
-|------|-------------------------------|
-| `src/zenml/zen_server/*` | ✅ Yes |
-| `src/zenml/client.py` | ❌ No |
-| `src/zenml/cli/*` | ❌ No |
-| `src/zenml/integrations/*` | ❌ No |
-| Any other ZenML code | ❌ No |
+Most server endpoints follow this order:
 
-### Correct Patterns
+1. Authorize.
+2. Check entitlements when feature access is gated.
+3. Verify RBAC permissions.
+4. Call `zen_store()` for the data operation.
+5. Use the async compatibility wrapper where existing routes do so.
 
-```python
-# ❌ Bad - importing server code from client code
-from zenml.zen_server.routers import pipeline_router
-from zenml.zen_server.utils import server_config
+Non-CRUD endpoints, such as trigger attach/detach, may need permission checks
+across multiple resource domains.
 
-# ✅ Good - use the Client abstraction instead
-from zenml.client import Client
-client = Client()
-# The client handles all communication with the server
-```
+## FastAPI Rules
 
-### If You Need Server Functionality
-
-If you're writing code that needs to interact with server functionality:
-
-1. **From client code**: Use the `Client` class which handles REST API communication
-2. **From server code**: You can import freely within `zen_server/`
-3. **Shared types**: Use models from `src/zenml/models/` which are shared between client and server
-
-## Standard Endpoint Pattern
-
-Server endpoints follow a consistent pattern:
-
-1. **Authorize** — call `authorize(...)` for authentication
-2. **Entitlement check** — verify feature access if the endpoint is gated
-3. **RBAC** — use `verify_permissions_and_*` wrappers or explicit permission checks
-4. **Store operation** — call `zen_store()` for the actual data operation
-5. **Async wrapper** — wrap with `async_fastapi_endpoint_wrapper` for async compatibility
-
-Non-CRUD endpoints (e.g., trigger attach/detach) may require permission checks across multiple resource domains.
-
-## FastAPI Agent Profile
-- ZenML OSS FastAPI work demands senior-level proficiency across FastAPI, SQLModel, SQLAlchemy 2.0, and modern Pydantic v2 patterns; study existing routers and services before proposing changes.
-- Favor object-oriented extensions over scattering helpers—extend service/repository classes or introduce cohesive new ones, and rely on dependency injection rather than module-level singletons.
-- Keep all shared state inside FastAPI's dependency system or app factory; never introduce fresh global variables outside the initializer.
-- Use descriptive auxiliary-verb-prefixed names and lower_snake_case paths (for example `routers/manage_invitation.py`, `services/issue_token.py`) so reviewers immediately understand intent.
-- Apply the Receive an Object, Return an Object (RORO) convention on public interfaces to keep payloads self-documenting and testable.
-
-## FastAPI Project Structure
-- Each FastAPI package must expose a router entry point plus clearly separated sub-routes, utilities, static assets, and schema/model definitions; keep imports explicit via named exports.
-- Co-locate Pydantic request/response models with their consuming routes, and keep reusable business logic inside services or repositories accessed through dependency injection.
-- Name directories/files with verbs or nouns that communicate behavior (e.g., `routers/register_user.py`, `services/create_invitation.py`) so navigation stays predictable.
-
-## FastAPI Error Handling & Validation
-- Lead with guard clauses in routes, dependencies, and services—validate payloads, auth context, and resources early; prefer early returns and keep the happy path last.
-- Skip redundant `else` blocks after returns; log context-rich errors and surface user-safe details while retaining debug information in structured logs.
-- Define custom exception types or factories so middleware can map them to consistent JSON payloads with trace metadata.
-- Raise `HTTPException` (with precise status codes and detail strings) for expected errors, and push unexpected failures through middleware that centralizes logging, metrics, and alerting.
-- Model inputs/outputs with Pydantic BaseModel derivatives to keep validation explicit and documentation synchronized automatically.
+- Prefer existing service or repository classes over scattered helpers.
+- Keep shared state inside dependency injection or the app factory.
+- Never introduce fresh global variables outside initialization.
+- Lead with guard clauses for auth, payload, dependency, and resource checks.
+- Raise `HTTPException` with precise status codes for expected failures.
+- Use Pydantic models for route inputs and outputs.

--- a/src/zenml/zen_stores/migrations/AGENTS.md
+++ b/src/zenml/zen_stores/migrations/AGENTS.md
@@ -1,82 +1,29 @@
-# ZenML Migrations — Agent Guidelines
+# ZenML Migration Agent Guidelines
 
-Guidance for agents writing or debugging Alembic migrations for ZenML's database schema.
+This file applies when Codex starts in `src/zenml/zen_stores/migrations/` or
+below. For detailed migration recipes and SQL inspection queries, use
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
-## Useful SQL Queries for Migration Development
+## Alembic Rules
 
-### Tracing Foreign Key Dependencies
+- Create migrations with descriptive names, for example
+  `alembic revision -m "Add X to Y table"`.
+- Test upgrade paths with `alembic upgrade head`.
+- Downgrade testing is optional because ZenML generally does not support
+  downgrades.
+- Never modify existing migrations that are already on `main` or `develop`.
+- Consider backward compatibility for rolling deployments.
+- Include both schema changes and data migrations when needed.
+- Run `scripts/check-alembic-branches.sh` to verify migration consistency.
 
-When modifying tables (especially when changing or deleting columns, or deciding on `ON DELETE` behavior), you need to understand which tables reference yours.
+## Testing Workflow
 
-**Query (MySQL):**
+1. Check out `develop` or the relevant old release.
+2. Populate the database from that version.
+3. Switch to the feature branch.
+4. Run `alembic upgrade head`.
 
-This query joins two MySQL system tables: `KEY_COLUMN_USAGE` (aliased as `kcu`) which tracks which columns participate in foreign keys, and `REFERENTIAL_CONSTRAINTS` (aliased as `rc`) which stores the ON DELETE/UPDATE rules for each constraint.
+## Coordination
 
-```sql
-SELECT
-  kcu.CONSTRAINT_NAME AS fk_name,
-  kcu.TABLE_SCHEMA AS referencing_schema,
-  kcu.TABLE_NAME AS referencing_table,
-  kcu.COLUMN_NAME AS referencing_column,
-  kcu.REFERENCED_TABLE_SCHEMA AS referenced_schema,
-  kcu.REFERENCED_TABLE_NAME AS referenced_table,
-  kcu.REFERENCED_COLUMN_NAME AS referenced_column,
-  rc.UPDATE_RULE,
-  rc.DELETE_RULE
-FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
-JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
-  ON rc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
- AND rc.CONSTRAINT_NAME  = kcu.CONSTRAINT_NAME
-WHERE kcu.REFERENCED_TABLE_SCHEMA = '<DB_NAME>'
-  AND kcu.REFERENCED_TABLE_NAME IN ('table1', 'table2')
-ORDER BY kcu.TABLE_NAME, kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION;
-```
-
-**When to use this:**
-
-1. **Before adding `ON DELETE CASCADE`** — Check what tables reference yours. A cascade delete on `user` might unexpectedly wipe out rows in `api_key`, `secret`, and other tables.
-
-2. **Before dropping a column or table** — If other tables have FKs pointing to what you're removing, the migration will fail. This query tells you what needs to change first.
-
-3. **Debugging migration failures** — If you see "Cannot delete or update a parent row: a foreign key constraint fails", this query helps you find all the referencing constraints.
-
-4. **Reviewing `ON DELETE` choices** — When auditing existing schemas, you can check whether current `DELETE_RULE` values (`CASCADE`, `SET NULL`, `RESTRICT`, `NO ACTION`) match business requirements.
-
-**Example output interpretation:**
-
-```
-fk_name           | referencing_table | referencing_column | referenced_table | DELETE_RULE
-------------------+-------------------+--------------------+------------------+------------
-fk_apikey_user    | api_key           | user_id            | user             | CASCADE
-fk_secret_user    | secret            | user_id            | user             | SET NULL
-```
-
-This tells you:
-- Deleting a `user` row will **automatically delete** related `api_key` rows (CASCADE)
-- Deleting a `user` row will **set `user_id` to NULL** in related `secret` rows (SET NULL)
-
----
-
-## Common Migration Patterns
-
-### Association Tables
-When introducing many-to-many relationships (e.g., trigger-snapshot associations), create a new table with composite primary keys referencing both sides. See `3855b5d051cd_add_v2_of_trigger_schemas.py` for a reference.
-
-### Self-Referential Foreign Keys
-For lineage tracking (e.g., `pipeline_run.original_run_id` → `pipeline_run.id`), add the FK column as nullable pointing back to the same table. See `bf4203afb657_pipeline_run_replays.py` for a reference.
-
-### Denormalized Filter Columns
-When storing polymorphic config as JSON but needing fast filtering, flatten hot filter fields into indexed columns (e.g., `trigger.next_occurrence`). Add indexes in the same migration.
-
-### Coordinated Updates
-Migration work often requires synchronized updates across: schemas, domain models, store methods, and client/CLI surfaces. Plan for all layers when designing schema changes.
-
-## Related Resources
-
-- **ORM schema patterns:** See `schemas/AGENTS.md` for SQLModel conventions and FK definition patterns
-- **Migration testing:** The `schemas/AGENTS.md` file includes a migration testing workflow
-- **Alembic basics:** See CLAUDE.md section "Database and Migration Guidelines"
-
----
-
-*This document is maintained to help agents write robust database migrations for ZenML.*
+Migration work often requires synchronized updates across ORM schemas, domain
+models, store methods, client methods, CLI commands, tests, and docs.

--- a/src/zenml/zen_stores/schemas/AGENTS.md
+++ b/src/zenml/zen_stores/schemas/AGENTS.md
@@ -1,267 +1,55 @@
-# ZenML Zen Stores — Agent Guidelines
+# ZenML ORM Schema Agent Guidelines
 
-Guidance for agents working with ZenML's data storage layer, including ORM schemas and database migrations.
+This file applies when Codex starts in `src/zenml/zen_stores/schemas/` or
+below. For detailed SQLModel examples, relationship patterns, and eager-loading
+notes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
-## ORM Usage
+## Storage Rules
 
-ZenML uses **SQLModel** (SQLAlchemy-based) for all database operations. No raw SQL unless absolutely necessary.
+- ZenML uses SQLModel and SQLAlchemy for database operations.
+- No raw SQL unless absolutely necessary.
+- General string column limit is about 250 characters because of MySQL.
+- Code outside `zen_stores/` should not import SQL-related code directly from
+  this directory.
+- External code should use `Client`; lower-level access should go through
+  `client.zen_store` only when truly needed.
 
-### Database Column Limits
+## Schema Patterns
 
-General string column limit: **~250 characters** (MySQL constraint). This affects:
-- Orchestrator run IDs and similar identifier fields
-- Any string field that might receive external system identifiers
+- Inherit from `BaseSchema` or `NamedSchema`.
+- Use declarative SQLModel style with explicit `table=True` and
+  `__tablename__`.
+- Keep ORM fields and types aligned with domain models.
+- Schema changes usually require migrations.
+- Export new schemas from `src/zenml/zen_stores/schemas/__init__.py`.
+- Add indexes, unique constraints, and nullability according to actual query
+  and business requirements.
 
-When designing schemas, ensure string fields that store external IDs have appropriate length constraints.
+## Relationships
 
----
+- Use `schema_utils.build_foreign_key_field` for foreign keys.
+- Always update both sides when adding or changing relationships.
+- Keep `back_populates` symmetric.
+- Use link models with composite primary keys for many-to-many relationships.
 
-## ⚠️ CRITICAL: Import Restriction for `zen_stores/`
+## Conversion and Updates
 
-**Rule:** Code outside `zen_stores/` should **NOT** import SQL-related code directly from this directory.
+- Implement `to_model`.
+- Implement `from_request` or `from_model` where appropriate.
+- Implement `update` or `update_from_model`.
+- Include heavy related resources only when requested by flags.
+- Always refresh `updated` on mutations.
+- Keep structured field serialization and decoding symmetric.
 
-### Why This Matters
+## Eager Loading
 
-1. **Optional SQL dependencies**: SQL dependencies (SQLAlchemy, SQLModel) may not be installed in all environments
-2. **Import check bypass**: Direct imports skip ZenML's dependency checking, leading to misleading error messages
-3. **Abstraction violation**: External code should use the Client abstraction, not raw database access
+- Collections use `selectinload`; `joinedload` on collections can multiply rows.
+- Single-valued relationships usually use `joinedload` on get paths when the
+  related row usually exists.
+- Keep `selectinload` for nullable foreign keys that are usually empty.
 
-### Correct Access Pattern
+## Migration Coupling
 
-```python
-# ❌ Bad - direct import from zen_stores
-from zenml.zen_stores.schemas import PipelineRunSchema
-from zenml.zen_stores.sql_zen_store import SqlZenStore
-
-# ✅ Good - use the Client
-from zenml.client import Client
-client = Client()
-runs = client.list_pipeline_runs()
-
-# ✅ If you need lower-level access (rare)
-client.zen_store  # Gives you access to the store with proper checks
-```
-
-### Why `client.zen_store` Is Better
-
-- Import checks run properly before accessing the store
-- Correct warnings are raised for missing dependencies
-- The client handles connection management and authentication
-
----
-
-## Migration Testing Workflow
-
-When testing database migrations, follow this workflow:
-
-1. **Check out `develop` branch** (or the relevant old release)
-2. **Populate the database** from that version (create runs, stacks, etc.)
-3. **Switch to your current branch**
-4. **Test whether the migration works** — run `alembic upgrade head`
-
-**Why this matters:** Migrations must handle existing data from older versions. Testing only with fresh databases misses edge cases.
-
-**Note:** CI performs basic migration testing by creating runs on all versions, but local testing with realistic data is still recommended for complex migrations.
-
-### Migration Best Practices
-
-- Create migrations with descriptive names: `alembic revision -m "Add X to Y table"`
-- Test upgrade path: `alembic upgrade head` (downgrade testing is optional—ZenML doesn't support downgrades in most cases)
-- Never modify existing migrations that are already on main/develop branches
-- Consider backward compatibility for rolling deployments
-- Include both schema changes and data migrations when needed
-- Run `scripts/check-alembic-branches.sh` to verify migration consistency
-
----
-
-## ORM Schemas — Concise Guide
-
-Scope and Location
-- Applies to all ORM schemas in src/zenml/zen_stores/schemas and their exports in __init__.py.
-- File naming: <concept>_schemas.py (e.g., stack_schemas.py). Prefer a single schema class per file unless multiple are needed for the same concept.
-- Keep ORM fields and types aligned with their corresponding domain models. See domain models under src/zenml/models/v2 and related documentation.
-- Schema changes typically require DB migrations. Update src/zenml/zen_stores/migrations accordingly and ensure domain models and exports stay in sync.
-
-1) Base Classes and Table Declaration
-- Inherit from BaseSchema or NamedSchema (defined in base_schemas.py):
-  - BaseSchema: id: UUID (uuid4), created: datetime, updated: datetime
-  - NamedSchema: extends BaseSchema with name: str
-- Use declarative SQLModel style with explicit table naming:
-```python
-from sqlmodel import SQLModel, Field, Relationship
-from typing import Optional, List
-from uuid import UUID
-from zenml.zen_stores.schemas.base_schemas import NamedSchema
-
-class ExampleSchema(NamedSchema, table=True):
-    """SQLModel table for examples."""
-    __tablename__ = "example"
-
-    # attributes mirror domain model fields
-    description: Optional[str] = None
-```
-
-2) Foreign Keys and Relationships
-- Use schema_utils.build_foreign_key_field to define FKs consistently; define bidirectional relationships with matching back_populates.
-- Always update both sides together when adding/changing relationships. Keep back_populates symmetric to maintain coherent bidirectional navigation.
-```python
-from typing import Optional
-from uuid import UUID
-from zenml.zen_stores.schemas.schema_utils import build_foreign_key_field
-
-class ChildSchema(NamedSchema, table=True):
-    __tablename__ = "child"
-
-    parent_id: Optional[UUID] = build_foreign_key_field(
-        source=__tablename__,
-        target="parent",          # or ParentSchema.__tablename__
-        source_column="parent_id",
-        target_column="id",
-        ondelete="SET NULL",
-        nullable=True,
-    )
-    parent: Optional["ParentSchema"] = Relationship(back_populates="children")
-
-class ParentSchema(NamedSchema, table=True):
-    __tablename__ = "parent"
-
-    children: List["ChildSchema"] = Relationship(back_populates="parent")
-```
-
-3) Many-to-Many via Association Table
-- Use a link model with both FKs as composite primary keys; cascade deletes to keep the link table clean.
-```python
-class ExampleLinkSchema(SQLModel, table=True):
-    """Join table between left and right."""
-    __tablename__ = "example_link"
-
-    left_id: UUID = build_foreign_key_field(
-        source=__tablename__, target="left", source_column="left_id",
-        target_column="id", ondelete="CASCADE", nullable=False, primary_key=True
-    )
-    right_id: UUID = build_foreign_key_field(
-        source=__tablename__, target="right", source_column="right_id",
-        target_column="id", ondelete="CASCADE", nullable=False, primary_key=True
-    )
-
-class LeftSchema(NamedSchema, table=True):
-    __tablename__ = "left"
-    rights: List["RightSchema"] = Relationship(
-        back_populates="lefts", link_model=ExampleLinkSchema
-    )
-
-class RightSchema(NamedSchema, table=True):
-    __tablename__ = "right"
-    lefts: List["LeftSchema"] = Relationship(
-        back_populates="rights", link_model=ExampleLinkSchema
-    )
-```
-
-4) Indexes and Constraints
-- Add indexes on frequently queried columns (via helpers in schema_utils when available) and/or SQLModel/SQLAlchemy features.
-- Unique constraints: enforce uniqueness for fields like names/emails where required.
-- Nullability: nullable=True/False must reflect business rules. Optional[T] signals nullable columns.
-- Minimal example using SQLModel Field indexing:
-```python
-from sqlmodel import Field
-
-class ExampleIndexSchema(NamedSchema, table=True):
-    __tablename__ = "example_index"
-    email: str = Field(index=True)  # simple index for faster lookups
-```
-
-5) Naming Conventions
-- Classes: Singular, PascalCase (e.g., StackComponentSchema).
-- Columns/attributes: snake_case aligned with domain model naming.
-- __tablename__: singular, snake_case aligned with the entity.
-
-6) Common Fields (inherited)
-- id: UUID primary key (default uuid4) from BaseSchema.
-- created, updated: datetimes from BaseSchema. Always refresh updated on mutations.
-
-7) Model Conversion and Updates
-- Provide to_model, class constructors (from_request/from_model), and update/update_from_model implementations.
-- Keep relationships optional and include related resources only when explicitly requested.
-- For structured fields serialized with base64/json, ensure decoding mirrors encoding in to_model or at the service layer to prevent subtle data mismatches.
-
-Examples:
-```python
-from datetime import datetime
-from typing import Any, Optional
-import base64, json
-
-class SecretSchema(NamedSchema, table=True):
-    __tablename__ = "secret"
-
-    user_id: Optional[UUID] = build_foreign_key_field(
-        source=__tablename__, target="user",
-        source_column="user_id", target_column="id",
-        ondelete="SET NULL", nullable=True
-    )
-    user: Optional["UserSchema"] = Relationship(back_populates="secrets")
-    configuration: bytes
-    labels: Optional[bytes] = None
-
-    def to_model(
-        self,
-        include_metadata: bool = False,
-        include_resources: bool = False,
-        **kwargs: Any,
-    ) -> "SecretResponse":
-        """Map ORM -> domain model. Only include extras when requested."""
-        metadata = None
-        if include_metadata:
-            metadata = SecretResponseMetadata(project=self.project.to_model())
-        body = SecretResponseBody(
-            user=self.user.to_model() if include_resources and self.user else None,
-            created=self.created,
-            updated=self.updated,
-        )
-        return SecretResponse(id=self.id, name=self.name, body=body, metadata=metadata)
-
-    @classmethod
-    def from_request(cls, request: "SecretRequest") -> "SecretSchema":
-        """Map domain request -> ORM. Serialize structures explicitly."""
-        return cls(
-            name=request.name,
-            user_id=request.user,
-            configuration=base64.b64encode(json.dumps(request.configuration).encode("utf-8")),
-            labels=(base64.b64encode(json.dumps(request.labels).encode("utf-8"))
-                    if request.labels is not None else None),
-        )
-
-    def update(self, update_obj: "SecretUpdate") -> "SecretSchema":
-        """Apply only provided fields; handle structured fields; refresh updated."""
-        for field, value in update_obj.model_dump(exclude_unset=True).items():
-            if field == "configuration" and value is not None:
-                self.configuration = base64.b64encode(json.dumps(value).encode("utf-8"))
-            elif field == "labels":
-                self.labels = (base64.b64encode(json.dumps(value).encode("utf-8"))
-                               if value is not None else None)
-            else:
-                setattr(self, field, value)
-        self.updated = datetime.utcnow()
-        return self
-```
-
-8) Formatting and Documentation
-- Docstrings are mandatory for all classes and methods; include arguments, returns, and raised exceptions where applicable.
-- Comments where mapping/business rules are non-obvious; avoid redundant or change-log style comments.
-
-### `get_query_options` eager-loading rules
-- Collections (`List[...]`) always use `selectinload`. `joinedload` on a collection Cartesian-multiplies rows and breaks the list path.
-- Single-valued relationships use `single_loader = selectinload if many else joinedload` (joinedload for `get_*`, selectinload for lists)
-- Use `joinedload` for a single-valued relationship when the related row usually exists, or when it is a 1:1 where the other table points back to this one (like `pipeline_run.trigger_execution`, where `trigger_execution` holds `pipeline_run_id`): selectinload always runs a query there even when there is no match, so joinedload always wins. Keep `selectinload` only for a nullable foreign key on this table that is usually empty (like snapshot's `build`/`schedule`): selectinload already skips it when the column is null, so `joinedload` would only add a useless JOIN.
-
-Practical Checklist for New/Updated Schemas
-- Pick BaseSchema vs. NamedSchema appropriately.
-- Set table=True and __tablename__.
-- Define fields mirroring domain model names/types; use Optional[T] for nullable columns.
-- Add FKs with build_foreign_key_field; define Relationship on both sides with matching back_populates.
-- For many-to-many, add a link model and set link_model on both sides.
-- Add indexes/uniques/nullability aligned with usage and business rules.
-- Implement to_model(...), from_request/from_model(...), and update/update_from_model(...).
-- Update src/zenml/zen_stores/schemas/__init__.py to export new schema(s).
-- Ensure updated is refreshed on mutations; avoid including heavy related resources unless requested via flags.
-- Plan and apply DB migrations for schema changes; update src/zenml/zen_stores/migrations and test the upgrade path. Downgrade testing is optional because ZenML does not generally support downgrades.
-- Consult domain models in src/zenml/models/v2 to keep names and types aligned.
+Schema changes typically require migrations and matching domain model updates.
+Check store behavior, client methods, CLI commands, tests, and docs when the
+schema backs a user-visible feature.


### PR DESCRIPTION
## Summary

Codex sessions now load the ZenML agent rules without silently crossing the project instruction cap. The always-loaded root and nested `AGENTS.md` files keep the safety rules, common commands, and local import boundaries in memory, while the longer examples and subsystem recipes move into a repo-local `zenml-repo-workflows` skill that can load only when relevant.

This keeps the guidance available without making every session carry the full handbook.

## Validation

- Ran `bash /Users/strickvl/.agents/skills/trim-agents-md/scripts/measure-context.sh --compare /tmp/zenml-agents-baseline.txt`
- Confirmed root launch chain drops from 39,824 bytes to 21,530 bytes, now under the 32,768-byte cap
- Confirmed worst nested chain drops from 52,035 bytes to 23,700 bytes, now under the cap
- Ran `git diff --cached --check`
- Confirmed hard rules such as secret handling, migration immutability, targeted tests, and `develop` branching remain in always-loaded files
