### PR TITLE
Improve DAG endpoint performance

### DIFF
--- a/src/zenml/zen_stores/dag/__init__.py
+++ b/src/zenml/zen_stores/dag/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""DAG generation utilities."""

--- a/src/zenml/zen_stores/dag/dag_generator.py
+++ b/src/zenml/zen_stores/dag/dag_generator.py
@@ -1,4 +1,4 @@
-#  Copyright (c) ZenML GmbH 2025. All Rights Reserved.
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -275,9 +275,9 @@ class DAGGeneratorHelper:
         Returns:
             The step node.
         """
-        for node in self.step_nodes.values():
-            if node.name == name:
-                return node
+        if node := self.step_nodes.get(self.get_step_node_id(name)):
+            return node
+
         raise KeyError(f"Step node with name {name} not found")
 
     def finalize_dag(

--- a/src/zenml/zen_stores/dag/models.py
+++ b/src/zenml/zen_stores/dag/models.py
@@ -1,0 +1,102 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""DAG helper models."""
+
+from typing import Any, Dict, NamedTuple, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from zenml.config.step_configurations import GroupInfo, StepSpec
+from zenml.enums import StepType
+
+
+class DAGStepConfigView(BaseModel):
+    """Step configuration projection for DAG generation."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    step_type: Optional[StepType] = None
+    group: Optional[GroupInfo] = None
+    substitutions: Dict[str, str] = {}
+    outputs: Dict[str, Any] = {}
+    client_lazy_loaders: Dict[str, Any] = {}
+    model_artifacts_or_metadata: Dict[str, Any] = {}
+    external_input_artifacts: Dict[str, Any] = {}
+
+
+class DAGStepView(BaseModel):
+    """Step projection for DAG generation."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    spec: StepSpec
+    config: DAGStepConfigView
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, Any],
+        substitutions: Dict[str, str],
+    ) -> "DAGStepView":
+        """Build a lightweight step view from stored step config data.
+
+        Args:
+            data: The step data.
+            substitutions: The pipeline substitutions.
+
+        Returns:
+            The step view.
+        """
+        config_data = (
+            data["config"]
+            if "config" in data
+            else data["step_config_overrides"]
+        )
+        config_data = {
+            **config_data,
+            "substitutions": {
+                **substitutions,
+                **(config_data.get("substitutions") or {}),
+            },
+        }
+        return cls.model_validate(
+            {"spec": data["spec"], "config": config_data}
+        )
+
+
+class InputArtifactRow(NamedTuple):
+    """Input artifact row."""
+
+    step_id: UUID
+    name: str
+    artifact_id: UUID
+    type: str
+    input_index: int
+    chunk_index: Optional[int]
+    chunk_size: Optional[int]
+    artifact_type: str
+    artifact_data_type: str
+    artifact_save_type: str
+
+
+class OutputArtifactRow(NamedTuple):
+    """Output artifact row."""
+
+    step_id: UUID
+    name: str
+    artifact_id: UUID
+    artifact_type: str
+    artifact_data_type: str
+    artifact_save_type: str

--- a/src/zenml/zen_stores/dag/utils.py
+++ b/src/zenml/zen_stores/dag/utils.py
@@ -1,0 +1,116 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""DAG generation utilities."""
+
+from collections import defaultdict
+from typing import Dict, List
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlmodel import Session, col
+
+from zenml.enums import ExecutionStatus
+from zenml.zen_stores.dag.models import InputArtifactRow, OutputArtifactRow
+from zenml.zen_stores.schemas import (
+    ArtifactVersionSchema,
+    StepRunInputArtifactSchema,
+    StepRunOutputArtifactSchema,
+    StepRunSchema,
+)
+
+
+def load_input_artifact_rows(
+    session: Session, pipeline_run_id: UUID
+) -> Dict[UUID, List[InputArtifactRow]]:
+    """Load the input artifact rows for a pipeline run.
+
+    Args:
+        session: The database session.
+        pipeline_run_id: The ID of the pipeline run.
+
+    Returns:
+        The input artifact rows, grouped by step run ID.
+    """
+    query = (
+        select(
+            col(StepRunInputArtifactSchema.step_id),
+            col(StepRunInputArtifactSchema.name),
+            col(StepRunInputArtifactSchema.artifact_id),
+            col(StepRunInputArtifactSchema.type),
+            col(StepRunInputArtifactSchema.input_index),
+            col(StepRunInputArtifactSchema.chunk_index),
+            col(StepRunInputArtifactSchema.chunk_size),
+            col(ArtifactVersionSchema.type),
+            col(ArtifactVersionSchema.data_type),
+            col(ArtifactVersionSchema.save_type),
+        )
+        .join(
+            StepRunSchema,
+            col(StepRunSchema.id) == StepRunInputArtifactSchema.step_id,
+        )
+        .join(
+            ArtifactVersionSchema,
+            col(ArtifactVersionSchema.id)
+            == StepRunInputArtifactSchema.artifact_id,
+        )
+        .where(col(StepRunSchema.pipeline_run_id) == pipeline_run_id)
+        .where(col(StepRunSchema.status) != ExecutionStatus.RETRIED.value)
+    )
+    rows: Dict[UUID, List[InputArtifactRow]] = defaultdict(list)
+    for db_row in session.execute(query):
+        row = InputArtifactRow(*db_row)
+        rows[row.step_id].append(row)
+
+    return rows
+
+
+def load_output_artifact_rows(
+    session: Session, pipeline_run_id: UUID
+) -> Dict[UUID, List[OutputArtifactRow]]:
+    """Load the output artifact rows for a pipeline run.
+
+    Args:
+        session: The database session.
+        pipeline_run_id: The ID of the pipeline run.
+
+    Returns:
+        The output artifact rows, grouped by step run ID.
+    """
+    query = (
+        select(
+            col(StepRunOutputArtifactSchema.step_id),
+            col(StepRunOutputArtifactSchema.name),
+            col(StepRunOutputArtifactSchema.artifact_id),
+            col(ArtifactVersionSchema.type),
+            col(ArtifactVersionSchema.data_type),
+            col(ArtifactVersionSchema.save_type),
+        )
+        .join(
+            StepRunSchema,
+            col(StepRunSchema.id) == StepRunOutputArtifactSchema.step_id,
+        )
+        .join(
+            ArtifactVersionSchema,
+            col(ArtifactVersionSchema.id)
+            == StepRunOutputArtifactSchema.artifact_id,
+        )
+        .where(col(StepRunSchema.pipeline_run_id) == pipeline_run_id)
+        .where(col(StepRunSchema.status) != ExecutionStatus.RETRIED.value)
+    )
+    rows: Dict[UUID, List[OutputArtifactRow]] = defaultdict(list)
+    for db_row in session.execute(query):
+        row = OutputArtifactRow(*db_row)
+        rows[row.step_id].append(row)
+
+    return rows

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -139,7 +139,7 @@ from zenml.config.pipeline_run_configuration import (
 from zenml.config.secrets_store_config import SecretsStoreConfiguration
 from zenml.config.server_config import ServerConfiguration
 from zenml.config.source import Source
-from zenml.config.step_configurations import Step, StepConfiguration, StepSpec
+from zenml.config.step_configurations import StepConfiguration, StepSpec
 from zenml.config.store_config import StoreConfiguration
 from zenml.constants import (
     DEFAULT_PASSWORD,
@@ -396,7 +396,16 @@ from zenml.zen_stores import template_utils
 from zenml.zen_stores.base_zen_store import (
     BaseZenStore,
 )
-from zenml.zen_stores.dag_generator import DAGGeneratorHelper
+from zenml.zen_stores.dag.dag_generator import (
+    DAGGeneratorHelper,
+)
+from zenml.zen_stores.dag.models import (
+    DAGStepView,
+)
+from zenml.zen_stores.dag.utils import (
+    load_input_artifact_rows,
+    load_output_artifact_rows,
+)
 from zenml.zen_stores.migrations.alembic import (
     Alembic,
 )
@@ -6248,28 +6257,6 @@ class SqlZenStore(BaseZenStore):
                         jl_arg(StepRunSchema.start_time),
                         jl_arg(StepRunSchema.end_time),
                     ),
-                    selectinload(jl_arg(PipelineRunSchema.step_runs))
-                    .selectinload(jl_arg(StepRunSchema.input_artifacts))
-                    .joinedload(
-                        jl_arg(StepRunInputArtifactSchema.artifact_version),
-                        innerjoin=True,
-                    )
-                    .load_only(
-                        jl_arg(ArtifactVersionSchema.type),
-                        jl_arg(ArtifactVersionSchema.data_type),
-                        jl_arg(ArtifactVersionSchema.save_type),
-                    ),
-                    selectinload(jl_arg(PipelineRunSchema.step_runs))
-                    .selectinload(jl_arg(StepRunSchema.output_artifacts))
-                    .joinedload(
-                        jl_arg(StepRunOutputArtifactSchema.artifact_version),
-                        innerjoin=True,
-                    )
-                    .load_only(
-                        jl_arg(ArtifactVersionSchema.type),
-                        jl_arg(ArtifactVersionSchema.data_type),
-                        jl_arg(ArtifactVersionSchema.save_type),
-                    ),
                     selectinload(
                         jl_arg(PipelineRunSchema.step_runs)
                     ).selectinload(jl_arg(StepRunSchema.dynamic_config)),
@@ -6335,22 +6322,32 @@ class SqlZenStore(BaseZenStore):
             if snapshot.is_dynamic:
                 # Ignore static config templates for dynamic pipeline DAGs
                 steps = {
-                    name: Step.from_dict(
+                    name: DAGStepView.from_dict(
                         json.loads(step_run.dynamic_config.config),  # type: ignore[union-attr]
-                        pipeline_configuration=pipeline_configuration,
-                        exclude_hook_sources=True,
+                        substitutions=pipeline_configuration.substitutions,
                     )
                     for name, step_run in step_runs.items()
                 }
             else:
                 steps = {
-                    config_table.name: Step.from_dict(
+                    config_table.name: DAGStepView.from_dict(
                         json.loads(config_table.config),
-                        pipeline_configuration=pipeline_configuration,
-                        exclude_hook_sources=False,
+                        substitutions=pipeline_configuration.substitutions,
                     )
                     for config_table in snapshot.step_configurations
                 }
+
+            if step_runs:
+                input_artifact_rows = load_input_artifact_rows(
+                    session=session, pipeline_run_id=pipeline_run_id
+                )
+                output_artifact_rows = load_output_artifact_rows(
+                    session=session, pipeline_run_id=pipeline_run_id
+                )
+            else:
+                input_artifact_rows = {}
+                output_artifact_rows = {}
+
             regular_output_artifact_nodes: Dict[
                 str, Dict[str, PipelineRunDAG.Node]
             ] = defaultdict(dict)
@@ -6404,7 +6401,7 @@ class SqlZenStore(BaseZenStore):
                 )
 
                 if step_run:
-                    for input in step_run.input_artifacts:
+                    for input in input_artifact_rows.get(step_run.id, []):
                         input_type = StepRunInputArtifactType(input.type)
 
                         if input_type == StepRunInputArtifactType.STEP_OUTPUT:
@@ -6453,11 +6450,11 @@ class SqlZenStore(BaseZenStore):
                                 ),
                                 id=input.artifact_id,
                                 name=input.name,
-                                type=input.artifact_version.type,
+                                type=input.artifact_type,
                                 data_type=Source.model_validate_json(
-                                    input.artifact_version.data_type
+                                    input.artifact_data_type
                                 ).import_path,
-                                save_type=input.artifact_version.save_type,
+                                save_type=input.artifact_save_type,
                             )
 
                         helper.add_edge(
@@ -6473,7 +6470,7 @@ class SqlZenStore(BaseZenStore):
                             artifact_node.node_id
                         )
 
-                    for output in step_run.output_artifacts:
+                    for output in output_artifact_rows.get(step_run.id, []):
                         # There is a very rare case where a node in the DAG
                         # already exists for an output artifact. This can happen
                         # when there are two steps that have no direct
@@ -6484,7 +6481,7 @@ class SqlZenStore(BaseZenStore):
                         # separately in the DAG, but if that should ever change
                         # this would be the place to merge them.
                         is_manual_save = (
-                            output.artifact_version.save_type
+                            output.artifact_save_type
                             == ArtifactSaveType.MANUAL
                         )
                         artifact_node = helper.add_artifact_node(
@@ -6498,26 +6495,26 @@ class SqlZenStore(BaseZenStore):
                                 if is_manual_save
                                 else output.name,
                                 step_name=step_name,
-                                io_type=output.artifact_version.save_type,
+                                io_type=output.artifact_save_type,
                                 is_input=False,
                             ),
                             id=output.artifact_id,
                             name=output.name,
-                            type=output.artifact_version.type,
+                            type=output.artifact_type,
                             data_type=Source.model_validate_json(
-                                output.artifact_version.data_type
+                                output.artifact_data_type
                             ).import_path,
-                            save_type=output.artifact_version.save_type,
+                            save_type=output.artifact_save_type,
                         )
 
                         helper.add_edge(
                             source=step_node.node_id,
                             target=artifact_node.node_id,
                             output_name=output.name,
-                            type=output.artifact_version.save_type,
+                            type=output.artifact_save_type,
                         )
                         if (
-                            output.artifact_version.save_type
+                            output.artifact_save_type
                             == ArtifactSaveType.STEP_OUTPUT
                         ):
                             regular_output_artifact_nodes[step_name][


### PR DESCRIPTION
For large DAGs, python overhead of parsing step configurations and creating ORM objects dominated the runtime of the endpoint. This PR adds two improvements:
- Only parse/validate necessary fields of the step configuration.
- Don't create ORM objects for step artifacts and instead work on the raw column values.

Benchmark on a 2893 node / 5141 edge DAG:

| | Total | DB | Python | DB Statements |
|---|---|---|---|---|
| Before | 1039 ms | 178 ms | 861 ms | 18 |
| After | 505 ms | 130 ms | 375 ms | 14 |