### PR TITLE
Fix missing project scope when deleting artifact versions

### DIFF
--- a/src/zenml/zen_server/AGENTS.md
+++ b/src/zenml/zen_server/AGENTS.md
@@ -30,6 +30,10 @@ Most server endpoints follow this order:
 Non-CRUD endpoints, such as trigger attach/detach, may need permission checks
 across multiple resource domains.
 
+When calling any `zen_store().list_*` method for a project-scoped resource,
+always set `project=...` on the filter. A list call without project scope
+queries across all projects.
+
 ## FastAPI Rules
 
 - Prefer existing service or repository classes over scattered helpers.

--- a/src/zenml/zen_server/routers/artifact_version_endpoints.py
+++ b/src/zenml/zen_server/routers/artifact_version_endpoints.py
@@ -260,7 +260,10 @@ def delete_artifact_version(
     if delete_metadata:
         unused_versions = zen_store().list_artifact_versions(
             ArtifactVersionFilter(
-                id=artifact_version.id, only_unused=True, size=1
+                id=artifact_version.id,
+                project=artifact_version.project_id,
+                only_unused=True,
+                size=1,
             )
         )
         if not unused_versions.items:


### PR DESCRIPTION
For any remote deployed server (= default project disabled), artifact deletion via the endpoint is currently broken because the list call to check if it's unused is missing a project scope.