### PR TITLE
Keep a stopping run out of running on a status refresh

### DIFF
--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -977,6 +977,21 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             # before the client environment can update the status to provisioning.
             return False
 
+        if (
+            current_status == ExecutionStatus.STOPPING
+            and requested_status is not None
+            and not requested_status.is_finished
+        ):
+            # Stopping is a state that only the server knows about: the user
+            # asked for the run to stop and the orchestrator has not finished
+            # doing it yet. Most orchestrators keep reporting the underlying
+            # job as running until it is gone, so a status refresh would
+            # otherwise move the run back out of stopping and lose the fact
+            # that a stop was requested. Drop the reported status rather than
+            # the whole update, so that a refresh which arrives once every
+            # step has finished can still settle the run at stopped.
+            requested_status = None
+
         # Snapshot always exists for pipeline runs of newer versions
         assert self.snapshot
         is_dynamic_pipeline = self.snapshot.is_dynamic

--- a/tests/unit/zen_stores/test_pipeline_run_status_transitions.py
+++ b/tests/unit/zen_stores/test_pipeline_run_status_transitions.py
@@ -1,0 +1,275 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for pipeline run status transitions."""
+
+from pathlib import Path
+from typing import Iterator, List
+from uuid import UUID, uuid4
+
+import pytest
+
+from zenml.enums import ExecutionStatus
+from zenml.models import (
+    PipelineRunUpdate,
+    ProjectFilter,
+    StackFilter,
+)
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    PipelineSchema,
+    PipelineSnapshotSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.sql_zen_store import (
+    Session,
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+
+@pytest.fixture
+def sql_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[SqlZenStore]:
+    """Create a fresh SQLite-backed SqlZenStore for tests.
+
+    Args:
+        tmp_path: The temporary directory to store the database in.
+        monkeypatch: The monkeypatch fixture.
+
+    Yields:
+        The store.
+    """
+    db_dir = tmp_path / "zenml-cfg"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ZENML_CONFIG_PATH", str(db_dir))
+    db_path = db_dir / "test.db"
+    config = SqlZenStoreConfiguration(url=f"sqlite:///{db_path}")
+    store = SqlZenStore(config=config, skip_default_registrations=False)
+    yield store
+
+
+def _project_id(store: SqlZenStore) -> UUID:
+    """Get the ID of the default project.
+
+    Args:
+        store: The store.
+
+    Returns:
+        The project ID.
+    """
+    return (
+        store.list_projects(project_filter_model=ProjectFilter()).items[0].id
+    )
+
+
+def _default_stack_id(store: SqlZenStore) -> UUID:
+    """Get the ID of the default stack.
+
+    The run status update publishes an analytics event once a run finishes,
+    and that event reads the stack off the snapshot.
+
+    Args:
+        store: The store.
+
+    Returns:
+        The stack ID.
+    """
+    return store.list_stacks(stack_filter_model=StackFilter()).items[0].id
+
+
+def _create_run(
+    sql_store: SqlZenStore,
+    *,
+    step_statuses: List[ExecutionStatus],
+    status: ExecutionStatus = ExecutionStatus.STOPPING,
+    is_dynamic: bool = False,
+) -> UUID:
+    """Create a pipeline run together with its snapshot and step runs.
+
+    Args:
+        sql_store: The store to create the run in.
+        step_statuses: The status of each step run to create.
+        status: The status to give the run.
+        is_dynamic: Whether the snapshot is a dynamic pipeline.
+
+    Returns:
+        The ID of the created run.
+    """
+    project_id = _project_id(sql_store)
+    now = utc_now()
+
+    pipeline = PipelineSchema(
+        id=uuid4(),
+        project_id=project_id,
+        name=f"pipeline-{uuid4().hex[:8]}",
+        run_count=0,
+    )
+    snapshot = PipelineSnapshotSchema(
+        id=uuid4(),
+        project_id=project_id,
+        pipeline_id=pipeline.id,
+        pipeline_configuration='{"name": "test_pipeline"}',
+        client_environment="{}",
+        run_name_template="t",
+        client_version="0.0.0",
+        server_version="0.0.0",
+        step_count=len(step_statuses),
+        is_dynamic=is_dynamic,
+        stack_id=_default_stack_id(sql_store),
+    )
+    run = PipelineRunSchema(
+        id=uuid4(),
+        project_id=project_id,
+        name=f"run-{uuid4().hex[:8]}",
+        orchestrator_run_id=None,
+        start_time=now,
+        end_time=None,
+        status=status.value,
+        index=1,
+        in_progress=True,
+        enable_heartbeat=False,
+        pipeline_id=pipeline.id,
+        snapshot_id=snapshot.id,
+    )
+
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(pipeline)
+        session.add(snapshot)
+        session.add(run)
+        session.flush()
+        for index, step_status in enumerate(step_statuses):
+            session.add(
+                StepRunSchema(
+                    id=uuid4(),
+                    project_id=project_id,
+                    pipeline_run_id=run.id,
+                    name=f"step_{index}",
+                    version=1,
+                    status=step_status.value,
+                    is_retriable=False,
+                    start_time=now,
+                    end_time=now if step_status.is_finished else None,
+                )
+            )
+        session.commit()
+
+    return run.id
+
+
+@pytest.mark.parametrize(
+    "is_dynamic", [False, True], ids=["static", "dynamic"]
+)
+def test_stopping_run_is_not_resurrected_by_a_status_refresh(
+    sql_store: SqlZenStore, is_dynamic: bool
+) -> None:
+    """A run being stopped must not go back to running.
+
+    Refreshing the status of a run asks the orchestrator what it thinks and
+    writes the answer back. While a run is being stopped the underlying job is
+    usually still running, so the orchestrator reports `RUNNING`, which must
+    not undo the stop that the user asked for.
+
+    Args:
+        sql_store: The store.
+        is_dynamic: Whether to run this against a dynamic pipeline.
+    """
+    run_id = _create_run(
+        sql_store,
+        step_statuses=[ExecutionStatus.RUNNING, ExecutionStatus.COMPLETED],
+        is_dynamic=is_dynamic,
+    )
+
+    sql_store.update_run(
+        run_id=run_id,
+        run_update=PipelineRunUpdate(status=ExecutionStatus.RUNNING),
+    )
+
+    assert sql_store.get_run(run_id).status == ExecutionStatus.STOPPING
+
+
+def test_stopping_run_still_reaches_stopped_once_its_steps_are_finished(
+    sql_store: SqlZenStore,
+) -> None:
+    """The stale status is dropped, not the whole update.
+
+    A refresh that arrives after the last step has finished still has to be
+    able to move the run out of `STOPPING`, so ignoring the requested status
+    must not mean ignoring the update.
+
+    Args:
+        sql_store: The store.
+    """
+    run_id = _create_run(
+        sql_store,
+        step_statuses=[ExecutionStatus.COMPLETED, ExecutionStatus.STOPPED],
+    )
+
+    sql_store.update_run(
+        run_id=run_id,
+        run_update=PipelineRunUpdate(status=ExecutionStatus.RUNNING),
+    )
+
+    assert sql_store.get_run(run_id).status == ExecutionStatus.STOPPED
+
+
+@pytest.mark.parametrize(
+    "reported_status",
+    [ExecutionStatus.COMPLETED, ExecutionStatus.STOPPED],
+)
+def test_stopping_run_still_accepts_a_finished_status(
+    sql_store: SqlZenStore, reported_status: ExecutionStatus
+) -> None:
+    """A finished status is never stale, so it is applied as before.
+
+    Args:
+        sql_store: The store.
+        reported_status: The status reported for the run.
+    """
+    run_id = _create_run(
+        sql_store,
+        step_statuses=[ExecutionStatus.COMPLETED],
+        is_dynamic=True,
+    )
+
+    sql_store.update_run(
+        run_id=run_id,
+        run_update=PipelineRunUpdate(status=reported_status),
+    )
+
+    assert sql_store.get_run(run_id).status == reported_status
+
+
+def test_running_run_is_still_updated_by_a_status_refresh(
+    sql_store: SqlZenStore,
+) -> None:
+    """The guard is limited to runs that are being stopped.
+
+    Args:
+        sql_store: The store.
+    """
+    run_id = _create_run(
+        sql_store,
+        step_statuses=[ExecutionStatus.RUNNING],
+        status=ExecutionStatus.RUNNING,
+        is_dynamic=True,
+    )
+
+    sql_store.update_run(
+        run_id=run_id,
+        run_update=PipelineRunUpdate(status=ExecutionStatus.FAILED),
+    )
+
+    assert sql_store.get_run(run_id).status == ExecutionStatus.FAILED


### PR DESCRIPTION
## Describe changes

Stopping a run and then refreshing it puts the run back into `running`. The
stop request is not undone — the orchestrator is still winding the job down —
but every reader of the run, the dashboard included, is now told the run is
executing normally, and the fact that somebody asked for it to stop is gone
from the record.

`stopping` is a state only the server knows about: it means the user has asked
for a stop and the orchestrator has not finished doing it. A status refresh
asks the orchestrator what it thinks and writes the answer back, and while a
graceful stop is in progress the job usually is still running, so that is what
comes back. Not everywhere: SageMaker has AWS's distinct `Stopping` state to
map from, and the Kubernetes orchestrator returns `None` unless the job is
complete or failed, so neither shows this. Vertex and AzureML report `running`.
`PipelineRunSchema.update_status` then applies that reading with no guard on
it. For a dynamic pipeline `new_status` becomes the reported
`running` directly; for a static one the reported status displaces `stopping`
in the first argument to `_compute_static_pipeline_run_status`, so the
`run_status == STOPPING` branch there never runs and the result falls through
to "a step is running, so the run is running".

The fix drops a reported status that is not a finished one while the run is
`stopping`, alongside the existing rule two lines above that ignores a
transition to `provisioning` from a non-initializing state — the same shape of
problem, one component's stale reading overwriting another's fresher one. It
drops the reported status rather than returning early, so a refresh that
arrives once every step has finished can still settle the run at `stopped`
instead of leaving it stuck in `stopping`. A finished status is never stale and
is still applied.

Guarding this in `refresh_run_status` instead would have been smaller, but
`update_status` is where every writer arrives — both refresh endpoints and
`Client().update_run` — and where the sibling transition rules already live.
`_verify_step_status_transition` in `SqlZenStore` makes the same rule for
*steps*: a stopping step may only go to `stopped` or `failed`. It raises rather
than ignores, which is right there because it is documented as validating
user-provided statuses; a refresh reporting `running` is a machine's honest
reading of a job that really is still running, so ignoring it is the better
answer than an error.

`tests/unit/zen_stores/test_pipeline_run_status_transitions.py` is new. Six
tests over a real SQLite-backed store, since `update_status` reads its step
statuses off the DB session. `test_stopping_run_is_not_resurrected_by_a_status_refresh`
covers the static and the dynamic path and fails on `develop` with
`assert <ExecutionStatus.RUNNING: 'running'> == <ExecutionStatus.STOPPING: 'stopping'>`
on both. The other four pass before and after, and pin down what the change
must not alter: that a stopping run still reaches `stopped` when its steps
finish, still accepts a finished status, and that a run which is not stopping
is still updated normally.

`tests/unit/zen_stores` and `tests/unit/utils` are 466 passed / 1 skipped
before and 472 passed / 1 skipped after, which is the six new tests and nothing
else.

I can't apply labels, so this needs `release-notes` or `no-release-notes` from
a maintainer for the label check to pass.

Fixes #4571

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io) — no documented behaviour changes; the run lifecycle is unchanged, this stops one state being lost.
  - [x] Dashboard: worth communicating. A run that is being stopped will now stay `stopping` in the UI across a refresh instead of flipping back to `running`.
  - [ ] Templates: not affected.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): not affected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
