### PR TITLE
Fix aws artifact store setup script for us-east-1 and missing dependencies

### DIFF
--- a/infra/scripts/aws-artifact-store-setup.sh
+++ b/infra/scripts/aws-artifact-store-setup.sh
@@ -3,6 +3,24 @@
 # Exit on error
 set -e
 
+if ! command -v aws &> /dev/null; then
+    echo "Error: AWS CLI is required but not installed."
+    echo "Install guide: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed."
+    echo "Install with: sudo apt-get install jq"
+    exit 1
+fi
+
+if ! aws sts get-caller-identity &> /dev/null; then
+    echo "Error: AWS credentials are not configured."
+    echo "Run: aws configure"
+    exit 1
+fi
+
 # Name used for the stack, service connector, and artifact store and as a prefix
 # for all created resources
 NAME="${NAME:-zenml-aws}"
@@ -47,11 +65,19 @@ trap print_cleanup_instructions EXIT
 
 
 # Create S3 bucket
+# us-east-1 is AWS's default region and the create-bucket API rejects an
+# explicit LocationConstraint for it.
 echo "Creating AWS bucket: $PREFIX"
-aws s3api create-bucket \
-    --bucket "$PREFIX" \
-    --region "$REGION" \
-    --create-bucket-configuration LocationConstraint="$REGION"
+if [ "$REGION" != "us-east-1" ]; then
+    aws s3api create-bucket \
+        --bucket "$PREFIX" \
+        --region "$REGION" \
+        --create-bucket-configuration LocationConstraint="$REGION"
+else
+    aws s3api create-bucket \
+        --bucket "$PREFIX" \
+        --region "$REGION"
+fi
 
 # Create IAM user and access key
 echo "Creating IAM user: $PREFIX"


### PR DESCRIPTION
## Summary

Fixes three bugs in `infra/scripts/aws-artifact-store-setup.sh` reported in #4682.

- The script crashed immediately when run against us-east-1 because that region's create-bucket API rejects an explicit LocationConstraint. The bucket creation step now branches on region.
- If jq was not installed, the script silently continued with empty AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, then registered a ZenML service connector with empty credentials. Added an early check that exits with a clear message.
- If the AWS CLI was missing or credentials were not configured, the script failed partway through with a cryptic error and left partial resources behind. Added checks for both at the top of the script, before anything gets created.

## Test plan

- [x] `bash -n infra/scripts/aws-artifact-store-setup.sh` passes
- [ ] Manual run against an AWS account in us-east-1 to confirm bucket creation succeeds
- [ ] Manual run with jq removed to confirm the script exits with the new error message instead of continuing

Fixes #4682