### PR TITLE
Fix Haystack agent example for Haystack 3

### DIFF
--- a/examples/agent_framework_integrations/haystack/haystack_agent.py
+++ b/examples/agent_framework_integrations/haystack/haystack_agent.py
@@ -13,7 +13,7 @@ expose ``pipeline`` so the Haystack adapter will auto-discover it.
 
 from haystack import Document, Pipeline
 from haystack.components.builders import PromptBuilder
-from haystack.components.generators import OpenAIGenerator
+from haystack.components.generators.chat import OpenAIChatGenerator
 from haystack.components.retrievers.in_memory import InMemoryBM25Retriever
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
@@ -55,7 +55,7 @@ Answer (concise):
 
 prompt_builder = PromptBuilder(template=prompt_template)
 
-llm = OpenAIGenerator(model="gpt-5-nano")
+llm = OpenAIChatGenerator(model="gpt-5-nano")
 
 # --------------------------------------------------------------------------- #
 # 3. Assemble the pipeline                                                    #
@@ -84,4 +84,4 @@ pipeline.warm_up()
 #         },
 #         include_outputs_from={"llm"},
 #     )
-#     print(result["llm"]["replies"][0].content)
+#     print(result["llm"]["replies"][0].text)

--- a/examples/agent_framework_integrations/haystack/requirements.txt
+++ b/examples/agent_framework_integrations/haystack/requirements.txt
@@ -1,4 +1,4 @@
-haystack-ai>=2.0.0
+haystack-ai>=3.0.0,<4.0.0
 zenml[local]
 jinja2>=3.1.0
 secure>=0.3.0

--- a/examples/agent_framework_integrations/haystack/run.py
+++ b/examples/agent_framework_integrations/haystack/run.py
@@ -5,7 +5,7 @@ for orchestration and artifact management.
 """
 
 import os
-from typing import Annotated, Any, Dict
+from typing import Annotated, Dict
 
 from haystack_agent import pipeline as haystack_pipeline
 
@@ -29,56 +29,53 @@ docker_settings = DockerSettings(
 @step
 def run_haystack_rag(
     question: str,
-) -> Annotated[Dict[str, Any], "rag_results"]:
-    """Execute the Haystack RAG pipeline and return results."""
-    try:
-        result = haystack_pipeline.run(
-            {
-                "retriever": {"query": question},
-                "prompt_builder": {"question": question},
-            },
-            include_outputs_from={"llm"},
-        )
+) -> Annotated[Dict[str, str], "rag_results"]:
+    """Execute the Haystack RAG pipeline and return its answer.
 
-        # Extract the response from the nested structure
-        if (
-            "llm" in result
-            and "replies" in result["llm"]
-            and result["llm"]["replies"]
-        ):
-            response = result["llm"]["replies"][
-                0
-            ]  # Already a string in newer Haystack versions
-        else:
-            response = "No response generated"
+    Args:
+        question: Question to answer using the in-memory documents.
 
-        return {"question": question, "answer": response, "status": "success"}
-    except Exception as e:
-        return {
-            "question": question,
-            "answer": f"RAG error: {str(e)}",
-            "status": "error",
-        }
+    Returns:
+        The original question and the generated answer.
+
+    Raises:
+        RuntimeError: If the Haystack pipeline returns no usable answer.
+    """
+    result = haystack_pipeline.run(
+        {
+            "retriever": {"query": question},
+            "prompt_builder": {"question": question},
+        },
+        include_outputs_from={"llm"},
+    )
+
+    replies = result.get("llm", {}).get("replies", [])
+    if not replies:
+        raise RuntimeError("Haystack pipeline returned no replies.")
+
+    answer = replies[0].text
+    if not answer or not answer.strip():
+        raise RuntimeError("Haystack pipeline returned an empty answer.")
+
+    return {"question": question, "answer": answer}
 
 
 @step
 def format_rag_response(
-    rag_data: Dict[str, Any],
+    rag_data: Dict[str, str],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the Haystack RAG results into a readable summary."""
+    """Format the Haystack RAG results into a readable summary.
+
+    Args:
+        rag_data: Question and generated answer to format.
+
+    Returns:
+        A readable summary of the RAG response.
+    """
     question = rag_data["question"]
     answer = rag_data["answer"]
-    status = rag_data["status"]
 
-    if status == "error":
-        formatted = f"""❌ HAYSTACK RAG ERROR
-{"=" * 40}
-
-Question: {question}
-Error: {answer}
-"""
-    else:
-        formatted = f"""🔍 HAYSTACK RAG RESPONSE
+    formatted = f"""🔍 HAYSTACK RAG RESPONSE
 {"=" * 40}
 
 Question: {question}
@@ -98,8 +95,11 @@ def agent_pipeline(
 ) -> str:
     """ZenML pipeline that orchestrates the Haystack RAG system.
 
+    Args:
+        question: Question to answer using the in-memory documents.
+
     Returns:
-        Formatted RAG response
+        Formatted RAG response.
     """
     # Run the Haystack RAG pipeline
     rag_results = run_haystack_rag(question=question)


### PR DESCRIPTION
## Describe changes

The Haystack agent example now runs against Haystack 3 instead of failing during import. Provider errors and missing or blank answers now propagate out of the ZenML pipeline, so the agent-examples workflow cannot report a false success.

The dependency is bounded to the Haystack 3 major version. The example uses `OpenAIChatGenerator` and reads `ChatMessage.text`, which are the Haystack 3 response contracts.

## Validation

- Installed the local ZenML package and the example requirements in an isolated Python 3.11 environment; dependency resolution selected `haystack-ai==3.0.0`.

- Constructed the real Haystack pipeline without making a provider call.

- Verified the success path and deterministic failures for zero replies, null text, empty text, whitespace-only text, and a raised provider exception.

- Verified a real OpenAI 401 causes the ZenML pipeline process to exit nonzero.

- Ran Ruff checks, Ruff format checks, pydoclint, and `git diff --check`.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.

- [ ] I have added tests to cover my changes. The example suite has no deterministic unit-test harness; the focused isolated checks above cover the changed paths.

- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.

- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:

  - [x] ZenML Docs: no documentation change is needed.

  - [x] Dashboard: no dashboard change is needed.

  - [x] Templates: no template change is needed.

  - [x] Projects: no project dependency change is needed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] Other (add details above)

## Post-Deploy Monitoring & Validation

- Check the first Agent Examples Test run on `develop` after merge and the next scheduled run.

- Healthy state: the Haystack example installs Haystack 3, produces a nonblank answer, and is listed under passed examples.

- Failure signals: `ImportError`, `PipelineRuntimeError`, `Haystack pipeline returned no replies`, `Haystack pipeline returned an empty answer`, or `haystack` in the workflow failure list.

- If the example fails after merge, revert this commit while inspecting the attached Haystack log. A temporary `<3` dependency cap is the fallback only if upstream Haystack 3 cannot be made compatible.
