### PR TITLE
Fail agent examples on provider errors

### DIFF
--- a/examples/agent_framework_integrations/aws_strands/run.py
+++ b/examples/agent_framework_integrations/aws_strands/run.py
@@ -24,19 +24,30 @@ docker_settings = DockerSettings(
 
 @step
 def run_strands_agent(query: str) -> Annotated[str, "agent_response"]:
-    """Execute the Strands agent and return the response."""
-    try:
-        response = agent(query)
-        return str(response)
-    except Exception as e:
-        return f"Agent error: {str(e)}"
+    """Execute the Strands agent and return the response.
+
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The agent response.
+    """
+    response = agent(query)
+    return str(response)
 
 
 @step
 def format_weather_response(
     response: str,
 ) -> Annotated[str, "formatted_response"]:
-    """Format the agent response into a readable summary."""
+    """Format the agent response into a readable summary.
+
+    Args:
+        response: Raw agent response.
+
+    Returns:
+        The formatted weather report.
+    """
     formatted = f"""🌤️ WEATHER REPORT
 {"=" * 30}
 

--- a/examples/agent_framework_integrations/crewai/run.py
+++ b/examples/agent_framework_integrations/crewai/run.py
@@ -81,38 +81,33 @@ crew = Crew(
 
 @step
 def run_crewai_agents(city: str) -> Annotated[Dict[str, Any], "crew_results"]:
-    """Execute the CrewAI crew and return results."""
-    try:
-        # Execute the crew with the city parameter
-        result = crew.kickoff(inputs={"city": city})
+    """Execute the CrewAI crew and return results.
 
-        # Convert result to dict for ZenML artifact storage
-        return {"city": city, "result": str(result), "status": "success"}
-    except Exception as e:
-        return {
-            "city": city,
-            "result": f"Crew execution error: {str(e)}",
-            "status": "error",
-        }
+    Args:
+        city: City for the travel plan.
+
+    Returns:
+        The city and generated travel plan.
+    """
+    result = crew.kickoff(inputs={"city": city})
+    return {"city": city, "result": str(result)}
 
 
 @step
 def format_travel_results(
     crew_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_results"]:
-    """Format the CrewAI results into a readable summary."""
+    """Format the CrewAI results into a readable summary.
+
+    Args:
+        crew_data: City and generated travel plan.
+
+    Returns:
+        The formatted travel plan.
+    """
     city = crew_data["city"]
     result = crew_data["result"]
-    status = crew_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ TRAVEL PLANNING ERROR FOR {city.upper()}
-{"=" * 50}
-
-{result}
-"""
-    else:
-        formatted = f"""✈️ TRAVEL PLANNING FOR {city.upper()}
+    formatted = f"""✈️ TRAVEL PLANNING FOR {city.upper()}
 {"=" * 50}
 
 {result}

--- a/examples/agent_framework_integrations/langchain/run.py
+++ b/examples/agent_framework_integrations/langchain/run.py
@@ -25,44 +25,38 @@ docker_settings = DockerSettings(
 def run_langchain_chain(
     url_input: str,
 ) -> Annotated[Dict[str, Any], "chain_results"]:
-    """Execute the LangChain chain for document summarization."""
-    try:
-        # Extract URL from input (assuming format "Summarize: URL")
-        if ":" in url_input and url_input.startswith("Summarize"):
-            url = url_input.split(":", 1)[1].strip()
-        else:
-            url = url_input  # Fallback to use input as URL directly
+    """Execute the LangChain chain for document summarization.
 
-        # Execute the LangChain chain
-        result = chain.invoke({"url": url})
+    Args:
+        url_input: URL or prefixed summarization request.
 
-        return {"url": url, "summary": result, "status": "success"}
-    except Exception as e:
-        return {
-            "url": url_input,
-            "summary": f"Chain error: {str(e)}",
-            "status": "error",
-        }
+    Returns:
+        The source URL and generated summary.
+    """
+    if ":" in url_input and url_input.startswith("Summarize"):
+        url = url_input.split(":", 1)[1].strip()
+    else:
+        url = url_input
+
+    result = chain.invoke({"url": url})
+    return {"url": url, "summary": result}
 
 
 @step
 def format_langchain_response(
     chain_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the LangChain results into a readable summary."""
+    """Format the LangChain results into a readable summary.
+
+    Args:
+        chain_data: Source URL and generated summary.
+
+    Returns:
+        The formatted document summary.
+    """
     url = chain_data["url"]
     summary = chain_data["summary"]
-    status = chain_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ LANGCHAIN CHAIN ERROR
-{"=" * 40}
-
-URL: {url}
-Error: {summary}
-"""
-    else:
-        formatted = f"""📄 LANGCHAIN DOCUMENT SUMMARY
+    formatted = f"""📄 LANGCHAIN DOCUMENT SUMMARY
 {"=" * 40}
 
 Source: {url}

--- a/examples/agent_framework_integrations/langgraph/run.py
+++ b/examples/agent_framework_integrations/langgraph/run.py
@@ -25,50 +25,44 @@ docker_settings = DockerSettings(
 def run_langgraph_agent(
     query: str,
 ) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the LangGraph ReAct agent and return results."""
-    try:
-        # LangGraph agents expect messages in a specific format
-        messages = [{"role": "user", "content": query}]
-        result = agent.invoke({"messages": messages})
+    """Execute the LangGraph ReAct agent and return results.
 
-        # Extract the response from the result
-        if "messages" in result and result["messages"]:
-            # Get the last message (assistant's response)
-            last_message = result["messages"][-1]
-            if hasattr(last_message, "content"):
-                response = last_message.content
-            else:
-                response = str(last_message)
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The query and generated response.
+    """
+    messages = [{"role": "user", "content": query}]
+    result = agent.invoke({"messages": messages})
+
+    if "messages" in result and result["messages"]:
+        last_message = result["messages"][-1]
+        if hasattr(last_message, "content"):
+            response = last_message.content
         else:
-            response = str(result)
+            response = str(last_message)
+    else:
+        response = str(result)
 
-        return {"query": query, "response": response, "status": "success"}
-    except Exception as e:
-        return {
-            "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
-        }
+    return {"query": query, "response": response}
 
 
 @step
 def format_langgraph_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the LangGraph agent results into a readable summary."""
+    """Format the LangGraph agent results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ LANGGRAPH AGENT ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🤖 LANGGRAPH REACT AGENT RESPONSE
+    formatted = f"""🤖 LANGGRAPH REACT AGENT RESPONSE
 {"=" * 40}
 
 Query: {query}

--- a/examples/agent_framework_integrations/llama_index/run.py
+++ b/examples/agent_framework_integrations/llama_index/run.py
@@ -25,56 +25,50 @@ docker_settings = DockerSettings(
 def run_llamaindex_agent(
     query: str,
 ) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the LlamaIndex Function Agent and return results."""
+    """Execute the LlamaIndex Function Agent and return results.
 
-    async def run_agent_async():
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The query and generated response.
+    """
+
+    async def run_agent_async() -> Any:
         return await agent.run(query)
 
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
-        # LlamaIndex agent.run() is actually async and needs proper await
-        import asyncio
+        response = loop.run_until_complete(run_agent_async())
+    finally:
+        loop.close()
 
-        # Create and run in event loop
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            response = loop.run_until_complete(run_agent_async())
-        finally:
-            loop.close()
+    if hasattr(response, "response"):
+        result = str(response.response)
+    else:
+        result = str(response)
 
-        # Extract the response content
-        if hasattr(response, "response"):
-            result = str(response.response)
-        else:
-            result = str(response)
-
-        return {"query": query, "response": result, "status": "success"}
-    except Exception as e:
-        return {
-            "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
-        }
+    return {"query": query, "response": result}
 
 
 @step
 def format_llamaindex_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the LlamaIndex agent results into a readable summary."""
+    """Format the LlamaIndex agent results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ LLAMAINDEX AGENT ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🦙 LLAMAINDEX FUNCTION AGENT RESPONSE
+    formatted = f"""🦙 LLAMAINDEX FUNCTION AGENT RESPONSE
 {"=" * 40}
 
 Query: {query}

--- a/examples/agent_framework_integrations/openai_agents_sdk/run.py
+++ b/examples/agent_framework_integrations/openai_agents_sdk/run.py
@@ -41,15 +41,24 @@ docker_settings = DockerSettings(
 
 @step
 def run_openai_agent(query: str) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the OpenAI Agents SDK agent and return results."""
-    try:
-        import json
-        import subprocess
-        import sys
-        import tempfile
+    """Execute the OpenAI Agents SDK agent and return results.
 
-        # Create a standalone script to run the agent in a separate process
-        agent_script = '''
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The query and generated response.
+
+    Raises:
+        RuntimeError: If the agent subprocess fails.
+    """
+    import json
+    import subprocess
+    import sys
+    import tempfile
+
+    # Create a standalone script to run the agent in a separate process
+    agent_script = '''
 import asyncio
 import sys
 import json
@@ -75,9 +84,7 @@ def main():
 
     try:
         response = loop.run_until_complete(run_agent(query))
-        print(json.dumps({"success": True, "response": response}))
-    except Exception as e:
-        print(json.dumps({"success": False, "error": str(e)}))
+        print(json.dumps({"response": response}))
     finally:
         loop.close()
 
@@ -85,90 +92,57 @@ if __name__ == "__main__":
     main()
 '''
 
-        # Write the script to a temporary file
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", delete=False
-        ) as f:
-            f.write(agent_script)
-            script_path = f.name
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False
+    ) as f:
+        f.write(agent_script)
+        script_path = f.name
 
-        try:
-            # Determine the correct working directory
-            import os
+    try:
+        current_file_dir = os.path.dirname(os.path.abspath(__file__))
+        work_dir = (
+            "/app/code" if os.path.exists("/app/code") else current_file_dir
+        )
 
-            current_file_dir = os.path.dirname(os.path.abspath(__file__))
-            work_dir = (
-                "/app/code"
-                if os.path.exists("/app/code")
-                else current_file_dir
-            )
+        result = subprocess.run(
+            [sys.executable, script_path, query],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=work_dir,
+            env={**os.environ, "PYTHONPATH": work_dir},
+        )
+        if result.returncode != 0:
+            error = result.stderr.strip() or "OpenAI agent subprocess failed."
+            raise RuntimeError(error)
 
-            # Run the agent in a separate process
-            result = subprocess.run(
-                [sys.executable, script_path, query],
-                capture_output=True,
-                text=True,
-                timeout=60,
-                cwd=work_dir,
-                env={**os.environ, "PYTHONPATH": work_dir},
-            )
-
-            if result.returncode == 0:
-                # Parse the JSON output
-                output_data = json.loads(result.stdout.strip())
-                if output_data.get("success"):
-                    return {
-                        "query": query,
-                        "response": output_data["response"],
-                        "status": "success",
-                    }
-                else:
-                    return {
-                        "query": query,
-                        "response": f"Agent error: {output_data.get('error', 'Unknown error')}",
-                        "status": "error",
-                    }
-            else:
-                return {
-                    "query": query,
-                    "response": f"Process error: {result.stderr}",
-                    "status": "error",
-                }
-        finally:
-            # Clean up the temporary file
-            import os
-
-            try:
-                os.unlink(script_path)
-            except Exception:
-                pass
-
-    except Exception as e:
+        output_data = json.loads(result.stdout.strip())
         return {
             "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
+            "response": output_data["response"],
         }
+    finally:
+        try:
+            os.unlink(script_path)
+        except OSError:
+            pass
 
 
 @step
 def format_openai_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the OpenAI Agents SDK results into a readable summary."""
+    """Format the OpenAI Agents SDK results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ OPENAI AGENTS SDK ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🤖 OPENAI AGENTS SDK RESPONSE
+    formatted = f"""🤖 OPENAI AGENTS SDK RESPONSE
 {"=" * 40}
 
 Query: {query}

--- a/examples/agent_framework_integrations/pydanticai/run.py
+++ b/examples/agent_framework_integrations/pydanticai/run.py
@@ -25,38 +25,33 @@ docker_settings = DockerSettings(
 def run_pydanticai_agent(
     query: str,
 ) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the PydanticAI agent and return results."""
-    try:
-        # Execute the PydanticAI agent
-        result = agent.run_sync(query)
+    """Execute the PydanticAI agent and return results.
 
-        return {"query": query, "response": result.output, "status": "success"}
-    except Exception as e:
-        return {
-            "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
-        }
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The query and generated response.
+    """
+    result = agent.run_sync(query)
+    return {"query": query, "response": result.output}
 
 
 @step
 def format_pydanticai_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the PydanticAI results into a readable summary."""
+    """Format the PydanticAI results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ PYDANTICAI AGENT ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🐍 PYDANTICAI RESPONSE
+    formatted = f"""🐍 PYDANTICAI RESPONSE
 {"=" * 40}
 
 Query: {query}

--- a/examples/agent_framework_integrations/qwen-agent/run.py
+++ b/examples/agent_framework_integrations/qwen-agent/run.py
@@ -28,54 +28,56 @@ docker_settings = DockerSettings(
 def run_qwen_agent(
     query: str,
 ) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the Qwen-Agent with the given query."""
-    try:
-        messages = [{"role": "user", "content": query}]
-        last_batch: list[Any] = []
-        for batch in agent.run(messages=messages):
-            # run() yields incremental message lists; keep the latest for the final assistant output
-            last_batch = batch
+    """Execute the Qwen-Agent with the given query.
 
-        final_text = ""
-        if last_batch:
-            last_msg = last_batch[-1]
-            final_text = (
-                last_msg.get("content", str(last_msg))
-                if isinstance(last_msg, dict)
-                else str(last_msg)
-            )
+    Args:
+        query: Question for the agent.
 
-        return {
-            "query": query,
-            "response": final_text,
-            "status": "success",
-        }
-    except Exception as e:
-        return {
-            "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
-        }
+    Returns:
+        The query and generated response.
+
+    Raises:
+        RuntimeError: If the agent returns no response.
+    """
+    messages = [{"role": "user", "content": query}]
+    last_batch: list[Any] = []
+    for batch in agent.run(messages=messages):
+        last_batch = batch
+
+    if not last_batch:
+        raise RuntimeError("Qwen-Agent returned no messages.")
+
+    last_msg = last_batch[-1]
+    if isinstance(last_msg, dict):
+        role = last_msg.get("role")
+        final_text = last_msg.get("content")
+    else:
+        role = getattr(last_msg, "role", None)
+        final_text = getattr(last_msg, "content", None)
+
+    if role != "assistant" or not isinstance(final_text, str):
+        raise RuntimeError("Qwen-Agent did not return a final response.")
+    if not final_text.strip():
+        raise RuntimeError("Qwen-Agent returned an empty response.")
+
+    return {"query": query, "response": final_text}
 
 
 @step
 def format_qwen_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the Qwen-Agent results into a readable summary."""
+    """Format the Qwen-Agent results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ QWEN-AGENT ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🤖 QWEN-AGENT RESPONSE
+    formatted = f"""🤖 QWEN-AGENT RESPONSE
 {"=" * 40}
 
 Query: {query}

--- a/examples/agent_framework_integrations/semantic_kernel/run.py
+++ b/examples/agent_framework_integrations/semantic_kernel/run.py
@@ -26,73 +26,63 @@ docker_settings = DockerSettings(
 def run_semantic_kernel_agent(
     query: str,
 ) -> Annotated[Dict[str, Any], "agent_results"]:
-    """Execute the Semantic Kernel agent and return results."""
+    """Execute the Semantic Kernel agent and return results.
+
+    Args:
+        query: Question for the agent.
+
+    Returns:
+        The query and generated response.
+    """
+
+    async def run_kernel_async() -> Any:
+        from semantic_kernel.connectors.ai.function_choice_behavior import (
+            FunctionChoiceBehavior,
+        )
+        from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_prompt_execution_settings import (
+            OpenAIChatPromptExecutionSettings,
+        )
+        from semantic_kernel.contents.chat_history import ChatHistory
+
+        chat_service = kernel.get_service("openai-chat")
+        history = ChatHistory()
+        history.add_user_message(query)
+
+        settings = OpenAIChatPromptExecutionSettings()
+        settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
+
+        response = await chat_service.get_chat_message_content(
+            chat_history=history,
+            settings=settings,
+            kernel=kernel,
+        )
+        return response.content
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     try:
+        response = loop.run_until_complete(run_kernel_async())
+    finally:
+        loop.close()
 
-        async def run_kernel_async():
-            from semantic_kernel.connectors.ai.function_choice_behavior import (
-                FunctionChoiceBehavior,
-            )
-            from semantic_kernel.connectors.ai.open_ai.prompt_execution_settings.open_ai_prompt_execution_settings import (
-                OpenAIChatPromptExecutionSettings,
-            )
-            from semantic_kernel.contents.chat_history import ChatHistory
-
-            # Get the chat service
-            chat_service = kernel.get_service("openai-chat")
-
-            # Create chat history with user message
-            history = ChatHistory()
-            history.add_user_message(query)
-
-            # Configure settings to enable function calling
-            settings = OpenAIChatPromptExecutionSettings()
-            settings.function_choice_behavior = FunctionChoiceBehavior.Auto()
-
-            # Execute the chat with the kernel
-            response = await chat_service.get_chat_message_content(
-                chat_history=history,
-                settings=settings,
-                kernel=kernel,
-            )
-
-            return response.content
-
-        # Run the async function
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            response = loop.run_until_complete(run_kernel_async())
-        finally:
-            loop.close()
-
-        return {"query": query, "response": response, "status": "success"}
-    except Exception as e:
-        return {
-            "query": query,
-            "response": f"Agent error: {str(e)}",
-            "status": "error",
-        }
+    return {"query": query, "response": response}
 
 
 @step
 def format_semantic_kernel_response(
     agent_data: Dict[str, Any],
 ) -> Annotated[str, "formatted_response"]:
-    """Format the Semantic Kernel results into a readable summary."""
+    """Format the Semantic Kernel results into a readable summary.
+
+    Args:
+        agent_data: Query and generated response.
+
+    Returns:
+        The formatted agent response.
+    """
     query = agent_data["query"]
     response = agent_data["response"]
-    status = agent_data["status"]
-
-    if status == "error":
-        formatted = f"""❌ SEMANTIC KERNEL AGENT ERROR
-{"=" * 40}
-
-Query: {query}
-Error: {response}
-"""
-    else:
-        formatted = f"""🧠 SEMANTIC KERNEL RESPONSE
+    formatted = f"""🧠 SEMANTIC KERNEL RESPONSE
 {"=" * 40}
 
 Query: {query}


### PR DESCRIPTION
## Describe changes

I removed broad exception handlers from the nine OpenAI-backed agent framework examples that were converting provider and framework failures into successful ZenML step outputs.

The examples now let provider exceptions fail their steps and the aggregate runner. The OpenAI Agents SDK example also converts a failing child process into a parent `RuntimeError`, and the Qwen example rejects missing, tool-only, or empty final responses.

This is a follow-up to #5142. The [develop workflow failure](https://github.com/zenml-io/zenml/actions/runs/31084533533) exposed a shared invalid OpenAI credential, but the other affected examples reported false success because they formatted caught exceptions as normal results. This PR deliberately makes those examples fail until the credential is repaired separately.

Validation:

- `ruff check` passed for all nine changed files.
- `ruff format --check` passed for all nine changed files.
- `python -m py_compile` passed for all nine changed files.
- A local aggregate run with an intentionally invalid OpenAI key produced ten failures: Haystack plus all nine examples changed here. Autogen and Google ADK remained the only passes because they do not use this OpenAI credential path.
- Focused runs confirmed CrewAI and OpenAI Agents SDK surface the upstream 401 and exit nonzero.
- Focused Qwen stubs confirmed missing, tool-only, and empty results raise, while a final assistant response succeeds.
- Success-path formatter comparisons against `origin/develop` passed for all nine examples with identical output.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. The repository has no lightweight harness for these standalone framework examples; the aggregate runner and focused failure stubs were used for validation.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] ZenML Docs: no documentation change is needed.
  - [x] Dashboard: no dashboard change is needed.
  - [x] Templates: no template change is needed.
  - [x] Projects: no zenml-projects change is needed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

## Post-deploy monitoring

- Rerun `Agent Examples Test` after replacing the invalid OpenAI secret. Healthy behavior is all provider-backed examples completing successfully.
- Treat any `401`, `invalid_api_key`, or entry in `agent-examples.failures.txt` as a real failure that now needs provider or framework investigation.
- If a valid-key run reveals an unintended propagation regression, revert this commit. Do not restore catch-and-format behavior merely to hide a provider failure.
