### PR TITLE
Narrow exception handling in list projects CLI to RuntimeError

### DIFF
--- a/src/zenml/cli/project.py
+++ b/src/zenml/cli/project.py
@@ -67,7 +67,7 @@ def list_projects(
             if active_project_id not in {p.id for p in projects.items}:
                 projects.items.insert(0, client.active_project)
             projects.items.sort(key=lambda p: p.id != active_project_id)
-        except Exception:
+        except RuntimeError:
             active_project_id = None
     else:
         active_project_id = None


### PR DESCRIPTION
## Summary

client.active_project only raises RuntimeError when no active project is configured, which is the one case the fallback in list_projects is meant to handle. The previous bare except Exception also masked unrelated failures such as server or network errors, silently falling back to no active project instead of surfacing the real error.

This narrows the except clause to RuntimeError.

Fixes #5073

## Test plan

- [x] Ran ruff check on the changed file, passed
- [x] Manually reasoned through client.active_project property in client.py, confirmed RuntimeError is the only exception type raised there