### PR TITLE
Fix Qwen-Agent example dependency installation

### DIFF
--- a/examples/agent_framework_integrations/qwen-agent/requirements.txt
+++ b/examples/agent_framework_integrations/qwen-agent/requirements.txt
@@ -2,6 +2,7 @@
 # See: https://github.com/QwenLM/Qwen-Agent/issues/768
 # Remove this cap once a fixed version is released
 qwen-agent>=0.0.10,<0.0.32
+tqdm>=4.0.0
 openai>=1.0.0
 zenml[local]
 json5>=0.9


### PR DESCRIPTION
## Describe changes
The Qwen-Agent example now installs `tqdm` directly. This prevents newer `openai` releases from exposing Qwen-Agent's undeclared runtime dependency and breaking the example during import.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. This is a requirements-only fix; the isolated example install and full Qwen-Agent pipeline were tested instead.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io) (no documentation change needed)
  - [x] Dashboard: no dashboard change needed.
  - [x] Templates: no template change needed.
  - [x] [Projects](https://github.com/zenml-io/zenml-projects): no project dependency change needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

## Validation
- A clean Python 3.11 environment installed the example requirements with `qwen-agent==0.0.31`, `openai==3.3.1`, and `tqdm==4.70.0`.
- `from qwen_agent.agents import Assistant` succeeded.
- The full Qwen-Agent pipeline completed successfully, including three OpenAI calls and both ZenML steps.
- `git diff --check` passed.
- Code review: skipped (mechanical diff).

## Post-Deploy Monitoring & Validation
No production monitoring is required because this changes only the dependency declaration for an example. The next scheduled `Agent Examples Test` run should show `qwen-agent` passing without `ModuleNotFoundError: No module named 'tqdm'`; that failure remains the rollback or follow-up signal.
