### PR TITLE
Relax click version cap to allow security patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires-python = ">=3.10,<3.15"
 
 dependencies = [
     "asgiref~=3.10.0",
-    "click>=8.0.1,<=8.2.1",
+    "click>=8.0.1,<9",
     "cloudpickle>=2.0.0",
     "distro>=1.6.0,<2.0.0",
     "docker~=7.1.0",


### PR DESCRIPTION
This change widens the version cap on click, one of zenml's dependencies, from 8.2.1 or older to anything below version 9. Right now zenml refuses to let anyone install a click version past 8.2.1, and that happens to be exactly the last version affected by a real security bug, CVE-2026-7246, a command injection issue in click's edit function that was fixed in click 8.3.3. Because of the cap, anyone using zenml is stuck on the vulnerable version even if they want to upgrade, and it makes pip-audit fail for them.

I looked through the git history for this line and there's no comment or reason given for capping it at 8.2.1, it looks like it was just carried over during an unrelated project file migration a while back. So this isn't removing a deliberate safety limit, it's just closing a gap that was probably never revisited.
What I checked before submitting: the file still parses correctly as valid project config, there's no lock file in the repo that also needed updating, and this is the only place click's version is referenced. No source code was touched, so there's nothing to test and no release notes should be needed since this is routine dependency maintenance, not a user facing change.

Closes #5077.