### PR TITLE
Disable the directory listing cache on GCS and S3 artifact stores

### DIFF
--- a/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
+++ b/src/zenml/integrations/gcp/artifact_stores/gcp_artifact_store.py
@@ -100,7 +100,14 @@ class GCPArtifactStore(BaseArtifactStore, AuthenticationMixin):
                 return self._filesystem
 
             token = self.get_credentials()
-            self._filesystem = gcsfs.GCSFileSystem(token=token)
+            # No directory listing cache: the server shares one artifact store
+            # instance across requests, and fsspec only invalidates a cached
+            # listing for writes made through that same instance. Step logs are
+            # written by the orchestrator in another process, so a listing
+            # cached while a step is running would never be refreshed.
+            self._filesystem = gcsfs.GCSFileSystem(
+                token=token, use_listings_cache=False
+            )
 
             return self._filesystem
 

--- a/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
+++ b/src/zenml/integrations/s3/artifact_stores/s3_artifact_store.py
@@ -295,6 +295,14 @@ class S3ArtifactStore(BaseArtifactStore, AuthenticationMixin):
             client_kwargs=client_kwargs,
             config_kwargs=self.config.config_kwargs,
             s3_additional_kwargs=self.config.s3_additional_kwargs,
+            # No directory listing cache, which is a different cache from the
+            # instance caching `ZenMLS3Filesystem` turns off: the server shares
+            # one artifact store instance across requests, and fsspec only
+            # invalidates a cached listing for writes made through that same
+            # instance. Step logs are written by the orchestrator in another
+            # process, so a listing cached while a step is running would never
+            # be refreshed.
+            use_listings_cache=False,
         )
 
     @property

--- a/tests/integration/integrations/azure/artifact_stores/test_azure_artifact_store.py
+++ b/tests/integration/integrations/azure/artifact_stores/test_azure_artifact_store.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -93,3 +94,26 @@ def test_must_be_azure_path():
         updated=datetime.now(),
     )
     assert artifact_store.path == "abfs://mycontainer"
+
+
+def test_azure_filesystem_does_not_cache_listings():
+    """Checks that the azure filesystem is built without a directory listing cache.
+
+    The server shares one instance across requests and step logs are written
+    by another process, so a cached listing would never be refreshed.
+    """
+    artifact_store = AzureArtifactStore(
+        name="",
+        id=uuid4(),
+        config=AzureArtifactStoreConfig(path="az://mycontainer"),
+        flavor="azure",
+        type=StackComponentType.ARTIFACT_STORE,
+        user=uuid4(),
+        created=datetime.now(),
+        updated=datetime.now(),
+    )
+
+    with patch("adlfs.AzureBlobFileSystem") as mock_filesystem:
+        _ = artifact_store.filesystem
+
+    assert mock_filesystem.call_args.kwargs["use_listings_cache"] is False

--- a/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
+++ b/tests/integration/integrations/gcp/artifact_stores/test_gcp_artifact_store.py
@@ -14,6 +14,7 @@
 
 
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -52,3 +53,17 @@ def test_must_be_gcs_path():
 
     artifact_store = _get_gcp_artifact_store(path="gs://mybucket")
     assert artifact_store.path == "gs://mybucket"
+
+
+def test_gcs_filesystem_does_not_cache_listings():
+    """Checks that the GCS filesystem is built without a directory listing cache.
+
+    The server shares one instance across requests and step logs are written
+    by another process, so a cached listing would never be refreshed.
+    """
+    artifact_store = _get_gcp_artifact_store(path="gs://mybucket")
+
+    with patch("gcsfs.GCSFileSystem") as mock_filesystem:
+        _ = artifact_store.filesystem
+
+    assert mock_filesystem.call_args.kwargs["use_listings_cache"] is False

--- a/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
+++ b/tests/integration/integrations/s3/artifact_stores/test_s3_artifact_store.py
@@ -258,3 +258,31 @@ def test_safe_aexit_propagates_unrelated_assertion_errors() -> None:
 
     with pytest.raises(AssertionError, match="Something else broke"):
         asyncio.run(ZenMLS3Filesystem._safe_aexit_s3_creator(creator))
+
+
+def test_s3_filesystem_does_not_cache_listings():
+    """Checks that the s3 filesystem is built without a directory listing cache.
+
+    This is a different cache from the instance caching `ZenMLS3Filesystem`
+    turns off. The server shares one instance across requests and step logs
+    are written by another process, so a cached listing would never be
+    refreshed.
+    """
+    with patch("boto3.resource", MagicMock()):
+        artifact_store = S3ArtifactStore(
+            name="",
+            id=uuid4(),
+            config=S3ArtifactStoreConfig(path="s3://mybucket"),
+            flavor="s3",
+            type=StackComponentType.ARTIFACT_STORE,
+            user=uuid4(),
+            created=datetime.now(),
+            updated=datetime.now(),
+        )
+
+    with patch(
+        "zenml.integrations.s3.artifact_stores.s3_artifact_store.ZenMLS3Filesystem"
+    ) as mock_filesystem:
+        _ = artifact_store.filesystem
+
+    assert mock_filesystem.call_args.kwargs["use_listings_cache"] is False


### PR DESCRIPTION
## Describe changes

Step logs on a GCP stack freeze at whatever was there the first time anybody
looked. Refreshing while the step is still running returns the same lines
again, and refreshing after it has finished does not recover the rest either.

The caching is fsspec's directory listing cache rather than anything in the log
store. Since #4974 the server keeps one artifact store instance per component
alive in an LRU (`instantiate_artifact_store` →
`zen_server/artifact_store_cache.py`), so a single `gcsfs.GCSFileSystem` serves
every request. fsspec invalidates a cached listing only when the write goes
through that same instance, and step logs are written by the orchestrator in a
different process — so the first log request caches the listing of the log
directory and nothing ever clears it. `_stream_logs_line_by_line` then lists a
stale set of files and opens each one at its cached size. It is also why a
refresh after completion does not help: `ArtifactLogExporter._merge` replaces
the per-chunk files with a single `<ts>_merged.log`, so the cached listing names
files that have been deleted and does not name the one that now exists.

`AzureArtifactStore` already builds its filesystem with
`use_listings_cache=False`; `GCPArtifactStore` and `S3ArtifactStore` did not.
This passes the same flag in both, so the three stores agree. For S3 it goes in
`_build_filesystem_kwargs()`, so the B2 and DigitalOcean stores inherit it. The
alternative was a short `cache_timeout` / `listings_expiry_time`, which keeps
some of the caching and bounds the staleness instead of removing it; I went with
the flag Azure already uses rather than introduce a timeout the codebase has
nowhere else, but that is a one-line change if you would rather keep the cache.
The cost of turning it off is a listing round trip on client-side reads, where
the cache is correct because the same process does the writes.

`test_gcs_filesystem_does_not_cache_listings` and
`test_s3_filesystem_does_not_cache_listings` are new and fail on `develop` with
`KeyError: 'use_listings_cache'`. `test_azure_filesystem_does_not_cache_listings`
passes before and after — it is there so the rule is held over all three stores
rather than the two that were wrong. Against the installed fsspec 2024.12.0, a
`gcsfs` or `s3fs` filesystem built the old way retains a seeded `dircache` entry
and one built with the flag does not, which is the behaviour those tests stand
for. I have no GCS bucket to reproduce the dashboard symptom end to end, so what
is demonstrated here is the mechanism.

I can't apply labels, so this needs `release-notes` or `no-release-notes` from a
maintainer for the label check to pass.

Fixes #5163

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io) — no documented behaviour changes.
  - [x] Dashboard: worth communicating. Step logs on GCS and S3 stacks will now advance on refresh while a step is running instead of stopping at the first read.
  - [ ] Templates: not affected.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): not affected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)
