### PR TITLE
Add unit tests for json_utils.py utility functions

### DIFF
--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -1,7 +1,15 @@
 import datetime
 from decimal import Decimal
 
-from zenml.utils.json_utils import _json_type_of, _schema_allowed_json_types, decimal_encoder, isoformat
+import pytest
+
+from zenml.utils.json_utils import (
+    _json_type_of,
+    _schema_allowed_json_types,
+    decimal_encoder,
+    isoformat,
+    pydantic_encoder,
+)
 
 
 def test_isoformat_date() -> None:
@@ -96,11 +104,71 @@ def test_schema_allowed_json_types_single_type() -> None:
 def test_schema_allowed_json_types_list_of_types() -> None:
     """A schema with a list of types should return all of them as
     a set."""
-    assert _schema_allowed_json_types(
-        {"type": ["string", "null"]}
-    ) == {"string", "null"}
+    assert _schema_allowed_json_types({"type": ["string", "null"]}) == {
+        "string",
+        "null",
+    }
 
 
 def test_schema_allowed_json_types_missing_type_key() -> None:
     """A schema with no 'type' key should return an empty set."""
     assert _schema_allowed_json_types({}) == set()
+
+
+def test_pydantic_encoder_pydantic_model() -> None:
+    """A pydantic BaseModel should be encoded via model_dump(mode='json')."""
+    from pydantic import BaseModel
+
+    class Sample(BaseModel):
+        name: str
+        value: int
+
+    result = pydantic_encoder(Sample(name="test", value=42))
+    assert result == {"name": "test", "value": 42}
+
+
+def test_pydantic_encoder_dataclass() -> None:
+    """A dataclass instance should be encoded via dataclasses.asdict."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class Point:
+        x: int
+        y: int
+
+    assert pydantic_encoder(Point(1, 2)) == {"x": 1, "y": 2}
+
+
+def test_pydantic_encoder_uuid() -> None:
+    """A UUID should be encoded as its string representation."""
+    from uuid import UUID
+
+    sample_uuid = UUID("12345678-1234-5678-1234-567812345678")
+    assert pydantic_encoder(sample_uuid) == str(sample_uuid)
+
+
+def test_pydantic_encoder_path() -> None:
+    """A Path should be encoded as its string representation."""
+    from pathlib import Path
+
+    assert pydantic_encoder(Path("/tmp/example")) == "/tmp/example"
+
+
+def test_pydantic_encoder_decimal_delegates_to_decimal_encoder() -> None:
+    """A Decimal should be routed through decimal_encoder."""
+    assert pydantic_encoder(Decimal("7.5")) == 7.5
+
+
+def test_pydantic_encoder_bytes() -> None:
+    """Bytes should be decoded into a str."""
+    assert pydantic_encoder(b"hello") == "hello"
+
+
+def test_pydantic_encoder_unsupported_type_raises_type_error() -> None:
+    """An object with no registered encoder should raise TypeError."""
+
+    class Unsupported:
+        pass
+
+    with pytest.raises(TypeError):
+        pydantic_encoder(Unsupported())

--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -1,0 +1,21 @@
+import datetime
+
+from zenml.utils.json_utils import isoformat
+
+
+def test_isoformat_date() -> None:
+    """A plain date object should convert to its ISO date string."""
+    assert isoformat(datetime.date(2026, 2, 18)) == "2026-02-18"
+
+
+def test_isoformat_datetime() -> None:
+    """A datetime object should convert to its full ISO string."""
+    assert (
+        isoformat(datetime.datetime(2026, 2, 18, 10, 15, 30))
+        == "2026-02-18T10:15:30"
+    )
+
+
+def test_isoformat_time() -> None:
+    """A time-only object should convert to its ISO time string."""
+    assert isoformat(datetime.time(10, 15, 30)) == "10:15:30"

--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -1,6 +1,7 @@
 import datetime
+from decimal import Decimal
 
-from zenml.utils.json_utils import isoformat
+from zenml.utils.json_utils import decimal_encoder, isoformat
 
 
 def test_isoformat_date() -> None:
@@ -19,3 +20,31 @@ def test_isoformat_datetime() -> None:
 def test_isoformat_time() -> None:
     """A time-only object should convert to its ISO time string."""
     assert isoformat(datetime.time(10, 15, 30)) == "10:15:30"
+
+
+def test_decimal_encoder_whole_number() -> None:
+    """A Decimal representing a whole number should encode as an int."""
+
+    assert decimal_encoder(Decimal("5")) == 5
+    assert isinstance(decimal_encoder(Decimal("5")), int)
+
+
+def test_decimal_encoder_fractional_number() -> None:
+    """A Decimal with a fractional part should encode as a float."""
+
+    assert decimal_encoder(Decimal("5.25")) == 5.25
+    assert isinstance(decimal_encoder(Decimal("5.25")), float)
+
+
+def test_decimal_encoder_negative_whole_number() -> None:
+    """A negative whole-number Decimal should still encode as an int."""
+
+    assert decimal_encoder(Decimal("-10")) == -10
+    assert isinstance(decimal_encoder(Decimal("-10")), int)
+
+
+def test_decimal_encoder_zero() -> None:
+    """A zero Decimal should encode as an int zero."""
+
+    assert decimal_encoder(Decimal("0")) == 0
+    assert isinstance(decimal_encoder(Decimal("0")), int)

--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -1,7 +1,7 @@
 import datetime
 from decimal import Decimal
 
-from zenml.utils.json_utils import _json_type_of, decimal_encoder, isoformat
+from zenml.utils.json_utils import _json_type_of, _schema_allowed_json_types, decimal_encoder, isoformat
 
 
 def test_isoformat_date() -> None:
@@ -85,3 +85,22 @@ def test_json_type_of_dict() -> None:
 def test_json_type_of_none() -> None:
     """None should map to the null JSON type."""
     assert _json_type_of(None) == "null"
+
+
+def test_schema_allowed_json_types_single_type() -> None:
+    """A schema with a single type string should return a set with
+    that one type."""
+    assert _schema_allowed_json_types({"type": "string"}) == {"string"}
+
+
+def test_schema_allowed_json_types_list_of_types() -> None:
+    """A schema with a list of types should return all of them as
+    a set."""
+    assert _schema_allowed_json_types(
+        {"type": ["string", "null"]}
+    ) == {"string", "null"}
+
+
+def test_schema_allowed_json_types_missing_type_key() -> None:
+    """A schema with no 'type' key should return an empty set."""
+    assert _schema_allowed_json_types({}) == set()

--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -8,6 +8,7 @@ from zenml.utils.json_utils import (
     _schema_allowed_json_types,
     decimal_encoder,
     isoformat,
+    parse_value_for_schema,
     pydantic_encoder,
 )
 
@@ -172,3 +173,50 @@ def test_pydantic_encoder_unsupported_type_raises_type_error() -> None:
 
     with pytest.raises(TypeError):
         pydantic_encoder(Unsupported())
+
+
+def test_parse_value_for_schema_valid_json_matching_type() -> None:
+    """A raw string parsing to the schema's expected type is returned
+    as the parsed value."""
+    assert parse_value_for_schema("42", {"type": "integer"}) == 42
+
+
+def test_parse_value_for_schema_integer_accepted_as_number() -> None:
+    """An integer value should satisfy a schema expecting 'number',
+    since JSON Schema treats integers as a subset of numbers."""
+    assert parse_value_for_schema("42", {"type": "number"}) == 42
+
+
+def test_parse_value_for_schema_type_mismatch_falls_back_to_string() -> None:
+    """If the parsed type doesn't match but 'string' is an allowed
+    type, the raw string is returned unchanged."""
+    assert parse_value_for_schema("42", {"type": "string"}) == "42"
+
+
+def test_parse_value_for_schema_type_mismatch_raises_value_error() -> None:
+    """If the parsed type doesn't match and 'string' is not allowed,
+    a ValueError is raised."""
+    with pytest.raises(ValueError):
+        parse_value_for_schema("42", {"type": "array"})
+
+
+def test_parse_value_for_schema_invalid_json_falls_back_to_string() -> None:
+    """Malformed JSON input should fall back to the raw string when
+    'string' is an allowed type."""
+    assert (
+        parse_value_for_schema("not valid json", {"type": "string"})
+        == "not valid json"
+    )
+
+
+def test_parse_value_for_schema_invalid_json_no_string_raises() -> None:
+    """Malformed JSON input should raise when 'string' is not an
+    allowed type."""
+    with pytest.raises(ValueError):
+        parse_value_for_schema("not valid json", {"type": "integer"})
+
+
+def test_parse_value_for_schema_empty_schema_returns_parsed_value() -> None:
+    """With no schema constraints, the parsed JSON value is returned
+    as-is."""
+    assert parse_value_for_schema("42", {}) == 42

--- a/tests/unit/utils/test_json_utils.py
+++ b/tests/unit/utils/test_json_utils.py
@@ -1,7 +1,7 @@
 import datetime
 from decimal import Decimal
 
-from zenml.utils.json_utils import decimal_encoder, isoformat
+from zenml.utils.json_utils import _json_type_of, decimal_encoder, isoformat
 
 
 def test_isoformat_date() -> None:
@@ -48,3 +48,40 @@ def test_decimal_encoder_zero() -> None:
 
     assert decimal_encoder(Decimal("0")) == 0
     assert isinstance(decimal_encoder(Decimal("0")), int)
+
+
+def test_json_type_of_bool_is_boolean_not_integer() -> None:
+    """bool is a subclass of int in Python, so this must be checked
+    before int to avoid misclassifying booleans as integers."""
+    assert _json_type_of(True) == "boolean"
+    assert _json_type_of(False) == "boolean"
+
+
+def test_json_type_of_integer() -> None:
+    """A plain int should map to the integer JSON type."""
+    assert _json_type_of(42) == "integer"
+
+
+def test_json_type_of_float() -> None:
+    """A float should map to the number JSON type."""
+    assert _json_type_of(3.14) == "number"
+
+
+def test_json_type_of_string() -> None:
+    """A str should map to the string JSON type."""
+    assert _json_type_of("hello") == "string"
+
+
+def test_json_type_of_list() -> None:
+    """A list should map to the array JSON type."""
+    assert _json_type_of([1, 2, 3]) == "array"
+
+
+def test_json_type_of_dict() -> None:
+    """A dict should map to the object JSON type."""
+    assert _json_type_of({"key": "value"}) == "object"
+
+
+def test_json_type_of_none() -> None:
+    """None should map to the null JSON type."""
+    assert _json_type_of(None) == "null"


### PR DESCRIPTION
## Describe changes

Adds comprehensive unit test coverage for `src/zenml/utils/json_utils.py`, which previously had 0 tests. This PR adds 31 test cases covering `isoformat`, `decimal_encoder`, `_json_type_of`, `_schema_allowed_json_types`, `pydantic_encoder`, and `parse_value_for_schema` — including expected behaviors, edge cases, and error handling. All 31 tests pass locally.

## Pre-requisites
Please ensure you have done the following:
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
- [X] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

