### PR TITLE
Prevent exchanging scoped workload tokens for unscoped ones

### DIFF
--- a/src/zenml/zen_server/auth.py
+++ b/src/zenml/zen_server/auth.py
@@ -538,6 +538,39 @@ def authenticate_credentials(
                     logger.error(error)
                     raise CredentialsNotValid(error)
 
+        if decoded_token.deployment_id:
+            # If the token contains a deployment ID, we need to check if the
+            # deployment still exists in the database. We use a cached version
+            # of the existence check to avoid unnecessary database queries.
+
+            @ttl_cache(
+                maxsize=config.memcache_max_capacity,
+                ttl=config.memcache_default_expiry,
+            )
+            def check_if_deployment_exists(deployment_id: UUID) -> bool:
+                """Check whether a deployment exists.
+
+                Args:
+                    deployment_id: The deployment ID.
+
+                Returns:
+                    Whether the deployment exists.
+                """
+                try:
+                    zen_store().get_deployment(deployment_id, hydrate=False)
+                except KeyError:
+                    return False
+
+                return True
+
+            if not check_if_deployment_exists(decoded_token.deployment_id):
+                error = (
+                    "Authentication error: deployment "
+                    f"{decoded_token.deployment_id} does not exist."
+                )
+                logger.error(error)
+                raise CredentialsNotValid(error)
+
         auth_context = AuthContext(
             user=user_model,
             access_token=decoded_token,

--- a/src/zenml/zen_server/routers/auth_endpoints.py
+++ b/src/zenml/zen_server/routers/auth_endpoints.py
@@ -546,12 +546,22 @@ def api_token(
                 "seconds."
             )
 
+        if token.schedule_id or token.pipeline_run_id or token.deployment_id:
+            logger.warning(
+                "A generic API token was requested using a workload-scoped "
+                "token. The generated token will retain the workload scope."
+            )
+
         return generate_access_token(
             user_id=token.user_id,
             # Keep the original API key and device token scopes.
             api_key=auth_context.api_key,
             device=auth_context.device,
             expires_in=expires_in,
+            # Workload-scoped tokens must not be exchanged for unscoped tokens.
+            schedule_id=token.schedule_id,
+            pipeline_run_id=token.pipeline_run_id,
+            deployment_id=token.deployment_id,
             # Don't include the access token as a cookie in the response
             response=None,
         ).access_token

--- a/tests/unit/zen_server/test_auth.py
+++ b/tests/unit/zen_server/test_auth.py
@@ -319,6 +319,93 @@ def test_authenticate_credentials_allows_local_service_account_api_key_token_for
     ]
 
 
+def test_authenticate_credentials_allows_token_for_existing_deployment(
+    monkeypatch,
+):
+    """Ensure deployment-scoped tokens work while the deployment exists."""
+    user = _user_model()
+    deployment_id = uuid4()
+    decoded_token = auth.JWTToken(
+        user_id=user.id,
+        issued_at=datetime.utcnow(),
+        deployment_id=deployment_id,
+    )
+    deployment_calls = []
+
+    class Store:
+        def get_user(self, user_name_or_id, include_private):
+            assert user_name_or_id == user.id
+            assert include_private
+            return user
+
+        def get_deployment(self, requested_id, hydrate):
+            deployment_calls.append((requested_id, hydrate))
+            return SimpleNamespace(id=deployment_id)
+
+    monkeypatch.setattr(auth, "zen_store", lambda: Store())
+    monkeypatch.setattr(
+        auth,
+        "server_config",
+        lambda: SimpleNamespace(
+            auth_scheme=AuthScheme.OAUTH2_PASSWORD_BEARER,
+            memcache_max_capacity=100,
+            memcache_default_expiry=60,
+        ),
+    )
+    monkeypatch.setattr(
+        auth.JWTToken, "decode_token", lambda token: decoded_token
+    )
+
+    auth_context = auth.authenticate_credentials(access_token="access-token")
+
+    assert auth_context.access_token is decoded_token
+    assert deployment_calls == [(deployment_id, False)]
+
+
+def test_authenticate_credentials_rejects_token_for_missing_deployment(
+    monkeypatch,
+):
+    """Ensure deployment-scoped tokens expire when deployment is deleted."""
+    user = _user_model()
+    deployment_id = uuid4()
+    decoded_token = auth.JWTToken(
+        user_id=user.id,
+        issued_at=datetime.utcnow(),
+        deployment_id=deployment_id,
+    )
+
+    class Store:
+        def get_user(self, user_name_or_id, include_private):
+            assert user_name_or_id == user.id
+            assert include_private
+            return user
+
+        def get_deployment(self, requested_id, hydrate):
+            assert requested_id == deployment_id
+            assert not hydrate
+            raise KeyError(deployment_id)
+
+    monkeypatch.setattr(auth, "zen_store", lambda: Store())
+    monkeypatch.setattr(
+        auth,
+        "server_config",
+        lambda: SimpleNamespace(
+            auth_scheme=AuthScheme.OAUTH2_PASSWORD_BEARER,
+            memcache_max_capacity=100,
+            memcache_default_expiry=60,
+        ),
+    )
+    monkeypatch.setattr(
+        auth.JWTToken, "decode_token", lambda token: decoded_token
+    )
+
+    with pytest.raises(
+        CredentialsNotValid,
+        match=f"deployment {deployment_id} does not exist",
+    ):
+        auth.authenticate_credentials(access_token="access-token")
+
+
 def test_api_key_token_generation_allows_legacy_tokens():
     """Ensure JWTs without a generation claim remain valid."""
     api_key = _api_key_model(


### PR DESCRIPTION
## Summary

This PR prevents workload-scoped API tokens from being exchanged for persistent, unscoped API tokens.

Pipeline workloads authenticate using tokens bound to a specific pipeline run, schedule, or deployment. These bindings ensure that the credentials stop working when the associated workload is no longer authorized.

Previously, a workload could request a generic API token from `GET /api/v1/api_token`. The generated token preserved the authenticated identity, API key, and device provenance, but omitted the workload binding. As a result, it could remain valid after the original workload token became invalid.

## Vulnerable behavior

```mermaid
flowchart LR
    A["Workload token<br/>user_id + pipeline_run_id"]
    B["GET /api/v1/api_token<br/>token_type=generic"]
    C["Generated token<br/>user_id only"]
    D["Pipeline run finishes"]
    E["Original token rejected"]
    F["Generated token remains valid"]

    A --> B
    B --> C
    A --> D
    D --> E
    C --> F

    style A fill:#fff3cd,stroke:#856404
    style C fill:#f8d7da,stroke:#842029
    style E fill:#d1e7dd,stroke:#0f5132
    style F fill:#f8d7da,stroke:#842029
```

Code executing inside a credential-bearing workload could therefore:

1. Use its valid workload token to request a generic API token.
2. Retain or exfiltrate the returned token.
3. Continue authenticating after the pipeline run, schedule, or deployment binding invalidated the original credential.

The generated token did not gain permissions beyond those of the issuing user or service account. However, it removed the workload’s temporal and resource binding, allowing access to continue for the configured generic-token lifetime.

## Fix

The API-token endpoint now propagates the authenticated token’s existing workload claims to the generated token:

- `schedule_id`
- `pipeline_run_id`
- `deployment_id`

```mermaid
flowchart LR
    A["Workload token<br/>user_id + pipeline_run_id"]
    B["GET /api/v1/api_token<br/>token_type=generic"]
    C["Generated token<br/>user_id + pipeline_run_id"]
    D["Pipeline run finishes"]
    E["Both tokens rejected"]

    A --> B
    B --> C
    A --> D
    C --> D
    D --> E

    style A fill:#fff3cd,stroke:#856404
    style C fill:#d1e7dd,stroke:#0f5132
    style E fill:#d1e7dd,stroke:#0f5132
```

If an unscoped user, API-key, or device token requests a generic token, behavior remains unchanged.

If a workload-scoped token makes the same request, the endpoint still succeeds for compatibility, but the returned token remains bound to the same workload. The server also logs a warning explaining that the requested token retained its workload scope.

This is intentionally a server-side-only fix. Existing clients do not need to detect scoped credentials or change the type of token they request.

## Additional changes

This change also adds validation for deployment-scoped workload tokens in authenticate_credentials. Previously, these tokens remained usable after their deployment record was deleted; ZenML now performs a cached existence check and rejects credentials referencing a missing deployment. The check intentionally does not depend on operational status because stopped deployments can be reprovisioned before their status transitions.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

