### PR TITLE
Clarify that dynamic pipelines are stable

### DIFF
--- a/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
+++ b/docs/book/how-to/steps-pipelines/dynamic_pipelines.md
@@ -4,6 +4,9 @@ description: Write dynamic pipelines
 
 # Dynamic Pipelines
 
+Dynamic pipelines are a stable, supported ZenML feature. Enable them with
+`@pipeline(dynamic=True)` when your workflow needs runtime control flow.
+
 ## Why Dynamic Pipelines?
 
 Traditional ZenML pipelines require you to define the entire DAG structure at pipeline definition time. While this works well for many use cases, there are scenarios where you need more flexibility:
@@ -15,7 +18,7 @@ Traditional ZenML pipelines require you to define the entire DAG structure at pi
 Dynamic pipelines allow you to write pipelines that generate their DAG structure dynamically at runtime, giving you the power of Python's control flow (loops, conditionals) combined with ZenML's orchestration capabilities.
 
 {% hint style="info" %}
-Dynamic pipelines are powerful but easy to get wrong (e.g., `.load()` vs `.chunk()`, mapping vs submit). If you use an AI coding agent, the `zenml-pipeline-authoring` skill can guide implementation step-by-step. See [LLM tooling](../../reference/llms-txt.md).
+If you use an AI coding agent, the `zenml-pipeline-authoring` skill provides guidance on artifact loading, mapping, and parallel step execution. See [LLM tooling](../../reference/llms-txt.md).
 {% endhint %}
 
 ## Basic Example


### PR DESCRIPTION
## Describe changes

Dynamic pipelines are no longer experimental. The latest `develop` docs already omit the old experimental label; this PR makes their stable, supported status explicit at the top of the guide and shows how to enable them with `@pipeline(dynamic=True)`.

Replace the introductory "powerful but easy to get wrong" wording with neutral guidance on artifact loading, mapping, and parallel execution. Keep all existing limitations and orchestrator support details unchanged.

Based on freshly fetched `origin/develop` (`6f016b5ba5`). Documentation only; no runtime behavior changes.

## Verification

- `git diff --check` passed.
- `python3 scripts/check_relative_links.py --dir docs/book/how-to/steps-pipelines` passed: 33 valid links, 0 broken links.
- Searched the documentation for remaining experimental/preview/beta messaging about dynamic pipelines; none remains.
- Attempted `bash scripts/format.sh --no-yamlfix docs/book/how-to/steps-pipelines`; Ruff is not installed, so its checks did not run. Only Markdown prose changed.
- No Python tests run because no code changed.

## Types of changes

- [x] Other: documentation messaging.
