### PR TITLE
feat: bumped otel version to support fastapi 0.138.0 version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,11 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 - Start routes, dependencies, and services with guard clauses.
 - Raise `HTTPException` with precise status codes for expected errors.
 - Use Pydantic models for route inputs and outputs.
+- When changing server framework (e.g., `fastapi`) or database library versions,
+  check whether related OpenTelemetry SDK, exporter, and instrumentation
+  dependencies also need updates. Breaking changes in instrumented libraries can
+  require coordinated OTel updates. Keep OTel SDK/exporter versions aligned with
+  the matching OpenTelemetry instrumentation beta line.
 - Code outside `src/zenml/zen_server/` should NEVER import from `zen_server/`.
 
 ## Database and Storage Rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ Router, service, error-handling, and validation conventions for the server live 
 
 ## Dependencies & Runtime Constraints
 - Align contributions with the FastAPI + Pydantic v2 + SQLAlchemy 2.0 + SQLModel stack defined for ZenML OSS; confirm any new dependency in `pyproject.toml` before adoption.
+- When changing server framework (e.g., `fastapi`) or database library versions, check whether related OpenTelemetry SDK, exporter, and instrumentation dependencies also need updates. Breaking changes in instrumented libraries can require coordinated OTel updates. Keep OTel SDK/exporter versions aligned with the matching OpenTelemetry instrumentation beta line.
 - The OSS runtime forbids async I/O in Claude-authored code even though FastAPI supports it—implement synchronous `def` handlers and delegate background/long-running work to workers or dependency-injected services; this supersedes generic async advice found elsewhere.
 - Prefer dependency injection over module-level singletons for clients, caches, and repositories so state management stays testable.
 - Cache static or frequently accessed data (e.g., dependency-scoped in-memory caches) and lazy-load heavyweight resources to control cold-start latency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ dependencies = [
     "docker~=7.1.0",
     "gitpython>=3.1.18,<4.0.0",
     "jsonref",
-    "opentelemetry-instrumentation-logging==0.61b0",
-    "opentelemetry-sdk==1.40.0",
+    "opentelemetry-instrumentation-logging==0.64b0",
+    "opentelemetry-sdk==1.43.0",
     "packaging>=24.1",
     "psutil>=5.0.0",
     "pydantic>=2.0,<=2.12.5",
@@ -98,10 +98,10 @@ server = [
 ]
 otel = [
     # Install otel dependencies to enable OpenTelemetry instrumentation in the server
-    "opentelemetry-exporter-otlp-proto-http>=1.40.0,<1.41.0",
-    "opentelemetry-instrumentation-fastapi>=0.61b0,<0.62b0",
-    "opentelemetry-instrumentation-requests>=0.61b0,<0.62b0",
-    "opentelemetry-instrumentation-sqlalchemy>=0.61b0,<0.62b0",
+    "opentelemetry-exporter-otlp-proto-http>=1.43.0,<1.44.0",
+    "opentelemetry-instrumentation-fastapi>=0.64b0,<0.65b0",
+    "opentelemetry-instrumentation-requests>=0.64b0,<0.65b0",
+    "opentelemetry-instrumentation-sqlalchemy>=0.64b0,<0.65b0",
 ]
 server-streaming = ["redis>=7.1.0,<8.0.0"]
 jupyter = ["rich[jupyter]>=12.0.0"]


### PR DESCRIPTION
Updating otel-sdk version to 1.43.0 along with other otel instrumention sdk versions to support fastapi version 0.138.0 in zenml, https://github.com/zenml-io/zenml/pull/5017.