### PR TITLE
Fix broken trigger filtering by associate ids

### DIFF
--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -493,6 +493,7 @@ class TriggerFilter(UnScopedTriggerFilter, ProjectScopedFilter):
         """
         from sqlmodel import col
 
+        from zenml.utils import uuid_utils
         from zenml.zen_stores.schemas import (
             PipelineSnapshotSchema,
             TriggerSchema,
@@ -516,8 +517,14 @@ class TriggerFilter(UnScopedTriggerFilter, ProjectScopedFilter):
                     if isinstance(self.pipeline_id, list)
                     else [self.pipeline_id]
                 )
+                normalized_pipeline_ids = [
+                    uuid_utils.to_uuid(pipeline_id)
+                    for pipeline_id in pipeline_ids
+                ]
                 query = query.where(
-                    col(PipelineSnapshotSchema.pipeline_id).in_(pipeline_ids)
+                    col(PipelineSnapshotSchema.pipeline_id).in_(
+                        normalized_pipeline_ids
+                    )
                 )
 
             if self.snapshot_id is not None:
@@ -526,8 +533,14 @@ class TriggerFilter(UnScopedTriggerFilter, ProjectScopedFilter):
                     if isinstance(self.snapshot_id, list)
                     else [self.snapshot_id]
                 )
+                normalized_snapshot_ids = [
+                    uuid_utils.to_uuid(snapshot_id)
+                    for snapshot_id in snapshot_ids
+                ]
                 query = query.where(
-                    col(TriggerSnapshotSchema.snapshot_id).in_(snapshot_ids)
+                    col(TriggerSnapshotSchema.snapshot_id).in_(
+                        normalized_snapshot_ids
+                    )
                 )
 
         return query

--- a/tests/integration/functional/triggers/test_crud.py
+++ b/tests/integration/functional/triggers/test_crud.py
@@ -9,20 +9,54 @@ from zenml import (
     PlatformEventTriggerResponse,
     PlatformEventTriggerUpdate,
 )
+from zenml.client import Client
 from zenml.config.pipeline_configurations import PipelineConfiguration
 from zenml.config.source import Source, SourceType
 from zenml.config.step_configurations import Step, StepConfiguration, StepSpec
 from zenml.enums import ExecutionStatus, TriggerFlavor, TriggerType
 from zenml.exceptions import IllegalOperationError
 from zenml.models import (
+    PipelineBuildRequest,
     PipelineRequest,
     PipelineRunFilter,
     PipelineRunRequest,
     PipelineSnapshotRequest,
+    PipelineSnapshotResponse,
     ScheduleTriggerRequest,
     ScheduleTriggerUpdate,
 )
 from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+def _create_runnable_snapshot(
+    client: Client, pipeline_id: uuid.UUID
+) -> PipelineSnapshotResponse:
+    project_id = client.active_project.id
+    build = client.zen_store.create_build(
+        PipelineBuildRequest(
+            project=project_id,
+            pipeline=pipeline_id,
+            stack=client.active_stack.id,
+            images={},
+            is_local=False,
+            contains_code=True,
+        )
+    )
+    return client.zen_store.create_snapshot(
+        PipelineSnapshotRequest(
+            project=project_id,
+            run_name_template=sample_name("trigger-filter-snapshot"),
+            pipeline_configuration=PipelineConfiguration(
+                name=sample_name("trigger-filter-config")
+            ),
+            pipeline=pipeline_id,
+            stack=client.active_stack.id,
+            build=build.id,
+            client_version="0.1.0",
+            server_version="0.1.0",
+            is_dynamic=False,
+        )
+    )
 
 
 def test_schedule_crud_happy_path(clean_client):
@@ -263,6 +297,56 @@ def test_snapshot_associations(clean_client):
             trigger_id=trigger_response.id,
             snapshot_id=snapshot.id,
         )
+
+
+def test_list_schedule_triggers_filters_by_pipeline_and_snapshot(clean_client):
+    project_id = clean_client.active_project.id
+    store = clean_client.zen_store
+
+    first_pipeline = store.create_pipeline(
+        PipelineRequest(
+            name=sample_name("trigger-filter-pipeline"),
+            project=project_id,
+        )
+    )
+    second_pipeline = store.create_pipeline(
+        PipelineRequest(
+            name=sample_name("trigger-filter-pipeline"),
+            project=project_id,
+        )
+    )
+    snapshots = [
+        _create_runnable_snapshot(clean_client, first_pipeline.id),
+        _create_runnable_snapshot(clean_client, first_pipeline.id),
+        _create_runnable_snapshot(clean_client, second_pipeline.id),
+    ]
+    triggers = [
+        clean_client.create_schedule_trigger(
+            name=sample_name("trigger-filter"),
+            cron_expression="* * * * *",
+        )
+        for _ in snapshots
+    ]
+    for trigger, snapshot in zip(triggers, snapshots):
+        store.attach_trigger_to_snapshot(
+            trigger_id=trigger.id,
+            snapshot_id=snapshot.id,
+        )
+
+    pipeline_triggers = clean_client.list_schedule_triggers(
+        pipeline_id=str(first_pipeline.id)
+    )
+    snapshot_triggers = clean_client.list_schedule_triggers(
+        snapshot_id=str(snapshots[0].id)
+    )
+
+    assert {trigger.id for trigger in pipeline_triggers.items} == {
+        triggers[0].id,
+        triggers[1].id,
+    }
+    assert {trigger.id for trigger in snapshot_triggers.items} == {
+        triggers[0].id
+    }
 
 
 def test_run_associations(clean_client):


### PR DESCRIPTION
## Describe changes

Fixes broken trigger filtering by associated ID (pipeline_id, snapshot_id)

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

