### PR TITLE
fix: decouple the zenml logging level setting from ZENML_DEBUG env var

### DIFF
--- a/.agents/skills/zenml-repo-workflows/SKILL.md
+++ b/.agents/skills/zenml-repo-workflows/SKILL.md
@@ -64,11 +64,16 @@ Former root headings covered here:
   dependencies more quickly and reliably than plain `pip`.
 - Useful development environment variables:
   - `ZENML_LOGGING_VERBOSITY=DEBUG`
-  - `ZENML_ANALYTICS_OPT_IN=false`
   - `MLSTACKS_ANALYTICS_OPT_OUT=true`
   - `AUTO_OPEN_DASHBOARD=false`
   - `ZENML_ENABLE_RICH_TRACEBACK=false`
   - `TOKENIZERS_PARALLELISM=false`
+- Always set the following environment variables when developing:
+  - `ZENML_ANALYTICS_OPT_IN=false`: Disables analytics during development
+  - `ZENML_DEBUG=true`: Uses the development ZenML analytics server to avoid
+    sending analytics to the official ZenML analytics server (IMPORTANT!). This
+    must be set even if `ZENML_ANALYTICS_OPT_IN=true` because in a client-server
+    setup, the server controls the client-side analytics opt-in status.
 
 ### Formatting, Linting, and Tests
 

--- a/.agents/skills/zenml-repo-workflows/SKILL.md
+++ b/.agents/skills/zenml-repo-workflows/SKILL.md
@@ -63,8 +63,7 @@ Former root headings covered here:
 - ZenML recommends `uv` for Python package installation because it resolves
   dependencies more quickly and reliably than plain `pip`.
 - Useful development environment variables:
-  - `ZENML_DEBUG=true`
-  - `ZENML_LOGGING_VERBOSITY=INFO`
+  - `ZENML_LOGGING_VERBOSITY=DEBUG`
   - `ZENML_ANALYTICS_OPT_IN=false`
   - `MLSTACKS_ANALYTICS_OPT_OUT=true`
   - `AUTO_OPEN_DASHBOARD=false`

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -120,6 +120,7 @@ Standard settings used across workflows:
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
+  ZENML_DEBUG: true
   PYTHONIOENCODING: utf-8
   UV_HTTP_TIMEOUT: 600
 ```

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -118,7 +118,7 @@ Standard settings used across workflows:
 
 ```yaml
 env:
-  ZENML_DEBUG: true
+  ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
   PYTHONIOENCODING: utf-8
   UV_HTTP_TIMEOUT: 600

--- a/.github/workflows/base-package-functionality.yml
+++ b/.github/workflows/base-package-functionality.yml
@@ -39,7 +39,7 @@ jobs:
     name: test-base-package-functionality
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
+      ZENML_LOGGING_VERBOSITY: debug
       ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600

--- a/.github/workflows/base-package-functionality.yml
+++ b/.github/workflows/base-package-functionality.yml
@@ -34,13 +34,14 @@ on:
         description: Git branch or ref
         type: string
         required: true
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
 jobs:
   test-base-package-functionality:
     name: test-base-package-functionality
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_LOGGING_VERBOSITY: debug
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'

--- a/.github/workflows/base-package-functionality.yml
+++ b/.github/workflows/base-package-functionality.yml
@@ -35,6 +35,7 @@ on:
         type: string
         required: true
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
+      ZENML_LOGGING_VERBOSITY: debug
     # if team member commented, not a draft, on a PR, using /fulltest
     if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -26,6 +26,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
+  ZENML_DEBUG: true
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -25,12 +25,12 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
 jobs:
   sqlite-db-migration-testing-random:
     runs-on: ubuntu-latest
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_LOGGING_VERBOSITY: debug
     # if team member commented, not a draft, on a PR, using /fulltest
     if: github.event.pull_request.draft == false || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -25,6 +25,9 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
 jobs:
   run-slow-ci-label-is-set:
     runs-on: ubuntu-latest
@@ -54,9 +57,6 @@ jobs:
   mysql-db-migration-testing-full:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -77,9 +77,6 @@ jobs:
   mysql-db-migration-testing-random:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -100,9 +97,6 @@ jobs:
   sqlite-db-migration-testing-full:
     needs: run-slow-ci-label-is-set
     runs-on: ubuntu-latest
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_LOGGING_VERBOSITY: debug
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout code
@@ -118,9 +112,6 @@ jobs:
   mariadb-db-migration-testing:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -176,7 +167,6 @@ jobs:
           bash scripts/check-security.sh
       - name: Check for alembic branch divergence
         env:
-          ZENML_ANALYTICS_OPT_IN: false
           ZENML_LOGGING_VERBOSITY: info
         run: |
           source .venv/bin/activate

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -56,7 +56,7 @@ jobs:
     needs: run-slow-ci-label-is-set
     env:
       ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
+      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -79,7 +79,7 @@ jobs:
     needs: run-slow-ci-label-is-set
     env:
       ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
+      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
+      ZENML_LOGGING_VERBOSITY: debug
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout code
@@ -120,7 +120,7 @@ jobs:
     needs: run-slow-ci-label-is-set
     env:
       ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
+      ZENML_LOGGING_VERBOSITY: debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -176,7 +176,8 @@ jobs:
           bash scripts/check-security.sh
       - name: Check for alembic branch divergence
         env:
-          ZENML_DEBUG: 0
+          ZENML_ANALYTICS_OPT_IN: false
+          ZENML_LOGGING_VERBOSITY: info
         run: |
           source .venv/bin/activate
           uv pip install alembic

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -26,6 +26,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
+  ZENML_DEBUG: true
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/generate-test-duration.yml
+++ b/.github/workflows/generate-test-duration.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: 0 8 * * 1  # Run every Monday at 8 am
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/generate-test-duration.yml
+++ b/.github/workflows/generate-test-duration.yml
@@ -4,6 +4,11 @@ on:
   workflow_call:
   schedule:
     - cron: 0 8 * * 1  # Run every Monday at 8 am
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   generate-test-duration-file:
     name: Generate test duration file
@@ -11,8 +16,6 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
           # on MAC OS, we need to set this environment variable

--- a/.github/workflows/generate-test-duration.yml
+++ b/.github/workflows/generate-test-duration.yml
@@ -4,11 +4,9 @@ on:
   workflow_call:
   schedule:
     - cron: 0 8 * * 1  # Run every Monday at 8 am
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   generate-test-duration-file:
     name: Generate test duration file

--- a/.github/workflows/integration-test-fast-services.yml
+++ b/.github/workflows/integration-test-fast-services.yml
@@ -84,6 +84,7 @@ on:
         default: 3
 
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 

--- a/.github/workflows/integration-test-fast-services.yml
+++ b/.github/workflows/integration-test-fast-services.yml
@@ -82,6 +82,11 @@ on:
         type: number
         required: false
         default: 3
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   integration-tests-fast:
     name: integration-tests-fast
@@ -91,8 +96,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_ENABLE_RICH_TRACEBACK: false
       WHYLOGS_NO_ANALYTICS: 'True'
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -82,6 +82,11 @@ on:
         type: number
         required: false
         default: 3
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   integration-tests-fast:
     name: integration-tests-fast
@@ -91,8 +96,6 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_ENABLE_RICH_TRACEBACK: false
       WHYLOGS_NO_ANALYTICS: 'True'
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -82,11 +82,9 @@ on:
         type: number
         required: false
         default: 3
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   integration-tests-fast:
     name: integration-tests-fast

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -83,6 +83,7 @@ on:
         required: false
         default: 3
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/integration-test-slow-services.yml
+++ b/.github/workflows/integration-test-slow-services.yml
@@ -81,6 +81,11 @@ on:
         type: number
         required: false
         default: 3
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   integration-tests-slow:
     name: integration-tests-slow
@@ -88,8 +93,6 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_ENABLE_RICH_TRACEBACK: false
       WHYLOGS_NO_ANALYTICS: 'True'
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/integration-test-slow-services.yml
+++ b/.github/workflows/integration-test-slow-services.yml
@@ -83,6 +83,7 @@ on:
         default: 3
 
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -81,11 +81,9 @@ on:
         type: number
         required: false
         default: 3
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   integration-tests-slow:
     name: integration-tests-slow

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -81,6 +81,11 @@ on:
         type: number
         required: false
         default: 3
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   integration-tests-slow:
     name: integration-tests-slow
@@ -88,8 +93,6 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_ENABLE_RICH_TRACEBACK: false
       WHYLOGS_NO_ANALYTICS: 'True'
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -82,6 +82,7 @@ on:
         required: false
         default: 3
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -51,11 +51,9 @@ on:
         type: string
         required: false
         default: ''
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   linting:
     name: linting

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -51,13 +51,16 @@ on:
         type: string
         required: false
         default: ''
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   linting:
     name: linting
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -52,6 +52,7 @@ on:
         required: false
         default: ''
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -10,6 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -9,11 +9,9 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   profile-cli-performance:
     name: Profile ZenML CLI Performance

--- a/.github/workflows/performance-profiling.yml
+++ b/.github/workflows/performance-profiling.yml
@@ -9,14 +9,17 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   profile-cli-performance:
     name: Profile ZenML CLI Performance
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
       TARGET_RESULTS_FILE: target_profile_results.json

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -8,11 +8,9 @@ name: pr-label
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   pr-labeler:
     if: github.repository == 'zenml-io/zenml'

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -8,13 +8,16 @@ name: pr-label
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   pr-labeler:
     if: github.repository == 'zenml-io/zenml'
     runs-on: ubuntu-latest
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: JulienKode/team-labeler-action@e912b4b3a2e329a4dc6ad282cfecad79cab8fe81  # v3.0.0

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -9,6 +9,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -3,14 +3,17 @@ name: Publish SDK Docs
 on:
   push:
     branches: [release/**]
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   publish:
     name: Build 🔨 and publish 📰 the api docs 📁 to gh-pages
     if: github.repository == 'zenml-io/zenml'
     runs-on: ubuntu-latest
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [release/**]
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_api_docs.yml
+++ b/.github/workflows/publish_api_docs.yml
@@ -3,11 +3,9 @@ name: Publish SDK Docs
 on:
   push:
     branches: [release/**]
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   publish:
     name: Build 🔨 and publish 📰 the api docs 📁 to gh-pages

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub
@@ -21,8 +26,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -13,11 +13,9 @@ on:
         required: false
         type: boolean
         default: false
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   publish_to_docker:
     name: Publish Docker 🐋 image 🖼️ to Dockerhub

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -14,6 +14,7 @@ on:
         type: boolean
         default: false
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_helm_chart.yml
+++ b/.github/workflows/publish_helm_chart.yml
@@ -5,6 +5,7 @@ on:
   workflow_call:
   workflow_dispatch:
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_helm_chart.yml
+++ b/.github/workflows/publish_helm_chart.yml
@@ -4,6 +4,11 @@ name: Publish Helm Chart
 on:
   workflow_call:
   workflow_dispatch:
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   publish_to_ecr:
     name: Publish Helm Chart 🛞 to ECR ☁️
@@ -12,8 +17,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish_helm_chart.yml
+++ b/.github/workflows/publish_helm_chart.yml
@@ -4,11 +4,9 @@ name: Publish Helm Chart
 on:
   workflow_call:
   workflow_dispatch:
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   publish_to_ecr:
     name: Publish Helm Chart 🛞 to ECR ☁️

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -2,11 +2,9 @@
 name: Publish Pypi package
 on:
   workflow_call:
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   publish_to_pypi:
     name: Publish Python 🐍 package 📦 to PyPI

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -3,6 +3,7 @@ name: Publish Pypi package
 on:
   workflow_call:
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -2,6 +2,11 @@
 name: Publish Pypi package
 on:
   workflow_call:
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   publish_to_pypi:
     name: Publish Python 🐍 package 📦 to PyPI
@@ -12,8 +17,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -8,11 +8,9 @@ on:
         required: false
         default: false
         type: boolean
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   build_nightly_python_package:
     name: Build Nightly Python 🐍 package 📦

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -9,6 +9,7 @@ on:
         default: false
         type: boolean
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/publish_to_pypi_nightly.yml
+++ b/.github/workflows/publish_to_pypi_nightly.yml
@@ -8,13 +8,16 @@ on:
         required: false
         default: false
         type: boolean
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   build_nightly_python_package:
     name: Build Nightly Python 🐍 package 📦
     runs-on: ubuntu-latest
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags: ['*']
 env:
+  ZENML_DEBUG: true
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,9 @@ name: Release Package & Docker Image
 on:
   push:
     tags: ['*']
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   setup-and-test:
     uses: ./.github/workflows/unit-test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release Package & Docker Image
 on:
   push:
     tags: ['*']
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   setup-and-test:
     uses: ./.github/workflows/unit-test.yml
@@ -14,9 +19,6 @@ jobs:
   # test full migrations.
   mysql-db-migration-testing:
     runs-on: ubuntu-latest
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -35,9 +37,6 @@ jobs:
         run: bash scripts/test-migrations.sh mysql latest
   sqlite-db-migration-testing:
     runs-on: ubuntu-latest
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -51,9 +50,6 @@ jobs:
         run: bash scripts/test-migrations.sh sqlite latest
   mariadb-db-migration-testing:
     runs-on: ubuntu-latest
-    env:
-      ZENML_ANALYTICS_OPT_IN: false
-      ZENML_DEBUG: true
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -88,8 +84,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -25,6 +25,11 @@ on:
         options: ['3.10', '3.11', '3.12', '3.13', '3.14']
         required: false
         default: '3.11'
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   all-template-tests:
     name: all-template-tests
@@ -38,8 +43,6 @@ jobs:
           - {repo: zenml-io/template-nlp, path: .github/actions/nlp_template_test}
       fail-fast: false
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
     if: ${{ ! startsWith(github.event.head_commit.message, 'GitBook:') && github.repository == 'zenml-io/zenml' }}

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -26,6 +26,7 @@ on:
         required: false
         default: '3.11'
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/templates-test.yml
+++ b/.github/workflows/templates-test.yml
@@ -25,11 +25,9 @@ on:
         options: ['3.10', '3.11', '3.12', '3.13', '3.14']
         required: false
         default: '3.11'
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   all-template-tests:
     name: all-template-tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -61,11 +61,9 @@ on:
         type: number
         required: false
         default: 3
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   unit-test:
     name: unit-test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -62,6 +62,7 @@ on:
         required: false
         default: 3
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -61,13 +61,16 @@ on:
         type: number
         required: false
         default: 3
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   unit-test:
     name: unit-test
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       UV_HTTP_TIMEOUT: 600
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
@@ -129,9 +132,6 @@ jobs:
       - name: Run unit tests
         run: |
           bash scripts/test-coverage-xml.sh unit
-        env:
-          ZENML_ANALYTICS_OPT_IN: false
-          ZENML_DEBUG: true
       - name: Setup tmate session after tests
         if: ${{ inputs.enable_tmate == 'always' || (inputs.enable_tmate == 'on-failure' && failure()) }}
         uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113  # v3.24

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -25,13 +25,16 @@ on:
         options: ['3.10', '3.11', '3.12', '3.13', '3.14']
         required: false
         default: '3.11'
+
+env:
+  ZENML_LOGGING_VERBOSITY: debug
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   update-e2e-batch-template-to-examples:
     name: update-e2e-batch-template-to-examples
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
     if: github.event_name == 'pull_request' && ! startsWith(github.event.head_commit.message,
@@ -106,8 +109,6 @@ jobs:
     name: update-nlp-template-to-examples
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
     if: github.event_name == 'pull_request' && ! startsWith(github.event.head_commit.message,
@@ -181,8 +182,6 @@ jobs:
     name: update-starter-template-to-examples
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
     if: github.event_name == 'pull_request' && ! startsWith(github.event.head_commit.message,
@@ -258,8 +257,6 @@ jobs:
     name: update-llm-finetuning-template-to-examples
     runs-on: ${{ inputs.os }}
     env:
-      ZENML_DEBUG: 1
-      ZENML_ANALYTICS_OPT_IN: false
       PYTHONIOENCODING: utf-8
       OBJC_DISABLE_INITIALIZE_FORK_SAFETY: 'YES'
     if: github.event_name == 'pull_request' && ! startsWith(github.event.head_commit.message,

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -26,6 +26,7 @@ on:
         required: false
         default: '3.11'
 env:
+  ZENML_DEBUG: 1
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
 jobs:

--- a/.github/workflows/update-templates-to-examples.yml
+++ b/.github/workflows/update-templates-to-examples.yml
@@ -25,11 +25,9 @@ on:
         options: ['3.10', '3.11', '3.12', '3.13', '3.14']
         required: false
         default: '3.11'
-
 env:
   ZENML_LOGGING_VERBOSITY: debug
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   update-e2e-batch-template-to-examples:
     name: update-e2e-batch-template-to-examples

--- a/.github/workflows/vscode-tutorial-pipelines-test.yml
+++ b/.github/workflows/vscode-tutorial-pipelines-test.yml
@@ -19,13 +19,15 @@ on:
         options: [no, on-failure, always, before-tests]
         required: false
         default: 'no'
+
+env:
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   test-tutorial-pipelines:
     name: test-tutorial-pipelines
     runs-on: ubuntu-latest
     env:
-      ZENML_DEBUG: true
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_LOGGING_VERBOSITY: INFO
       MLSTACKS_ANALYTICS_OPT_OUT: true
       AUTO_OPEN_DASHBOARD: false

--- a/.github/workflows/vscode-tutorial-pipelines-test.yml
+++ b/.github/workflows/vscode-tutorial-pipelines-test.yml
@@ -19,10 +19,8 @@ on:
         options: [no, on-failure, always, before-tests]
         required: false
         default: 'no'
-
 env:
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   test-tutorial-pipelines:
     name: test-tutorial-pipelines

--- a/.github/workflows/vscode-tutorial-pipelines-test.yml
+++ b/.github/workflows/vscode-tutorial-pipelines-test.yml
@@ -20,6 +20,7 @@ on:
         required: false
         default: 'no'
 env:
+  ZENML_DEBUG: true
   ZENML_ANALYTICS_OPT_IN: false
 jobs:
   test-tutorial-pipelines:

--- a/.github/workflows/weekly-agent-pipelines-test.yml
+++ b/.github/workflows/weekly-agent-pipelines-test.yml
@@ -8,10 +8,8 @@ on:
   push:
     branches: [main, develop]
   workflow_dispatch:
-
 env:
   ZENML_ANALYTICS_OPT_IN: false
-
 jobs:
   test-agent-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-agent-pipelines-test.yml
+++ b/.github/workflows/weekly-agent-pipelines-test.yml
@@ -8,14 +8,16 @@ on:
   push:
     branches: [main, develop]
   workflow_dispatch:
+
+env:
+  ZENML_ANALYTICS_OPT_IN: false
+
 jobs:
   test-agent-examples:
     runs-on: ubuntu-latest
     env:
       # Ensure examples run with OpenAI credentials and consistent env behaviour
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ZENML_DEBUG: true
-      ZENML_ANALYTICS_OPT_IN: false
       ZENML_LOGGING_VERBOSITY: INFO
       AUTO_OPEN_DASHBOARD: false
       ZENML_ENABLE_RICH_TRACEBACK: false

--- a/.github/workflows/weekly-agent-pipelines-test.yml
+++ b/.github/workflows/weekly-agent-pipelines-test.yml
@@ -9,6 +9,7 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 env:
+  ZENML_DEBUG: true
   ZENML_ANALYTICS_OPT_IN: false
 jobs:
   test-agent-examples:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,13 @@ Router, service, error-handling, and validation conventions for the server live 
   - `AUTO_OPEN_DASHBOARD=false`: Prevents automatic dashboard opening
   - `ZENML_ENABLE_RICH_TRACEBACK=false`: Disables rich traceback formatting
   - `TOKENIZERS_PARALLELISM=false`: Avoids tokenizers parallelism warnings
+- Always set the following environment variables:
+  - `ZENML_ANALYTICS_OPT_IN=false`: Disables analytics during development
+  - `ZENML_DEBUG=true`: Uses the development ZenML analytics server to avoid
+    sending analytics to the official ZenML analytics server (IMPORTANT!). This
+    must be set even if `ZENML_ANALYTICS_OPT_IN=true` because in a client-server
+    setup, the server controls the client-side analytics opt-in status.
+
 
 ### Branch Management
 - **IMPORTANT**: `develop` is our primary working branch, NOT `main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,8 +236,7 @@ Router, service, error-handling, and validation conventions for the server live 
 
 ### Environment Variables
 - Several environment variables are useful during ZenML development:
-  - `ZENML_DEBUG=true`: Enables verbose debug logging
-  - `ZENML_LOGGING_VERBOSITY=INFO`: Controls logging verbosity
+  - `ZENML_LOGGING_VERBOSITY=DEBUG`: Controls logging verbosity
   - `ZENML_ANALYTICS_OPT_IN=false`: Disables analytics during development
   - `MLSTACKS_ANALYTICS_OPT_OUT=true`: Disables MLStacks analytics
   - `AUTO_OPEN_DASHBOARD=false`: Prevents automatic dashboard opening

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -159,7 +159,7 @@ ENV \
   ZENML_CONTAINER=1 \
   # Set the ZenML global configuration path
   ZENML_CONFIG_PATH=/zenml/.zenconfig \
-  # Set ZenML debug mode to false
+  # Send ZenML analytics events to the official ZenML analytics server
   ZENML_DEBUG=false \
   # Enable ZenML server-side analytics
   ZENML_ANALYTICS_OPT_IN=true

--- a/docker/zenml-dev.Dockerfile
+++ b/docker/zenml-dev.Dockerfile
@@ -88,8 +88,6 @@ ENV \
   VIRTUAL_ENV=$VIRTUAL_ENV \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
-  # Set ZenML debug mode to true
-  ZENML_DEBUG=true \
   # Set ZenML logging verbosity to INFO
   #
   # NOTE: debug logs can be very verbose and make it in fact more difficult to

--- a/docker/zenml-dev.Dockerfile
+++ b/docker/zenml-dev.Dockerfile
@@ -88,6 +88,8 @@ ENV \
   VIRTUAL_ENV=$VIRTUAL_ENV \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
+  # Send ZenML analytics events to the development ZenML analytics server
+  ZENML_DEBUG=true \
   # Set ZenML logging verbosity to INFO
   #
   # NOTE: debug logs can be very verbose and make it in fact more difficult to

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -116,8 +116,6 @@ ENV \
   ZENML_CONFIG_PATH=/zenml/.zenconfig \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
-  # Set ZenML debug mode to true
-  ZENML_DEBUG=true \
   # Set ZenML logging verbosity to DEBUG
   ZENML_LOGGING_VERBOSITY=DEBUG \
   # Disable ZenML server-side analytics

--- a/docker/zenml-server-dev.Dockerfile
+++ b/docker/zenml-server-dev.Dockerfile
@@ -116,6 +116,8 @@ ENV \
   ZENML_CONFIG_PATH=/zenml/.zenconfig \
   # Signal to ZenML that it is running in a container
   ZENML_CONTAINER=1 \
+  # Send ZenML analytics events to the development ZenML analytics server
+  ZENML_DEBUG=true \
   # Set ZenML logging verbosity to DEBUG
   ZENML_LOGGING_VERBOSITY=DEBUG \
   # Disable ZenML server-side analytics

--- a/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
+++ b/docs/book/getting-started/deploying-zenml/deploy-with-helm.md
@@ -731,20 +731,24 @@ podSecurityContext:
 
 ### Observability and OpenTelemetry
 
-You can configure server log output and OpenTelemetry export through the `server.environment` Helm value. For example:
+You can configure server log output and OpenTelemetry export through dedicated Helm values. For example:
 
 ```yaml
 server:
-  environment:
-    ZENML_CONSOLE_LOGGING_FORMAT: <console|json|custom_format>  # default is console
-    ZENML_LOGGING_COLORS_DISABLED: <true|false>  # default is false
-    ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
-    ZENML_SERVER_OTEL_SERVICE_NAME: zenml-server
+  logging:
+    verbosity: <debug|info|warning|error|critical>  # default is info
+    format: <console|json|custom_format>  # default is console
+    colorsDisabled: <true|false>  # default is false
+  openTelemetry:
+    endpoint: http://otel-collector:4318
+    serviceName: zenml-server
 ```
 
-`ZENML_CONSOLE_LOGGING_FORMAT` can be set to `console` (default), `json`, or a valid Python `%`-style logging format string. This controls the server container stdout/stderr output, i.e. the logs that Kubernetes pod log collectors scrape. The older `ZENML_LOGGING_FORMAT` environment variable is still supported as a deprecated alias but will be removed in a future version.
+`server.logging.verbosity` sets the ZenML server log level. The legacy `server.debug` option is still supported for compatibility and forces the server log level to `debug` when set to `true`, but new deployments should use `server.logging.verbosity` instead.
 
-Setting `ZENML_SERVER_OTEL_EXPORTER_OTLP_ENDPOINT` enables server OpenTelemetry instrumentation and exports traces, metrics, and logs using OTLP/HTTP. The standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is also supported as a fallback. Configure the base collector endpoint and ZenML appends `/v1/traces`, `/v1/metrics`, and `/v1/logs` for each signal.
+`server.logging.format` can be set to `console` (default), `json`, or a valid Python `%`-style logging format string. This controls the server container stdout/stderr output, i.e. the logs that Kubernetes pod log collectors scrape. The older `ZENML_LOGGING_FORMAT` environment variable is still supported through `server.environment` as a deprecated alias but will be removed in a future version.
+
+Setting `server.openTelemetry.endpoint` enables server OpenTelemetry instrumentation and exports traces, metrics, and logs using OTLP/HTTP. The standard `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is also supported as a fallback through `server.environment`. Configure the base collector endpoint and ZenML appends `/v1/traces`, `/v1/metrics`, and `/v1/logs` for each signal.
 
 You can override individual signal endpoints with the standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` variables, or with the matching `ZENML_SERVER_OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT` names.
 

--- a/docs/book/reference/environment-variables.md
+++ b/docs/book/reference/environment-variables.md
@@ -63,6 +63,14 @@ Please see [our full page](global-settings.md#usage-analytics) on what analytics
 export ZENML_ANALYTICS_OPT_IN=false
 ```
 
+## Debug mode
+
+Setting to `true` switches to developer mode. This redirects all ZenML analytics events to the development ZenML analytics server instead of the official ZenML analytics server. Should not be used in production environments.
+
+```bash
+export ZENML_DEBUG=true
+```
+
 ## Active stack
 
 Setting the `ZENML_ACTIVE_STACK_ID` to a specific UUID will make the corresponding stack the active stack:

--- a/docs/book/reference/environment-variables.md
+++ b/docs/book/reference/environment-variables.md
@@ -63,14 +63,6 @@ Please see [our full page](global-settings.md#usage-analytics) on what analytics
 export ZENML_ANALYTICS_OPT_IN=false
 ```
 
-## Debug mode
-
-Setting to `true` switches to developer mode:
-
-```bash
-export ZENML_DEBUG=true
-```
-
 ## Active stack
 
 Setting the `ZENML_ACTIVE_STACK_ID` to a specific UUID will make the corresponding stack the active stack:

--- a/helm/README.md
+++ b/helm/README.md
@@ -119,6 +119,7 @@ You can configure server log output and OpenTelemetry export with dedicated Helm
 ```yaml
 server:
   logging:
+    verbosity: "info" # debug, info, warning, error, or critical
     format: "console" # console, json, or a custom %-style format
     colorsDisabled: false
   openTelemetry:
@@ -131,6 +132,8 @@ server:
     metricsEnabled: true
     logsEnabled: true
 ```
+
+`server.logging.verbosity` sets the ZenML server log level. The legacy `server.debug` option is still supported for compatibility and forces the server log level to `debug` when set to `true`, but new deployments should use `server.logging.verbosity` instead.
 
 `server.logging.format` controls the server container stdout/stderr output. It can be set to `console`, `json`, or a valid Python `%`-style logging format string. The older `ZENML_LOGGING_FORMAT` environment variable is still supported through `server.environment` as a deprecated alias but will be removed in a future version.
 

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -635,6 +635,7 @@ Returns a dictionary with common configuration env vars.
 */}}
 {{- define "zenml.baseEnvVariables" -}}
 {{- $server := include "zenml.serverValues" . | fromYaml -}}
+{{- $logging := $server.logging | default dict -}}
 ZENML_SERVER: "True"
 NODE_OPTIONS: "--use-openssl-ca"
 {{- if or $server.certificates.customCAs $server.certificates.secretRefs }}
@@ -644,9 +645,9 @@ SSL_CERT_FILE: "/updated-certs/ca-certificates.crt"
 {{- if $server.debug }}
 ZENML_LOGGING_VERBOSITY: "DEBUG"
 {{- else }}
-ZENML_LOGGING_VERBOSITY: "INFO"
+ZENML_LOGGING_VERBOSITY: {{ default "info" $logging.verbosity | upper | quote }}
 {{- end }}
-{{- with $server.logging }}
+{{- with $logging }}
 {{- if .format }}
 ZENML_CONSOLE_LOGGING_FORMAT: {{ .format | quote }}
 {{- end }}

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -643,6 +643,8 @@ SSL_CERT_FILE: "/updated-certs/ca-certificates.crt"
 {{- end }}
 {{- if $server.debug }}
 ZENML_LOGGING_VERBOSITY: "DEBUG"
+{{- else }}
+ZENML_LOGGING_VERBOSITY: "INFO"
 {{- end }}
 {{- with $server.logging }}
 {{- if .format }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,7 +133,6 @@ server:
   # This value is overridden if the `zenml.pro.enabled` value is set.
   dashboardURL:
 
-  debug: true
 
   # Flag to enable/disable the tracking process of the analytics
   analyticsOptIn: true
@@ -1126,6 +1125,10 @@ server:
 
   # Logging settings for the ZenML server container.
   logging:
+    # Set the logging verbosity.
+    # Supported values are: debug, info, warning, error, critical
+    verbosity: info
+
     # Log output format. Use "console", "json", or a custom Python logging
     # format string in %-style format like "%(levelname)s:%(name)s:%(message)s".
     format: console

--- a/scripts/check-security.sh
+++ b/scripts/check-security.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 SRC=${1:-"src/zenml tests examples"}
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/check-security.sh
+++ b/scripts/check-security.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 SRC=${1:-"src/zenml tests examples"}
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 bandit -c pyproject.toml \

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 set -x
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 typos .

--- a/scripts/check-spelling.sh
+++ b/scripts/check-spelling.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 set -x
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 typos .

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 set -x
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 rm -rf dist \

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 set -x
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/docstring.sh
+++ b/scripts/docstring.sh
@@ -6,7 +6,7 @@ set -x
 
 DOCSTRING_SRC=${1:-"src/zenml tests/harness"}
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 pydoclint $DOCSTRING_SRC

--- a/scripts/docstring.sh
+++ b/scripts/docstring.sh
@@ -6,6 +6,7 @@ set -x
 
 DOCSTRING_SRC=${1:-"src/zenml tests/harness"}
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -52,7 +52,7 @@ if [ -z "$SRC" ]; then
     SRC="$default_src"
 fi
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 # autoflake replacement: removes unused imports and variables

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -52,6 +52,7 @@ if [ -z "$SRC" ]; then
     SRC="$default_src"
 fi
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -41,6 +41,7 @@ done
 [ -z "${VERSION-}" ] && die "Missing required parameter: VERSION. Please supply a doc version"
 
 ##################################################### Setup ############################################################
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 export DISABLE_DATABASE_MIGRATION=1

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -41,7 +41,7 @@ done
 [ -z "${VERSION-}" ] && die "Missing required parameter: VERSION. Please supply a doc version"
 
 ##################################################### Setup ############################################################
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 export DISABLE_DATABASE_MIGRATION=1
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -191,7 +191,7 @@ install_integrations() {
 set -x
 set -e
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 parse_args "$@"

--- a/scripts/install-zenml-dev.sh
+++ b/scripts/install-zenml-dev.sh
@@ -191,6 +191,7 @@ install_integrations() {
 set -x
 set -e
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,6 +8,7 @@ SRC=${1:-"src/zenml tests examples"}
 SRC_NO_TESTS=${1:-"src/zenml tests/harness"}
 TESTS_EXAMPLES=${1:-"tests examples"}
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 ruff check $SRC_NO_TESTS

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -8,7 +8,7 @@ SRC=${1:-"src/zenml tests examples"}
 SRC_NO_TESTS=${1:-"src/zenml tests/harness"}
 TESTS_EXAMPLES=${1:-"tests examples"}
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 ruff check $SRC_NO_TESTS
 # TODO: Fix docstrings in tests and examples and remove the `--extend-ignore D` flag

--- a/scripts/run-ci-checks.sh
+++ b/scripts/run-ci-checks.sh
@@ -2,6 +2,7 @@
 set -e
 set -x
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 

--- a/scripts/run-ci-checks.sh
+++ b/scripts/run-ci-checks.sh
@@ -2,7 +2,7 @@
 set -e
 set -x
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 
 scripts/lint.sh

--- a/scripts/serve_api_docs.sh
+++ b/scripts/serve_api_docs.sh
@@ -4,7 +4,7 @@ set -x
 
 SRC=${1:-"src/zenml"}
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 rm -rf docs/mkdocs/api_docs || true
 rm docs/mkdocs/index.md || true

--- a/scripts/serve_api_docs.sh
+++ b/scripts/serve_api_docs.sh
@@ -4,6 +4,7 @@ set -x
 
 SRC=${1:-"src/zenml"}
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 rm -rf docs/mkdocs/api_docs || true

--- a/scripts/test-coverage-html.sh
+++ b/scripts/test-coverage-html.sh
@@ -3,6 +3,7 @@
 set -e
 set -x
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 bash ./scripts/test-coverage-xml.sh

--- a/scripts/test-coverage-html.sh
+++ b/scripts/test-coverage-html.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 bash ./scripts/test-coverage-xml.sh
 coverage html

--- a/scripts/test-coverage-xml.sh
+++ b/scripts/test-coverage-xml.sh
@@ -43,6 +43,7 @@ fi
 
 PYTEST_RERUN_ARGS=(--reruns "$RERUNS" --reruns-delay "$RERUNS_DELAY")
 
+export ZENML_DEBUG=1
 export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 export EVIDENTLY_DISABLE_TELEMETRY=1

--- a/scripts/test-coverage-xml.sh
+++ b/scripts/test-coverage-xml.sh
@@ -43,7 +43,7 @@ fi
 
 PYTEST_RERUN_ARGS=(--reruns "$RERUNS" --reruns-delay "$RERUNS_DELAY")
 
-export ZENML_DEBUG=1
+export ZENML_LOGGING_VERBOSITY=debug
 export ZENML_ANALYTICS_OPT_IN=false
 export EVIDENTLY_DISABLE_TELEMETRY=1
 

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -4,6 +4,7 @@ DB="sqlite"
 DB_STARTUP_DELAY=30 # Time in seconds to wait for the database container to start
 
 export ZENML_ANALYTICS_OPT_IN=false
+export ZENML_DEBUG=true
 export ZENML_LOGGING_VERBOSITY=debug
 
 # Use a temporary directory for the config path

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -4,7 +4,7 @@ DB="sqlite"
 DB_STARTUP_DELAY=30 # Time in seconds to wait for the database container to start
 
 export ZENML_ANALYTICS_OPT_IN=false
-export ZENML_DEBUG=true
+export ZENML_LOGGING_VERBOSITY=debug
 
 # Use a temporary directory for the config path
 export ZENML_CONFIG_PATH=/tmp/upgrade-tests

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -312,6 +312,14 @@ ENV_ZENML_STREAM_PUBLISHER_BATCH_SIZE = "ZENML_STREAM_PUBLISHER_BATCH_SIZE"
 # Logging variables
 IS_DEBUG_ENV: bool = handle_bool_env_var(ENV_ZENML_DEBUG, default=False)
 
+ZENML_LOGGING_VERBOSITY = os.getenv(
+    ENV_ZENML_LOGGING_VERBOSITY, default="INFO"
+).upper()
+
+ZENML_STORAGE_LOGGING_VERBOSITY = os.getenv(
+    ENV_ZENML_STORAGE_LOGGING_VERBOSITY, default=None
+)
+
 INSIDE_ZENML_CONTAINER = handle_bool_env_var(ENV_ZENML_CONTAINER, False)
 
 # Analytics constants

--- a/src/zenml/constants.py
+++ b/src/zenml/constants.py
@@ -312,21 +312,6 @@ ENV_ZENML_STREAM_PUBLISHER_BATCH_SIZE = "ZENML_STREAM_PUBLISHER_BATCH_SIZE"
 # Logging variables
 IS_DEBUG_ENV: bool = handle_bool_env_var(ENV_ZENML_DEBUG, default=False)
 
-if IS_DEBUG_ENV:
-    ZENML_LOGGING_VERBOSITY = os.getenv(
-        ENV_ZENML_LOGGING_VERBOSITY, default="DEBUG"
-    ).upper()
-    ZENML_STORAGE_LOGGING_VERBOSITY = os.getenv(
-        ENV_ZENML_STORAGE_LOGGING_VERBOSITY, default=None
-    )
-else:
-    ZENML_LOGGING_VERBOSITY = os.getenv(
-        ENV_ZENML_LOGGING_VERBOSITY, default="INFO"
-    ).upper()
-    ZENML_STORAGE_LOGGING_VERBOSITY = os.getenv(
-        ENV_ZENML_STORAGE_LOGGING_VERBOSITY, default=None
-    )
-
 INSIDE_ZENML_CONTAINER = handle_bool_env_var(ENV_ZENML_CONTAINER, False)
 
 # Analytics constants

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Callable, Optional, Type
 
 from zenml.client import Client
-from zenml.constants import ENV_ZENML_ANALYTICS_OPT_IN, ENV_ZENML_DEBUG
+from zenml.constants import ENV_ZENML_DEBUG
 from zenml.enums import VisualizationType
 from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.materializers.materializer_registry import materializer_registry
@@ -25,11 +25,8 @@ from zenml.metadata.metadata_types import MetadataTypeTuple
 
 
 def test_debug_mode_enabled_for_tests():
-    """Checks that the ZENML_DEBUG is set in the tests or ZENML_ANALYTICS_OPT_IN is set to false."""
-    assert (
-        os.environ[ENV_ZENML_DEBUG] == "true"
-        or os.environ[ENV_ZENML_ANALYTICS_OPT_IN] == "false"
-    )
+    """Checks that the ZENML_DEBUG is set in the tests."""
+    assert os.environ[ENV_ZENML_DEBUG] == "true"
 
 
 def _test_materializer(

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Callable, Optional, Type
 
 from zenml.client import Client
-from zenml.constants import ENV_ZENML_DEBUG
+from zenml.constants import ENV_ZENML_DEBUG, ENV_ZENML_ANALYTICS_OPT_IN
 from zenml.enums import VisualizationType
 from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.materializers.materializer_registry import materializer_registry
@@ -25,8 +25,8 @@ from zenml.metadata.metadata_types import MetadataTypeTuple
 
 
 def test_debug_mode_enabled_for_tests():
-    """Checks that the ZENML_DEBUG is set in the tests."""
-    assert os.environ[ENV_ZENML_DEBUG] == "true"
+    """Checks that the ZENML_DEBUG is set in the tests or ZENML_ANALYTICS_OPT_IN is set to false."""
+    assert os.environ[ENV_ZENML_DEBUG] == "true" or os.environ[ENV_ZENML_ANALYTICS_OPT_IN] == "false"
 
 
 def _test_materializer(

--- a/tests/unit/test_general.py
+++ b/tests/unit/test_general.py
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Callable, Optional, Type
 
 from zenml.client import Client
-from zenml.constants import ENV_ZENML_DEBUG, ENV_ZENML_ANALYTICS_OPT_IN
+from zenml.constants import ENV_ZENML_ANALYTICS_OPT_IN, ENV_ZENML_DEBUG
 from zenml.enums import VisualizationType
 from zenml.materializers.base_materializer import BaseMaterializer
 from zenml.materializers.materializer_registry import materializer_registry
@@ -26,7 +26,10 @@ from zenml.metadata.metadata_types import MetadataTypeTuple
 
 def test_debug_mode_enabled_for_tests():
     """Checks that the ZENML_DEBUG is set in the tests or ZENML_ANALYTICS_OPT_IN is set to false."""
-    assert os.environ[ENV_ZENML_DEBUG] == "true" or os.environ[ENV_ZENML_ANALYTICS_OPT_IN] == "false"
+    assert (
+        os.environ[ENV_ZENML_DEBUG] == "true"
+        or os.environ[ENV_ZENML_ANALYTICS_OPT_IN] == "false"
+    )
 
 
 def _test_materializer(

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -843,8 +843,8 @@ def test_logging_context_step_name_prefix_uses_legacy_env_semantics(
         monkeypatch.setenv(ENV_ZENML_DISABLE_STEP_NAMES_IN_LOGS, env_value)
     monkeypatch.setenv(ENV_ZENML_LOGGING_COLORS_DISABLED, "true")
 
-    # CI may run tests with ZENML_DEBUG=1. Pin INFO formatting so this test
-    # verifies step-prefix semantics, not the DEBUG structured-log layout.
+    # Pin INFO formatting so this test verifies step-prefix semantics,
+    # not the DEBUG structured-log layout.
     monkeypatch.setattr(
         zenml_logger_module,
         "get_logging_level",


### PR DESCRIPTION
The `ZENML_DEBUG` environment variable has been historically tied to two unrelated concerns:

1. it decides which telemetry target to use  (setting `ZENML_DEBUG` when telemetry is enabled will send telemetry events to the ZenML development target instead of the regular production target). 
2. it changes the logging verbosity to DEBUG when set (unless already set via its usual `ZENML_LOGGING_VERBOSITY` env variable).

This has been a constant cause of confusion and conflict, making it difficult to debug issues related to logging verbosity and telemetry and carrying a high risk of sending telemetry events to the wrong target when changes are made with the sole intention to affect the logging verbosity.

This PR makes a stand and finally detaches `ZENML_DEBUG` from the logging verbosity concern, leaving `ZENML_LOGGING_VERBOSITY` as the one and only way used to control logging verbosity.

IMPORTANT: `ZENML_DEBUG` is still kept in all the original places where it was used, even when telemetry is explicitly turned off through `ZENML_ANALYTICS_OPT_IN=false`, because of these two important aspects:

* client-side telemetry is decided by the server's telemetry setting in a client-server setup, even when the client telemetry is explicitly turned off with `ZENML_ANALYTICS_OPT_IN=false`
* the UI uses the server's telemetry setting and the `ZENML_DEBUG` environment variable to decide where to send the UI telemetry events.