### PR TITLE
Return 404 when dashboard assets are missing

### DIFF
--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -411,6 +411,9 @@ async def catch_all(request: Request, file_path: str) -> Any:
 
     Returns:
         The ZenML dashboard.
+
+    Raises:
+        HTTPException: If the dashboard files are not included.
     """
     if DASHBOARD_REDIRECT_URL:
         return RedirectResponse(url=DASHBOARD_REDIRECT_URL)
@@ -423,4 +426,9 @@ async def catch_all(request: Request, file_path: str) -> Any:
 
     # everything else is directed to the index.html file that hosts the
     # single-page application
+    if not os.path.isfile(os.path.join(dashboard_directory(), "index.html")):
+        raise HTTPException(
+            status_code=404,
+            detail="Dashboard assets are not installed.",
+        )
     return templates.TemplateResponse(request=request, name="index.html")

--- a/tests/unit/zen_server/test_zen_server_api.py
+++ b/tests/unit/zen_server/test_zen_server_api.py
@@ -1,0 +1,46 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for the ZenML server API."""
+
+from pathlib import Path
+
+import anyio
+import pytest
+from fastapi import HTTPException, Request
+from pytest_mock import MockerFixture
+
+from zenml.zen_server import zen_server_api
+
+
+def test_dashboard_route_without_dashboard_assets_returns_404(
+    mocker: MockerFixture, tmp_path: Path
+) -> None:
+    """Test that SPA routes return 404 when dashboard assets are missing."""
+    mocker.patch.object(
+        zen_server_api, "dashboard_directory", return_value=str(tmp_path)
+    )
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/devices/verify",
+            "headers": [],
+        }
+    )
+
+    with pytest.raises(HTTPException, match="Dashboard assets") as exc_info:
+        anyio.run(zen_server_api.catch_all, request, "devices/verify")
+
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Describe changes

I fixed the server SPA fallback so installations without bundled dashboard assets return a clear `404` with `Dashboard assets are not installed.` instead of raising `jinja2.TemplateNotFound` and producing a generic `500`.

The guard runs immediately before rendering `index.html`, after the existing redirect and static-file branches, so configured dashboard redirects and real static assets keep their current behavior. A behavioral regression test exercises the actual `/devices/verify` catch-all path with an empty dashboard directory.

Fixes #4603.

This follows the implementation direction approved by @stefannica in the issue. It also supersedes the intent of closed PR #4734, which was closed for inactivity with an invitation to reopen the work against `develop`.

### Verification

- `pytest tests/unit/zen_server/test_zen_server_api.py tests/unit/zen_server/test_exceptions.py tests/unit/zen_server/test_middleware.py -q` — 40 passed
- `ruff check src/zenml/zen_server/zen_server_api.py tests/unit/zen_server/test_zen_server_api.py` — passed
- `ruff format --check src/zenml/zen_server/zen_server_api.py tests/unit/zen_server/test_zen_server_api.py` — passed
- `mypy src/zenml/zen_server/zen_server_api.py tests/unit/zen_server/test_zen_server_api.py` — passed
- `git diff --check` — passed

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [x] **IMPORTANT**: I reviewed whether these resources are affected:
  - [x] Docs: no user-facing workflow or API documentation change is required.
  - [x] Dashboard: no frontend code or bundled asset behavior changes.
  - [x] Templates: not affected.
  - [x] Projects: not affected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)