### PR TITLE
CRUD for webhook triggers

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -34,7 +34,7 @@ jobs:
           name: nightly-python-package-distributions
           path: dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
   wait-for-package-release:
     if: github.repository == 'zenml-io/zenml'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
   wait-for-package-release:
     runs-on: ubuntu-latest
     needs: publish-python-package

--- a/src/zenml/cli/trigger.py
+++ b/src/zenml/cli/trigger.py
@@ -18,7 +18,11 @@ from uuid import UUID
 
 import click
 
-from zenml import PlatformEventTriggerResponse, ScheduleTriggerResponse
+from zenml import (
+    PlatformEventTriggerResponse,
+    ScheduleTriggerResponse,
+    WebhookTriggerResponse,
+)
 from zenml.cli import utils as cli_utils
 from zenml.cli.cli import TagGroup, cli
 from zenml.client import Client
@@ -29,6 +33,7 @@ from zenml.enums import (
     SourceType,
     TriggerRunConcurrency,
     TriggerType,
+    WebhookType,
 )
 from zenml.logger import get_logger
 from zenml.models import TriggerFilter
@@ -53,6 +58,11 @@ def schedule() -> None:
 @trigger.group()
 def platform_event() -> None:
     """Commands for platform events triggers."""
+
+
+@trigger.group()
+def webhook() -> None:
+    """Commands for webhook triggers."""
 
 
 # SCHEDULE commands
@@ -283,7 +293,11 @@ def get_trigger_by_type(
     hydrate: bool,
     allow_name_prefix_match: bool,
     is_archived: bool = False,
-) -> ScheduleTriggerResponse | PlatformEventTriggerResponse:
+) -> (
+    ScheduleTriggerResponse
+    | PlatformEventTriggerResponse
+    | WebhookTriggerResponse
+):
     """Getter helper. Resolves trigger type getter by id.
 
     Args:
@@ -308,6 +322,13 @@ def get_trigger_by_type(
         )
     elif trigger_type == TriggerType.PLATFORM_EVENT:
         return Client().get_platform_event_trigger(
+            trigger_name_id_or_prefix=trigger_name_id_or_prefix,
+            hydrate=hydrate,
+            is_archived=is_archived,
+            allow_name_prefix_match=allow_name_prefix_match,
+        )
+    elif trigger_type == TriggerType.WEBHOOK:
+        return Client().get_webhook_trigger(
             trigger_name_id_or_prefix=trigger_name_id_or_prefix,
             hydrate=hydrate,
             is_archived=is_archived,
@@ -756,9 +777,180 @@ def list_platform_events(
     )
 
 
+# WEBHOOK COMMANDS
+
+
+@webhook.command("create", help="Create a new webhook trigger.")
+@click.argument("name", type=str)
+@click.option(
+    "--webhook-type",
+    type=click.Choice(WebhookType.values()),
+    required=True,
+    help="The compatible webhook provider type.",
+)
+@click.option(
+    "--webhook-integration",
+    type=str,
+    help="Optional webhook integration name or ID.",
+)
+@click.option(
+    "--concurrency",
+    type=click.Choice(TriggerRunConcurrency.values()),
+    default=TriggerRunConcurrency.SKIP.value,
+    help="Option to control the concurrency of the trigger.",
+)
+@click.option("--active", type=bool, default=True)
+def create_webhook_trigger(
+    name: str,
+    webhook_type: str,
+    webhook_integration: str | None,
+    concurrency: str,
+    active: bool,
+) -> None:
+    """Create a webhook trigger.
+
+    Args:
+        name: The trigger name.
+        webhook_type: The compatible webhook provider type.
+        webhook_integration: Optional integration name or ID.
+        concurrency: The trigger run concurrency behavior.
+        active: Whether the trigger should be active.
+    """
+    try:
+        created = Client().create_webhook_trigger(
+            name=name,
+            webhook_type=WebhookType(webhook_type),
+            webhook_integration=webhook_integration,
+            concurrency=TriggerRunConcurrency(concurrency),
+            active=active,
+        )
+    except Exception as e:
+        cli_utils.exception(e)
+    else:
+        cli_utils.declare(f"Created webhook trigger '{created.id}'.")
+
+
+@webhook.command("update", help="Update a webhook trigger.")
+@click.argument("trigger_name_or_id", type=str)
+@click.option("--name", type=str)
+@click.option("--active", type=bool)
+@click.option(
+    "--concurrency",
+    type=click.Choice(TriggerRunConcurrency.values()),
+    help="Option to control the concurrency of the trigger.",
+)
+@click.option(
+    "--webhook-integration",
+    type=str,
+    help="Replacement webhook integration name or ID.",
+)
+@click.option(
+    "--detach-webhook-integration",
+    is_flag=True,
+    help="Detach the webhook integration and deactivate the trigger.",
+)
+def update_webhook_trigger(
+    trigger_name_or_id: str,
+    name: str | None,
+    active: bool | None,
+    concurrency: str | None,
+    webhook_integration: str | None,
+    detach_webhook_integration: bool,
+) -> None:
+    """Update a webhook trigger.
+
+    Args:
+        trigger_name_or_id: The trigger name or ID.
+        name: The new trigger name.
+        active: The new active state.
+        concurrency: The new concurrency behavior.
+        webhook_integration: A replacement integration name or ID.
+        detach_webhook_integration: Whether to detach the integration.
+    """
+    if (
+        not any(
+            value is not None
+            for value in [name, active, concurrency, webhook_integration]
+        )
+        and not detach_webhook_integration
+    ):
+        cli_utils.declare("No webhook trigger update requested.")
+        return
+
+    try:
+        Client().update_webhook_trigger(
+            trigger_name_id_or_prefix=trigger_name_or_id,
+            name=name,
+            active=active,
+            concurrency=(
+                TriggerRunConcurrency(concurrency) if concurrency else None
+            ),
+            webhook_integration=webhook_integration,
+            detach_webhook_integration=detach_webhook_integration,
+        )
+    except Exception as e:
+        cli_utils.exception(e)
+    else:
+        cli_utils.declare(f"Updated webhook trigger '{trigger_name_or_id}'.")
+
+
+@webhook.command("list", help="List available webhook triggers.")
+@click.option(
+    "--webhook-type",
+    type=click.Choice(WebhookType.values()),
+    help="Filter by compatible webhook provider type.",
+)
+@click.option(
+    "--webhook-integration-id",
+    type=UUID,
+    help="Filter by webhook integration ID.",
+)
+@cli_utils.list_options(
+    TriggerFilter,
+    default_columns=[
+        "id",
+        "name",
+        "active",
+        "webhook_integration_id",
+        "concurrency",
+    ],
+)
+def list_webhook_triggers(
+    columns: str,
+    output_format: cli_utils.OutputFormat,
+    webhook_type: str | None,
+    webhook_integration_id: UUID | None,
+    **kwargs: Any,
+) -> None:
+    """List webhook triggers that fulfill the filter requirements.
+
+    Args:
+        columns: Columns to display in output.
+        output_format: Format for output.
+        webhook_type: Filter by compatible webhook provider type.
+        webhook_integration_id: Filter by webhook integration ID.
+        **kwargs: Additional trigger filters.
+    """
+    with console.status("Listing triggers...\n"):
+        triggers = Client().list_webhook_triggers(
+            webhook_type=(
+                WebhookType(webhook_type) if webhook_type is not None else None
+            ),
+            webhook_integration_id=webhook_integration_id,
+            **kwargs,
+        )
+    cli_utils.print_page(
+        triggers,
+        columns,
+        output_format,
+        empty_message="No triggers found for the given filters.",
+    )
+
+
 for group, tr_type in [
     (schedule, TriggerType.SCHEDULE),
     (platform_event, TriggerType.PLATFORM_EVENT),
+    (webhook, TriggerType.WEBHOOK),
 ]:
     group.add_command(make_delete_command(tr_type))
     group.add_command(make_attach_command(tr_type))

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -62,7 +62,6 @@ from zenml.constants import (
     handle_bool_env_var,
 )
 from zenml.enums import (
-    WEBHOOK_TRIGGER_FLAVOR_TO_TYPE,
     WEBHOOK_TYPE_TO_TRIGGER_FLAVOR,
     ColorVariants,
     CuratedVisualizationSize,
@@ -4816,30 +4815,24 @@ class Client(metaclass=ClientMetaClass):
             trigger_name_id_or_prefix=trigger_name_id_or_prefix,
             allow_name_prefix_match=False,
         )
-        update_values: dict[str, Any] = {}
+        webhook_integration_id = trigger.webhook_integration_id
         if webhook_integration is not None:
             integration = self.get_webhook(webhook_integration)
-            expected_type = WEBHOOK_TRIGGER_FLAVOR_TO_TYPE[trigger.flavor]
-            if integration.webhook_type != expected_type:
-                raise IllegalOperationError(
-                    f"The {trigger.flavor.value} trigger flavor requires a "
-                    f"{expected_type.value} webhook integration."
-                )
-            update_values["webhook_integration_id"] = integration.id
+            webhook_integration_id = integration.id
         elif detach_webhook_integration:
-            update_values["webhook_integration_id"] = None
+            webhook_integration_id = None
 
         response = self.zen_store.update_trigger(
             trigger_id=trigger.id,
             trigger_update=WebhookTriggerUpdate(
-                name=name or trigger.name,
+                name=name if name is not None else trigger.name,
                 active=active if active is not None else trigger.active,
                 concurrency=(
                     concurrency
                     if concurrency is not None
                     else trigger.concurrency
                 ),
-                **update_values,
+                webhook_integration_id=webhook_integration_id,
             ),
         )
         assert isinstance(response, WebhookTriggerResponse)

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -62,6 +62,8 @@ from zenml.constants import (
     handle_bool_env_var,
 )
 from zenml.enums import (
+    WEBHOOK_TRIGGER_FLAVOR_TO_TYPE,
+    WEBHOOK_TYPE_TO_TRIGGER_FLAVOR,
     ColorVariants,
     CuratedVisualizationSize,
     LogicalOperators,
@@ -223,6 +225,9 @@ from zenml.models import (
     WebhookIntegrationRotateSecretRequest,
     WebhookIntegrationSecretResponse,
     WebhookIntegrationUpdate,
+    WebhookTriggerRequest,
+    WebhookTriggerResponse,
+    WebhookTriggerUpdate,
 )
 from zenml.models.v2.base.filter import (
     DatetimeFilterOption,
@@ -4715,6 +4720,277 @@ class Client(metaclass=ClientMetaClass):
                 size=size,
                 logical_operator=logical_operator,
                 next_occurrence=None,
+                pipeline_id=pipeline_ids,
+                snapshot_id=snapshot_ids,
+            ),
+            hydrate=hydrate,
+        )
+
+    def create_webhook_trigger(
+        self,
+        name: str,
+        webhook_type: WebhookType,
+        webhook_integration: str | UUID | None = None,
+        project_id: str | UUID | None = None,
+        active: bool = True,
+        concurrency: TriggerRunConcurrency = TriggerRunConcurrency.SKIP,
+    ) -> WebhookTriggerResponse:
+        """Create a webhook trigger.
+
+        Args:
+            name: The trigger name.
+            webhook_type: The compatible webhook provider type.
+            webhook_integration: Optional integration name, ID, or ID prefix.
+            project_id: The project ID.
+            active: Whether the trigger should be active. Detached triggers
+                are always created inactive.
+            concurrency: The trigger run concurrency behavior.
+
+        Returns:
+            The created webhook trigger.
+
+        Raises:
+            IllegalOperationError: If the integration type is incompatible.
+        """
+        integration_id = None
+        if webhook_integration is not None:
+            integration = self.get_webhook(
+                webhook_integration,
+                project=project_id,
+            )
+            if integration.webhook_type != webhook_type:
+                raise IllegalOperationError(
+                    f"A {webhook_type.value} webhook trigger requires a "
+                    f"{webhook_type.value} webhook integration."
+                )
+            integration_id = integration.id
+
+        trigger = self.zen_store.create_trigger(
+            trigger=WebhookTriggerRequest(
+                project=project_id or self.active_project.id,
+                name=name,
+                flavor=WEBHOOK_TYPE_TO_TRIGGER_FLAVOR[webhook_type],
+                active=active,
+                concurrency=concurrency,
+                webhook_integration_id=integration_id,
+            )
+        )
+        assert isinstance(trigger, WebhookTriggerResponse)
+        return trigger
+
+    def update_webhook_trigger(
+        self,
+        trigger_name_id_or_prefix: Union[str, UUID],
+        name: str | None = None,
+        active: bool | None = None,
+        concurrency: TriggerRunConcurrency | None = None,
+        webhook_integration: str | UUID | None = None,
+        detach_webhook_integration: bool = False,
+    ) -> WebhookTriggerResponse:
+        """Update a webhook trigger.
+
+        Args:
+            trigger_name_id_or_prefix: The trigger name, ID, or ID prefix.
+            name: The new trigger name.
+            active: The new active state.
+            concurrency: The new trigger run concurrency behavior.
+            webhook_integration: A replacement integration name, ID, or ID
+                prefix.
+            detach_webhook_integration: Whether to clear the integration
+                association and deactivate the trigger.
+
+        Returns:
+            The updated webhook trigger.
+
+        Raises:
+            IllegalOperationError: If conflicting association changes are
+                requested or the integration type is incompatible.
+        """
+        if webhook_integration is not None and detach_webhook_integration:
+            raise IllegalOperationError(
+                "Can not attach and detach a webhook integration in the same "
+                "update."
+            )
+
+        trigger = self.get_webhook_trigger(
+            trigger_name_id_or_prefix=trigger_name_id_or_prefix,
+            allow_name_prefix_match=False,
+        )
+        update_values: dict[str, Any] = {}
+        if webhook_integration is not None:
+            integration = self.get_webhook(webhook_integration)
+            expected_type = WEBHOOK_TRIGGER_FLAVOR_TO_TYPE[trigger.flavor]
+            if integration.webhook_type != expected_type:
+                raise IllegalOperationError(
+                    f"The {trigger.flavor.value} trigger flavor requires a "
+                    f"{expected_type.value} webhook integration."
+                )
+            update_values["webhook_integration_id"] = integration.id
+        elif detach_webhook_integration:
+            update_values["webhook_integration_id"] = None
+
+        response = self.zen_store.update_trigger(
+            trigger_id=trigger.id,
+            trigger_update=WebhookTriggerUpdate(
+                name=name or trigger.name,
+                active=active if active is not None else trigger.active,
+                concurrency=(
+                    concurrency
+                    if concurrency is not None
+                    else trigger.concurrency
+                ),
+                **update_values,
+            ),
+        )
+        assert isinstance(response, WebhookTriggerResponse)
+        return response
+
+    def get_webhook_trigger(
+        self,
+        trigger_name_id_or_prefix: Union[str, UUID],
+        allow_name_prefix_match: bool = True,
+        project: Optional[Union[str, UUID]] = None,
+        hydrate: bool = True,
+        is_archived: bool = False,
+    ) -> WebhookTriggerResponse:
+        """Retrieve a webhook trigger by name, ID, or prefix.
+
+        Args:
+            trigger_name_id_or_prefix: The trigger name, ID, or ID prefix.
+            allow_name_prefix_match: Whether to allow name prefix matching.
+            project: The project name or ID.
+            hydrate: Whether to hydrate the response.
+            is_archived: Whether to search archived triggers.
+
+        Returns:
+            The webhook trigger.
+
+        Raises:
+            ValueError: If the resolved trigger has an incompatible type.
+        """
+
+        def _get_webhook_trigger_by_id(
+            trigger_id: UUID, hydrate: bool = True
+        ) -> WebhookTriggerResponse:
+            trigger = self.zen_store.get_trigger(
+                trigger_id=trigger_id,
+                hydrate=hydrate,
+            )
+            if (
+                not isinstance(trigger, WebhookTriggerResponse)
+                or trigger.is_archived != is_archived
+            ):
+                raise KeyError(
+                    f"No webhook trigger found for ID `{trigger_id}`."
+                )
+            return trigger
+
+        list_method = cast(
+            Callable[..., Page[WebhookTriggerResponse]],
+            functools.partial(
+                self.list_webhook_triggers,
+                is_archived=is_archived,
+            ),
+        )
+        trigger = self._get_entity_by_id_or_name_or_prefix(
+            get_method=_get_webhook_trigger_by_id,
+            list_method=list_method,
+            name_id_or_prefix=trigger_name_id_or_prefix,
+            allow_name_prefix_match=allow_name_prefix_match,
+            project=project,
+            hydrate=hydrate,
+        )
+        if not isinstance(trigger, WebhookTriggerResponse):
+            raise ValueError(
+                f"Found trigger {trigger.id} of incompatible type "
+                f"(expected {TriggerType.WEBHOOK})."
+            )
+        return trigger
+
+    def list_webhook_triggers(
+        self,
+        sort_by: str = "created",
+        page: int = PAGINATION_STARTING_PAGE,
+        size: int = PAGE_SIZE_DEFAULT,
+        logical_operator: LogicalOperators = LogicalOperators.AND,
+        user: UUIDFilterOption = None,
+        project: Optional[Union[str, UUID]] = None,
+        id: UUIDFilterOption = None,
+        created: DatetimeFilterOption = None,
+        updated: DatetimeFilterOption = None,
+        name: StringFilterOption = None,
+        active: bool | None = None,
+        concurrency: EnumFilterOption[TriggerRunConcurrency] = None,
+        is_archived: bool = False,
+        webhook_type: WebhookType | None = None,
+        webhook_integration_id: UUIDFilterOption = None,
+        pipeline_id: UUIDFilterOption = None,
+        snapshot_id: UUIDFilterOption = None,
+        hydrate: bool = True,
+    ) -> Page[WebhookTriggerResponse]:
+        """List webhook triggers.
+
+        Args:
+            sort_by: The column to sort by.
+            page: The page of items.
+            size: The maximum page size.
+            logical_operator: The operator used to combine filters.
+            user: Filter by creating user.
+            project: Filter by project name or ID.
+            id: Filter by trigger ID.
+            created: Filter by creation time.
+            updated: Filter by update time.
+            name: Filter by trigger name.
+            active: Filter by active state.
+            concurrency: Filter by concurrency behavior.
+            is_archived: Filter by archived state.
+            webhook_type: Filter by compatible webhook provider type.
+            webhook_integration_id: Filter by webhook integration ID.
+            pipeline_id: Filter by pipeline with attached snapshots.
+            snapshot_id: Filter by attached snapshot.
+            hydrate: Whether to hydrate responses.
+
+        Returns:
+            A page of webhook triggers.
+        """
+        pipeline_ids = None
+        if pipeline_id is not None:
+            pipeline_ids = (
+                [str(value) for value in pipeline_id]
+                if isinstance(pipeline_id, list)
+                else [str(pipeline_id)]
+            )
+        snapshot_ids = None
+        if snapshot_id is not None:
+            snapshot_ids = (
+                [str(value) for value in snapshot_id]
+                if isinstance(snapshot_id, list)
+                else [str(snapshot_id)]
+            )
+
+        flavor = (
+            WEBHOOK_TYPE_TO_TRIGGER_FLAVOR[webhook_type]
+            if webhook_type is not None
+            else None
+        )
+        return self.zen_store.list_triggers(  # type: ignore[return-value]
+            triggers_filter_model=TriggerFilter(
+                project=project or self.active_project.id,
+                user=user,
+                id=id,
+                created=created,
+                updated=updated,
+                name=name,
+                active=active,
+                concurrency=concurrency,
+                is_archived=is_archived,
+                flavor=flavor,
+                type=TriggerType.WEBHOOK,
+                sort_by=sort_by,
+                page=page,
+                size=size,
+                logical_operator=logical_operator,
+                webhook_integration_id=webhook_integration_id,
                 pipeline_id=pipeline_ids,
                 snapshot_id=snapshot_ids,
             ),

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -676,6 +676,7 @@ class TriggerType(StrEnum):
 
     SCHEDULE = "schedule"
     PLATFORM_EVENT = "platform_event"
+    WEBHOOK = "webhook"
 
 
 class TriggerFlavor(StrEnum):
@@ -683,6 +684,8 @@ class TriggerFlavor(StrEnum):
 
     NATIVE_SCHEDULE = "native schedule"
     PLATFORM_EVENT = "platform event"
+    GITHUB_WEBHOOK = "github webhook"
+    CUSTOM_WEBHOOK = "custom webhook"
 
 
 class TriggerRunConcurrency(StrEnum):
@@ -697,6 +700,16 @@ class WebhookType(StrEnum):
 
     GITHUB = "github"
     CUSTOM = "custom"
+
+
+WEBHOOK_TRIGGER_FLAVOR_TO_TYPE: dict[TriggerFlavor, WebhookType] = {
+    TriggerFlavor.GITHUB_WEBHOOK: WebhookType.GITHUB,
+    TriggerFlavor.CUSTOM_WEBHOOK: WebhookType.CUSTOM,
+}
+WEBHOOK_TYPE_TO_TRIGGER_FLAVOR: dict[WebhookType, TriggerFlavor] = {
+    webhook_type: flavor
+    for flavor, webhook_type in WEBHOOK_TRIGGER_FLAVOR_TO_TYPE.items()
+}
 
 
 class ContainerEngineType(StrEnum):

--- a/src/zenml/models/__init__.py
+++ b/src/zenml/models/__init__.py
@@ -423,6 +423,11 @@ from zenml.models.v2.core.triggers import (
     TriggerResponseResources,
     TriggerSnapshotDispatchState,
     TriggerUpdate,
+    WebhookTrigger,
+    WebhookTriggerRequest,
+    WebhookTriggerResponse,
+    WebhookTriggerResponseBody,
+    WebhookTriggerUpdate,
 )
 from zenml.models.v2.core.user import (
     UserFilter,
@@ -657,6 +662,11 @@ PlatformEventTriggerRequest.model_rebuild()
 PlatformEventTriggerUpdate.model_rebuild()
 PlatformEventTriggerResponse.model_rebuild()
 PlatformEventTriggerResponseBody.model_rebuild()
+WebhookTrigger.model_rebuild()
+WebhookTriggerRequest.model_rebuild()
+WebhookTriggerUpdate.model_rebuild()
+WebhookTriggerResponse.model_rebuild()
+WebhookTriggerResponseBody.model_rebuild()
 WebhookIntegrationResponseBody.model_rebuild()
 WebhookIntegrationStats.model_rebuild()
 WebhookIntegrationResponseMetadata.model_rebuild()
@@ -1041,6 +1051,11 @@ __all__ = [
     "PlatformEventTriggerResponse",
     "PlatformEventTriggerResponseBody",
     "PlatformEventTrigger",
+    "WebhookTrigger",
+    "WebhookTriggerRequest",
+    "WebhookTriggerUpdate",
+    "WebhookTriggerResponse",
+    "WebhookTriggerResponseBody",
     "TRIGGER_UPDATE_TYPE_UNION",
     "TRIGGER_CREATE_TYPE_UNION",
     "TRIGGER_RETURN_TYPE_UNION",

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -35,10 +35,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from zenml.constants import STR_FIELD_MAX_LENGTH
 from zenml.enums import (
     PLATFORM_EVENT_REGISTRY,
+    WEBHOOK_TRIGGER_FLAVOR_TO_TYPE,
     SourceType,
     TriggerFlavor,
     TriggerRunConcurrency,
     TriggerType,
+    WebhookType,
 )
 from zenml.models.v2.base.base import BaseUpdate
 from zenml.models.v2.base.filter import (
@@ -47,6 +49,7 @@ from zenml.models.v2.base.filter import (
     DatetimeFilterOption,
     EnumFilterOption,
     StringFilterOption,
+    UUIDFilterOption,
 )
 from zenml.models.v2.base.scoped import (
     ProjectScopedFilter,
@@ -409,6 +412,10 @@ class UnScopedTriggerFilter(BaseFilter):
     concurrency: EnumFilterOption[TriggerRunConcurrency] = Field(
         default=None, description="The trigger concurrency."
     )
+    webhook_integration_id: UUIDFilterOption = Field(
+        default=None,
+        description="The webhook integration associated with the trigger.",
+    )
 
     def apply_filter(
         self,
@@ -455,6 +462,7 @@ class TriggerFilter(UnScopedTriggerFilter, ProjectScopedFilter):
         "type",
         "flavor",
         "next_occurrence",
+        "webhook_integration_id",
     ]
     API_SINGLE_INPUT_PARAMS: ClassVar[list[str]] = [
         *UnScopedTriggerFilter.API_SINGLE_INPUT_PARAMS,
@@ -1078,6 +1086,112 @@ class PlatformEventTriggerResponse(
         return self.get_body().target_events
 
 
+# ----------- WEBHOOK CLASSES ------------------- #
+
+
+class WebhookTrigger(BaseModel):
+    """Base class for webhook-specific parameters."""
+
+    webhook_integration_id: UUID | None = None
+
+
+class WebhookTriggerRequest(TriggerRequest, WebhookTrigger):
+    """Class representing a webhook trigger request."""
+
+    type: Literal[TriggerType.WEBHOOK] = TriggerType.WEBHOOK
+    flavor: Literal[
+        TriggerFlavor.GITHUB_WEBHOOK,
+        TriggerFlavor.CUSTOM_WEBHOOK,
+    ]
+
+    @model_validator(mode="after")
+    def deactivate_detached_trigger(self) -> "WebhookTriggerRequest":
+        """Ensure a detached webhook trigger is inactive.
+
+        Returns:
+            The validated webhook trigger request.
+        """
+        if self.webhook_integration_id is None:
+            self.active = False
+        return self
+
+    def get_config(self) -> str:
+        """Return the serialized webhook trigger configuration.
+
+        Returns:
+            An empty JSON object. The integration association is stored in a
+            dedicated database column.
+        """
+        return "{}"
+
+    def get_extra_fields(self) -> dict[str, Any]:
+        """Return flat webhook trigger fields.
+
+        Returns:
+            The webhook integration association.
+        """
+        return {"webhook_integration_id": self.webhook_integration_id}
+
+
+class WebhookTriggerUpdate(TriggerUpdate, WebhookTrigger):
+    """Class representing a webhook trigger update."""
+
+    type: Literal[TriggerType.WEBHOOK] = TriggerType.WEBHOOK
+
+    def get_config(self) -> str:
+        """Return the serialized webhook trigger configuration.
+
+        Returns:
+            An empty JSON object. The integration association is stored in a
+            dedicated database column.
+        """
+        return "{}"
+
+    def get_extra_fields(self) -> dict[str, Any]:
+        """Return explicitly updated flat webhook trigger fields.
+
+        Returns:
+            The webhook integration association when it was explicitly set.
+        """
+        if "webhook_integration_id" not in self.model_fields_set:
+            return {}
+        return {"webhook_integration_id": self.webhook_integration_id}
+
+
+class WebhookTriggerResponseBody(WebhookTrigger, TriggerResponseBody):
+    """Class representing a webhook trigger response body."""
+
+    def get_extra_fields(self) -> list[str]:
+        """Return flat fields required for the response.
+
+        Returns:
+            The webhook integration association field.
+        """
+        return ["webhook_integration_id"]
+
+
+class WebhookTriggerResponse(TriggerResponse[WebhookTriggerResponseBody,]):
+    """Class representing a webhook trigger response."""
+
+    @property
+    def webhook_integration_id(self) -> UUID | None:
+        """Return the associated webhook integration ID.
+
+        Returns:
+            The associated webhook integration ID, if any.
+        """
+        return self.get_body().webhook_integration_id
+
+    @property
+    def webhook_type(self) -> WebhookType:
+        """Return the compatible webhook integration type.
+
+        Returns:
+            The compatible webhook integration type.
+        """
+        return WEBHOOK_TRIGGER_FLAVOR_TO_TYPE[self.flavor]
+
+
 class TriggerExecutionInfo(BaseModel):
     """Class representing a trigger execution information."""
 
@@ -1086,13 +1200,17 @@ class TriggerExecutionInfo(BaseModel):
 
 
 TRIGGER_UPDATE_TYPE_UNION: TypeAlias = Annotated[
-    ScheduleTriggerUpdate | PlatformEventTriggerUpdate,
+    ScheduleTriggerUpdate | PlatformEventTriggerUpdate | WebhookTriggerUpdate,
     Field(discriminator="type"),
 ]
 TRIGGER_CREATE_TYPE_UNION: TypeAlias = Annotated[
-    ScheduleTriggerRequest | PlatformEventTriggerRequest,
+    ScheduleTriggerRequest
+    | PlatformEventTriggerRequest
+    | WebhookTriggerRequest,
     Field(discriminator="type"),
 ]
 TRIGGER_RETURN_TYPE_UNION: TypeAlias = (
-    ScheduleTriggerResponse | PlatformEventTriggerResponse
+    ScheduleTriggerResponse
+    | PlatformEventTriggerResponse
+    | WebhookTriggerResponse
 )

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -247,6 +247,7 @@ if TYPE_CHECKING:
         PipelineRunResponse,
         PipelineSnapshotResponse,
         UserResponse,
+        WebhookIntegrationResponse,
     )
     from zenml.models.v2.base.filter import AnySchema
 
@@ -360,6 +361,7 @@ class TriggerResponseResources(ProjectScopedResponseResources):
     executable_snapshots: list["PipelineSnapshotResponse"] = []
     user: Optional["UserResponse"] = None
     latest_run: Optional["PipelineRunResponse"] = None
+    webhook_integration: Optional["WebhookIntegrationResponse"] = None
     snapshot_dispatch_states: dict[UUID, TriggerSnapshotDispatchState] = Field(
         default_factory=dict
     )
@@ -1138,6 +1140,30 @@ class WebhookTriggerUpdate(TriggerUpdate, WebhookTrigger):
 
     type: Literal[TriggerType.WEBHOOK] = TriggerType.WEBHOOK
 
+    @model_validator(mode="after")
+    def validate_complete_update(self) -> "WebhookTriggerUpdate":
+        """Ensure webhook trigger updates preserve PUT semantics.
+
+        Returns:
+            The validated webhook trigger update.
+
+        Raises:
+            ValueError: If any mutable trigger field was omitted.
+        """
+        required_fields = {
+            "name",
+            "active",
+            "concurrency",
+            "webhook_integration_id",
+        }
+        missing_fields = required_fields - self.model_fields_set
+        if missing_fields:
+            raise ValueError(
+                "Webhook trigger updates must include all mutable fields. "
+                f"Missing: {', '.join(sorted(missing_fields))}."
+            )
+        return self
+
     def get_config(self) -> str:
         """Return the serialized webhook trigger configuration.
 
@@ -1179,6 +1205,15 @@ class WebhookTriggerResponse(TriggerResponse[WebhookTriggerResponseBody,]):
             The associated webhook integration ID, if any.
         """
         return self.get_body().webhook_integration_id
+
+    @property
+    def webhook_integration(self) -> Optional["WebhookIntegrationResponse"]:
+        """Return the associated webhook integration.
+
+        Returns:
+            The associated webhook integration, if any.
+        """
+        return self.get_resources().webhook_integration
 
     @property
     def webhook_type(self) -> WebhookType:

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -1148,13 +1148,11 @@ class WebhookTriggerUpdate(TriggerUpdate, WebhookTrigger):
         return "{}"
 
     def get_extra_fields(self) -> dict[str, Any]:
-        """Return explicitly updated flat webhook trigger fields.
+        """Return flat webhook trigger fields.
 
         Returns:
-            The webhook integration association when it was explicitly set.
+            The webhook integration association.
         """
-        if "webhook_integration_id" not in self.model_fields_set:
-            return {}
         return {"webhook_integration_id": self.webhook_integration_id}
 
 

--- a/src/zenml/triggers/registry.py
+++ b/src/zenml/triggers/registry.py
@@ -19,6 +19,8 @@ from zenml.models.v2.core.triggers import (
     PlatformEventTriggerResponseBody,
     ScheduleTriggerResponse,
     ScheduleTriggerResponseBody,
+    WebhookTriggerResponse,
+    WebhookTriggerResponseBody,
 )
 
 # Type to return class mappings - should be extended with new type classes
@@ -26,13 +28,20 @@ from zenml.models.v2.core.triggers import (
 TYPE_TO_RESPONSE_BODY_MAPPING = {
     TriggerType.SCHEDULE.value: ScheduleTriggerResponseBody,
     TriggerType.PLATFORM_EVENT.value: PlatformEventTriggerResponseBody,
+    TriggerType.WEBHOOK.value: WebhookTriggerResponseBody,
 }
 
 TYPE_TO_RESPONSE_MAPPING: dict[
-    str, type[ScheduleTriggerResponse | PlatformEventTriggerResponse]
+    str,
+    type[
+        ScheduleTriggerResponse
+        | PlatformEventTriggerResponse
+        | WebhookTriggerResponse
+    ],
 ] = {
     TriggerType.SCHEDULE.value: ScheduleTriggerResponse,
     TriggerType.PLATFORM_EVENT.value: PlatformEventTriggerResponse,
+    TriggerType.WEBHOOK.value: WebhookTriggerResponse,
 }
 
 # Union type objects - should be extended with the future type classes (e.g. Webhook)

--- a/src/zenml/zen_server/rbac/utils.py
+++ b/src/zenml/zen_server/rbac/utils.py
@@ -524,6 +524,8 @@ def get_resource_type_for_model(
         TriggerRequest,
         WebhookIntegrationRequest,
         WebhookIntegrationResponse,
+        WebhookTriggerRequest,
+        WebhookTriggerResponse,
     )
 
     mapping: Dict[
@@ -585,6 +587,8 @@ def get_resource_type_for_model(
         TriggerRequest: ResourceType.TRIGGER,
         WebhookIntegrationRequest: ResourceType.WEBHOOK_INTEGRATION,
         WebhookIntegrationResponse: ResourceType.WEBHOOK_INTEGRATION,
+        WebhookTriggerRequest: ResourceType.TRIGGER,
+        WebhookTriggerResponse: ResourceType.TRIGGER,
     }
 
     return mapping.get(type(model))

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -308,9 +308,7 @@ def attach_trigger_to_snapshot(
     snapshot = zen_store().get_snapshot(snapshot_id=snapshot_id, hydrate=True)
 
     if trigger.project_id != snapshot.project_id:
-        raise IllegalOperationError(
-            "Trigger and snapshot must be in the same project"
-        )
+        raise KeyError(f"Snapshot {snapshot_id} not found.")
 
     if not snapshot.name:
         raise IllegalOperationError(

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -36,6 +36,8 @@ from zenml.models import (
     PlatformEventTriggerRequest,
     PlatformEventTriggerUpdate,
     TriggerFilter,
+    WebhookTriggerRequest,
+    WebhookTriggerUpdate,
 )
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
@@ -102,6 +104,20 @@ def verify_permissions_for_source_entity(
         raise ValueError(f"Unexpected source type: {format(source_type)}")
 
 
+def verify_permissions_for_webhook_integration(
+    webhook_integration_id: UUID,
+) -> None:
+    """Verify read permission for a webhook trigger integration.
+
+    Args:
+        webhook_integration_id: The webhook integration ID.
+    """
+    verify_permission_for_model(
+        model=zen_store().get_webhook_integration(webhook_integration_id),
+        action=Action.READ,
+    )
+
+
 @router.post(
     TRIGGERS,
     responses={401: error_response, 409: error_response, 422: error_response},
@@ -123,6 +139,13 @@ def create_trigger(
         verify_permissions_for_source_entity(
             source_type=trigger.source_entity.type,
             source_id=trigger.source_entity.id,
+        )
+    elif (
+        isinstance(trigger, WebhookTriggerRequest)
+        and trigger.webhook_integration_id is not None
+    ):
+        verify_permissions_for_webhook_integration(
+            trigger.webhook_integration_id
         )
 
     check_entitlement(feature=SCHEDULE_FEATURE)
@@ -214,6 +237,13 @@ def update_trigger(
         verify_permissions_for_source_entity(
             source_type=trigger_update.source_entity.type,
             source_id=trigger_update.source_entity.id,
+        )
+    elif (
+        isinstance(trigger_update, WebhookTriggerUpdate)
+        and trigger_update.webhook_integration_id is not None
+    ):
+        verify_permissions_for_webhook_integration(
+            trigger_update.webhook_integration_id
         )
 
     check_entitlement(feature=SCHEDULE_FEATURE)

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -294,6 +294,7 @@ def attach_trigger_to_snapshot(
 
     Raises:
         IllegalOperationError: If the trigger is already attached to the snapshot.
+        KeyError: If the trigger and snapshot belong to different projects.
     """
     trigger = zen_store().get_trigger(trigger_id=trigger_id, hydrate=True)
 

--- a/src/zenml/zen_server/routers/trigger_endpoints.py
+++ b/src/zenml/zen_server/routers/trigger_endpoints.py
@@ -104,20 +104,6 @@ def verify_permissions_for_source_entity(
         raise ValueError(f"Unexpected source type: {format(source_type)}")
 
 
-def verify_permissions_for_webhook_integration(
-    webhook_integration_id: UUID,
-) -> None:
-    """Verify read permission for a webhook trigger integration.
-
-    Args:
-        webhook_integration_id: The webhook integration ID.
-    """
-    verify_permission_for_model(
-        model=zen_store().get_webhook_integration(webhook_integration_id),
-        action=Action.READ,
-    )
-
-
 @router.post(
     TRIGGERS,
     responses={401: error_response, 409: error_response, 422: error_response},
@@ -144,8 +130,11 @@ def create_trigger(
         isinstance(trigger, WebhookTriggerRequest)
         and trigger.webhook_integration_id is not None
     ):
-        verify_permissions_for_webhook_integration(
-            trigger.webhook_integration_id
+        verify_permission_for_model(
+            model=zen_store().get_webhook_integration(
+                trigger.webhook_integration_id
+            ),
+            action=Action.READ,
         )
 
     check_entitlement(feature=SCHEDULE_FEATURE)
@@ -242,8 +231,11 @@ def update_trigger(
         isinstance(trigger_update, WebhookTriggerUpdate)
         and trigger_update.webhook_integration_id is not None
     ):
-        verify_permissions_for_webhook_integration(
-            trigger_update.webhook_integration_id
+        verify_permission_for_model(
+            model=zen_store().get_webhook_integration(
+                trigger_update.webhook_integration_id
+            ),
+            action=Action.READ,
         )
 
     check_entitlement(feature=SCHEDULE_FEATURE)

--- a/src/zenml/zen_stores/migrations/versions/7c0d9e4a1b2f_add_webhook_integrations.py
+++ b/src/zenml/zen_stores/migrations/versions/7c0d9e4a1b2f_add_webhook_integrations.py
@@ -14,7 +14,7 @@
 """Add webhook integrations [7c0d9e4a1b2f].
 
 Revision ID: 7c0d9e4a1b2f
-Revises: b6f2a8d9c3e1
+Revises: 0.96.2
 Create Date: 2026-07-07
 
 """
@@ -24,7 +24,7 @@ import sqlmodel
 from alembic import op
 
 revision = "7c0d9e4a1b2f"
-down_revision = "b6f2a8d9c3e1"
+down_revision = "0.96.2"
 branch_labels = None
 depends_on = None
 

--- a/src/zenml/zen_stores/migrations/versions/e4b8f2c7a913_add_webhook_triggers.py
+++ b/src/zenml/zen_stores/migrations/versions/e4b8f2c7a913_add_webhook_triggers.py
@@ -1,0 +1,46 @@
+"""Add webhook triggers [e4b8f2c7a913].
+
+Revision ID: e4b8f2c7a913
+Revises: 7c0d9e4a1b2f
+Create Date: 2026-07-15
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e4b8f2c7a913"
+down_revision = "7c0d9e4a1b2f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the webhook integration association to triggers."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("webhook_integration_id", sa.Uuid(), nullable=True)
+        )
+        batch_op.create_foreign_key(
+            "fk_trigger_webhook_integration_id_webhook_integration",
+            "webhook_integration",
+            ["webhook_integration_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_index(
+            "ix_trigger_type_webhook_integration_id",
+            ["type", "webhook_integration_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Remove the webhook integration association from triggers."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.drop_index("ix_trigger_type_webhook_integration_id")
+        batch_op.drop_constraint(
+            "fk_trigger_webhook_integration_id_webhook_integration",
+            type_="foreignkey",
+        )
+        batch_op.drop_column("webhook_integration_id")

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -315,6 +315,7 @@ from zenml.models import (
     WebhookIntegrationRotateSecretRequest,
     WebhookIntegrationSecretResponse,
     WebhookIntegrationUpdate,
+    WebhookTriggerUpdate,
 )
 from zenml.service_connectors.service_connector_registry import (
     service_connector_registry,
@@ -2796,7 +2797,7 @@ class RestZenStore(BaseZenStore):
             f"{TRIGGERS}/{trigger_id}",
             body=trigger_update,
             params=None,
-            exclude_unset=False,
+            exclude_unset=isinstance(trigger_update, WebhookTriggerUpdate),
         )
         try:
             response_model = TYPE_TO_RESPONSE_MAPPING[body["body"]["type"]]

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -315,7 +315,6 @@ from zenml.models import (
     WebhookIntegrationRotateSecretRequest,
     WebhookIntegrationSecretResponse,
     WebhookIntegrationUpdate,
-    WebhookTriggerUpdate,
 )
 from zenml.service_connectors.service_connector_registry import (
     service_connector_registry,
@@ -2797,7 +2796,7 @@ class RestZenStore(BaseZenStore):
             f"{TRIGGERS}/{trigger_id}",
             body=trigger_update,
             params=None,
-            exclude_unset=isinstance(trigger_update, WebhookTriggerUpdate),
+            exclude_unset=False,
         )
         try:
             response_model = TYPE_TO_RESPONSE_MAPPING[body["body"]["type"]]

--- a/src/zenml/zen_stores/schemas/trigger_schemas.py
+++ b/src/zenml/zen_stores/schemas/trigger_schemas.py
@@ -247,6 +247,7 @@ class TriggerSchema(NamedSchema, table=True):
                         jl_arg(PipelineSnapshotSchema.source_snapshot)
                     ),
                     selectinload(jl_arg(TriggerSchema.snapshot_links)),
+                    selectinload(jl_arg(TriggerSchema.webhook_integration)),
                 ]
             )
 
@@ -385,6 +386,9 @@ class TriggerSchema(NamedSchema, table=True):
                 executable_snapshots=executable_snapshots,
                 latest_run=latest_run.to_model()
                 if latest_run is not None
+                else None,
+                webhook_integration=self.webhook_integration.to_model()
+                if self.webhook_integration is not None
                 else None,
                 snapshot_dispatch_states=snapshot_dispatch_states,
             )

--- a/src/zenml/zen_stores/schemas/trigger_schemas.py
+++ b/src/zenml/zen_stores/schemas/trigger_schemas.py
@@ -56,10 +56,13 @@ from zenml.zen_stores.schemas.user_schemas import UserSchema
 from zenml.zen_stores.schemas.utils import (
     jl_arg,
 )
+from zenml.zen_stores.schemas.webhook_integration_schemas import (
+    WebhookIntegrationSchema,
+)
 
 
 class TriggerSchema(NamedSchema, table=True):
-    """SQL Model for schedules."""
+    """SQL model for triggers."""
 
     __tablename__ = "trigger"
     __table_args__ = (
@@ -81,6 +84,10 @@ class TriggerSchema(NamedSchema, table=True):
         build_index(
             table_name=__tablename__,
             column_names=["flavor", "source_entity"],
+        ),
+        build_index(
+            table_name=__tablename__,
+            column_names=["type", "webhook_integration_id"],
         ),
     )
 
@@ -148,6 +155,18 @@ class TriggerSchema(NamedSchema, table=True):
     )
 
     user: UserSchema | None = Relationship(back_populates="triggers")
+
+    webhook_integration_id: UUID | None = build_foreign_key_field(
+        source=__tablename__,
+        target=WebhookIntegrationSchema.__tablename__,
+        source_column="webhook_integration_id",
+        target_column="id",
+        ondelete="SET NULL",
+        nullable=True,
+    )
+    webhook_integration: WebhookIntegrationSchema | None = Relationship(
+        back_populates="triggers"
+    )
 
     # ------------------ FLAT DATA FIELDS FOR FAST FILTERING ----------------------
 

--- a/src/zenml/zen_stores/schemas/webhook_integration_schemas.py
+++ b/src/zenml/zen_stores/schemas/webhook_integration_schemas.py
@@ -14,7 +14,7 @@
 """SQL schemas for webhook integrations."""
 
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any, Sequence, TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import TEXT, Column, UniqueConstraint
@@ -42,6 +42,9 @@ from zenml.zen_stores.schemas.schema_utils import (
 from zenml.zen_stores.schemas.secret_schemas import SecretSchema
 from zenml.zen_stores.schemas.user_schemas import UserSchema
 from zenml.zen_stores.schemas.utils import jl_arg
+
+if TYPE_CHECKING:
+    from zenml.zen_stores.schemas.trigger_schemas import TriggerSchema
 
 
 class WebhookIntegrationSchema(NamedSchema, table=True):
@@ -80,6 +83,9 @@ class WebhookIntegrationSchema(NamedSchema, table=True):
         nullable=True,
     )
     user: UserSchema | None = Relationship()
+    triggers: list["TriggerSchema"] = Relationship(
+        back_populates="webhook_integration"
+    )
     secret_id: UUID = build_foreign_key_field(
         source=__tablename__,
         target=SecretSchema.__tablename__,

--- a/src/zenml/zen_stores/schemas/webhook_integration_schemas.py
+++ b/src/zenml/zen_stores/schemas/webhook_integration_schemas.py
@@ -14,7 +14,7 @@
 """SQL schemas for webhook integrations."""
 
 from datetime import datetime
-from typing import Any, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Sequence
 from uuid import UUID
 
 from sqlalchemy import TEXT, Column, UniqueConstraint

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -8491,8 +8491,10 @@ class SqlZenStore(BaseZenStore):
             session: The active database session.
 
         Raises:
-            IllegalOperationError: If the association crosses projects or the
-                integration type is incompatible with the trigger flavor.
+            KeyError: If the integration does not belong to the trigger
+                project.
+            IllegalOperationError: If the integration type is incompatible
+                with the trigger flavor.
         """
         integration = self._get_schema_by_id(
             resource_id=webhook_integration_id,
@@ -8500,9 +8502,8 @@ class SqlZenStore(BaseZenStore):
             session=session,
         )
         if integration.project_id != project_id:
-            raise IllegalOperationError(
-                "Webhook triggers and integrations must be in the same "
-                "project."
+            raise KeyError(
+                f"Webhook integration {webhook_integration_id} not found."
             )
 
         expected_type = WEBHOOK_TRIGGER_FLAVOR_TO_TYPE[flavor]
@@ -8765,15 +8766,18 @@ class SqlZenStore(BaseZenStore):
             if not snapshot:
                 raise KeyError(f"Snapshot {snapshot_id} doesn't exist.")
 
-            if not snapshot.is_runnable:
-                raise IllegalOperationError(
-                    f"Can not attach trigger {trigger_id} to non-runnable snapshot {snapshot_id}"
-                )
-
             trigger = session.get(TriggerSchema, trigger_id)
 
             if not trigger:
                 raise KeyError(f"Trigger {trigger_id} doesn't exist.")
+
+            if trigger.project_id != snapshot.project_id:
+                raise KeyError(f"Snapshot {snapshot_id} doesn't exist.")
+
+            if not snapshot.is_runnable:
+                raise IllegalOperationError(
+                    f"Can not attach trigger {trigger_id} to non-runnable snapshot {snapshot_id}"
+                )
 
             if trigger.is_archived:
                 raise IllegalOperationError(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -159,6 +159,7 @@ from zenml.constants import (
     is_true_string_value,
 )
 from zenml.enums import (
+    WEBHOOK_TRIGGER_FLAVOR_TO_TYPE,
     ArtifactSaveType,
     AuthScheme,
     DatabaseBackupStrategy,
@@ -180,6 +181,8 @@ from zenml.enums import (
     StepRunInputArtifactType,
     StoreType,
     TaggableResourceTypes,
+    TriggerFlavor,
+    TriggerType,
     VisualizationResourceTypes,
     WebhookType,
 )
@@ -384,6 +387,8 @@ from zenml.models import (
     WebhookIntegrationRotateSecretRequest,
     WebhookIntegrationSecretResponse,
     WebhookIntegrationUpdate,
+    WebhookTriggerRequest,
+    WebhookTriggerUpdate,
 )
 from zenml.service_connectors.service_connector_registry import (
     service_connector_registry,
@@ -8314,7 +8319,7 @@ class SqlZenStore(BaseZenStore):
             )
 
     def delete_webhook_integration(self, integration_id: UUID) -> None:
-        """Delete a webhook integration and its internal secret.
+        """Delete a webhook integration and deactivate its triggers.
 
         Args:
             integration_id: The webhook integration ID.
@@ -8326,6 +8331,17 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
             secret_id = schema.secret_id
+            session.exec(
+                update(TriggerSchema)
+                .where(
+                    col(TriggerSchema.webhook_integration_id) == integration_id
+                )
+                .values(
+                    active=False,
+                    webhook_integration_id=None,
+                    updated=utc_now(),
+                )
+            )
             session.delete(schema)
             session.commit()
             self._delete_secret_schema(secret_id=secret_id, session=session)
@@ -8458,6 +8474,44 @@ class SqlZenStore(BaseZenStore):
 
     # -------------------- Triggers ---------------------
 
+    def _validate_webhook_trigger_integration(
+        self,
+        *,
+        webhook_integration_id: UUID,
+        project_id: UUID,
+        flavor: TriggerFlavor,
+        session: Session,
+    ) -> None:
+        """Validate a webhook trigger integration association.
+
+        Args:
+            webhook_integration_id: The integration to associate.
+            project_id: The trigger project.
+            flavor: The webhook trigger flavor.
+            session: The active database session.
+
+        Raises:
+            IllegalOperationError: If the association crosses projects or the
+                integration type is incompatible with the trigger flavor.
+        """
+        integration = self._get_schema_by_id(
+            resource_id=webhook_integration_id,
+            schema_class=WebhookIntegrationSchema,
+            session=session,
+        )
+        if integration.project_id != project_id:
+            raise IllegalOperationError(
+                "Webhook triggers and integrations must be in the same "
+                "project."
+            )
+
+        expected_type = WEBHOOK_TRIGGER_FLAVOR_TO_TYPE[flavor]
+        if WebhookType(integration.webhook_type) != expected_type:
+            raise IllegalOperationError(
+                f"The {flavor.value} trigger flavor requires a "
+                f"{expected_type.value} webhook integration."
+            )
+
     @track_decorator(AnalyticsEvent.CREATED_TRIGGER)
     def create_trigger(
         self, trigger: TriggerRequest
@@ -8472,6 +8526,16 @@ class SqlZenStore(BaseZenStore):
         """
         with Session(self.engine) as session:
             self._set_request_user_id(request_model=trigger, session=session)
+            if (
+                isinstance(trigger, WebhookTriggerRequest)
+                and trigger.webhook_integration_id is not None
+            ):
+                self._validate_webhook_trigger_integration(
+                    webhook_integration_id=trigger.webhook_integration_id,
+                    project_id=trigger.project,
+                    flavor=trigger.flavor,
+                    session=session,
+                )
             self._verify_name_uniqueness(
                 resource=trigger,
                 schema=TriggerSchema,
@@ -8589,8 +8653,29 @@ class SqlZenStore(BaseZenStore):
 
             if existing_trigger.is_archived:
                 raise IllegalOperationError(
-                    "Archived schedules can not be updated."
+                    "Archived triggers can not be updated."
                 )
+
+            if existing_trigger.type != trigger_update.type.value:
+                raise IllegalOperationError(
+                    "A trigger can not be updated with a different trigger "
+                    "type."
+                )
+
+            detach_webhook_integration = False
+            if isinstance(trigger_update, WebhookTriggerUpdate):
+                if "webhook_integration_id" in trigger_update.model_fields_set:
+                    if trigger_update.webhook_integration_id is None:
+                        detach_webhook_integration = True
+                    else:
+                        self._validate_webhook_trigger_integration(
+                            webhook_integration_id=(
+                                trigger_update.webhook_integration_id
+                            ),
+                            project_id=existing_trigger.project_id,
+                            flavor=TriggerFlavor(existing_trigger.flavor),
+                            session=session,
+                        )
 
             self._verify_name_uniqueness(
                 resource=trigger_update,
@@ -8598,8 +8683,13 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
 
-            # Update the schedule
+            # Update the trigger.
             existing_trigger = existing_trigger.update(trigger_update)
+            if detach_webhook_integration or (
+                existing_trigger.type == TriggerType.WEBHOOK.value
+                and existing_trigger.webhook_integration_id is None
+            ):
+                existing_trigger.active = False
             session.add(existing_trigger)
             session.commit()
             return existing_trigger.to_model(
@@ -8636,6 +8726,7 @@ class SqlZenStore(BaseZenStore):
                 # Soft deletion - set is_archived
                 trigger.is_archived = True
                 trigger.active = False
+                trigger.webhook_integration_id = None
                 # Renames to name_(hash) to enable re-using the name.
                 trigger.name = f"{trigger.name}_({str(uuid.uuid4())[:8]})"
                 session.add(trigger)

--- a/tests/integration/functional/triggers/test_webhook_cli.py
+++ b/tests/integration/functional/triggers/test_webhook_cli.py
@@ -1,0 +1,99 @@
+"""Functional tests for webhook trigger CLI CRUD."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+import zenml_cli
+from tests.cli_runner_utils import cli_runner
+from tests.integration.functional.utils import sample_name
+from zenml.cli.cli import cli
+from zenml.enums import WebhookType
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+trigger_command = cli.commands["trigger"]
+webhook_command = trigger_command.commands["webhook"]
+create_command = webhook_command.commands["create"]
+list_command = webhook_command.commands["list"]
+update_command = webhook_command.commands["update"]
+delete_command = webhook_command.commands["delete"]
+
+
+def test_webhook_trigger_cli_lifecycle(clean_client):
+    """Webhook triggers can be managed through CLI commands."""
+    if isinstance(clean_client.zen_store, SqlZenStore):
+        pytest.skip("Webhooks require a REST store.")
+
+    runner = cli_runner()
+    integration = clean_client.create_webhook(
+        name=sample_name("webhook-trigger-cli-integration"),
+        webhook_type=WebhookType.CUSTOM,
+    ).webhook
+    trigger_name = sample_name("webhook-trigger-cli")
+    updated_name = sample_name("webhook-trigger-cli-updated")
+
+    result = runner.invoke(
+        create_command,
+        [
+            trigger_name,
+            "--webhook-type",
+            WebhookType.CUSTOM.value,
+            "--webhook-integration",
+            integration.name,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    trigger = clean_client.get_webhook_trigger(trigger_name)
+    assert trigger.webhook_integration_id == integration.id
+
+    list_output_buffer = io.StringIO()
+    with patch.object(zenml_cli, "_original_stdout", list_output_buffer):
+        result = runner.invoke(
+            list_command,
+            ["--webhook-integration-id", str(integration.id)],
+        )
+    list_output = list_output_buffer.getvalue() + result.output
+
+    assert result.exit_code == 0, result.output
+    assert trigger_name in list_output
+
+    result = runner.invoke(
+        update_command,
+        [
+            trigger_name,
+            "--name",
+            updated_name,
+            "--detach-webhook-integration",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    detached = clean_client.get_webhook_trigger(updated_name)
+    assert detached.webhook_integration_id is None
+    assert detached.active is False
+
+    result = runner.invoke(
+        update_command,
+        [
+            updated_name,
+            "--webhook-integration",
+            integration.name,
+            "--active",
+            "true",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    reactivated = clean_client.get_webhook_trigger(updated_name)
+    assert reactivated.webhook_integration_id == integration.id
+    assert reactivated.active is True
+
+    result = runner.invoke(delete_command, [updated_name])
+
+    assert result.exit_code == 0, result.output
+    archived = clean_client.get_webhook_trigger(
+        reactivated.id, is_archived=True
+    )
+    assert archived.webhook_integration_id is None

--- a/tests/integration/functional/triggers/test_webhook_cli.py
+++ b/tests/integration/functional/triggers/test_webhook_cli.py
@@ -47,6 +47,7 @@ def test_webhook_trigger_cli_lifecycle(clean_client):
     assert result.exit_code == 0, result.output
     trigger = clean_client.get_webhook_trigger(trigger_name)
     assert trigger.webhook_integration_id == integration.id
+    assert trigger.webhook_integration == integration
 
     list_output_buffer = io.StringIO()
     with patch.object(zenml_cli, "_original_stdout", list_output_buffer):
@@ -61,9 +62,18 @@ def test_webhook_trigger_cli_lifecycle(clean_client):
 
     result = runner.invoke(
         update_command,
+        [trigger_name, "--name", updated_name],
+    )
+
+    assert result.exit_code == 0, result.output
+    renamed = clean_client.get_webhook_trigger(updated_name)
+    assert renamed.webhook_integration_id == integration.id
+    assert renamed.webhook_integration == integration
+    assert renamed.active is True
+
+    result = runner.invoke(
+        update_command,
         [
-            trigger_name,
-            "--name",
             updated_name,
             "--detach-webhook-integration",
         ],
@@ -72,6 +82,7 @@ def test_webhook_trigger_cli_lifecycle(clean_client):
     assert result.exit_code == 0, result.output
     detached = clean_client.get_webhook_trigger(updated_name)
     assert detached.webhook_integration_id is None
+    assert detached.webhook_integration is None
     assert detached.active is False
 
     result = runner.invoke(

--- a/tests/integration/functional/triggers/test_webhook_crud.py
+++ b/tests/integration/functional/triggers/test_webhook_crud.py
@@ -62,6 +62,7 @@ def test_webhook_trigger_store_lifecycle(clean_client):
     assert isinstance(trigger, WebhookTriggerResponse)
     assert trigger.active is True
     assert trigger.webhook_integration_id == custom_integration.id
+    assert trigger.webhook_integration == custom_integration
     assert trigger.webhook_type == WebhookType.CUSTOM
 
     retrieved = store.get_trigger(trigger.id)
@@ -74,6 +75,23 @@ def test_webhook_trigger_store_lifecycle(clean_client):
 
     assert retrieved.model_dump() == trigger.model_dump()
     assert trigger.id in {item.id for item in listed.items}
+
+    updated_name = sample_name("webhook-trigger-updated")
+    trigger = store.update_trigger(
+        trigger_id=trigger.id,
+        trigger_update=WebhookTriggerUpdate(
+            name=updated_name,
+            active=trigger.active,
+            concurrency=trigger.concurrency,
+            webhook_integration_id=trigger.webhook_integration_id,
+        ),
+    )
+
+    assert trigger.name == updated_name
+    assert trigger.webhook_integration_id == custom_integration.id
+    assert trigger.webhook_integration == custom_integration
+    assert trigger.active is True
+    assert trigger.concurrency == TriggerRunConcurrency.SUBMIT
 
     other_project = store.create_project(
         ProjectRequest(name=sample_name("webhook-trigger-other-project"))
@@ -129,17 +147,21 @@ def test_webhook_trigger_store_lifecycle(clean_client):
     )
 
     assert detached.webhook_integration_id is None
+    assert detached.webhook_integration is None
     assert detached.active is False
 
     reattached = store.update_trigger(
         trigger_id=trigger.id,
         trigger_update=WebhookTriggerUpdate(
             name=trigger.name,
+            active=detached.active,
+            concurrency=detached.concurrency,
             webhook_integration_id=custom_integration.id,
         ),
     )
 
     assert reattached.webhook_integration_id == custom_integration.id
+    assert reattached.webhook_integration == custom_integration
     assert reattached.active is False
 
     reactivated = store.update_trigger(
@@ -147,6 +169,7 @@ def test_webhook_trigger_store_lifecycle(clean_client):
         trigger_update=WebhookTriggerUpdate(
             name=trigger.name,
             active=True,
+            concurrency=reattached.concurrency,
             webhook_integration_id=custom_integration.id,
         ),
     )
@@ -157,6 +180,7 @@ def test_webhook_trigger_store_lifecycle(clean_client):
     retained = store.get_trigger(trigger.id)
 
     assert retained.webhook_integration_id is None
+    assert retained.webhook_integration is None
     assert retained.active is False
     assert retained.is_archived is False
 
@@ -184,6 +208,7 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     )
 
     assert trigger.webhook_integration_id == integration.id
+    assert trigger.webhook_integration == integration
     assert trigger.webhook_type == WebhookType.GITHUB
     assert clean_client.get_webhook_trigger(trigger.name).id == trigger.id
 
@@ -193,6 +218,18 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     )
 
     assert trigger.id in {item.id for item in listed.items}
+
+    updated_name = sample_name("webhook-trigger-client-updated")
+    updated = clean_client.update_webhook_trigger(
+        trigger.id,
+        name=updated_name,
+    )
+
+    assert updated.name == updated_name
+    assert updated.webhook_integration_id == integration.id
+    assert updated.webhook_integration == integration
+    assert updated.active is True
+    assert updated.concurrency == TriggerRunConcurrency.SUBMIT
 
     updated = clean_client.update_webhook_trigger(
         trigger.id,
@@ -209,6 +246,7 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     )
 
     assert detached.webhook_integration_id is None
+    assert detached.webhook_integration is None
     assert detached.active is False
 
     reattached = clean_client.update_webhook_trigger(
@@ -231,6 +269,7 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     retained = clean_client.get_webhook_trigger(trigger.id)
 
     assert retained.webhook_integration_id is None
+    assert retained.webhook_integration is None
     assert retained.active is False
 
     clean_client.delete_trigger(trigger.id)

--- a/tests/integration/functional/triggers/test_webhook_crud.py
+++ b/tests/integration/functional/triggers/test_webhook_crud.py
@@ -74,6 +74,17 @@ def test_webhook_trigger_store_lifecycle(clean_client):
     assert retrieved.model_dump() == trigger.model_dump()
     assert trigger.id in {item.id for item in listed.items}
 
+    with pytest.raises(IllegalOperationError, match="custom webhook"):
+        store.update_trigger(
+            trigger_id=trigger.id,
+            trigger_update=WebhookTriggerUpdate(
+                name=trigger.name,
+                active=trigger.active,
+                concurrency=trigger.concurrency,
+                webhook_integration_id=github_integration.id,
+            ),
+        )
+
     detached = store.update_trigger(
         trigger_id=trigger.id,
         trigger_update=WebhookTriggerUpdate(
@@ -149,6 +160,15 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     )
 
     assert trigger.id in {item.id for item in listed.items}
+
+    updated = clean_client.update_webhook_trigger(
+        trigger.id,
+        concurrency=TriggerRunConcurrency.SKIP,
+    )
+
+    assert updated.webhook_integration_id == integration.id
+    assert updated.active is True
+    assert updated.concurrency == TriggerRunConcurrency.SKIP
 
     detached = clean_client.update_webhook_trigger(
         trigger.id,

--- a/tests/integration/functional/triggers/test_webhook_crud.py
+++ b/tests/integration/functional/triggers/test_webhook_crud.py
@@ -1,0 +1,184 @@
+"""Functional tests for webhook trigger store and client CRUD."""
+
+import pytest
+
+from tests.integration.functional.utils import sample_name
+from zenml.enums import (
+    TriggerFlavor,
+    TriggerRunConcurrency,
+    WebhookType,
+)
+from zenml.exceptions import IllegalOperationError
+from zenml.models import (
+    TriggerFilter,
+    WebhookIntegrationRequest,
+    WebhookTriggerRequest,
+    WebhookTriggerResponse,
+    WebhookTriggerUpdate,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+def test_webhook_trigger_store_lifecycle(clean_client):
+    """Webhook triggers support store CRUD and detached lifecycle rules."""
+    store = clean_client.zen_store
+    project_id = clean_client.active_project.id
+    custom_integration = store.create_webhook_integration(
+        WebhookIntegrationRequest(
+            project=project_id,
+            name=sample_name("custom-webhook-integration"),
+            webhook_type=WebhookType.CUSTOM,
+        )
+    ).webhook
+    github_integration = store.create_webhook_integration(
+        WebhookIntegrationRequest(
+            project=project_id,
+            name=sample_name("github-webhook-integration"),
+            webhook_type=WebhookType.GITHUB,
+        )
+    ).webhook
+
+    with pytest.raises(IllegalOperationError, match="custom webhook"):
+        store.create_trigger(
+            WebhookTriggerRequest(
+                project=project_id,
+                name=sample_name("incompatible-webhook-trigger"),
+                flavor=TriggerFlavor.CUSTOM_WEBHOOK,
+                webhook_integration_id=github_integration.id,
+            )
+        )
+
+    trigger = store.create_trigger(
+        WebhookTriggerRequest(
+            project=project_id,
+            name=sample_name("webhook-trigger"),
+            flavor=TriggerFlavor.CUSTOM_WEBHOOK,
+            webhook_integration_id=custom_integration.id,
+            concurrency=TriggerRunConcurrency.SUBMIT,
+        )
+    )
+
+    assert isinstance(trigger, WebhookTriggerResponse)
+    assert trigger.active is True
+    assert trigger.webhook_integration_id == custom_integration.id
+    assert trigger.webhook_type == WebhookType.CUSTOM
+
+    retrieved = store.get_trigger(trigger.id)
+    listed = store.list_triggers(
+        TriggerFilter(
+            project=project_id,
+            webhook_integration_id=custom_integration.id,
+        )
+    )
+
+    assert retrieved.model_dump() == trigger.model_dump()
+    assert trigger.id in {item.id for item in listed.items}
+
+    detached = store.update_trigger(
+        trigger_id=trigger.id,
+        trigger_update=WebhookTriggerUpdate(
+            name=trigger.name,
+            active=True,
+            concurrency=TriggerRunConcurrency.SKIP,
+            webhook_integration_id=None,
+        ),
+    )
+
+    assert detached.webhook_integration_id is None
+    assert detached.active is False
+
+    reattached = store.update_trigger(
+        trigger_id=trigger.id,
+        trigger_update=WebhookTriggerUpdate(
+            name=trigger.name,
+            webhook_integration_id=custom_integration.id,
+        ),
+    )
+
+    assert reattached.webhook_integration_id == custom_integration.id
+    assert reattached.active is False
+
+    reactivated = store.update_trigger(
+        trigger_id=trigger.id,
+        trigger_update=WebhookTriggerUpdate(
+            name=trigger.name,
+            active=True,
+            webhook_integration_id=custom_integration.id,
+        ),
+    )
+
+    assert reactivated.active is True
+
+    store.delete_webhook_integration(custom_integration.id)
+    retained = store.get_trigger(trigger.id)
+
+    assert retained.webhook_integration_id is None
+    assert retained.active is False
+    assert retained.is_archived is False
+
+    store.delete_trigger(trigger.id, soft=True)
+    archived = store.get_trigger(trigger.id)
+
+    assert archived.is_archived is True
+    assert archived.webhook_integration_id is None
+
+
+def test_webhook_trigger_client_lifecycle(clean_client):
+    """Webhook triggers can be managed through the public client."""
+    if isinstance(clean_client.zen_store, SqlZenStore):
+        pytest.skip("Webhooks require a REST store.")
+
+    integration = clean_client.create_webhook(
+        name=sample_name("webhook-trigger-client-integration"),
+        webhook_type=WebhookType.GITHUB,
+    ).webhook
+    trigger = clean_client.create_webhook_trigger(
+        name=sample_name("webhook-trigger-client"),
+        webhook_type=WebhookType.GITHUB,
+        webhook_integration=integration.name,
+        concurrency=TriggerRunConcurrency.SUBMIT,
+    )
+
+    assert trigger.webhook_integration_id == integration.id
+    assert trigger.webhook_type == WebhookType.GITHUB
+    assert clean_client.get_webhook_trigger(trigger.name).id == trigger.id
+
+    listed = clean_client.list_webhook_triggers(
+        webhook_type=WebhookType.GITHUB,
+        webhook_integration_id=integration.id,
+    )
+
+    assert trigger.id in {item.id for item in listed.items}
+
+    detached = clean_client.update_webhook_trigger(
+        trigger.id,
+        detach_webhook_integration=True,
+    )
+
+    assert detached.webhook_integration_id is None
+    assert detached.active is False
+
+    reattached = clean_client.update_webhook_trigger(
+        trigger.id,
+        webhook_integration=integration.id,
+    )
+
+    assert reattached.webhook_integration_id == integration.id
+    assert reattached.active is False
+
+    reactivated = clean_client.update_webhook_trigger(
+        trigger.id,
+        webhook_integration=integration.id,
+        active=True,
+    )
+
+    assert reactivated.active is True
+
+    clean_client.delete_trigger(trigger.id)
+
+    with pytest.raises(KeyError):
+        clean_client.get_webhook_trigger(trigger.id)
+
+    archived = clean_client.get_webhook_trigger(trigger.id, is_archived=True)
+    assert archived.is_archived is True
+    assert archived.webhook_integration_id is None

--- a/tests/integration/functional/triggers/test_webhook_crud.py
+++ b/tests/integration/functional/triggers/test_webhook_crud.py
@@ -227,6 +227,12 @@ def test_webhook_trigger_client_lifecycle(clean_client):
 
     assert reactivated.active is True
 
+    clean_client.delete_webhook(integration.id)
+    retained = clean_client.get_webhook_trigger(trigger.id)
+
+    assert retained.webhook_integration_id is None
+    assert retained.active is False
+
     clean_client.delete_trigger(trigger.id)
 
     with pytest.raises(KeyError):
@@ -235,3 +241,70 @@ def test_webhook_trigger_client_lifecycle(clean_client):
     archived = clean_client.get_webhook_trigger(trigger.id, is_archived=True)
     assert archived.is_archived is True
     assert archived.webhook_integration_id is None
+
+    clean_client.delete_trigger(trigger.id, soft=False)
+
+    with pytest.raises(KeyError):
+        clean_client.get_webhook_trigger(trigger.id, is_archived=True)
+
+
+def test_webhook_trigger_client_association_transitions(clean_client):
+    """Public client validates webhook trigger association transitions."""
+    if isinstance(clean_client.zen_store, SqlZenStore):
+        pytest.skip("Webhooks require a REST store.")
+
+    primary = clean_client.create_webhook(
+        name=sample_name("webhook-trigger-primary-integration"),
+        webhook_type=WebhookType.CUSTOM,
+    ).webhook
+    replacement = clean_client.create_webhook(
+        name=sample_name("webhook-trigger-replacement-integration"),
+        webhook_type=WebhookType.CUSTOM,
+    ).webhook
+    incompatible = clean_client.create_webhook(
+        name=sample_name("webhook-trigger-incompatible-integration"),
+        webhook_type=WebhookType.GITHUB,
+    ).webhook
+    trigger = clean_client.create_webhook_trigger(
+        name=sample_name("detached-webhook-trigger"),
+        webhook_type=WebhookType.CUSTOM,
+        active=True,
+    )
+
+    assert trigger.webhook_integration_id is None
+    assert trigger.active is False
+
+    with pytest.raises(IllegalOperationError):
+        clean_client.update_webhook_trigger(
+            trigger.id,
+            webhook_integration=primary.id,
+            detach_webhook_integration=True,
+        )
+
+    with pytest.raises(IllegalOperationError, match="custom webhook"):
+        clean_client.update_webhook_trigger(
+            trigger.id,
+            webhook_integration=incompatible.id,
+        )
+
+    attached = clean_client.update_webhook_trigger(
+        trigger.id,
+        webhook_integration=primary.id,
+        active=True,
+    )
+
+    assert attached.webhook_integration_id == primary.id
+    assert attached.active is True
+
+    replaced = clean_client.update_webhook_trigger(
+        trigger.id,
+        webhook_integration=replacement.id,
+    )
+
+    assert replaced.webhook_integration_id == replacement.id
+    assert replaced.active is True
+
+    clean_client.delete_trigger(trigger.id, soft=False)
+    clean_client.delete_webhook(primary.id)
+    clean_client.delete_webhook(replacement.id)
+    clean_client.delete_webhook(incompatible.id)

--- a/tests/integration/functional/triggers/test_webhook_crud.py
+++ b/tests/integration/functional/triggers/test_webhook_crud.py
@@ -10,6 +10,7 @@ from zenml.enums import (
 )
 from zenml.exceptions import IllegalOperationError
 from zenml.models import (
+    ProjectRequest,
     TriggerFilter,
     WebhookIntegrationRequest,
     WebhookTriggerRequest,
@@ -73,6 +74,38 @@ def test_webhook_trigger_store_lifecycle(clean_client):
 
     assert retrieved.model_dump() == trigger.model_dump()
     assert trigger.id in {item.id for item in listed.items}
+
+    other_project = store.create_project(
+        ProjectRequest(name=sample_name("webhook-trigger-other-project"))
+    )
+    cross_project_integration = store.create_webhook_integration(
+        WebhookIntegrationRequest(
+            project=other_project.id,
+            name=sample_name("cross-project-webhook-integration"),
+            webhook_type=WebhookType.CUSTOM,
+        )
+    ).webhook
+
+    with pytest.raises(KeyError, match="not found"):
+        store.create_trigger(
+            WebhookTriggerRequest(
+                project=project_id,
+                name=sample_name("cross-project-webhook-trigger"),
+                flavor=TriggerFlavor.CUSTOM_WEBHOOK,
+                webhook_integration_id=cross_project_integration.id,
+            )
+        )
+
+    with pytest.raises(KeyError, match="not found"):
+        store.update_trigger(
+            trigger_id=trigger.id,
+            trigger_update=WebhookTriggerUpdate(
+                name=trigger.name,
+                active=trigger.active,
+                concurrency=trigger.concurrency,
+                webhook_integration_id=cross_project_integration.id,
+            ),
+        )
 
     with pytest.raises(IllegalOperationError, match="custom webhook"):
         store.update_trigger(

--- a/tests/integration/functional/webhooks/test_client.py
+++ b/tests/integration/functional/webhooks/test_client.py
@@ -36,6 +36,7 @@ def test_client_webhook_lifecycle(clean_client):
     )
 
     assert result.secret is not None
+    initial_secret = result.secret.get_secret_value()
     integration = result.webhook
     assert integration.name == name
     assert integration.webhook_type == WebhookType.CUSTOM
@@ -75,6 +76,12 @@ def test_client_webhook_lifecycle(clean_client):
     inactive_integrations = clean_client.list_webhooks(active=False)
 
     assert integration.id in {item.id for item in inactive_integrations.items}
+
+    generated_rotation = clean_client.rotate_webhook_secret(
+        name_id_or_prefix=updated_name,
+    )
+
+    assert generated_rotation.secret.get_secret_value() != initial_secret
 
     rotated = clean_client.rotate_webhook_secret(
         name_id_or_prefix=updated_name,

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -39,11 +39,31 @@ def test_trigger_execution_info_defaults_pipeline_lineage() -> None:
     assert "upstream_pipeline_ids" in info.model_dump()
 
 
-def test_webhook_trigger_update_uses_full_association_state() -> None:
-    """Webhook trigger updates should always replace the association."""
-    update = WebhookTriggerUpdate(name="webhook-trigger")
+def test_webhook_trigger_update_requires_complete_payload() -> None:
+    """Webhook trigger updates preserve PUT semantics."""
+    with pytest.raises(
+        ValidationError, match="must include all mutable fields"
+    ):
+        WebhookTriggerUpdate(name="webhook-trigger")
 
-    assert update.get_extra_fields() == {"webhook_integration_id": None}
+    detached = WebhookTriggerUpdate(
+        name="webhook-trigger",
+        active=False,
+        concurrency=TriggerRunConcurrency.SKIP,
+        webhook_integration_id=None,
+    )
+    integration_id = uuid4()
+    attached = WebhookTriggerUpdate(
+        name="webhook-trigger",
+        active=True,
+        concurrency=TriggerRunConcurrency.SUBMIT,
+        webhook_integration_id=integration_id,
+    )
+
+    assert detached.get_extra_fields() == {"webhook_integration_id": None}
+    assert attached.get_extra_fields() == {
+        "webhook_integration_id": integration_id
+    }
 
 
 def test_schedule_trigger_valid_and_inheritance():

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -22,6 +22,7 @@ from zenml.models import (
     TriggerExecutionInfo,
     TriggerResponseResources,
     TriggerSnapshotDispatchState,
+    WebhookTriggerUpdate,
 )
 
 
@@ -36,6 +37,13 @@ def test_trigger_execution_info_defaults_pipeline_lineage() -> None:
     assert info.upstream_run_id == upstream_run_id
     assert info.upstream_pipeline_ids == []
     assert "upstream_pipeline_ids" in info.model_dump()
+
+
+def test_webhook_trigger_update_uses_full_association_state() -> None:
+    """Webhook trigger updates should always replace the association."""
+    update = WebhookTriggerUpdate(name="webhook-trigger")
+
+    assert update.get_extra_fields() == {"webhook_integration_id": None}
 
 
 def test_schedule_trigger_valid_and_inheritance():

--- a/tests/unit/zen_stores/test_rest_zen_store.py
+++ b/tests/unit/zen_stores/test_rest_zen_store.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 import pytest
 from pytest_mock import MockerFixture
 
+from zenml.enums import TriggerRunConcurrency
 from zenml.models import WebhookTriggerUpdate
 from zenml.zen_stores.rest_zen_store import (
     ARTIFACT_VERSIONS,
@@ -104,7 +105,12 @@ def test_webhook_trigger_updates_use_full_serialization(
     """Tests that webhook trigger PUT requests include the complete model."""
     store = mocker.Mock()
     trigger_id = uuid4()
-    trigger_update = WebhookTriggerUpdate(name="webhook-trigger")
+    trigger_update = WebhookTriggerUpdate(
+        name="webhook-trigger",
+        active=True,
+        concurrency=TriggerRunConcurrency.SKIP,
+        webhook_integration_id=None,
+    )
     store.put.return_value = {}
 
     with pytest.raises(ValueError, match="Bad response"):

--- a/tests/unit/zen_stores/test_rest_zen_store.py
+++ b/tests/unit/zen_stores/test_rest_zen_store.py
@@ -15,10 +15,13 @@
 
 from uuid import uuid4
 
+import pytest
 from pytest_mock import MockerFixture
 
+from zenml.models import WebhookTriggerUpdate
 from zenml.zen_stores.rest_zen_store import (
     ARTIFACT_VERSIONS,
+    TRIGGERS,
     RestZenStore,
     RestZenStoreConfiguration,
 )
@@ -92,4 +95,28 @@ def test_delete_artifact_version_can_preserve_metadata(
             "delete_metadata": False,
             "delete_from_artifact_store": True,
         },
+    )
+
+
+def test_webhook_trigger_updates_use_full_serialization(
+    mocker: MockerFixture,
+) -> None:
+    """Tests that webhook trigger PUT requests include the complete model."""
+    store = mocker.Mock()
+    trigger_id = uuid4()
+    trigger_update = WebhookTriggerUpdate(name="webhook-trigger")
+    store.put.return_value = {}
+
+    with pytest.raises(ValueError, match="Bad response"):
+        RestZenStore.update_trigger(
+            store,
+            trigger_id=trigger_id,
+            trigger_update=trigger_update,
+        )
+
+    store.put.assert_called_once_with(
+        f"{TRIGGERS}/{trigger_id}",
+        body=trigger_update,
+        params=None,
+        exclude_unset=False,
     )


### PR DESCRIPTION
## Describe changes

CRUD webhook trigger functionality:

- [x] SDK tools for webhook trigger management
- [x] CLI tools for webhook trigger management
- [x] Full backend support for new models & DB/Store extension

Out of scope:

- Integration with webhook endpoints to trigger execution
- Webhook event aware filtering to locate triggers

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

