### PR TITLE
Fix completed pipeline with failed steps bug

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/future_registry.py
+++ b/src/zenml/execution/pipeline/dynamic/future_registry.py
@@ -288,11 +288,3 @@ class FutureRegistry:
                 #   sets the active exception (the wrapped one) as the context
                 e.__suppress_context__ = True
                 pass
-
-    def has_in_progress_work(self) -> bool:
-        """Check whether any tracked future is still running.
-
-        Returns:
-            True if any tracked future is still running, False otherwise.
-        """
-        return any(future.running() for future in self.get_all_futures())

--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -1961,7 +1961,18 @@ class DynamicPipelineRunner:
         while True:
             if self._exception:
                 raise self._exception
-            if not self._future_registry.has_in_progress_work():
+
+            has_in_progress_work = False
+            for future in self._future_registry.get_all_futures():
+                if future.running():
+                    has_in_progress_work = True
+                else:
+                    # A terminal future can represent either a successful or
+                    # failed invocation. Consume its result so an unawaited
+                    # failure cannot be mistaken for successful settlement.
+                    future.wait()
+
+            if not has_in_progress_work:
                 return
             time.sleep(1)
 

--- a/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
+++ b/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
@@ -13,10 +13,20 @@
 #  permissions and limitations under the License.
 """Tests for the exception raised when a dynamic step fails."""
 
+from types import SimpleNamespace
+from uuid import uuid4
+
 import pytest
 
 from zenml import pipeline, step
+from zenml.enums import ExecutionStatus
 from zenml.exceptions import StepExecutionException
+from zenml.execution.pipeline.dynamic.future_registry import FutureRegistry
+from zenml.execution.pipeline.dynamic.outputs import (
+    StepFuture,
+    _IsolatedStepFuture,
+)
+from zenml.execution.pipeline.dynamic.runner import DynamicPipelineRunner
 
 
 @step
@@ -98,6 +108,40 @@ def unawaited_pipeline() -> None:
 def test_unawaited_failure_raises_step_execution_exception() -> None:
     with pytest.raises(StepExecutionException):
         unawaited_pipeline()
+
+
+def test_unawaited_isolated_failure_raises_during_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An isolated failure is raised even before the monitor processes it."""
+    failed_step_run = SimpleNamespace(
+        status=ExecutionStatus.FAILED,
+        exception_info=None,
+    )
+    monkeypatch.setattr(
+        "zenml.execution.pipeline.dynamic.utils.get_latest_step_run",
+        lambda *_args, **_kwargs: failed_step_run,
+    )
+
+    registry = FutureRegistry()
+    registry.register_step_future(
+        invocation_id="failing_step",
+        future=StepFuture(
+            invocation_id="failing_step",
+            output_keys=[],
+            execution_future=_IsolatedStepFuture(
+                pipeline_run_id=uuid4(),
+                invocation_id="failing_step",
+            ),
+        ),
+    )
+
+    runner = object.__new__(DynamicPipelineRunner)
+    runner._exception = None
+    runner._future_registry = registry
+
+    with pytest.raises(RuntimeError, match="failing_step"):
+        runner._settle_concurrent_work()
 
 
 @pipeline(dynamic=True, enable_cache=False)


### PR DESCRIPTION
## Describe changes

Fixes the case of dynamic pipelines with execution mode = STOP_ON_FAILURE completing successfully despite failing steps.

Python pipeline used to reproduce the issue and verify the fix: 

```
@step(runtime=StepRuntime.ISOLATED)
def failing_step() -> None:
    raise RuntimeError("Intentional isolated step failure")


@pipeline(
    dynamic=True,
    enable_cache=False,
    execution_mode=ExecutionMode.STOP_ON_FAILURE,
    settings={"docker": docker_settings},
)
def reproduce_failed_step_successful_pipeline() -> None:
    # Deliberately do not call `.result()`.
    failing_step.submit()


if __name__ == "__main__":
    run = reproduce_failed_step_successful_pipeline()

    # Refresh so we see the final persisted statuses.
    run = Client().get_pipeline_run(run.id)

    print(f"Pipeline status: {run.status}")
    for name, step_run in run.steps.items():
        print(f"Step {name}: {step_run.status}")
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

