### PR TITLE
Stop format_name_template from mutating the caller substitutions dict

### DIFF
--- a/src/zenml/utils/string_utils.py
+++ b/src/zenml/utils/string_utils.py
@@ -183,7 +183,7 @@ def format_name_template(
         KeyError: If a key in template is missing in the substitutions.
         ValueError: If the formatted name is empty.
     """
-    substitutions = substitutions or {}
+    substitutions = dict(substitutions or {})
 
     if ("date" not in substitutions and "{date}" in name_template) or (
         "time" not in substitutions and "{time}" in name_template

--- a/tests/unit/utils/test_string_utils.py
+++ b/tests/unit/utils/test_string_utils.py
@@ -116,3 +116,29 @@ def test_string_substitution() -> None:
         {3: "value_suffix", "key_suffix": model_sub},
         set(["set_value_suffix", 4]),
     ]
+
+
+def test_format_name_template_does_not_mutate_substitutions() -> None:
+    """The caller's substitutions dict must not be modified.
+
+    `substitutions or {}` only builds a new dict for a falsy argument, so a
+    non-empty dict was aliased and had date/time injected into it.
+    """
+    substitutions = {"custom": "value"}
+
+    formatted = string_utils.format_name_template(
+        "run-{custom}-{date}-{time}", substitutions=substitutions
+    )
+
+    assert substitutions == {"custom": "value"}
+    assert formatted.startswith("run-value-")
+
+
+def test_format_name_template_uses_given_substitutions() -> None:
+    """Explicit date/time substitutions are still honored."""
+    formatted = string_utils.format_name_template(
+        "run-{date}-{time}",
+        substitutions={"date": "2020_01_01", "time": "00_00_00"},
+    )
+
+    assert formatted == "run-2020_01_01-00_00_00"


### PR DESCRIPTION
## Describe changes

`format_name_template` mutates the caller's `substitutions` dict.

`substitutions or {}` only builds a new dict when the argument is **falsy**, so a non-empty dict is aliased and then written into by the `.update()` / `.setdefault()` calls below:

```python
subs = {"custom": "abc"}
format_name_template("run-{custom}-{date}-{time}", substitutions=subs)
subs
# {'custom': 'abc', 'date': '2026_07_16', 'time': '16_50_23_522789'}
```

An empty dict masks the bug (`{} or {}` yields a fresh dict), which is likely why it went unnoticed.

### Why it matters

`_create_snapshot` passes `pipeline_configuration.substitutions` straight in when deriving a schedule name (`pipeline_definition.py:995-998`), and that happens **before** the snapshot is serialized into the `PipelineSnapshotRequest` (`:1085`) — so the injected `date`/`time` get persisted into the snapshot.

`finalize_substitutions` then uses `setdefault`, so the baked-in values win over the real start time from that point on:

```python
cfg = PipelineConfiguration(name="p", substitutions={"env": "prod"})
format_name_template("p-{env}-{date}", substitutions=cfg.substitutions)

cfg.finalize_substitutions(start_time=datetime(2027, 1, 1, 9, 0, 0), inplace=False)["date"]
# '2026_07_16'   <- the future start time is ignored
```

Every run off that schedule then resolves the same frozen `{date}`/`{time}`, i.e. the same run name — the collision the server warns about in `sql_zen_store.py`. Triggering it needs nothing unusual: a schedule without an explicit name, a non-empty `@pipeline(substitutions={...})` (public, documented), and a `run_name_template` containing `{date}`/`{time}` — which is the **default** (`run_utils.py:73`).

## Changes

One line: copy the dict. Explicit `date`/`time` substitutions still take precedence, and the returned name is unchanged.

Two tests added — the mutation guard fails on `develop` and passes here; the second pins that caller-supplied date/time are still honored. `format_name_template` had no test coverage, which is why this survived.

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io) — internal helper, no doc change needed
  - [ ] Dashboard: not affected
  - [ ] Templates: not affected
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): not affected

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

## Verification

- `pytest tests/unit/utils/test_string_utils.py` — 6 passed.
- `ruff check` (with `--extend-ignore D` for tests, per `scripts/lint.sh`) and `ruff format --check` clean.
- `mypy src/zenml/utils/string_utils.py` reports one pre-existing `unused-ignore` at line 252, unrelated to this change — it appears identically on a clean `develop` (verified via `git stash`).

xref: #5080 also touches `string_utils.py`, but only adds a new `append_random_suffix` helper near the top of the file — no overlap with `format_name_template`.

I could not add a release-notes label myself (external contributors lack label permissions); this looks like `no-release-notes` to me, but happy to defer.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the tests locally and reviewed the diff before opening.
