### PR TITLE
Count an installed prerelease as installed

### DIFF
--- a/src/zenml/utils/package_utils.py
+++ b/src/zenml/utils/package_utils.py
@@ -78,7 +78,7 @@ def requirement_installed(requirement: Union[str, Requirement]) -> bool:
     except PackageNotFoundError:
         return False
 
-    return requirement.specifier.contains(dist.version)
+    return requirement.specifier.contains(dist.version, prereleases=True)
 
 
 def get_dependencies(

--- a/tests/unit/utils/test_package_utils.py
+++ b/tests/unit/utils/test_package_utils.py
@@ -17,6 +17,7 @@ from zenml import __version__ as current_zenml_version
 from zenml.utils.package_utils import (
     clean_requirements,
     get_package_information,
+    requirement_installed,
 )
 
 
@@ -82,3 +83,23 @@ def test_clean_requirements_mixed_types():
 def test_get_package_information_works():
     """Test that the package information is returned."""
     assert get_package_information()["zenml"] == current_zenml_version
+
+
+@pytest.mark.parametrize(
+    "requirement, installed_version",
+    [
+        ("package", "1.0.0rc1"),
+        ("package", "2.0.0b2"),
+        ("package>=1.0", "1.5.0rc1"),
+    ],
+)
+def test_requirement_installed_accepts_prereleases(
+    requirement: str, installed_version: str, mocker
+) -> None:
+    """Check that an installed prerelease counts as installed."""
+    mocker.patch(
+        "zenml.utils.package_utils.distribution",
+        return_value=mocker.Mock(version=installed_version),
+    )
+
+    assert requirement_installed(requirement) is True


### PR DESCRIPTION
## What

`requirement_installed` reports an installed prerelease as not installed:

```python
# pkg 1.0.0rc1 is installed
>>> requirement_installed("pkg")
False        # expected True
```

`SpecifierSet.contains` excludes prereleases unless asked otherwise. That's the sensible default when *resolving* a requirement, but this function is asking a different question — "is this already installed?" — and the answer shouldn't depend on whether the installed version happens to be an rc.

The empty-specifier case is the sharp edge: a requirement with **no version constraint at all** still hits the default, so a bare `"pkg"` doesn't match an installed `1.0.0rc1`.

```
requirement 'pkg'         vs installed 1.0.0rc1 -> False   (prereleases=True: True)
requirement 'pkg'         vs installed 1.0.0    -> True
requirement 'pkg>=1.0'    vs installed 1.5.0rc1 -> False   (prereleases=True: True)
requirement 'pkg>=1.0'    vs installed 1.5.0    -> True
requirement 'pkg==1.0.0rc1' vs installed 1.0.0rc1 -> True   # explicit prerelease pin already works
```

## Why it matters

`Integration.check_installation` (`integration.py:69`) walks `get_dependencies()` recursively, so this isn't limited to what the user asked for — **one prerelease anywhere in an integration's transitive dependencies marks the whole integration uninstalled**, with only a `logger.debug` to explain it.

Also reachable from `cli/utils.py:1055`/`:1097` (the uv path), `:1127` (pip) and `:3269` (notebook), each of which reads as "is this tool available?".

## Fix

```python
return requirement.specifier.contains(dist.version, prereleases=True)
```

Explicit prerelease pins (`pkg==1.0.0rc1`) already worked and are unaffected — `packaging` enables prereleases automatically when the specifier itself names one. This only changes the cases that were answering the wrong question.

## Testing

Added `test_requirement_installed_accepts_prereleases`, parametrized over a bare requirement with an rc, a bare requirement with a beta, and a constrained requirement with an rc. `requirement_installed` had no coverage in `tests/unit/utils/test_package_utils.py` at all.

Verified all three fail first and pass after. `tests/unit/utils/` — 200 passed (excluding `test_visualization_utils.py`, which needs IPython that I don't have locally). `ruff check`/`format --check` and `mypy src/zenml/utils/package_utils.py` clean — the one `D100` in the test file is already on `develop`, which I checked against a clean tree rather than assuming.

## Release notes label

Can't add labels as an external contributor — reads like `no-release-notes` to me, but happy to defer.

---

This change was AI-assisted (Claude). I reproduced the behaviour myself against a real install, traced the `check_installation` path by reading it rather than taking it on faith, confirmed no open PR touches this function (#5085 touches the same file but not `requirement_installed`), and ran the tests and lint baselines above myself.
