### PR TITLE
Apply the failure policy when settling unawaited dynamic work

### DIFF
--- a/src/zenml/execution/pipeline/dynamic/runner.py
+++ b/src/zenml/execution/pipeline/dynamic/runner.py
@@ -1966,11 +1966,25 @@ class DynamicPipelineRunner:
             for future in self._future_registry.get_all_futures():
                 if future.running():
                     has_in_progress_work = True
-                else:
-                    # A terminal future can represent either a successful or
-                    # failed invocation. Consume its result so an unawaited
-                    # failure cannot be mistaken for successful settlement.
+                    continue
+                if self._continue_on_failure:
+                    # A failed node never fails the run in this mode, see
+                    # `_fail_concurrent_node`.
+                    continue
+                # A terminal future can represent a failed invocation that
+                # the monitor has not processed yet. Consume its result so an
+                # unawaited failure cannot be mistaken for successful
+                # settlement.
+                try:
                     future.wait()
+                except RunPaused:
+                    # A paused child is not a failure; the pause is already
+                    # recorded on this runner.
+                    pass
+                except BaseException as failure:
+                    # The monitor may have recorded the root cause meanwhile,
+                    # leaving this future cancelled only as a consequence.
+                    raise self._exception or failure
 
             if not has_in_progress_work:
                 return

--- a/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
+++ b/tests/unit/execution/pipeline/dynamic/test_step_failure_exceptions.py
@@ -26,7 +26,10 @@ from zenml.execution.pipeline.dynamic.outputs import (
     StepFuture,
     _IsolatedStepFuture,
 )
-from zenml.execution.pipeline.dynamic.runner import DynamicPipelineRunner
+from zenml.execution.pipeline.dynamic.runner import (
+    DynamicPipelineRunner,
+    RunPaused,
+)
 
 
 @step
@@ -110,10 +113,21 @@ def test_unawaited_failure_raises_step_execution_exception() -> None:
         unawaited_pipeline()
 
 
-def test_unawaited_isolated_failure_raises_during_settlement(
+def _settling_runner(
+    registry: FutureRegistry, *, continue_on_failure: bool = False
+) -> DynamicPipelineRunner:
+    """Build a runner with only the state that settlement reads."""
+    runner = object.__new__(DynamicPipelineRunner)
+    runner._exception = None
+    runner._continue_on_failure = continue_on_failure
+    runner._future_registry = registry
+    return runner
+
+
+def _unawaited_failed_isolated_step(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An isolated failure is raised even before the monitor processes it."""
+) -> FutureRegistry:
+    """Register an isolated step that failed before the monitor noticed."""
     failed_step_run = SimpleNamespace(
         status=ExecutionStatus.FAILED,
         exception_info=None,
@@ -135,13 +149,43 @@ def test_unawaited_isolated_failure_raises_during_settlement(
             ),
         ),
     )
+    return registry
 
-    runner = object.__new__(DynamicPipelineRunner)
-    runner._exception = None
-    runner._future_registry = registry
+
+def test_unawaited_isolated_failure_raises_during_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An isolated failure is raised even before the monitor processes it."""
+    runner = _settling_runner(_unawaited_failed_isolated_step(monkeypatch))
 
     with pytest.raises(RuntimeError, match="failing_step"):
         runner._settle_concurrent_work()
+
+
+def test_unawaited_isolated_failure_settles_when_continuing_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CONTINUE_ON_FAILURE lets the run settle past an unawaited failure."""
+    runner = _settling_runner(
+        _unawaited_failed_isolated_step(monkeypatch),
+        continue_on_failure=True,
+    )
+
+    runner._settle_concurrent_work()
+
+
+def test_paused_node_settles_without_failing() -> None:
+    """A node that inherited a pause is not a failure at settlement."""
+    registry = FutureRegistry()
+    registry.register_step_future(
+        invocation_id="paused_step",
+        future=StepFuture(invocation_id="paused_step", output_keys=[]),
+    )
+    registry.set_startup_exception(
+        invocation_id="paused_step", exception=RunPaused()
+    )
+
+    _settling_runner(registry)._settle_concurrent_work()
 
 
 @pipeline(dynamic=True, enable_cache=False)


### PR DESCRIPTION
## Summary

Fixes the 7 dynamic-pipeline unit tests that have failed on every PR's `unit-test` jobs since #5182 merged (#5182's own `ubuntu-setup-and-unit-test` run showed the same 7 failures):

- `test_continue_on_failure.py`: `test_map_partial_failure_does_not_fail_run`, `test_downstream_of_failed_async_step_is_cancelled`, `test_unawaited_async_failure_does_not_fail_run`
- `test_child_pipelines.py`: `test_parent_pauses_when_{future_wait_observes,async_step_depends_on,sync_step_depends_on}_paused_child`, `test_submit_child_wait_timeout_pauses_both_parent_and_child`

## Root cause

#5182 changed `DynamicPipelineRunner._settle_concurrent_work` to call `future.wait()` on every terminal future so an unawaited failure of an isolated step can no longer be mistaken for successful settlement (the run used to end up `COMPLETED` with a failed step). That part is right, but `wait()` re-raises unconditionally, which broke two behaviors settlement previously left alone:

- In `CONTINUE_ON_FAILURE` mode a failed node must not fail the run — `_fail_concurrent_node` already makes exactly that decision for the monitor path, and settlement now contradicted it.
- A child that paused surfaces as `RunPaused` from `wait()`. That is not a failure: the pause is already recorded on the runner via `_mark_paused` / the node's `RunPaused` startup exception, so re-raising it turned a paused parent into a failed one.

## Fix

`_settle_concurrent_work` now applies the runner's existing failure policy instead of a blanket wait:

- skip the consume step entirely in `CONTINUE_ON_FAILURE` mode;
- tolerate `RunPaused`;
- if the monitor recorded a failure while we were waiting, raise that root cause rather than a future that was only cancelled (`StartupCancelled`) as a consequence of it.

The behavior #5182 introduced (unawaited isolated failure fails the run in `FAIL_FAST` / `STOP_ON_FAILURE`) is unchanged and still covered by `test_unawaited_isolated_failure_raises_during_settlement`.

## Tests

- `test_step_failure_exceptions.py`: the bare-runner settlement test from #5182 is refactored into a helper, plus two new cases — the same unawaited failure settles cleanly in `CONTINUE_ON_FAILURE`, and a node carrying a `RunPaused` startup exception settles without failing.
- Locally: all 84 tests in `tests/unit/execution/pipeline/dynamic/` pass; `ruff`, the isolated `F401/F841` check, and `mypy` on `runner.py` are clean.

## Notes for review

- No SQL/model/API changes; only `runner.py` and its unit test.
- The `check-absolute-links` (`docs.bentoml.org` HTTP 429) and `windows-linting` (scikit-learn 1.5.2 source build on Python 3.14) failures seen on open PRs are unrelated to this and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
