### PR TITLE
Fix force stop leaving STARTING nodes running orphaned in DagRunner

### DIFF
--- a/src/zenml/orchestrators/dag_runner.py
+++ b/src/zenml/orchestrators/dag_runner.py
@@ -259,8 +259,8 @@ class DagRunner:
         self.node_stop_function(node)
 
     def _stop_all_nodes(self) -> None:
-        """Stop all running nodes."""
-        for node in self.running_nodes:
+        """Stop all running or starting nodes."""
+        for node in self.active_nodes:
             self._stop_node(node)
             node.status = NodeStatus.CANCELLED
 
@@ -365,7 +365,13 @@ class DagRunner:
 
         self.shutdown_event.set()
         if interrupt_mode == InterruptMode.FORCE:
-            # If a force interrupt was requested, we stop all running nodes.
+            # If a force interrupt was requested, we stop all running or
+            # starting nodes. A node's startup task may already be past the
+            # shutdown check and still be creating the underlying resource,
+            # so we wait for all startup tasks to finish and then stop again
+            # to catch any node that only turned running while we waited.
+            self._stop_all_nodes()
+            self.startup_executor.shutdown(wait=True)
             self._stop_all_nodes()
 
         self.monitoring_thread.join()

--- a/tests/unit/orchestrators/test_dag_runner.py
+++ b/tests/unit/orchestrators/test_dag_runner.py
@@ -12,9 +12,16 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
+import threading
 from contextlib import ExitStack as does_not_raise
-from typing import Dict, List
+from typing import Dict, List, Optional
 
+from zenml.orchestrators.dag_runner import (
+    DagRunner,
+    InterruptMode,
+    Node,
+    NodeStatus,
+)
 from zenml.orchestrators.legacy_dag_runner import (
     ThreadedDagRunner,
     reverse_dag,
@@ -77,3 +84,96 @@ def test_dag_runner_multi_path():  # 3->(2, 5)->1
 def test_dag_runner_cyclic():
     """Test that nothing happens for cyclic graphs, and no error is raised."""
     _test_runner({"1": ["2"], "2": ["1"]}, correct_results=[0])
+
+
+def test_dag_runner_stop_all_nodes_cancels_starting_node():
+    """A force stop must also cancel a node whose startup is still running.
+
+    Regression test: `_stop_all_nodes` used to only look at nodes with
+    status RUNNING. A node whose startup function had already passed the
+    shutdown check but not yet returned was left out, so it was never
+    stopped, kept its underlying resource alive, and could later flip to
+    RUNNING after the force stop had already finished.
+    """
+    stopped_ids: List[str] = []
+
+    def noop_fn(node: Node) -> NodeStatus:
+        return node.status
+
+    def stop_fn(node: Node) -> None:
+        stopped_ids.append(node.id)
+
+    runner = DagRunner(
+        nodes=[Node(id="1"), Node(id="2")],
+        node_startup_function=noop_fn,
+        node_monitoring_function=noop_fn,
+        node_stop_function=stop_fn,
+    )
+    runner.nodes["1"].status = NodeStatus.STARTING
+    runner.nodes["2"].status = NodeStatus.RUNNING
+
+    runner._stop_all_nodes()
+
+    assert set(stopped_ids) == {"1", "2"}
+    assert runner.nodes["1"].status == NodeStatus.CANCELLED
+    assert runner.nodes["2"].status == NodeStatus.CANCELLED
+
+
+def test_dag_runner_force_stop_waits_for_late_starting_node():
+    """A force stop should also cancel a node that only just started.
+
+    End to end regression test for the race where a node's startup task has
+    already passed the shutdown check and is still creating its underlying
+    resource when the force stop happens. Once the startup task finishes and
+    flips the node to RUNNING, the runner must stop and cancel it too instead
+    of leaving it running after `run()` has already returned.
+    """
+    started = threading.Event()
+    release = threading.Event()
+    stopped_ids: List[str] = []
+
+    def startup_fn(node: Node) -> NodeStatus:
+        started.set()
+        release.wait(timeout=5)
+        return NodeStatus.RUNNING
+
+    def monitoring_fn(node: Node) -> NodeStatus:
+        return node.status
+
+    def stop_fn(node: Node) -> None:
+        stopped_ids.append(node.id)
+
+    def interrupt_fn() -> Optional[InterruptMode]:
+        return InterruptMode.FORCE if started.is_set() else None
+
+    runner = DagRunner(
+        nodes=[Node(id="1")],
+        node_startup_function=startup_fn,
+        node_monitoring_function=monitoring_fn,
+        node_stop_function=stop_fn,
+        interrupt_function=interrupt_fn,
+        interrupt_check_interval=0,
+        monitoring_interval=0.05,
+    )
+
+    # Release the blocked startup function only once the force stop has
+    # actually run its first pass, so the node is still STARTING at that
+    # point and only flips to RUNNING afterwards, regardless of wall clock
+    # timing.
+    original_stop_all_nodes = runner._stop_all_nodes
+    stop_all_nodes_calls = 0
+
+    def wrapped_stop_all_nodes() -> None:
+        nonlocal stop_all_nodes_calls
+        stop_all_nodes_calls += 1
+        original_stop_all_nodes()
+        if stop_all_nodes_calls == 1:
+            release.set()
+
+    runner._stop_all_nodes = wrapped_stop_all_nodes  # type: ignore[method-assign]
+
+    statuses = runner.run()
+
+    assert stopped_ids
+    assert all(node_id == "1" for node_id in stopped_ids)
+    assert statuses["1"] == NodeStatus.CANCELLED


### PR DESCRIPTION
## Summary

`DagRunner._stop_all_nodes`, used when a pipeline run is force stopped, only looked at nodes with status `RUNNING`. A node moves to `STARTING` synchronously in `_start_node`, then its startup work runs asynchronously on `startup_executor` and only flips the node to `RUNNING` once `node_startup_function` returns.

If a force stop landed while a node's startup task had already passed its `shutdown_event.is_set()` check but had not yet finished, that node was skipped by `_stop_all_nodes` entirely, no stop call was made, and it could flip to `RUNNING` after `run()` had already returned. On an orchestrator like Kubernetes this means a Job for that step gets created and keeps running against a pipeline the user already force stopped, with nothing left tracking it.

## Changes

- `_stop_all_nodes` now iterates `active_nodes` (`RUNNING` or `STARTING`) instead of `running_nodes`, so a node that is still starting gets stopped and cancelled too
- The force stop path now waits for `startup_executor` to drain and runs the stop pass a second time, to catch a node that only turned `RUNNING` while we were waiting for its startup task to finish

## Tests

Added two regression tests in `tests/unit/orchestrators/test_dag_runner.py`:
- a direct test of `_stop_all_nodes` cancelling a `STARTING` node
- an end to end `run()` test simulating the race where the startup task is still in flight when the force stop happens, using a hook on `_stop_all_nodes` rather than wall clock sleeps so it is deterministic

Both fail on the previous code and pass with this change.

Fixes #5178

## Test plan

- [x] `pytest tests/unit/orchestrators/test_dag_runner.py` passes (8/8)
- [x] `ruff check` / `ruff format --check` / `mypy` on the changed files pass
- [ ] Manual force stop of a dynamic pipeline on a real orchestrator (Kubernetes) to confirm no orphaned Job is left behind