### PR TITLE
Allow requesting extra step metadata in dag endpoint

### DIFF
--- a/src/zenml/zen_server/routers/runs_endpoints.py
+++ b/src/zenml/zen_server/routers/runs_endpoints.py
@@ -466,12 +466,15 @@ def get_run_status(
 @async_fastapi_endpoint_wrapper
 def get_run_dag(
     run_id: UUID,
+    include_step_metadata: Optional[List[str]] = Query(default=None),
     _: AuthContext = Security(authorize),
 ) -> PipelineRunDAG:
     """Get the DAG of a specific pipeline run.
 
     Args:
         run_id: ID of the pipeline run for which to get the DAG.
+        include_step_metadata: Run metadata keys for which to include the
+            values in the step nodes.
 
     Returns:
         The DAG of the pipeline run.
@@ -482,7 +485,9 @@ def get_run_dag(
         get_method=zen_store().get_run,
         hydrate=False,
     )
-    return zen_store().get_pipeline_run_dag(run_id)
+    return zen_store().get_pipeline_run_dag(
+        pipeline_run_id=run_id, include_step_metadata=include_step_metadata
+    )
 
 
 @router.post(

--- a/src/zenml/zen_stores/dag/utils.py
+++ b/src/zenml/zen_stores/dag/utils.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """DAG generation utilities."""
 
+import json
 from collections import defaultdict
 from typing import Dict, List
 from uuid import UUID
@@ -20,14 +21,19 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlmodel import Session, col
 
-from zenml.enums import ExecutionStatus
+from zenml.enums import ExecutionStatus, MetadataResourceTypes
+from zenml.metadata.metadata_types import MetadataType
+from zenml.models import RunMetadataEntry
 from zenml.zen_stores.dag.models import InputArtifactRow, OutputArtifactRow
 from zenml.zen_stores.schemas import (
     ArtifactVersionSchema,
+    RunMetadataResourceSchema,
+    RunMetadataSchema,
     StepRunInputArtifactSchema,
     StepRunOutputArtifactSchema,
     StepRunSchema,
 )
+from zenml.zen_stores.schemas.utils import resolve_metadata_collection
 
 
 def load_input_artifact_rows(
@@ -114,3 +120,56 @@ def load_output_artifact_rows(
         rows[row.step_id].append(row)
 
     return rows
+
+
+def load_step_run_metadata(
+    session: Session,
+    pipeline_run_id: UUID,
+    metadata_keys: List[str],
+) -> Dict[UUID, Dict[str, MetadataType]]:
+    """Load run metadata values for the step runs of a pipeline run.
+
+    Args:
+        session: The database session.
+        pipeline_run_id: The ID of the pipeline run.
+        metadata_keys: The run metadata keys to load.
+
+    Returns:
+        The resolved metadata values, grouped by step run ID.
+    """
+    query = (
+        select(
+            col(RunMetadataResourceSchema.resource_id),
+            col(RunMetadataSchema.key),
+            col(RunMetadataSchema.value),
+            col(RunMetadataSchema.created),
+        )
+        .join(
+            RunMetadataSchema,
+            col(RunMetadataSchema.id)
+            == RunMetadataResourceSchema.run_metadata_id,
+        )
+        .join(
+            StepRunSchema,
+            col(StepRunSchema.id) == RunMetadataResourceSchema.resource_id,
+        )
+        .where(
+            col(RunMetadataResourceSchema.resource_type)
+            == MetadataResourceTypes.STEP_RUN
+        )
+        .where(col(StepRunSchema.pipeline_run_id) == pipeline_run_id)
+        .where(col(StepRunSchema.status) != ExecutionStatus.RETRIED.value)
+        .where(col(RunMetadataSchema.key).in_(metadata_keys))
+    )
+    metadata_collections: Dict[UUID, Dict[str, List[RunMetadataEntry]]] = (
+        defaultdict(dict)
+    )
+    for step_id, key, value, created in session.execute(query):
+        metadata_collections[step_id].setdefault(key, []).append(
+            RunMetadataEntry(value=json.loads(value), created=created)
+        )
+
+    return {
+        step_id: resolve_metadata_collection(collection)
+        for step_id, collection in metadata_collections.items()
+    }

--- a/src/zenml/zen_stores/schemas/utils.py
+++ b/src/zenml/zen_stores/schemas/utils.py
@@ -126,24 +126,40 @@ class RunMetadataInterface:
             A dictionary, where the key is the key of the metadata entry
                 and the values represent the latest entry with this key.
         """
-        metadata_collection = self.fetch_metadata_collection(**kwargs)
-        metadata: Dict[str, MetadataType] = {}
+        return resolve_metadata_collection(
+            self.fetch_metadata_collection(**kwargs)
+        )
 
-        for key, values in metadata_collection.items():
-            values = sorted(values, key=lambda x: x.created, reverse=False)
 
-            if all(isinstance(item.value, dict) for item in values):
-                # All metadata values for this key are dictionaries, so we can
-                # merge them into a single dictionary
-                metadata[key] = {
-                    k: v
-                    for item in values
-                    for k, v in item.value.items()  # type: ignore[union-attr]
-                }
-            else:
-                metadata[key] = values[-1].value
+def resolve_metadata_collection(
+    metadata_collection: Dict[str, List[RunMetadataEntry]],
+) -> Dict[str, MetadataType]:
+    """Resolves a metadata collection to the latest entry per key.
 
-        return metadata
+    Args:
+        metadata_collection: The metadata collection to resolve.
+
+    Returns:
+        A dictionary, where the key is the key of the metadata entry
+            and the values represent the latest entry with this key.
+    """
+    metadata: Dict[str, MetadataType] = {}
+
+    for key, values in metadata_collection.items():
+        values = sorted(values, key=lambda x: x.created, reverse=False)
+
+        if all(isinstance(item.value, dict) for item in values):
+            # All metadata values for this key are dictionaries, so we can
+            # merge them into a single dictionary
+            metadata[key] = {
+                k: v
+                for item in values
+                for k, v in item.value.items()  # type: ignore[union-attr]
+            }
+        else:
+            metadata[key] = values[-1].value
+
+    return metadata
 
 
 def get_resource_type_name(schema_class: Type[BaseSchema]) -> str:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -405,6 +405,7 @@ from zenml.zen_stores.dag.models import (
 from zenml.zen_stores.dag.utils import (
     load_input_artifact_rows,
     load_output_artifact_rows,
+    load_step_run_metadata,
 )
 from zenml.zen_stores.migrations.alembic import (
     Alembic,
@@ -6227,11 +6228,17 @@ class SqlZenStore(BaseZenStore):
 
     # ----------------------------- Pipeline runs -----------------------------
 
-    def get_pipeline_run_dag(self, pipeline_run_id: UUID) -> PipelineRunDAG:
+    def get_pipeline_run_dag(
+        self,
+        pipeline_run_id: UUID,
+        include_step_metadata: Optional[List[str]] = None,
+    ) -> PipelineRunDAG:
         """Get the DAG of a pipeline run.
 
         Args:
             pipeline_run_id: The ID of the pipeline run.
+            include_step_metadata: Run metadata keys for which to include the
+                values in the step nodes.
 
         Returns:
             The DAG of the pipeline run.
@@ -6344,6 +6351,9 @@ class SqlZenStore(BaseZenStore):
                     for config_table in snapshot.step_configurations
                 }
 
+            input_artifact_rows = {}
+            output_artifact_rows = {}
+            step_metadata: Dict[UUID, Dict[str, "MetadataType"]] = {}
             if step_runs:
                 input_artifact_rows = load_input_artifact_rows(
                     session=session, pipeline_run_id=pipeline_run_id
@@ -6351,9 +6361,12 @@ class SqlZenStore(BaseZenStore):
                 output_artifact_rows = load_output_artifact_rows(
                     session=session, pipeline_run_id=pipeline_run_id
                 )
-            else:
-                input_artifact_rows = {}
-                output_artifact_rows = {}
+                if include_step_metadata:
+                    step_metadata = load_step_run_metadata(
+                        session=session,
+                        pipeline_run_id=pipeline_run_id,
+                        metadata_keys=include_step_metadata,
+                    )
 
             regular_output_artifact_nodes: Dict[
                 str, Dict[str, PipelineRunDAG.Node]
@@ -6399,6 +6412,9 @@ class SqlZenStore(BaseZenStore):
                             metadata["duration"] = (
                                 step_run.end_time - step_run.start_time
                             ).total_seconds()
+
+                    if extra_metadata := step_metadata.get(step_run.id):
+                        metadata["run_metadata"] = extra_metadata
 
                 step_node = helper.add_step_node(
                     node_id=helper.get_step_node_id(name=step_name),

--- a/tests/integration/functional/models/test_step_run.py
+++ b/tests/integration/functional/models/test_step_run.py
@@ -25,7 +25,7 @@ from tests.integration.functional.zen_stores.utils import (
     constant_int_output_test_step,
     int_plus_one_test_step,
 )
-from zenml import step
+from zenml import log_metadata, step
 from zenml.constants import TEXT_FIELD_MAX_LENGTH
 from zenml.enums import ExecutionStatus, StepType
 
@@ -89,6 +89,30 @@ def test_step_run_and_dag_include_step_type(
 
     step_node = next(node for node in dag.nodes if node.type == "step")
     assert step_node.metadata["type"] == expected_type.value
+
+
+@step
+def metadata_logging_step() -> int:
+    log_metadata(metadata={"accuracy": 0.9, "loss": 0.1})
+    return 1
+
+
+def test_dag_includes_requested_metadata_keys(
+    clean_client: "Client", one_step_pipeline
+):
+    """Tests that DAG step nodes contain the requested run metadata values."""
+    pipeline_instance = one_step_pipeline(metadata_logging_step)
+    pipeline_run = pipeline_instance()
+
+    dag = clean_client.zen_store.get_pipeline_run_dag(pipeline_run.id)
+    step_node = next(node for node in dag.nodes if node.type == "step")
+    assert "run_metadata" not in step_node.metadata
+
+    dag = clean_client.zen_store.get_pipeline_run_dag(
+        pipeline_run.id, include_step_metadata=["accuracy"]
+    )
+    step_node = next(node for node in dag.nodes if node.type == "step")
+    assert step_node.metadata["run_metadata"] == {"accuracy": 0.9}
 
 
 def test_step_run_parent_steps_linkage(


### PR DESCRIPTION
This PR adds a new option to the DAG endpoint that allows the UI to request certain run metadata values that will be included for every step node.