### PR TITLE
Dispatch staging workspace runtime builds

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -206,6 +206,10 @@ Creates tracking issues from PRs when `snack-it` label is applied. Adds to GitHu
 
 Runs GitHub Actions security analysis on workflow/config changes, pushes to `main`/`develop`, a weekly schedule, and manual dispatch. Use the same config locally with `GH_TOKEN=$(gh auth token) uvx zizmor --config=.github/zizmor.yml .github/workflows/`.
 
+### publish_staging_workspace_runtime.yml
+
+Dispatches a `zenml-develop-updated` repository event to `zenml-cloud-plugins` on every push to `develop`, carrying the exact merge SHA. That repository builds and publishes the internal staging workspace image; this repo only needs the `CLOUD_PLUGINS_REPO_PAT` secret. Gated to the upstream repository so forks never fail on the missing secret.
+
 ### check-links.yml / check-markdown-links.yml / gitbook-redirect-check.yml
 
 Documentation link safety net. Use these as the source of truth when changing docs URL structure, generated API docs, or GitBook redirects.

--- a/.github/workflows/publish_staging_workspace_runtime.yml
+++ b/.github/workflows/publish_staging_workspace_runtime.yml
@@ -1,24 +1,22 @@
+---
 name: Publish staging workspace runtime
-
 on:
   push:
-    branches:
-      - develop
-  workflow_dispatch:
-
+    branches: [develop]
 permissions:
   contents: read
-
 jobs:
   dispatch:
     name: Request staging runtime build
+    # Forks have no secret and must not publish into the staging channel.
+    if: github.repository == 'zenml-io/zenml'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch exact ZenML revision
         env:
           GH_TOKEN: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
           ZENML_SHA: ${{ github.sha }}
-        run: |
+        run: |-
           gh api \
             --method POST \
             repos/zenml-io/zenml-cloud-plugins/dispatches \

--- a/.github/workflows/publish_staging_workspace_runtime.yml
+++ b/.github/workflows/publish_staging_workspace_runtime.yml
@@ -1,0 +1,26 @@
+name: Publish staging workspace runtime
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Request staging runtime build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch exact ZenML revision
+        env:
+          GH_TOKEN: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+          ZENML_SHA: ${{ github.sha }}
+        run: |
+          gh api \
+            --method POST \
+            repos/zenml-io/zenml-cloud-plugins/dispatches \
+            -f event_type=zenml-develop-updated \
+            -F "client_payload[zenml_sha]=$ZENML_SHA"


### PR DESCRIPTION
## Summary

- Dispatch a staging workspace runtime build after every merge to `develop`.
- Send the exact ZenML commit SHA to the Cloud Plugins publisher.
- Keep Pro image construction, registry access, and channel publication outside the OSS repository.

## Coordinated PRs

- Cloud API: https://github.com/zenml-io/zenml-cloud-api/pull/671
- Cloud Plugins: https://github.com/zenml-io/zenml-cloud-plugins/pull/57
- ZenML: https://github.com/zenml-io/zenml/pull/5185

## Why

Staging needs to exercise merged ZenML code before an official release exists. A branch name is not a stable runtime identity, so this workflow sends the immutable merge commit to the repository that builds the complete Pro server image. It does not change ZenML's package version or publish a ZenML release.

## Flow

`develop` merge -> exact ZenML SHA -> Cloud Plugins repository dispatch -> complete immutable staging image

## Coordinated rollout

This is the final PR in the rollout order:

1. Deploy the Cloud API runtime-channel infrastructure and workspace pinning.
2. Merge the Cloud Plugins image publisher so its first successful build can enable the channel.
3. Merge this dispatcher so future ZenML `develop` updates rebuild that channel.

Existing workspaces are unaffected; the channel is resolved only when an eligible new staging workspace is created.

## Changes after the first review pass

- Job is gated to `github.repository == 'zenml-io/zenml'` so forks never fail on the missing secret (Codex P2).
- `workflow_dispatch` removed: a manual run could publish an arbitrary ref under the `zenml-develop-updated` event (Codex P2), and the Cloud Plugins publisher already has a manual build for any ZenML ref.
- Formatted with `yamlfix`, which is what was failing the linting jobs.

## Reviewer focus

- The dispatch payload contains `github.sha`, not a mutable branch name.
- `CLOUD_PLUGINS_REPO_PAT` must be able to create repository dispatches in `zenml-cloud-plugins`.
- This repository has no AWS credentials or image-publishing responsibility.

## Validation

- `yamlfix --check` and `zizmor` pass on the workflow; the remaining red checks on this PR (zizmor workflow, template syncs) are also red on `develop` and unrelated to this file.
- Checked the embedded shell block with `bash -n`.
- `git diff --check` passed before commit.

Not run locally: the cross-repository dispatch itself; that requires the repository secret and live GitHub Actions.

## Type of change

- [x] Other: internal staging CI/deployment automation

