### PR TITLE
Escape $ in generated Docker Compose files

### DIFF
--- a/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
+++ b/src/zenml/integrations/hyperai/orchestrators/hyperai_orchestrator.py
@@ -20,7 +20,6 @@ from shlex import quote
 from typing import IO, TYPE_CHECKING, Any, Dict, Optional, Type, cast
 
 import paramiko
-import yaml
 
 from zenml.config.base_settings import BaseSettings
 from zenml.entrypoints import StepEntrypointConfiguration
@@ -31,6 +30,7 @@ from zenml.integrations.hyperai.flavors.hyperai_orchestrator_flavor import (
 )
 from zenml.logger import get_logger
 from zenml.orchestrators import ContainerizedOrchestrator, SubmissionResult
+from zenml.orchestrators.utils import dump_compose_yaml
 from zenml.stack import Stack, StackValidator
 
 if TYPE_CHECKING:
@@ -293,7 +293,7 @@ class HyperAIOrchestrator(ContainerizedOrchestrator):
                         }
                     )
 
-        compose_definition_yaml: str = yaml.dump(compose_definition)
+        compose_definition_yaml: str = dump_compose_yaml(compose_definition)
 
         # Connect to configured HyperAI instance
         logger.info(

--- a/src/zenml/integrations/ssh/orchestrators/ssh_orchestrator.py
+++ b/src/zenml/integrations/ssh/orchestrators/ssh_orchestrator.py
@@ -30,8 +30,6 @@ from typing import (
 )
 from uuid import UUID
 
-import yaml
-
 from zenml.config.base_settings import BaseSettings
 from zenml.entrypoints.step_entrypoint_configuration import (
     StepEntrypointConfiguration,
@@ -228,9 +226,7 @@ class SSHOrchestrator(ContainerizedOrchestrator):
             RuntimeError: If a remote command fails.
         """
         remote_dir = self._remote_run_directory(run_id)
-        compose_yaml = yaml.dump(
-            compose, default_flow_style=False, sort_keys=False
-        )
+        compose_yaml = orchestrator_utils.dump_compose_yaml(compose)
         docker = self.config.docker_binary
 
         with SSHClient(self.config) as ssh:

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -19,6 +19,8 @@ import shlex
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 from uuid import UUID
 
+import yaml
+
 from zenml.client import Client
 from zenml.config.global_config import (
     GlobalConfiguration,
@@ -282,6 +284,31 @@ def shell_join(command: List[str]) -> str:
         The command tokens joined into a single shell-escaped string.
     """
     return shlex.join(command)
+
+
+def dump_compose_yaml(compose: Dict[str, Any]) -> str:
+    """Serialize a Docker Compose definition to YAML safe for ``compose up``.
+
+    Docker Compose interpolates variables (``$VAR``, ``${VAR}``) across the
+    whole file before creating containers, using ``$$`` as the literal-``$``
+    escape. ZenML generates Compose files from already-resolved values (step
+    environments, secrets, bind-mount paths), none of which are meant to be
+    interpolated. Left unescaped, a ``$`` in such a value is silently mangled
+    (``pa$$word`` -> ``pa$word``) or, for forms like ``${X:?}``, aborts
+    ``compose up`` entirely. Escaping every ``$`` in the serialized document
+    makes each value round-trip verbatim, mirroring what Compose's own
+    serializer emits.
+
+    Args:
+        compose: The Docker Compose definition.
+
+    Returns:
+        YAML text ready to write to a ``docker-compose.yml``.
+    """
+    yaml_text: str = yaml.dump(
+        compose, default_flow_style=False, sort_keys=False
+    )
+    return yaml_text.replace("$", "$$")
 
 
 class register_artifact_store_filesystem:

--- a/src/zenml/orchestrators/utils.py
+++ b/src/zenml/orchestrators/utils.py
@@ -19,6 +19,8 @@ import shlex
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 from uuid import UUID
 
+import yaml
+
 from zenml.client import Client
 from zenml.config.global_config import (
     GlobalConfiguration,
@@ -282,6 +284,29 @@ def shell_join(command: List[str]) -> str:
         The command tokens joined into a single shell-escaped string.
     """
     return shlex.join(command)
+
+
+def dump_compose_yaml(compose: dict[str, Any]) -> str:
+    """Serialize a Docker Compose definition to YAML safe for ``compose up``.
+
+    Docker Compose interpolates variables (``$VAR``, ``${VAR}``) across the
+    whole file before creating containers, using ``$$`` as the literal-``$``
+    escape. ZenML generates Compose files from already-resolved values (step
+    environments, secrets, bind-mount paths), none of which are meant to be
+    interpolated. Left unescaped, a ``$`` in such a value is silently mangled
+    (``a$$b`` reaching the container as ``a$b``) or, for forms like
+    ``${X:?}``, aborts ``compose up``. Escaping every ``$`` in the document
+    makes each value round-trip verbatim, mirroring what Compose's own
+    serializer emits.
+
+    Args:
+        compose: The Docker Compose definition.
+
+    Returns:
+        YAML text ready to write to a ``docker-compose.yml``.
+    """
+    yaml_text: str = yaml.dump(compose, sort_keys=False)
+    return yaml_text.replace("$", "$$")
 
 
 class register_artifact_store_filesystem:

--- a/tests/unit/integrations/ssh/orchestrators/test_ssh_orchestrator.py
+++ b/tests/unit/integrations/ssh/orchestrators/test_ssh_orchestrator.py
@@ -223,6 +223,51 @@ class TestStaticSubmit:
         }
         assert names1.isdisjoint(names2)
 
+    def test_env_values_with_dollar_are_escaped_for_compose(self) -> None:
+        """A step env value containing ``$`` must not be interpolated.
+
+        Compose interpolates ``$VAR``/``${VAR}`` across the whole file before
+        creating containers. Since ZenML writes already-resolved values
+        (secrets included), a raw ``$`` would be silently mangled or, for
+        forms like ``${X:?}``, abort ``docker compose up``. The uploaded file
+        must escape ``$`` so every value round-trips verbatim.
+        """
+        orch = _make_orchestrator()
+        snap = _fake_snapshot({"only": _fake_step()})
+        run = MagicMock()
+        run.id = uuid4()
+        hostile = {
+            "DB_PASSWORD": "pa$$word",
+            "API_KEY": "abc$UNSET",
+            "HARDFAIL": "x${MISSING:?boom}y",
+        }
+        with (
+            _patched_ssh() as ssh,
+            patch.object(orch, "get_image", return_value="img"),
+            patch.object(
+                orch, "get_settings", return_value=SSHOrchestratorSettings()
+            ),
+        ):
+            orch.submit_pipeline(
+                snapshot=snap,
+                stack=MagicMock(),
+                base_environment={},
+                step_environments={"only": dict(hostile)},
+                placeholder_run=run,
+            )
+        raw_yaml = next(
+            call.args[1]
+            for call in ssh.put_text.call_args_list
+            if call.args[0].endswith("docker-compose.yml")
+        )
+        # No lone "$" survives in the uploaded file.
+        assert "$" not in raw_yaml.replace("$$", "")
+        # After Compose collapses "$$" -> "$", the values are byte-identical.
+        services = yaml.safe_load(raw_yaml.replace("$$", "$"))["services"]
+        env = next(iter(services.values()))["environment"]
+        for key, value in hostile.items():
+            assert env[key] == value
+
     def test_compose_up_invoked(self) -> None:
         orch = _make_orchestrator()
         snap = _fake_snapshot({"only": _fake_step()})

--- a/tests/unit/integrations/ssh/orchestrators/test_ssh_orchestrator.py
+++ b/tests/unit/integrations/ssh/orchestrators/test_ssh_orchestrator.py
@@ -223,6 +223,51 @@ class TestStaticSubmit:
         }
         assert names1.isdisjoint(names2)
 
+    def test_env_values_with_dollar_are_escaped_for_compose(self) -> None:
+        """A step env value containing ``$`` must not be interpolated.
+
+        Compose interpolates ``$VAR``/``${VAR}`` across the whole file before
+        creating containers. Since ZenML writes already-resolved values
+        (secrets included), a raw ``$`` would be silently mangled or, for
+        forms like ``${X:?}``, abort ``docker compose up``. The uploaded file
+        must escape ``$`` so every value round-trips verbatim.
+        """
+        orch = _make_orchestrator()
+        snap = _fake_snapshot({"only": _fake_step()})
+        run = MagicMock()
+        run.id = uuid4()
+        hostile = {
+            "LITERAL_DOLLAR": "cost$$100",
+            "UNSET_REFERENCE": "abc$UNSET",
+            "HARD_FAIL_REFERENCE": "x${MISSING:?boom}y",
+        }
+        with (
+            _patched_ssh() as ssh,
+            patch.object(orch, "get_image", return_value="img"),
+            patch.object(
+                orch, "get_settings", return_value=SSHOrchestratorSettings()
+            ),
+        ):
+            orch.submit_pipeline(
+                snapshot=snap,
+                stack=MagicMock(),
+                base_environment={},
+                step_environments={"only": dict(hostile)},
+                placeholder_run=run,
+            )
+        raw_yaml = next(
+            call.args[1]
+            for call in ssh.put_text.call_args_list
+            if call.args[0].endswith("docker-compose.yml")
+        )
+        # No lone "$" survives in the uploaded file.
+        assert "$" not in raw_yaml.replace("$$", "")
+        # After Compose collapses "$$" -> "$", the values are byte-identical.
+        services = yaml.safe_load(raw_yaml.replace("$$", "$"))["services"]
+        env = next(iter(services.values()))["environment"]
+        for key, value in hostile.items():
+            assert env[key] == value
+
     def test_compose_up_invoked(self) -> None:
         orch = _make_orchestrator()
         snap = _fake_snapshot({"only": _fake_step()})

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -16,14 +16,61 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+import yaml
 
 from zenml.enums import StackComponentType
 from zenml.orchestrators.utils import (
+    dump_compose_yaml,
     get_orchestrator_run_name,
     get_step_entrypoint_command,
     is_setting_enabled,
     register_artifact_store_filesystem,
 )
+
+
+def _compose_interpolate(yaml_text: str) -> str:
+    """Mimic Docker Compose's literal-``$`` handling: ``$$`` collapses to ``$``.
+
+    Compose interpolates ``$VAR``/``${VAR}`` against the environment and treats
+    ``$$`` as an escaped literal ``$``. This models only the escape collapse,
+    which is enough to prove that a serialized value round-trips verbatim.
+    """
+    return yaml_text.replace("$$", "$")
+
+
+def test_dump_compose_yaml_escapes_dollar_signs():
+    """Every ``$`` is escaped so Compose does not interpolate our values."""
+    compose = {
+        "services": {
+            "step": {
+                "environment": {
+                    "DB_PASSWORD": "pa$$word",
+                    "API_KEY": "abc$UNSET",
+                    "HARDFAIL": "x${MISSING:?boom}y",
+                },
+                "volumes": ["/srv/$DATA:/data"],
+            }
+        }
+    }
+
+    dumped = dump_compose_yaml(compose)
+
+    # No lone "$" survives: each original "$" became "$$".
+    assert "$" in dumped
+    assert "$" not in dumped.replace("$$", "")
+
+    # After Compose collapses "$$" -> "$", the parsed values are byte-identical
+    # to the originals: no interpolation, no truncation, no mangling.
+    recovered = yaml.safe_load(_compose_interpolate(dumped))
+    service = recovered["services"]["step"]
+    assert service["environment"] == compose["services"]["step"]["environment"]
+    assert service["volumes"] == compose["services"]["step"]["volumes"]
+
+
+def test_dump_compose_yaml_no_dollar_is_unchanged_content():
+    """A definition without ``$`` round-trips to identical parsed content."""
+    compose = {"services": {"s": {"image": "img:latest", "environment": {}}}}
+    assert yaml.safe_load(dump_compose_yaml(compose)) == compose
 
 
 class _FakeEntrypointConfig:

--- a/tests/unit/orchestrators/test_utils.py
+++ b/tests/unit/orchestrators/test_utils.py
@@ -16,14 +16,61 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+import yaml
 
 from zenml.enums import StackComponentType
 from zenml.orchestrators.utils import (
+    dump_compose_yaml,
     get_orchestrator_run_name,
     get_step_entrypoint_command,
     is_setting_enabled,
     register_artifact_store_filesystem,
 )
+
+
+def _compose_interpolate(yaml_text: str) -> str:
+    """Mimic Docker Compose's literal-``$`` handling: ``$$`` collapses to ``$``.
+
+    Compose interpolates ``$VAR``/``${VAR}`` against the environment and treats
+    ``$$`` as an escaped literal ``$``. This models only the escape collapse,
+    which is enough to prove that a serialized value round-trips verbatim.
+    """
+    return yaml_text.replace("$$", "$")
+
+
+def test_dump_compose_yaml_escapes_dollar_signs():
+    """Every ``$`` is escaped so Compose does not interpolate our values."""
+    compose = {
+        "services": {
+            "step": {
+                "environment": {
+                    "LITERAL_DOLLAR": "cost$$100",
+                    "UNSET_REFERENCE": "abc$UNSET",
+                    "HARD_FAIL_REFERENCE": "x${MISSING:?boom}y",
+                },
+                "volumes": ["/srv/$DATA:/data"],
+            }
+        }
+    }
+
+    dumped = dump_compose_yaml(compose)
+
+    # No lone "$" survives: each original "$" became "$$".
+    assert "$" in dumped
+    assert "$" not in dumped.replace("$$", "")
+
+    # After Compose collapses "$$" -> "$", the parsed values are byte-identical
+    # to the originals: no interpolation, no truncation, no mangling.
+    recovered = yaml.safe_load(_compose_interpolate(dumped))
+    service = recovered["services"]["step"]
+    assert service["environment"] == compose["services"]["step"]["environment"]
+    assert service["volumes"] == compose["services"]["step"]["volumes"]
+
+
+def test_dump_compose_yaml_no_dollar_is_unchanged_content():
+    """A definition without ``$`` round-trips to identical parsed content."""
+    compose = {"services": {"s": {"image": "img:latest", "environment": {}}}}
+    assert yaml.safe_load(dump_compose_yaml(compose)) == compose
 
 
 class _FakeEntrypointConfig:


### PR DESCRIPTION
Docker Compose interpolates `$VAR` and `${VAR}` across the whole compose file before starting containers. The SSH and HyperAI orchestrators write already resolved step environments (secrets included) and bind mount paths straight into the file, so any value containing `$` was corrupted: a `pa$$word` secret reached the container as `pa$word`, host environment values leaked in, and values shaped like `${X:?}` aborted `docker compose up` and the whole run.

Both orchestrators now serialize through a shared `dump_compose_yaml` helper that escapes every `$` as `$$`, so values round trip verbatim. The escape covers the whole document because mount paths are affected too, not only the environment block.

Tests: helper round trip, plus an SSH regression asserting values containing `$` survive.
