### PR TITLE
Allow old API keys to be used for adopted service accounts

### DIFF
--- a/docs/book/getting-started/zenml-pro/service-accounts.md
+++ b/docs/book/getting-started/zenml-pro/service-accounts.md
@@ -383,7 +383,15 @@ For self-hosted ZenML Pro API servers, also set the ZenML Pro API URL:
 
 4. Run the affected workloads once to verify that they authenticate successfully with the organization-level service account.
 5. If the migration is successful and the correct username is used at step 1, the old workspace-level service account is automatically "adopted" by the new organization-level service account and will no longer be listed in the workspace settings.
-6. For workspace-level service accounts that are no longer used, deactivate them or delete them. Deactivation immediately prevents their API keys from being used. Deletion can fail if the service account already owns resources such as pipeline runs; in that case, deactivate the service account instead.
+
+{% hint style="info" %}
+**Existing API keys continue to work after adoption**
+
+Adopting a workspace-level service account does not invalidate its existing workspace-level API keys. Those keys continue to authenticate to the workspace as the adopted organization-level service account, allowing you to migrate workloads without interruption. This compatibility period also gives you time to identify workloads that still use legacy keys: inspect the **Last used** timestamp of each workspace-level API key in the UI to see whether it is still authenticating. The keys remain workspace-level credentials and do not become ZenML Pro organization API keys, so you should still replace them with an organization-level API key as part of the migration.
+{% endhint %}
+
+6. Monitor the **Last used** timestamp for each existing workspace-level API key in the UI. If a timestamp continues to update after you believe a workload has migrated, that workload is likely still using the old key. Account for infrequent jobs before concluding that a key is unused.
+7. Once you have confirmed that the workspace-level API keys are no longer used, deactivate the keys or their service account. Deactivation immediately prevents the keys from being used. You can also delete the service account, but deletion can fail if it already owns resources such as pipeline runs; in that case, deactivate it instead.
 
 ## Troubleshooting
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -17,6 +17,15 @@ ruff check $TESTS_EXAMPLES --extend-ignore D --extend-exclude "*.ipynb"
 
 pydoclint $SRC_NO_TESTS
 
+# autoflake replacement: checks for unused imports and variables
+ruff check $SRC --select F401,F841 --exclude "__init__.py" --exclude "*.ipynb" --isolated
+
+ruff format $SRC  --check
+
+# check type annotations
+mypy $SRC_NO_TESTS
+
+
 # Flag checks for skipping optional linters
 SKIP_YAMLFIX=false
 SKIP_ZIZMOR=false
@@ -54,11 +63,3 @@ if [ "$SKIP_ZIZMOR" = false ] && [ -d ".github/workflows" ]; then
         echo "   Run: GH_TOKEN=\$(gh auth token) bash scripts/lint.sh"
     fi
 fi
-
-# autoflake replacement: checks for unused imports and variables
-ruff check $SRC --select F401,F841 --exclude "__init__.py" --exclude "*.ipynb" --isolated
-
-ruff format $SRC  --check
-
-# check type annotations
-mypy $SRC_NO_TESTS

--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -119,8 +119,7 @@ def _fetch_and_verify_api_key(
     Raises:
         CredentialsNotValid: If the API key could not be found, is not
             active, if it could not be verified against the supplied key value
-            or if the associated service account is not active or is an
-            external service account.
+            or if the associated service account is not active.
     """
     store = zen_store()
 
@@ -141,12 +140,11 @@ def _fetch_and_verify_api_key(
         raise CredentialsNotValid(error)
 
     if api_key.service_account.external_user_id:
-        error = (
-            "Authentication error: cannot use an API key associated with an "
+        warning = (
+            "Authentication warning: using an API key associated with an "
             "external service account to authenticate to the ZenML server"
         )
-        logger.exception(error)
-        raise CredentialsNotValid(error)
+        logger.warning(warning)
 
     if not api_key.active:
         error = (

--- a/tests/unit/zen_server/test_auth.py
+++ b/tests/unit/zen_server/test_auth.py
@@ -29,12 +29,14 @@ from zenml.zen_server import auth
 
 
 class _ApiKey:
-    def __init__(self):
+    def __init__(self, *, external_user_id=None):
         self.id = uuid4()
         self.name = "test-key"
         self.active = True
         self.service_account = SimpleNamespace(
-            active=True, external_user_id=None, name="test-service-account"
+            active=True,
+            external_user_id=external_user_id,
+            name="test-service-account",
         )
         self.verified_keys = []
 
@@ -122,6 +124,29 @@ def test_fetch_and_verify_api_key_allows_internal_skip(monkeypatch):
 
     assert api_key.verified_keys == []
     assert store.updated_api_key_ids == [api_key.id]
+
+
+def test_fetch_and_verify_api_key_allows_adopted_service_account(monkeypatch):
+    """Ensure adopted service accounts retain their existing API keys."""
+    api_key = _ApiKey(external_user_id=uuid4())
+    store = _ZenStore(api_key)
+    warnings = []
+    monkeypatch.setattr(auth, "zen_store", lambda: store)
+    monkeypatch.setattr(
+        auth.logger, "warning", lambda message: warnings.append(message)
+    )
+
+    result = auth._fetch_and_verify_api_key(
+        api_key_id=api_key.id, key_to_verify="valid"
+    )
+
+    assert result is api_key
+    assert api_key.verified_keys == ["valid"]
+    assert store.updated_api_key_ids == [api_key.id]
+    assert warnings == [
+        "Authentication warning: using an API key associated with an external "
+        "service account to authenticate to the ZenML server"
+    ]
 
 
 def test_authenticate_api_key_keeps_pro_api_key_flow(monkeypatch):


### PR DESCRIPTION
## Summary

Workspace-level service accounts are automatically adopted when an organization-level service account with the same name is created. Previously, this adoption caused existing workspace-level API keys to stop authenticating because the service account was now associated with an external identity.

This change keeps those existing API keys functional after adoption, allowing users to migrate workloads gradually without interruption.

## User-facing impact

Users can now:

- Adopt workspace-level service accounts without immediately breaking workloads that use their existing API keys.
- Replace legacy keys incrementally with organization-level API keys.
- Use each legacy API key’s **Last used** timestamp to identify workloads that have not yet migrated.
- Deactivate legacy keys after confirming they are no longer used.

Authentication with an adopted key emits a server warning for visibility. Existing validation for inactive accounts, inactive keys, invalid secrets, and rotated keys remains unchanged.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

