### PR TITLE
Fix exception info cutoff

### DIFF
--- a/src/zenml/utils/exception_utils.py
+++ b/src/zenml/utils/exception_utils.py
@@ -16,7 +16,6 @@
 import inspect
 import os
 import re
-import textwrap
 import traceback
 from typing import Any, Callable, Optional, Type
 
@@ -42,7 +41,9 @@ def collect_exception_information(
     Returns:
         The exception information.
     """
-    tb = traceback.format_tb(exception.__traceback__)
+    tb = traceback.format_exception(
+        type(exception), exception, exception.__traceback__
+    )
     line_number = None
     start_index = None
 
@@ -76,7 +77,7 @@ def collect_exception_information(
         # part of the traceback that is happening in the ZenML code.
         tb = tb[start_index:]
 
-    tb_bytes = textwrap.dedent("\n".join(tb)).encode()
+    tb_bytes = "".join(tb).encode()
     tb_bytes = tb_bytes[:MEDIUMTEXT_MAX_LENGTH]
 
     source = None

--- a/tests/unit/utils/test_exception_utils.py
+++ b/tests/unit/utils/test_exception_utils.py
@@ -119,6 +119,44 @@ def test_collect_exception_information_includes_source_and_message():
     assert info.message == "failure"
 
 
+def test_collect_exception_information_includes_cause_and_exception_line():
+    """Test that the traceback includes chained causes and the exception line."""
+    try:
+        try:
+            raise TypeError("root cause")
+        except TypeError as e:
+            raise ValueError("wrapper") from e
+    except ValueError as exception:
+        info = collect_exception_information(exception)
+
+    assert "TypeError: root cause" in info.traceback
+    assert (
+        "The above exception was the direct cause of the following exception:"
+        in info.traceback
+    )
+    assert "ValueError: wrapper" in info.traceback
+
+
+def _failing_user_func() -> None:
+    raise ValueError("failure in user code")
+
+
+def test_collect_exception_information_trims_to_user_code():
+    """Test that the traceback starts at the user code frame."""
+    try:
+        _failing_user_func()
+    except ValueError as exception:
+        info = collect_exception_information(exception, _failing_user_func)
+
+    first_line = info.traceback.splitlines()[0]
+    assert "_failing_user_func" in first_line
+    assert "test_collect_exception_information_trims_to_user_code" not in (
+        info.traceback
+    )
+    assert "ValueError: failure in user code" in info.traceback
+    assert info.user_code_line == 1
+
+
 def test_reconstruct_exception_recreates_exception_type_and_message():
     """Test reconstruction of an exception from serialized exception info."""
     try:


### PR DESCRIPTION
Update the exception info to include not just the traceback of the final exception, but the whole traceback lineage as well as the final exception.