### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #5066)

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -2,7 +2,7 @@
 description: Format code, stage changes, and create a pull request
 allowed-tools:
   - Bash
-argument-hint: [base-branch]
+argument-hint: "[base-branch]"
 ---
 
 # Prepare and create pull request


### PR DESCRIPTION
Closes #5066.

## Summary

Purely mechanical single-character transform to 1 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (1)

- `.claude/commands/pr.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- Regression sweep: no unquoted-bracket `argument-hint:` lines remain in these files
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
