### PR TITLE
Build multi-arch server image in release-cloudbuild-preparation

### DIFF
--- a/release-cloudbuild-preparation.yaml
+++ b/release-cloudbuild-preparation.yaml
@@ -10,36 +10,27 @@ steps:
       - USERNAME
       - PASSWORD
 
-  # Build server image
   - name: gcr.io/cloud-builders/docker
     args:
       - '-c'
       - |
-        docker build . \
-          --platform linux/amd64 \
+        docker run --privileged --rm tonistiigi/binfmt --install arm64
+        docker buildx create --name zenml-multiarch --driver docker-container --use
+        docker buildx inspect --bootstrap
+        docker buildx build . \
+          --platform linux/amd64,linux/arm64 \
+          --push \
           -f docker/zenml-server-dev.Dockerfile \
           -t $$USERNAME/prepare-release:server-${_ZENML_NEW_VERSION}
 
     id: build-server
-    waitFor: ['-']
-    entrypoint: bash
-    secretEnv:
-      - USERNAME
-
-  # Push server images
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - '-c'
-      - docker push $$USERNAME/prepare-release:server-${_ZENML_NEW_VERSION}
-    id: push-server
     waitFor:
       - docker-login
-      - build-server
     entrypoint: bash
     secretEnv:
       - USERNAME
 
-timeout: 3600s
+timeout: 7200s
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/docker-password/versions/1


### PR DESCRIPTION
  This is the first, smallest step toward fixing issue 4644 - zenml's server Docker image is      
  currently only built for one type of computer chip, amd64, which means Apple Silicon Mac users  
  have to run it through an emulator. Rather than changing all four of the build files the issue  
  mentions at once, I'm starting with just the smallest and lowest risk one, the throwaway prep   
  image used before a release, so this can be checked in isolation before touching the real       
  release pipeline.

  What changed: this file used to build the image for amd64 only, then push it in a separate step.
  It now builds for both amd64 and arm64 in one combined step, using Docker's buildx tool, since  
  a multi platform image bundle can only be created by pushing straight to the registry rather    
  than building locally first.

  I compared this against the existing pattern already used in the real release file to make sure 
  the login credentials and build steps line up the same way that already works in production     
  today.

  One caveat: I don't have access to actually run Google Cloud Build myself, so this hasn't
  been tested end to end, only checked for valid syntax and consistency with the existing setup.  
  I'd appreciate it if a maintainer could run this through CI or a manual trigger to confirm the  
  multi arch push actually succeeds before this goes further.

  Relates to issue number 4644. This is intended as the first of a few small follow up pull       
  requests rather than one large change, since the issue itself suggests going safest first.      