### PR TITLE
chore(deps): relax click dependency cap to allow security fixes (#5077)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires-python = ">=3.10,<3.15"
 
 dependencies = [
     "asgiref~=3.10.0",
-    "click>=8.0.1,<=8.2.1",
+    "click>=8.0.1,<9.0.0",
     "cloudpickle>=2.0.0",
     "distro>=1.6.0,<2.0.0",
     "docker~=7.1.0",


### PR DESCRIPTION
Fixes #5077

Relaxes the `click` upper constraint (`<=8.2.1` -> `<9.0.0`) in `pyproject.toml` to allow installing Click 8.2.2+ for CVE security fixes without breaking CLI subcommands.