### PR TITLE
Support zenml enrollment key as a kubernetes secrets

### DIFF
--- a/docs/book/getting-started/zenml-pro/enroll-workspace.md
+++ b/docs/book/getting-started/zenml-pro/enroll-workspace.md
@@ -67,7 +67,7 @@ These details will need to be passed to the workspace server container in the fo
 | `ZENML_SERVER_PRO_WORKSPACE_NAME` | The name of the workspace. |
 | `ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET` | The enrollment key for the workspace. |
 
-When deploying with Helm, store the enrollment key in a Kubernetes Secret and reference it from the chart values:
+NOTE: in the case of Helm, these values are configurable as Helm values when deploying the workspace server:
 
 ```yaml
 server:
@@ -76,15 +76,23 @@ server:
     enabled: true
     apiURL: https://zenml-pro.my.domain/api/v1
     dashboardURL: https://zenml-pro.my.domain
-    enrollmentKeySecretRef:
-      name: <secret-name>
-      key: <secret-key>
+    enrollmentKey: <enrollment-key>
     organizationID: <organization-id>
     organizationName: <organization-name>
     workspaceID: <workspace-id>
     workspaceName: <workspace-name>
 ```
 
-The existing `server.pro.enrollmentKey` value remains available for backward compatibility, but it stores the enrollment key in the Helm release state. Do not configure `enrollmentKey` and `enrollmentKeySecretRef` at the same time.
+Alternatively, use `enrollmentKeySecretRef` to source the enrollment key from an existing Kubernetes Secret:
+
+```yaml
+server:
+  pro:
+    enrollmentKeySecretRef:
+      name: <secret-name>
+      key: <secret-key>
+```
+
+Configure only one of `enrollmentKey` and `enrollmentKeySecretRef`.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/getting-started/zenml-pro/enroll-workspace.md
+++ b/docs/book/getting-started/zenml-pro/enroll-workspace.md
@@ -67,7 +67,7 @@ These details will need to be passed to the workspace server container in the fo
 | `ZENML_SERVER_PRO_WORKSPACE_NAME` | The name of the workspace. |
 | `ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET` | The enrollment key for the workspace. |
 
-NOTE: in the case of Helm, these values are configurable as Helm values when deploying the workspace server:
+When deploying with Helm, store the enrollment key in a Kubernetes Secret and reference it from the chart values:
 
 ```yaml
 server:
@@ -76,11 +76,15 @@ server:
     enabled: true
     apiURL: https://zenml-pro.my.domain/api/v1
     dashboardURL: https://zenml-pro.my.domain
-    enrollmentKey: <enrollment-key>
+    enrollmentKeySecretRef:
+      name: <secret-name>
+      key: <secret-key>
     organizationID: <organization-id>
     organizationName: <organization-name>
     workspaceID: <workspace-id>
     workspaceName: <workspace-name>
 ```
+
+The existing `server.pro.enrollmentKey` value remains available for backward compatibility, but it stores the enrollment key in the Helm release state. Do not configure `enrollmentKey` and `enrollmentKeySecretRef` at the same time.
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -11,6 +11,10 @@ The following enrollment key has been used to enroll your server in the ZenML Pr
 
   {{ $server.pro.enrollmentKey }}
 
+{{- else if $server.pro.enrollmentKeySecretRef }}
+
+The enrollment key has been sourced from key "{{ $server.pro.enrollmentKeySecretRef.key }}" in the existing Kubernetes Secret "{{ $server.pro.enrollmentKeySecretRef.name }}".
+
 {{- else }}
 
 An enrollment key has been auto-generated for your server. Please use the following command to fetch the enrollment key:

--- a/helm/templates/server-db-job.yaml
+++ b/helm/templates/server-db-job.yaml
@@ -161,6 +161,13 @@ spec:
                   name: {{ $server.database.passwordSecretRef.name }}
                   key: {{ $server.database.passwordSecretRef.key }}
             {{- end }}
+            {{- if and $server.pro.enabled $server.pro.enrollmentKeySecretRef }}
+            - name: ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $server.pro.enrollmentKeySecretRef.name }}
+                  key: {{ $server.pro.enrollmentKeySecretRef.key }}
+            {{- end }}
             {{- range $server.environmentSecretKeyRefs }}
             - name: {{ .name }}
               valueFrom:

--- a/helm/templates/server-deployment.yaml
+++ b/helm/templates/server-deployment.yaml
@@ -165,6 +165,13 @@ spec:
                   name: {{ $server.database.passwordSecretRef.name }}
                   key: {{ $server.database.passwordSecretRef.key }}
             {{- end }}
+            {{- if and $server.pro.enabled $server.pro.enrollmentKeySecretRef }}
+            - name: ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $server.pro.enrollmentKeySecretRef.name }}
+                  key: {{ $server.pro.enrollmentKeySecretRef.key }}
+            {{- end }}
             {{- range $server.environmentSecretKeyRefs }}
             - name: {{ .name }}
               valueFrom:

--- a/helm/templates/server-secret.yaml
+++ b/helm/templates/server-secret.yaml
@@ -1,6 +1,15 @@
 {{- define "secret.content" -}}
 {{- $server := include "zenml.serverValues" . | fromYaml -}}
 {{- $prevServerSecret := (lookup "v1" "Secret" .Release.Namespace (include "zenml.fullname" .)) -}}
+{{- $enrollmentKeySecretRef := $server.pro.enrollmentKeySecretRef | default dict -}}
+{{- $hasEnrollmentKeySecretName := not (empty $enrollmentKeySecretRef.name) -}}
+{{- $hasEnrollmentKeySecretKey := not (empty $enrollmentKeySecretRef.key) -}}
+{{- if ne $hasEnrollmentKeySecretName $hasEnrollmentKeySecretKey -}}
+{{- fail "server.pro.enrollmentKeySecretRef requires both name and key" -}}
+{{- end -}}
+{{- if and $server.pro.enrollmentKey $hasEnrollmentKeySecretName -}}
+{{- fail "server.pro.enrollmentKey and server.pro.enrollmentKeySecretRef cannot both be configured" -}}
+{{- end -}}
 data:
   {{- if $server.jwtSecretKey }}
   ZENML_SERVER_JWT_SECRET_KEY: {{ $server.jwtSecretKey | b64enc | quote }}
@@ -15,10 +24,12 @@ data:
   {{- if $server.pro.enabled }}
   {{- if $server.pro.enrollmentKey }}
   ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET: {{ $server.pro.enrollmentKey | b64enc | quote }}
-  {{- else if or .Release.IsInstall (not $prevServerSecret) }}
+  {{- else if not $hasEnrollmentKeySecretName }}
+  {{- if or .Release.IsInstall (not $prevServerSecret) }}
   ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET: {{ randAlphaNum 64 | b64enc | quote }}
   {{- else }}
   ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET: {{ $prevServerSecret.data.ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET | default (randAlphaNum 64 | b64enc | quote) }}
+  {{- end }}
   {{- end }}
   {{- end }}
 
@@ -40,7 +51,7 @@ metadata:
     {{- include "zenml.labels" . | nindent 4 }}
 {{ include "secret.content" . }}
 ---
-{{- $server := include "zenml.serverValues" . | fromYaml -}}
+{{ $server := include "zenml.serverValues" . | fromYaml -}}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/helm/templates/worker-deployments.yaml
+++ b/helm/templates/worker-deployments.yaml
@@ -169,6 +169,13 @@ spec:
                   name: {{ $server.database.passwordSecretRef.name }}
                   key: {{ $server.database.passwordSecretRef.key }}
             {{- end }}
+            {{- if and $server.pro.enabled $server.pro.enrollmentKeySecretRef }}
+            - name: ZENML_SERVER_PRO_OAUTH2_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $server.pro.enrollmentKeySecretRef.name }}
+                  key: {{ $server.pro.enrollmentKeySecretRef.key }}
+            {{- end }}
             {{- range $server.environmentSecretKeyRefs }}
             - name: {{ .name }}
               valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -112,8 +112,7 @@ server:
     organizationName:
 
     # The enrollment key to use for the ZenML Pro workspace. If not specified,
-    # an enrollment key will be auto-generated unless `enrollmentKeySecretRef`
-    # is configured.
+    # an enrollment key will be auto-generated.
     enrollmentKey:
 
     # Reference an enrollment key stored in an existing Kubernetes Secret.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -112,8 +112,15 @@ server:
     organizationName:
 
     # The enrollment key to use for the ZenML Pro workspace. If not specified,
-    # an enrollment key will be auto-generated.
+    # an enrollment key will be auto-generated unless `enrollmentKeySecretRef`
+    # is configured.
     enrollmentKey:
+
+    # Reference an enrollment key stored in an existing Kubernetes Secret.
+    # This cannot be used together with `enrollmentKey`.
+    enrollmentKeySecretRef:
+      # name:
+      # key:
 
   # The URL where the ZenML server API is reachable. If not specified, the
   # clients will use the same URL used to connect them to the ZenML server.


### PR DESCRIPTION
## Describe changes

The Helm chart only accepted the ZenML Pro enrollment key as an inline value. This stored the sensitive key in Helm’s release state. It also meant users could not configure the enrollment key through a dedicated reference to an existing Kubernetes Secret.

This PR adds `server.pro.enrollmentKeySecretRef`, which injects the key using Kubernetes `secretKeyRef`. The reference is applied to the server, migration, and worker containers because the previous Helm-managed Secret was shared with all three.

The existing inline value and automatic key generation remain supported for backward compatibility. Helm now reports an error if both configuration methods are used or if the Secret reference is incomplete.


## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

