### PR TITLE
Add OrcaRouter support to agent comparison example

### DIFF
--- a/examples/agent_comparison/README.md
+++ b/examples/agent_comparison/README.md
@@ -55,6 +55,9 @@ export ANTHROPIC_API_KEY="your-anthropic-key"
 export GROQ_API_KEY="your-groq-key"
 export COHERE_API_KEY="your-cohere-key"
 
+# Or use OrcaRouter (OpenAI-compatible gateway, one key for many models)
+export ORCAROUTER_API_KEY="your-orcarouter-key"
+
 # Optional: Enable Langfuse observability (tracks costs, performance, traces)
 # Note: LiteLLM requires Langfuse v2, ensure you have: pip install "langfuse>=2,<3"
 export LANGFUSE_PUBLIC_KEY="your-langfuse-public-key"
@@ -229,6 +232,7 @@ response = completion(
     # model="claude-3-sonnet",  # Anthropic
     # model="groq/llama2-70b-4096",  # Groq
     # model="command-r",  # Cohere
+    # model="orcarouter/auto",  # OrcaRouter auto-routing (set ORCAROUTER_API_KEY)
     messages=[{"role": "user", "content": query}],
     max_tokens=200,
     # Langfuse integration (automatic when env vars are set)
@@ -241,6 +245,7 @@ response = completion(
 - **Anthropic**: `claude-3-opus`, `claude-3-sonnet`, `claude-3-haiku`
 - **Groq**: `groq/llama2-70b-4096`, `groq/mixtral-8x7b-32768`
 - **Cohere**: `command-r`, `command-r-plus`
+- **OrcaRouter**: OpenAI-compatible gateway with many models behind one key (set `ORCAROUTER_API_KEY`)
 - **100+ other providers** - see [LiteLLM docs](https://docs.litellm.ai/docs/providers)
 
 **Langfuse Observability Benefits:**

--- a/examples/agent_comparison/llm_utils.py
+++ b/examples/agent_comparison/llm_utils.py
@@ -32,6 +32,7 @@ def should_use_real_llm() -> bool:
         or os.getenv("ANTHROPIC_API_KEY")
         or os.getenv("GROQ_API_KEY")
         or os.getenv("COHERE_API_KEY")
+        or os.getenv("ORCAROUTER_API_KEY")
     )
 
 
@@ -104,6 +105,21 @@ def call_llm(
         # Add metadata for Langfuse if available
         if metadata and should_use_langfuse():
             call_params["metadata"] = metadata
+
+        # Route through the OrcaRouter gateway when configured. OrcaRouter is
+        # an OpenAI-compatible gateway that exposes many providers behind a
+        # single key, so LiteLLM needs an explicit api_base, api_key and
+        # provider instead of the default OpenAI endpoint. Gateway model slugs
+        # (e.g. "orcarouter/auto") are passed through verbatim; the default
+        # model is swapped for the gateway's auto-routing model so the example
+        # works out of the box for users who only set ORCAROUTER_API_KEY.
+        orcarouter_api_key = os.getenv("ORCAROUTER_API_KEY")
+        if orcarouter_api_key:
+            call_params["api_base"] = "https://api.orcarouter.ai/v1"
+            call_params["api_key"] = orcarouter_api_key
+            call_params["custom_llm_provider"] = "openai"
+            if model == "gpt-3.5-turbo":
+                call_params["model"] = "orcarouter/auto"
 
         response = litellm.completion(**call_params)
 


### PR DESCRIPTION
## Describe changes

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing LiteLLM-backed providers (Anthropic, Groq, Cohere) are wired, so the provider list, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint, screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `examples/agent_comparison/llm_utils.py`: `should_use_real_llm` now recognizes `ORCAROUTER_API_KEY` as a provider key, and `call_llm` routes LiteLLM calls through the OrcaRouter gateway (`api_base`, `api_key`, `custom_llm_provider`) when it is set. When the caller leaves the default model, the gateway's auto-routing model `orcarouter/auto` is used so the example works out of the box for users who only set `ORCAROUTER_API_KEY`.
- `examples/agent_comparison/README.md`: documents the `ORCAROUTER_API_KEY` environment variable alongside the existing provider keys, plus a model example in the LiteLLM customization section.

## Why this change

The example already treats each LiteLLM provider as a single environment variable. OrcaRouter fits that same pattern and gives users many models behind one key, with automatic per-request routing when the `orcarouter/auto` model is selected.

## Verification

- `ruff check` and `ruff format --check` pass on `examples/agent_comparison/llm_utils.py`.
- A standalone logic test covering `should_use_real_llm` and the `call_llm` parameter building passes (11 assertions, including the no-key fallback regression).
- End-to-end with a live OrcaRouter key: `call_llm` returns a real completion through the gateway for both the auto-routing default and an explicit `anthropic/claude-sonnet-4.6` slug, and falls back to the mock response when no key is set.

## Pre-requisites

Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. (The example has no existing test suite; verification is documented above via standalone logic tests and a live end-to-end check.)
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above): example documentation and a small utility enhancement
