### PR TITLE
Backport: Refresh the Kitaru SDK reference (#5156)

### DIFF
--- a/docs/book/sdk-docs/README.md
+++ b/docs/book/sdk-docs/README.md
@@ -1,13 +1,13 @@
 ---
-description: Reference for the ZenML and Kitaru Python SDKs and CLIs.
+description: Reference hub for the ZenML and Kitaru SDKs and CLIs.
 ---
 
 # Overview
 
-ZenML ships two Python SDKs, each with its own reference site:
+ZenML and Kitaru each provide SDKs for working with their APIs:
 
-* **ZenML** — build, manage, and deploy production-ready ML pipelines.
-* **Kitaru** — ZenML's sibling project for recording, replaying, and improving AI agents: real runs get recorded as sessions, then replayed against your real code with one thing changed (sessions, replays, evaluators, cohorts, experiments), published at [sdkdocs.kitaru.ai](https://sdkdocs.kitaru.ai).
+* **ZenML** provides a Python SDK and CLI for building, managing, and deploying production-ready ML pipelines.
+* **Kitaru** provides Python and TypeScript SDKs for recording, replaying, and improving AI agents. Its CLI ships with the Python package.
 
 ## ZenML SDK
 
@@ -17,8 +17,8 @@ The ZenML SDK provides Python tools and interfaces for building, managing, and d
 
 ## Kitaru SDK
 
-[Kitaru](https://docs.zenml.io/kitaru) is ZenML's sibling project for recording, replaying, and improving AI agents: traces you can run, not just read. Its Python SDK and CLI reference are generated from the Kitaru source and published on a dedicated site.
+[Kitaru](https://docs.zenml.io/kitaru) is ZenML's sibling project for recording, replaying, and improving AI agents: traces you can run, not just read. Its Python and TypeScript SDKs talk to the same Kitaru server over the same REST API. Framework adapters support [Python and TypeScript agents](https://docs.zenml.io/kitaru/adapters/adapters). The generated Python SDK and CLI reference is published on a dedicated site.
 
-<table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>SDK &#x26; CLI Reference</strong></td><td>Complete API reference for the Kitaru Python SDK and command-line interface.</td><td><a href="https://sdkdocs.kitaru.ai">https://sdkdocs.kitaru.ai</a></td></tr><tr><td><strong>Kitaru Client</strong></td><td>Programmatic interface to a Kitaru server: sessions, replays, evaluators, cohorts, and experiments.</td><td><a href="kitaru/client.md">kitaru/client.md</a></td></tr></tbody></table>
+<table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>Python SDK &#x26; CLI Reference</strong></td><td>Complete generated API reference for the Kitaru Python SDK and command-line interface.</td><td><a href="https://sdkdocs.kitaru.ai">https://sdkdocs.kitaru.ai</a></td></tr><tr><td><strong>Python &#x26; TypeScript SDK Guide</strong></td><td>How both SDKs connect, authenticate, expose resources, and hand work to Kitaru workers.</td><td><a href="https://docs.zenml.io/kitaru/get-help/sdks">https://docs.zenml.io/kitaru/get-help/sdks</a></td></tr><tr><td><strong>Python Client</strong></td><td>Programmatic interface to a Kitaru server: sessions, replays, evaluators, cohorts, and experiments.</td><td><a href="kitaru/client.md">kitaru/client.md</a></td></tr></tbody></table>
 
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/sdk-docs/kitaru/client.md
+++ b/docs/book/sdk-docs/kitaru/client.md
@@ -2,54 +2,67 @@
 icon: plug
 ---
 
-# Client
+# Python client
 
-[Kitaru](https://docs.zenml.io/kitaru) is ZenML's sibling project for recording, replaying, and improving AI agents — the runs that happen in production become sessions you can replay against your real code. `KitaruAPIClient` is the async programmatic interface to a Kitaru server.
+[Kitaru](https://docs.zenml.io/kitaru) is ZenML's sibling project for recording, replaying, and improving AI agents. The runs that happen in production become sessions you can replay against your real code. `KitaruAPIClient` is the async Python interface to a Kitaru server.
 
 This page groups the client into thematic areas. For the complete, auto-generated API (every method and signature), see the [full Kitaru SDK reference](https://sdkdocs.kitaru.ai/reference/python/client/).
 
 ```python
 from kitaru.client import KitaruAPIClient
 
-client = KitaruAPIClient()   # server and credential resolve from the environment
+async with KitaruAPIClient() as client:
+    server = await client.info.get()
 ```
 
-The client exposes its functionality through sub-APIs accessed as attributes.
+The client resolves its server URL from `KITARU_API_URL` or the server selected by `kitaru login`. It resolves credentials from the worker-provided `KITARU_API_TOKEN`, `KITARU_API_KEY`, or stored login credentials. If no server URL is configured, client creation fails instead of guessing a destination.
+
+The client exposes its functionality through resource namespaces accessed as attributes.
 
 ## Sessions
 
 `client.sessions` reads and writes the recordings:
 
-* `list` / `iter` / `get` — find sessions, with filters for agent, tag, origin, and time
-* `list_nodes` — the recorded model and tool calls, with payloads
-* `create` / `ingest_nodes` — the raw recording API adapters are built on
-* `merge_evaluations` — write evaluations (including human verdicts) onto a session
+* `list` / `iter` / `get` - find sessions, with filters for agent, tag, origin, and time
+* `get_with_nodes` / `list_nodes` / `iter_nodes` - read the recorded model and tool calls, with payloads
+* `create` / `ingest_nodes` - use the raw recording API that adapters build on
+* `merge_evaluations` - attach externally produced evaluation results to a session
+* `update` / `delete` - maintain recorded or imported sessions
 
 ## Replays and evaluations
 
-* `client.replays` — create and inspect single-session replays: baseline session, optional override, tool policy, evaluators
-* `client.evaluations` — batch-evaluate stored sessions and read evaluation rows back
+* `client.replays` - create and inspect single-session replays: baseline session, optional override, tool policy, and evaluators
+* `client.evaluations` - batch-evaluate stored sessions and read evaluation rows back
 
 ## Cohorts and experiments
 
-* `client.cohorts` / `client.cohort_versions` — freeze immutable populations of sessions
-* `client.experiments` — name a change (override, tool policy, evaluators) and `start_run` it against a cohort version
+* `client.cohorts` / `client.cohort_versions` - freeze immutable populations of sessions
+* `client.experiments` - name a change and start it against a cohort version
+* `client.experiment_runs` - inspect a run, its child jobs, and its cancellation state
 
 ## Registry
 
-* `client.agents` / `client.agent_versions` — the agents sessions belong to, and the run commands replay executes
-* `client.evaluators` / `client.importers` — versioned plugins, registered from a script or package
-* `client.imports` — bring Langfuse exports in as sessions
+* `client.agents` / `client.agent_versions` - the agents sessions belong to, and the run commands replay executes
+* `client.evaluators` / `client.importers` - versioned plugins registered from a script or package
+* `client.imports` - import Langfuse, LangSmith, Braintrust, Logfire, or Kitaru JSONL traces as sessions
 
 ## Review
 
-* `client.investigations` / `client.annotations` — structured human review: questions over a set of sessions, answers pinned to exact trace locations
+* `client.investigations` / `client.annotations` - structure human review as questions, evidence-linked answers, and session verdicts
 
-## Operations
+## Execution and operations
 
-* `client.workers` / `client.jobs` — the execution fleet and the work it claims
-* `client.api_keys` / `client.accounts` — authentication for processes and people
+* `client.session_runs` - submit a registered agent version as a job
+* `client.workers` / `client.jobs` / `client.tasks` - register workers and inspect, cancel, or recover queued work
+* `client.tags` - group sessions, versions, cohorts, and experiments
+* `client.blobs` / `client.secrets` - store plugin source and runtime credentials
+
+## Authentication
+
+* `client.auth` / `client.devices` - authenticate interactive clients
+* `client.api_keys` / `client.service_accounts` - issue and rotate process credentials
+* `client.accounts` / `client.users` - inspect accounts and their users
 
 ***
 
-For complete signatures and the full method list, see the [Kitaru SDK reference](https://sdkdocs.kitaru.ai/reference/python/client/). For the command-line equivalents, see the [Kitaru CLI reference](https://sdkdocs.kitaru.ai/cli/).
+For complete signatures and the full method list, see the [Python SDK reference](https://sdkdocs.kitaru.ai/reference/python/client/). For the command-line equivalents, see the [Kitaru CLI reference](https://sdkdocs.kitaru.ai/cli/). For the TypeScript client, see [How to use the SDK](https://docs.zenml.io/kitaru/get-help/sdks).

--- a/docs/book/sdk-docs/kitaru/example-usages.md
+++ b/docs/book/sdk-docs/kitaru/example-usages.md
@@ -2,13 +2,13 @@
 icon: code
 ---
 
-# Example usages
+# Python examples
 
-Common patterns with the Kitaru Python SDK. For the complete reference, see [sdkdocs.kitaru.ai](https://sdkdocs.kitaru.ai); for conceptual guides, see the [Kitaru docs](https://docs.zenml.io/kitaru).
+Common patterns with the Kitaru Python SDK. For complete signatures, see the [Python SDK reference](https://sdkdocs.kitaru.ai/reference/python/). For the TypeScript client, see [How to use the SDK](https://docs.zenml.io/kitaru/get-help/sdks). For supported frameworks, see the [adapter overview](https://docs.zenml.io/kitaru/adapters/adapters).
 
 ## Record an agent's runs
 
-Wrap an existing PydanticAI agent and every run is recorded as a session — each model call and tool call a node. Each adapter ships as its own distribution, installed alongside `kitaru` — here, `uv add kitaru-pydantic-ai`:
+Wrap an existing PydanticAI agent and every run is recorded as a session: each model call and tool call becomes a node. Each adapter ships as its own distribution, installed alongside `kitaru`. Here, install it with `uv add kitaru-pydantic-ai`:
 
 ```python
 import os
@@ -20,39 +20,73 @@ from kitaru_pydantic_ai import KitaruAgent
 base_agent = Agent("openai:gpt-5.4", system_prompt="You resolve support tickets.")
 
 agent = KitaruAgent(base_agent, agent_id=uuid.UUID(os.environ["KITARU_AGENT_ID"]))
-result = agent.run_sync("Refund order #4821 — the card reader was double-charged.")
+result = agent.run_sync("Refund order #4821; the card reader was double-charged.")
 ```
 
 ## Inspect sessions
 
 ```python
+import asyncio
+
 from kitaru.client import KitaruAPIClient
 from kitaru.api_models.v1.session import SessionListParams
+from kitaru.api_models.v1.session_node import SessionNodeListParams
 
-client = KitaruAPIClient()
-sessions = await client.sessions.list(SessionListParams(size=5))
-nodes = await client.sessions.list_nodes(sessions.items[0].id, include_payloads=True)
+
+async def main() -> None:
+    async with KitaruAPIClient() as client:
+        sessions = await client.sessions.list(SessionListParams(size=5))
+        if not sessions.items:
+            return
+        baseline_session_id = sessions.items[0].id
+        nodes = await client.sessions.list_nodes(
+            baseline_session_id, SessionNodeListParams(include_payloads=True)
+        )
+        print(baseline_session_id, len(nodes.items))
+
+
+asyncio.run(main())
 ```
 
 ## Replay with one thing changed
 
-Recorded tool calls answered from the session, the model swapped, evaluations on both sides:
+Answer tool calls from the recorded session, swap the model, and run the same evaluator on both sides:
 
 ```python
-from kitaru.api_models.v1.replay import ReplayCreateRequest, ReplayOverride
+import asyncio
+import os
+import uuid
+
+from kitaru.client import KitaruAPIClient
+from kitaru.api_models.v1.replay import ReplayCreateRequest
 from kitaru.api_models.v1.replay_config import (
-    EvaluatorConfig, HistoryConfig, ToolPolicy,
+    EvaluatorConfig,
+    HistoryConfig,
+    ReplayOverride,
+    ToolPolicy,
 )
 
-replay = await client.replays.create(
-    ReplayCreateRequest(
-        baseline_session_id=session_id,
-        override=ReplayOverride(model={"openai:gpt-5.4": "openai:gpt-5-nano"}),
-        evaluators=[EvaluatorConfig(evaluator="refund-check")],
-        tool_policy=ToolPolicy(default=HistoryConfig(scope="baseline", on_miss="fail")),
-        evaluate_baselines=True,
-    )
-)
+
+async def main() -> None:
+    baseline_session_id = uuid.UUID(os.environ["KITARU_BASELINE_SESSION_ID"])
+    async with KitaruAPIClient() as client:
+        replay = await client.replays.create(
+            ReplayCreateRequest(
+                baseline_session_id=baseline_session_id,
+                override=ReplayOverride(
+                    model={"openai:gpt-5.4": "openai:gpt-5-nano"}
+                ),
+                evaluators=[EvaluatorConfig(evaluator="refund-check")],
+                tool_policy=ToolPolicy(
+                    default=HistoryConfig(scope="baseline", on_miss="fail")
+                ),
+                evaluate_baselines=True,
+            )
+        )
+        print(replay.id, replay.job_id)
+
+
+asyncio.run(main())
 ```
 
-The full walkthrough — recording, replaying, cohorts, experiments — is the [Kitaru quickstart](https://docs.zenml.io/kitaru/getting-started/quickstart).
+The full walkthrough, from recording through replaying cohorts and experiments, is the [Kitaru quickstart](https://docs.zenml.io/kitaru/getting-started/quickstart).

--- a/docs/book/sdk-docs/toc.md
+++ b/docs/book/sdk-docs/toc.md
@@ -10,6 +10,7 @@
 
 ## Kitaru
 
-* [Client](kitaru/client.md)
-* [Example usages](kitaru/example-usages.md)
-* [Full SDK & CLI reference](https://sdkdocs.kitaru.ai)
+* [Python client](kitaru/client.md)
+* [Python examples](kitaru/example-usages.md)
+* [Python & TypeScript SDK guide](https://docs.zenml.io/kitaru/get-help/sdks)
+* [Python SDK & CLI reference](https://sdkdocs.kitaru.ai)


### PR DESCRIPTION
Backports the docs-only changes from #5156 (merge commit `bdc252d985`) from `develop` to `release/0.96.3`, so the refreshed Kitaru SDK reference shows up in the live release docs.

Files touched (all under `docs/book/sdk-docs/`):
- `README.md`
- `kitaru/client.md`
- `kitaru/example-usages.md`
- `toc.md`

Clean cherry-pick, no conflicts.