### PR TITLE
Fix flag syntax in `service-connector register` help example

### DIFF
--- a/src/zenml/cli/service_connectors.py
+++ b/src/zenml/cli/service_connectors.py
@@ -379,8 +379,8 @@ that it's authorized to access using IAM role credentials:
 
     $ zenml service-connector register aws-s3-multi --description \\   
 "Multi-bucket S3 connector" --type aws --resource-type s3-bucket \\    
---auth_method iam-role --role_arn=arn:aws:iam::<account>:role/<role> \\
---aws_region=us-east-1 --aws-access-key-id=<aws-key-id> \\            
+--auth-method iam-role --role_arn=arn:aws:iam::<account>:role/<role> \\
+--aws_region=us-east-1 --aws_access_key_id=<aws-key-id> \\            
 --aws_secret_access_key=<aws-secret-key> --expiration-seconds 3600
 
 All registered service connectors are validated before being registered. To


### PR DESCRIPTION
The non-interactive AWS example in the `zenml service-connector register` docstring taught two flag spellings that break when copy-pasted.

## What was wrong

The example (lines 380–384 of `src/zenml/cli/service_connectors.py`) contained:

```
--auth_method iam-role ... --aws-access-key-id=<aws-key-id> ...
```

Two separate defects, failing in two different ways:

1. **`--aws-access-key-id` — fails loudly.** This is a custom pass-through config arg. Those keys become Python keyword arguments and are validated with `str.isidentifier()` (`utils.py:888`). Hyphens are not valid identifiers, so the command aborts with `Invalid argument: ... provide args with a proper identifier as the key`. Fixed to `--aws_access_key_id`.

2. **`--auth_method` — fails silently.** The declared Click option is `--auth-method` (hyphens). With no token normalization on the CLI group, Click does not bind the underscore form; it drops through to the leftover args and — because `auth_method` *is* a valid identifier — quietly becomes a config entry. The real `auth_method` parameter stays `None`, with no error. Fixed to `--auth-method`.

## The rule (for future reference)

- **Declared options** use hyphens (`--auth-method`, `--resource-type`, `--expiration-seconds`) — Click maps them to their underscore Python dest.
- **Custom pass-through args** use underscores (`--role_arn`, `--aws_region`, `--aws_secret_access_key`) — the flag name becomes a keyword argument verbatim, so it must be a valid identifier.

The other flags in the example were already correct.

## Scope

Documentation-only change to the command help text. No CLI behavior changes; the validator and Click parser were both already doing the right thing — the example was handing them input they were designed to refuse. The `docs/site/` HTML and search index regenerate from this docstring, so no manual edits there.