### PR TITLE
Stop format_name_template from mutating the caller's substitutions dict

### DIFF
--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -183,8 +183,6 @@ def format_name_template(
         KeyError: If a key in template is missing in the substitutions.
         ValueError: If the formatted name is empty.
     """
-    # Copy: `date`/`time` are filled in below, and callers pass dicts that
-    # outlive this call (e.g. a pipeline's configured substitutions).
     substitutions = dict(substitutions or {})
 
     if ("date" not in substitutions and "{date}" in name_template) or (

--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -183,7 +183,9 @@ def format_name_template(
         KeyError: If a key in template is missing in the substitutions.
         ValueError: If the formatted name is empty.
     """
-    substitutions = substitutions or {}
+    # Copy: `date`/`time` are filled in below, and callers pass dicts that
+    # outlive this call (e.g. a pipeline's configured substitutions).
+    substitutions = dict(substitutions or {})
 
     if ("date" not in substitutions and "{date}" in name_template) or (
         "time" not in substitutions and "{time}" in name_template

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -116,3 +116,14 @@ def test_string_substitution() -> None:
         {3: "value_suffix", "key_suffix": model_sub},
         set(["set_value_suffix", 4]),
     ]
+
+
+def test_format_name_template_does_not_mutate_substitutions() -> None:
+    """Check that format_name_template leaves the caller's dict untouched."""
+    substitutions = {"env": "prod"}
+
+    string_utils.format_name_template(
+        "run_{env}_{date}_{time}", substitutions=substitutions
+    )
+
+    assert substitutions == {"env": "prod"}


### PR DESCRIPTION
## What

`format_name_template` aliases the caller's `substitutions` dict instead of copying it, then writes `date`/`time` into it:

```python
substitutions = substitutions or {}          # non-empty dict -> alias, not a copy
...
substitutions.update(pr.config.substitutions)
substitutions.setdefault("date", start_time.strftime("%Y_%m_%d"))
substitutions.setdefault("time", start_time.strftime("%H_%M_%S_%f"))
```

```python
>>> mine = {"env": "prod"}
>>> format_name_template("run_{env}_{date}_{time}", substitutions=mine)
'run_prod_2026_07_16_15_20_41_525927'
>>> mine
{'env': 'prod', 'date': '2026_07_16', 'time': '15_20_41_525927'}   # caller's dict, mutated
```

An empty dict masks it — `{} or {}` yields a fresh dict — so only callers passing a *non-empty* dict are affected, which is likely why it hasn't surfaced.

## Why it matters

`pipeline_definition.py:995-998` calls this inside `_create_snapshot`, *before* `:1085` builds `PipelineSnapshotRequest(**snapshot.model_dump())`. So the injected `date`/`time` are persisted into the snapshot's substitutions. `finalize_substitutions` then uses `setdefault`, so the frozen values win over each run's real start time, and every scheduled run of that pipeline resolves to the same run name — the collision `sql_zen_store.py:6773` warns about.

The triggering conditions are ordinary: a schedule without an explicit name, `@pipeline(substitutions={...})` non-empty, and a `run_name_template` containing `{date}`/`{time}` — which is the default (`run_utils.py:73`).

## Fix

`substitutions = dict(substitutions or {})` — one line, no behaviour change for any caller that wasn't relying on the mutation.

## Testing

Added `test_format_name_template_does_not_mutate_substitutions` — `format_name_template` had no coverage in `tests/unit/utils/test_string_utils.py` at all.

Verified it fails first (caller's dict comes back with `date`/`time` added) and passes after. `tests/unit/utils/` — 199 passed (excluding `test_visualization_utils.py`, which needs IPython that I don't have installed locally). `ruff check`, `ruff format --check` and `mypy src/zenml/utils/string_utils.py` show nothing beyond the two findings already present on `develop` (a module-level `D100` in the test file and an `unused-ignore` in `string_utils.py`) — I checked both against a clean tree rather than assuming.

## Release notes label

I can't add labels as an external contributor — this looks like `no-release-notes` to me (small internal bug fix), but happy to defer to whatever you prefer.

---

This change was AI-assisted (Claude). I reproduced the mutation myself against a real install before writing anything, traced the snapshot path by reading it, confirmed no open PR touches this function (#5080 touches `string_utils.py` but not `format_name_template`), and ran the tests and lint baselines above myself.
