### PR TITLE
Fix device auth getting stuck to a previous user

### DIFF
--- a/src/zenml/models/v2/core/device.py
+++ b/src/zenml/models/v2/core/device.py
@@ -103,6 +103,15 @@ class OAuthDeviceInternalUpdate(OAuthDeviceUpdate):
     user_id: Optional[UUID] = Field(
         default=None, description="User that owns the OAuth2 device."
     )
+    clear_user_id: bool = Field(
+        default=False,
+        description="Whether to clear the user association of the OAuth2 "
+        "device. `user_id` is dropped by the generic exclude_none update "
+        "logic when it is None, so this explicit flag is needed to actually "
+        "unset it (e.g. when a device is reused for a new authorization "
+        "attempt and must no longer be considered owned by the previous "
+        "user).",
+    )
     status: Optional[OAuthDeviceStatus] = Field(
         default=None, description="The new status of the OAuth2 device."
     )

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -428,7 +428,11 @@ def device_authorization(
     else:
         # Put the device into pending state and generate new codes. This
         # effectively invalidates the old codes and the device cannot be used
-        # for authentication anymore.
+        # for authentication anymore. Also clear any user association left
+        # over from a previous authorization of this device (e.g. a prior
+        # login from a different user on the same client machine/client ID)
+        # so the upcoming verification isn't rejected as belonging to
+        # another user.
         device_model = store.update_internal_authorized_device(
             device_id=device_model.id,
             update=OAuthDeviceInternalUpdate(
@@ -437,6 +441,7 @@ def device_authorization(
                 status=OAuthDeviceStatus.PENDING,
                 failed_auth_attempts=0,
                 generate_new_codes=True,
+                clear_user_id=True,
                 ip_address=ip_address,
                 city=city,
                 region=region,

--- a/src/zenml/zen_stores/schemas/device_schemas.py
+++ b/src/zenml/zen_stores/schemas/device_schemas.py
@@ -217,6 +217,14 @@ class OAuthDeviceSchema(BaseSchema, table=True):
         # name in the internal model and the schema.
         self.update(device_update)
 
+        # `update()` excludes None values, so it can never unset `user_id`.
+        # Devices reused for a new authorization attempt (see
+        # `device_authorization` in auth_endpoints.py) need that, otherwise
+        # the previous owner's user association survives the reset and
+        # blocks a different user from verifying the device.
+        if device_update.clear_user_id:
+            self.user_id = None
+
         if device_update.expires_in is not None:
             if device_update.expires_in <= 0:
                 self.expires = None

--- a/tests/unit/zen_stores/test_device_schemas.py
+++ b/tests/unit/zen_stores/test_device_schemas.py
@@ -1,0 +1,88 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+"""Unit tests for OAuthDeviceSchema.internal_update."""
+
+from uuid import uuid4
+
+from zenml.enums import OAuthDeviceStatus
+from zenml.models import (
+    OAuthDeviceInternalRequest,
+    OAuthDeviceInternalUpdate,
+)
+from zenml.zen_stores.schemas.device_schemas import OAuthDeviceSchema
+
+
+def _new_device() -> OAuthDeviceSchema:
+    schema, _, _ = OAuthDeviceSchema.from_request(
+        OAuthDeviceInternalRequest(client_id=uuid4(), expires_in=600)
+    )
+    return schema
+
+
+def test_internal_update_clears_user_id_when_requested() -> None:
+    """Test that clear_user_id detaches a device from its previous owner.
+
+    A device reused for a new authorization attempt must lose its
+    previous owner, otherwise verification as a different user is rejected
+    as belonging to someone else.
+    """
+    device = _new_device()
+    device.user_id = uuid4()
+
+    device.internal_update(
+        OAuthDeviceInternalUpdate(
+            status=OAuthDeviceStatus.PENDING,
+            clear_user_id=True,
+        )
+    )
+
+    assert device.user_id is None
+    assert device.status == OAuthDeviceStatus.PENDING.value
+
+
+def test_internal_update_leaves_user_id_untouched_by_default() -> None:
+    """Test that a plain update leaves an existing user_id untouched.
+
+    Without clear_user_id, an existing user association must survive an
+    update -- e.g. the verification step that only changes status/attempt
+    counters shouldn't accidentally detach the device from its owner.
+    """
+    device = _new_device()
+    owner_id = uuid4()
+    device.user_id = owner_id
+
+    device.internal_update(OAuthDeviceInternalUpdate(failed_auth_attempts=1))
+
+    assert device.user_id == owner_id
+
+
+def test_internal_update_sets_user_id_on_verification() -> None:
+    """Test that normal verification still sets user_id as before.
+
+    Verifying a pending device assigns it to the verifying user, the
+    normal (non-reuse) path this fix must not disturb.
+    """
+    device = _new_device()
+    assert device.user_id is None
+
+    new_owner = uuid4()
+    device.internal_update(
+        OAuthDeviceInternalUpdate(
+            status=OAuthDeviceStatus.VERIFIED,
+            user_id=new_owner,
+        )
+    )
+
+    assert device.user_id == new_owner


### PR DESCRIPTION
Ran into this while poking at the device auth flow (#3976). If a device gets reused for a new authorization attempt — say a shared CI runner or a machine where a different person logs in — the old `user_id` sticks around on the device row even after the reset. That's because `update()` uses `exclude_none=True`, so passing `user_id=None` never actually clears it, it just gets skipped.

End result: the next person to verify that device gets a "this device is associated with another user" error, even though the device was supposed to be reset for a fresh login.

Fix is a `clear_user_id` bool flag on `OAuthDeviceInternalUpdate`, same pattern the code already uses for `generate_new_codes` and `update_last_login` — explicit flags checked after the generic field copy, since `exclude_none` can't tell "leave alone" from "set to null." Set it to `True` in the device-reuse branch of `device_authorization`.

Added tests in `tests/unit/zen_stores/test_device_schemas.py` covering: clearing works when the flag is set, existing user_id survives a normal update without the flag, and the regular verification path (setting user_id) still works.