### PR TITLE
docs(cli): clarify deployment URLs in pretty_print_deployment (#4711)

### DIFF
--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -2586,16 +2586,24 @@ def pretty_print_deployment(
     declare(f"[bold]Snapshot:[/bold] [bold cyan]{snapshot_name}[/bold cyan]")
     declare(f"[bold]Stack:[/bold] [bold cyan]{stack_name}[/bold cyan]")
 
+    
     # Connection section
     if deployment.url:
         declare("\n[bold]Connection information:[/bold]")
 
         declare(
-            f"\n[bold]Endpoint URL:[/bold] [link]{deployment.url}[/link]",
+            f"\n[bold]Endpoint URL:[/bold] [link]{deployment.url}[/link] "
+            f"[dim](Base API endpoint for model predictions & invocation)[/dim]",
             soft_wrap=True,
         )
         declare(
-            f"[bold]Swagger URL:[/bold] [link]{deployment.url.rstrip('/')}/docs[/link]",
+            f"[bold]Swagger UI Docs:[/bold] [link]{deployment.url.rstrip('/')}/docs[/link] "
+            f"[dim](Interactive API documentation & schema explorer)[/dim]",
+            soft_wrap=True,
+        )
+        declare(
+            f"[bold]Health Check URL:[/bold] [link]{deployment.url.rstrip('/')}/health[/link] "
+            f"[dim](Endpoint for server status & deployment health checks)[/dim]",
             soft_wrap=True,
         )
 


### PR DESCRIPTION
Fixes #4711

Adds explicit inline descriptions to deployment URLs printed in `pretty_print_deployment` (Endpoint URL, Swagger UI Docs, and Health Check URL) so users can immediately distinguish between interactive API docs, invocation endpoints, and status checks.