### PR TITLE
Run the Kubernetes release quickstart inside staging

### DIFF
--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -198,7 +198,6 @@ jobs:
           - cloud: aws
           - cloud: azure
           - cloud: gcp
-          - cloud: kubernetes_aws
     steps:
       - name: Free disk space
         run: |
@@ -227,6 +226,32 @@ jobs:
         run: |
           scripts/qs_run_release_flow.sh \
             --cloud "${{ matrix.cloud }}" \
+            --new-version "${NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION}"
+        env:
+          NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION: ${{ needs.fetch-versions.outputs.new_version }}
+  run_kubernetes_aws_quickstart:
+    needs: [fetch-versions, setup-prep-release-tenant]
+    runs-on: codebuild-release-qs-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+    env:
+      ZENML_STORE_URL: ${{ secrets.RELEASE_TENANT_URL }}
+      ZENML_STORE_API_KEY: ${{ secrets.RELEASE_TENANT_SERVICE_ACCOUNT_KEY }}
+      ZENML_ACTIVE_PROJECT_ID: ${{ secrets.RELEASE_TENANT_PROJECT_ID }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Install ZenML
+        run: scripts/install-zenml-dev.sh --system --integrations "no"
+      - name: Run Quickstart release flow on kubernetes_aws
+        run: |
+          scripts/qs_run_release_flow.sh \
+            --cloud kubernetes_aws \
             --new-version "${NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION}"
         env:
           NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION: ${{ needs.fetch-versions.outputs.new_version }}


### PR DESCRIPTION
## Summary

- move only the `kubernetes_aws` release quickstart from `ubuntu-latest` to the ephemeral `release-qs` CodeBuild runner
- keep the AWS, Azure, and GCP quickstarts on GitHub-hosted runners
- preserve the existing release tenant credentials and quickstart command
- omit GitHub-hosted disk cleanup and Docker service management from the CodeBuild job

## Why

The Kubernetes quickstart must connect directly to the staging EKS API. A public GitHub-hosted runner cannot reach that endpoint, so the job times out before Kubernetes authentication. The dedicated runner supplied by the infrastructure PR executes inside the staging VPC instead.

## Dependency

This PR must not merge until [zenml-cloud-infra #246](https://github.com/zenml-io/zenml-cloud-infra/pull/246) has been reviewed, applied to staging, and its CodeBuild webhook is ready.

## Reviewer focus

- the CodeBuild `runs-on` label matches the infrastructure project name exactly
- only the Kubernetes matrix entry moves to private-network compute
- job dependencies, permissions, secrets, and the release version input remain equivalent to the original matrix lane

## Validation

- `yamlfix --check .github/workflows/release_prepare.yml`
- `zizmor .github/workflows/release_prepare.yml`
- Ruby YAML parsing
- `bash -n scripts/qs_run_release_flow.sh`
- `git diff --check`

All focused checks pass. Zizmor reports no findings beyond the repository's existing suppressions.

No live release-preparation workflow has been run. End-to-end proof remains a rollout gate after the staging infrastructure is applied.
