### PR TITLE
Always track pipeline image when using skip_build=True

### DIFF
--- a/src/zenml/orchestrators/containerized_orchestrator.py
+++ b/src/zenml/orchestrators/containerized_orchestrator.py
@@ -120,13 +120,18 @@ class ContainerizedOrchestrator(BaseOrchestrator, ABC):
                 builds.append(pipeline_build)
                 included_pipeline_build = True
 
-        if not included_pipeline_build and self.should_build_pipeline_image(
-            snapshot
-        ):
-            pipeline_build = BuildConfiguration(
-                key=ORCHESTRATOR_DOCKER_IMAGE_KEY,
-                settings=pipeline_settings,
-            )
-            builds.append(pipeline_build)
+        if not included_pipeline_build:
+            # If the pipeline settings specify to skip the build, we can always
+            # include them in the builds because there is no cost associated
+            # with building the image.
+            if (
+                pipeline_settings.skip_build
+                or self.should_build_pipeline_image(snapshot)
+            ):
+                pipeline_build = BuildConfiguration(
+                    key=ORCHESTRATOR_DOCKER_IMAGE_KEY,
+                    settings=pipeline_settings,
+                )
+                builds.append(pipeline_build)
 
         return builds

--- a/tests/unit/orchestrators/test_containerized_orchestrator.py
+++ b/tests/unit/orchestrators/test_containerized_orchestrator.py
@@ -157,6 +157,45 @@ def test_builds_with_custom_docker_settings_for_all_steps():
     assert step_2_build.settings == custom_step_2_settings
 
 
+def test_builds_with_skipped_pipeline_build():
+    """Tests that the generic pipeline image is included if the pipeline
+    Docker settings specify to skip the build, even if all steps specify
+    their custom Docker settings."""
+    orchestrator = _get_orchestrator()
+    pipeline_settings = DockerSettings(
+        skip_build=True, parent_image="parent_image"
+    )
+    custom_step_1_settings = DockerSettings(
+        requirements=["step_1_requirements"]
+    )
+    snapshot = PipelineSnapshotBase(
+        run_name_template="",
+        pipeline_configuration={
+            "name": "pipeline",
+            "settings": {"docker": pipeline_settings},
+        },
+        step_configurations={
+            "step_1": _get_step(
+                name="step_1", docker_settings=custom_step_1_settings
+            ),
+        },
+        client_version="0.12.3",
+        server_version="0.12.3",
+    )
+
+    builds = orchestrator.get_docker_builds(snapshot=snapshot)
+    assert len(builds) == 2
+    step_1_build = builds[0]
+    assert step_1_build.key == "orchestrator"
+    assert step_1_build.step_name == "step_1"
+    assert step_1_build.settings == custom_step_1_settings
+
+    pipeline_build = builds[1]
+    assert pipeline_build.key == "orchestrator"
+    assert pipeline_build.step_name is None
+    assert pipeline_build.settings == pipeline_settings
+
+
 def test_getting_image_from_snapshot(
     sample_snapshot_response_model, sample_build_response_model
 ):


### PR DESCRIPTION
Always include the pipeline-level image in the `PipelineBuild` for a snapshot when it's specified with `skip_build=True`.