### PR TITLE
Fix AWS Strands GPT-5 temperature

### DIFF
--- a/examples/agent_framework_integrations/aws_strands/agent.py
+++ b/examples/agent_framework_integrations/aws_strands/agent.py
@@ -26,7 +26,6 @@ model = OpenAIModel(
         "api_key": os.getenv("OPENAI_API_KEY", ""),
     },
     model_id="gpt-5-nano",
-    params={"temperature": 0.7},
 )
 
 


### PR DESCRIPTION
## Describe changes

The AWS Strands agent example no longer sends `temperature=0.7` to `gpt-5-nano`, which only accepts its default temperature. This fixes the provider error exposed after #5144 made agent example failures propagate correctly.

Validation:

- `uv run ruff check examples/agent_framework_integrations/aws_strands/agent.py`
- `uv run ruff format --check examples/agent_framework_integrations/aws_strands/agent.py`
- `python -m py_compile examples/agent_framework_integrations/aws_strands/agent.py`
- Focused end-to-end run with the CI dependency versions: both OpenAI requests returned HTTP 200, the weather tool ran, and the ZenML pipeline completed successfully.

Related: #5144

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. There is no lightweight unit-test harness for this standalone example; I ran the example end to end against the provider instead.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] ZenML Docs: no documentation change is needed.
  - [x] Dashboard: no dashboard change is needed.
  - [x] Templates: no template change is needed.
  - [x] Projects: no zenml-projects change is needed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
