### PR TITLE
[DB growth initiative #7, 2/3] Read and verify execution archives

### DIFF
--- a/docs/book/how-to/manage-zenml-server/archive-execution-history.md
+++ b/docs/book/how-to/manage-zenml-server/archive-execution-history.md
@@ -1,0 +1,113 @@
+---
+description: Keep old execution history available without keeping its large payloads in the metadata database.
+---
+
+# Archive execution history
+
+Execution archiving moves the large, immutable payload of completed pipeline
+runs — snapshot configurations, step configurations, source code,
+environments, exception details — out of the metadata database into object
+storage, while every run, step and snapshot stays listable, filterable and
+readable exactly as before. When an archived run is opened, the server loads
+its payload from the archive, verifies it and returns the same response it
+would have returned from the database.
+
+{% hint style="info" %}
+Archiving is explicit and administrator-driven: nothing is archived until an
+administrator runs a pass; nothing leaves the database in this
+version. Archiving never touches artifact or log data, and this
+version never deletes archived objects.
+{% endhint %}
+
+This feature bounds snapshot, step-configuration, and execution payload growth
+for eligible completed execution families. It does not yet archive failed or
+stopped families, artifact metadata, run metadata, logs, relationships, or
+other SQL records.
+
+## Configure the archive storage
+
+Archive storage is server infrastructure, not a stack component. Configure it
+on every server replica with an artifact store flavor (`s3`, `gcp`, `azure`,
+`local`, an S3-compatible service through the `s3` flavor's `client_kwargs`,
+or a custom flavor), its configuration and a path prefix:
+
+```bash
+export ZENML_SERVER_EXECUTION_ARCHIVE_FLAVOR=s3
+export ZENML_SERVER_EXECUTION_ARCHIVE_CONFIGURATION='{"path": "s3://example-archive-bucket/workspace"}'
+export ZENML_SERVER_EXECUTION_ARCHIVE_PATH_PREFIX=execution-archive
+```
+
+The server authenticates to the destination with its own identity — an IAM
+role, workload identity or credentials in its environment; the configuration
+holds no credentials. The first archive pass writes a small probe object and
+reads it back, and records the configuration as an immutable storage target
+that every archive written under it points to. Changing the configuration
+records another target; archives written to the previous one keep being read
+from it, so never remove a destination that still holds archives.
+
+{% hint style="warning" %}
+A `local` destination is safe for a server with several replicas only when its
+path is a shared, durable volume mounted at the same location on every
+replica. Archives written through a ZenML integration flavor (`s3`, `gcp`,
+`azure`, …) can only be read by replicas that have that integration installed;
+archives written through a custom flavor depend on the import path recorded
+when the target was created.
+{% endhint %}
+
+Bucket versioning, retention, encryption and lifecycle rules are properties of
+the destination and stay under the operator's control. Archive objects are
+content-addressed and verified by their SHA-256 digest on every read, so a
+destination that returns corrupt or missing data fails closed: the request
+returns HTTP 503 instead of incomplete history.
+
+## Preview and export
+
+Administrators preview what a pass would archive without writing anything:
+
+```text
+POST /api/v1/archive?dry_run=true
+```
+
+```json
+{
+  "project": "<PROJECT-ID>",
+  "older_than_days": 180,
+  "limit": 25
+}
+```
+
+The request may also name the `root_run_ids` to consider. A family is
+eligible once every run and step in it completed, nothing in it is still
+waiting or active, its snapshots are used by nothing else, its payload is
+below 128 MiB in the database, and its last change is older than
+`older_than_days`. The response lists every considered family with its
+eligibility, its payload size in the database and what blocks it. A dry run
+reads identities and sizes only, never payload.
+
+The same request with `dry_run=false` runs the pass on the server's
+maintenance worker, one family at a time, and returns a task ID immediately;
+search the server logs for it to follow progress. A second maintenance task
+while one is running is rejected with HTTP 429.
+
+An export writes the family's objects to the storage target, reads them back,
+verifies them against a fresh capture of the database and records the
+generation as `verified`. **The database keeps its payload and stays the
+source of truth**; a verified archive is a checked copy. A family whose
+payload changes between export and verification is recorded as `failed` and
+archived again as a new generation on the next pass.
+
+List archives with `GET /api/v1/archive?project_id=<PROJECT-ID>`, optionally
+filtered by `state`.
+
+## Compaction ships separately
+
+Replacing the database payload of verified archives with a placeholder —
+compaction — ships in a later release, after every server replica runs a
+version that can read archived payload. Until then the database keeps every
+byte and a verified archive is a checked copy.
+
+## Downgrading
+
+The database migration that introduces archiving refuses to downgrade while
+any archive is still authoritative for rows in the database. Restore every
+archive listed as `compacting`, `cold` or `restoring` first.

--- a/docs/book/toc.md
+++ b/docs/book/toc.md
@@ -27,6 +27,7 @@
 * [Manage](how-to/manage-zenml-server/upgrade-zenml-server.md)
   * [Best practices for upgrading](how-to/manage-zenml-server/best-practices-upgrading-zenml.md)
   * [Using ZenML server in production](how-to/manage-zenml-server/using-zenml-server-in-prod.md)
+  * [Archive execution history](how-to/manage-zenml-server/archive-execution-history.md)
   * [Troubleshoot your ZenML server](how-to/manage-zenml-server/troubleshoot-your-deployed-server.md)
   * [Migration guide](how-to/manage-zenml-server/migration-guide/migration-guide.md)
     * [Migration guide 0.13.2 → 0.20.0](how-to/manage-zenml-server/migration-guide/migration-zero-twenty.md)

--- a/src/zenml/models/__init__.py
+++ b/src/zenml/models/__init__.py
@@ -444,6 +444,9 @@ from zenml.models.v2.misc.auth_models import (
 from zenml.models.v2.misc.build_item import BuildItem
 from zenml.models.v2.misc.exception_info import ExceptionInfo
 from zenml.models.v2.misc.execution_archive import (
+    ExecutionArchiveCandidate,
+    ExecutionArchiveMaintenanceRequest,
+    ExecutionArchiveMaintenanceResponse,
     ExecutionArchiveObject,
     ExecutionArchiveResponse,
 )
@@ -897,6 +900,9 @@ __all__ = [
     "ServerSettingsResponseBody",
     "ServerSettingsResponseMetadata",
     "ServerSettingsUpdate",
+    "ExecutionArchiveCandidate",
+    "ExecutionArchiveMaintenanceRequest",
+    "ExecutionArchiveMaintenanceResponse",
     "ExecutionArchiveObject",
     "ExecutionArchiveResponse",
     "ServiceAccountFilter",

--- a/src/zenml/models/v2/misc/execution_archive.py
+++ b/src/zenml/models/v2/misc/execution_archive.py
@@ -24,6 +24,8 @@ from zenml.models.v2.base.base import BaseZenModel
 
 Sha256Digest = Annotated[str, StringConstraints(pattern=r"^[0-9a-f]{64}$")]
 
+MAX_ARCHIVE_MAINTENANCE_FAMILIES = 50
+
 
 def validate_relative_path(value: str) -> str:
     """Require a relative path that cannot escape its root.
@@ -102,3 +104,58 @@ class ExecutionArchiveResponse(BaseZenModel):
     created: datetime
 
     model_config = ConfigDict(frozen=True)
+
+
+class ExecutionArchiveMaintenanceRequest(BaseZenModel):
+    """Bounded archive maintenance pass over one project."""
+
+    project: UUID = Field(description="The project to archive in.")
+    root_run_ids: List[UUID] = Field(
+        default_factory=list,
+        max_length=MAX_ARCHIVE_MAINTENANCE_FAMILIES,
+        description="Root runs to consider. If empty, the oldest completed "
+        "root runs of the project that are not archived yet are considered.",
+    )
+    older_than_days: int = Field(
+        default=180,
+        ge=30,
+        le=3650,
+        description="Only families unchanged for at least this many days "
+        "are archived.",
+    )
+    limit: int = Field(
+        default=25,
+        ge=1,
+        le=MAX_ARCHIVE_MAINTENANCE_FAMILIES,
+        description="Maximum number of execution families to consider.",
+    )
+
+
+class ExecutionArchiveCandidate(BaseZenModel):
+    """Eligibility of one execution family."""
+
+    root_run_id: UUID
+    eligible: bool
+    eligible_at: Optional[datetime] = None
+    stored_bytes: Optional[int] = Field(
+        default=None,
+        description="Bytes of payload the family holds in the database.",
+    )
+    blockers: List[str] = Field(default_factory=list)
+    archive_id: Optional[UUID] = None
+    archive_state: Optional[ExecutionArchiveState] = None
+
+
+class ExecutionArchiveMaintenanceResponse(BaseZenModel):
+    """Result of a dry run, or the task scheduled for an apply."""
+
+    candidates: List[ExecutionArchiveCandidate] = Field(
+        default_factory=list,
+        description="Eligibility of every considered family. Filled by a "
+        "dry run only.",
+    )
+    task_id: Optional[str] = Field(
+        default=None,
+        description="ID of the background task running the pass, bound to "
+        "every log record it emits. Unset for a dry run.",
+    )

--- a/src/zenml/zen_server/exceptions.py
+++ b/src/zenml/zen_server/exceptions.py
@@ -19,6 +19,7 @@ import requests
 from pydantic import BaseModel
 
 from zenml.exceptions import (
+    ArchiveUnavailableError,
     AuthorizationException,
     CredentialsNotValid,
     DoesNotExistException,
@@ -68,6 +69,8 @@ error_response = dict(model=ErrorModel)
 # exception can be reconstructed from two or more HTTP error responses with
 # different status codes (e.g. `ValueError` and the 400 and 422 status codes).
 REST_API_EXCEPTIONS: List[Tuple[Type[Exception], int]] = [
+    # 503 Service Unavailable
+    (ArchiveUnavailableError, 503),
     # 409 Conflict
     (EntityExistsError, 409),
     # 403 Forbidden

--- a/src/zenml/zen_server/routers/execution_archive_endpoints.py
+++ b/src/zenml/zen_server/routers/execution_archive_endpoints.py
@@ -1,0 +1,131 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Admin endpoints for execution-history archiving."""
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Query, Security
+
+from zenml.constants import API, VERSION_1
+from zenml.enums import ExecutionArchiveState
+from zenml.exceptions import IllegalOperationError
+from zenml.logger import get_logger
+from zenml.models import (
+    ExecutionArchiveMaintenanceRequest,
+    ExecutionArchiveMaintenanceResponse,
+    ExecutionArchiveResponse,
+)
+from zenml.zen_server.auth import AuthContext, authorize
+from zenml.zen_server.exceptions import error_response
+from zenml.zen_server.utils import (
+    async_fastapi_endpoint_wrapper,
+    submit_maintenance_task,
+    zen_store,
+)
+from zenml.zen_stores.execution_archive.maintenance import (
+    ExecutionArchiveMaintainer,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(
+    prefix=API + VERSION_1 + "/archive",
+    tags=["archive"],
+    responses={401: error_response, 403: error_response},
+)
+
+
+def _require_admin(auth_context: AuthContext, action: str) -> None:
+    """Restrict an operation to server administrators.
+
+    Unlike `verify_admin_status_if_no_rbac`, this check also applies when
+    RBAC is enabled: archiving has no RBAC resource, and moving execution
+    history is a server operation, never a project-level permission.
+
+    Args:
+        auth_context: The authenticated caller.
+        action: What the caller is trying to do, for the error message.
+
+    Raises:
+        IllegalOperationError: If the caller is not an administrator.
+    """
+    if not auth_context.user.is_admin:
+        raise IllegalOperationError(f"Only administrators can {action}.")
+
+
+@router.get("", responses={422: error_response})
+@async_fastapi_endpoint_wrapper
+def list_execution_archives(
+    project_id: UUID,
+    state: Optional[ExecutionArchiveState] = None,
+    limit: int = Query(default=100, ge=1, le=100),
+    auth_context: AuthContext = Security(authorize),
+) -> List[ExecutionArchiveResponse]:
+    """List the newest archive generations of a project.
+
+    Args:
+        project_id: The project.
+        state: Only generations in this state, if given.
+        limit: Maximum generations to return.
+        auth_context: The authenticated caller.
+
+    Returns:
+        The generations, newest first.
+    """
+    _require_admin(auth_context, "list execution archives")
+    return ExecutionArchiveMaintainer(zen_store()).list_archives(
+        project_id=project_id, state=state, limit=limit
+    )
+
+
+@router.post("", responses={422: error_response, 429: error_response})
+@async_fastapi_endpoint_wrapper
+def maintain_execution_archive(
+    request: ExecutionArchiveMaintenanceRequest,
+    dry_run: bool = True,
+    auth_context: AuthContext = Security(authorize),
+) -> ExecutionArchiveMaintenanceResponse:
+    """Preview, or archive in the background, a bounded set of families.
+
+    A dry run reads identities and sizes only and returns the eligibility
+    of every family. Otherwise the whole pass runs on the maintenance
+    worker, so the request returns as soon as the task is accepted; the
+    response then carries only the task ID bound to its log records.
+
+    Args:
+        request: The project and, optionally, root runs to consider.
+        dry_run: Whether to only report eligibility.
+        auth_context: The authenticated caller.
+
+    Returns:
+        The candidates of a dry run, or the task ID of the pass.
+    """
+    _require_admin(auth_context, "run execution archive maintenance")
+    maintenance = ExecutionArchiveMaintainer(zen_store())
+    if dry_run:
+        return ExecutionArchiveMaintenanceResponse(
+            candidates=maintenance.preview(request)
+        )
+
+    def _apply() -> None:
+        results = maintenance.apply(request)
+        logger.info(
+            f"Archived {sum(1 for c in results if c.archive_state)} of "
+            f"{len(results)} execution families of project {request.project}."
+        )
+
+    return ExecutionArchiveMaintenanceResponse(
+        task_id=submit_maintenance_task(_apply)
+    )

--- a/src/zenml/zen_server/utils.py
+++ b/src/zenml/zen_server/utils.py
@@ -36,7 +36,7 @@ from typing import (
     Union,
     overload,
 )
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import psutil
 from pydantic import BaseModel, ValidationError
@@ -51,8 +51,12 @@ from zenml.constants import (
     INFO,
     VERSION_1,
 )
-from zenml.exceptions import IllegalOperationError, OAuthError
-from zenml.logger import get_logger
+from zenml.exceptions import (
+    IllegalOperationError,
+    MaxConcurrentTasksError,
+    OAuthError,
+)
+from zenml.logger import get_logger, get_logging_context, logging_context
 from zenml.models.v2.base.scoped import ProjectScopedFilter
 from zenml.zen_server.exceptions import http_exception_from_error
 from zenml.zen_server.feature_gate.feature_gate_interface import (
@@ -98,6 +102,7 @@ _feature_gate: Optional[FeatureGateInterface] = None
 _workload_manager: Optional[WorkloadManagerInterface] = None
 _resource_pool_store: Optional[ResourcePoolsSQLStoreInterface] = None
 _snapshot_executor: Optional["BoundedThreadPoolExecutor"] = None
+_maintenance_executor: Optional["BoundedThreadPoolExecutor"] = None
 _snapshot_run_dispatcher: Optional[SnapshotRunDispatcher] = None
 _request_manager: Optional[RequestManager] = None
 _stream_broker: Optional[StreamBroker] = None
@@ -122,6 +127,77 @@ def zen_store() -> "SqlZenStore":
     if _zen_store is None:
         raise RuntimeError("ZenML Store not initialized")
     return _zen_store
+
+
+def maintenance_executor() -> "BoundedThreadPoolExecutor":
+    """Return the initialized maintenance executor.
+
+    Raises:
+        RuntimeError: If the maintenance executor is not initialized.
+
+    Returns:
+        The maintenance executor.
+    """
+    global _maintenance_executor
+    if _maintenance_executor is None:
+        raise RuntimeError("Maintenance executor not initialized")
+
+    return _maintenance_executor
+
+
+def initialize_maintenance_executor() -> None:
+    """Initialize the maintenance executor.
+
+    Maintenance jobs such as archiving scan large tables and are not
+    expected to overlap, so a single worker serializes them per server
+    process and rejects a job while another one is still running.
+    """
+    global _maintenance_executor
+    from zenml.zen_server.pipeline_execution.utils import (
+        BoundedThreadPoolExecutor,
+    )
+
+    _maintenance_executor = BoundedThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="zenml-maintenance-executor",
+    )
+
+
+def submit_maintenance_task(task: Callable[[], Any]) -> str:
+    """Run a task on the maintenance executor.
+
+    The task runs detached from the request that submitted it, so its outcome
+    is only reported through the server logs. Every log record it emits
+    carries the returned task ID and the ID of the submitting request.
+
+    Args:
+        task: The task to run.
+
+    Raises:
+        MaxConcurrentTasksError: If another maintenance task is still running.
+
+    Returns:
+        The ID of the scheduled task.
+    """
+    task_id = str(uuid4())
+    request_id = get_logging_context().get("request_id")
+
+    def _run() -> None:
+        with logging_context(task_id=task_id, request_id=request_id):
+            try:
+                task()
+            except Exception:
+                logger.exception("Maintenance task failed.")
+
+    try:
+        maintenance_executor().submit(_run)
+    except MaxConcurrentTasksError:
+        raise MaxConcurrentTasksError(
+            "Another maintenance task is still running. Retry once it has "
+            "finished."
+        ) from None
+
+    return task_id
 
 
 def rbac() -> RBACInterface:

--- a/src/zenml/zen_server/zen_server_api.py
+++ b/src/zenml/zen_server/zen_server_api.py
@@ -64,6 +64,7 @@ from zenml.zen_server.routers import (
     curated_visualization_endpoints,
     deployment_endpoints,
     devices_endpoints,
+    execution_archive_endpoints,
     flavors_endpoints,
     hook_invocations_endpoints,
     logs_endpoints,
@@ -104,6 +105,7 @@ from zenml.zen_server.utils import (
     cleanup_request_manager,
     initialize_artifact_store_cache,
     initialize_feature_gate,
+    initialize_maintenance_executor,
     initialize_rbac,
     initialize_request_manager,
     initialize_resource_pool_store,
@@ -112,6 +114,7 @@ from zenml.zen_server.utils import (
     initialize_streaming,
     initialize_workload_manager,
     initialize_zen_store,
+    maintenance_executor,
     register_event_handlers,
     server_config,
     shutdown_snapshot_run_dispatcher,
@@ -198,8 +201,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     await register_event_handlers()
 
+    initialize_maintenance_executor()
     yield
-
+    # Maintenance work is resumable batch by batch, so a shutdown does not
+    # wait for a running pass.
+    maintenance_executor().shutdown(wait=False, cancel_futures=True)
     if logger.isEnabledFor(logging.DEBUG):
         stop_event_loop_lag_monitor()
     shutdown_otel()
@@ -308,6 +314,7 @@ app.include_router(artifact_endpoint.artifact_router)
 app.include_router(artifact_version_endpoints.artifact_version_router)
 app.include_router(auth_endpoints.router)
 app.include_router(devices_endpoints.router)
+app.include_router(execution_archive_endpoints.router)
 app.include_router(code_repositories_endpoints.router)
 app.include_router(deployment_endpoints.router)
 app.include_router(curated_visualization_endpoints.router)

--- a/src/zenml/zen_stores/execution_archive/archiver.py
+++ b/src/zenml/zen_stores/execution_archive/archiver.py
@@ -1,0 +1,347 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Archiving one execution family: export, verify, switch authority, compact.
+
+An export writes the family's two payload objects and its manifest, reads
+them back and compares a fresh capture of SQL with what was written; the
+generation ends `VERIFIED` and SQL stays authoritative. Every operation
+claims the generation first, so two workers never work on one generation
+at once. Compaction — making the archive authoritative and clearing SQL —
+ships separately, once every server replica can read archived payload.
+"""
+
+import os
+import socket
+from datetime import datetime, timedelta
+from typing import Callable, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy.engine import Engine
+
+from zenml.constants import (
+    DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_MAX_FAMILY_STORED_BYTES,
+)
+from zenml.enums import ExecutionArchiveState
+from zenml.exceptions import ArchiveUnavailableError
+from zenml.models import ExecutionArchiveResponse
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.execution_archive.capture import (
+    ExecutionArchiveCapture,
+    ExecutionArchiveCapturer,
+    ExecutionArchiveFamily,
+)
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.codec import canonical_json
+from zenml.zen_stores.execution_archive.eligibility import (
+    evaluate_eligibility,
+)
+from zenml.zen_stores.execution_archive.exceptions import (
+    ChecksumMismatchError,
+    ExecutionArchiveNotEligibleError,
+    ExecutionArchiveParityError,
+    ExecutionArchiveStateError,
+)
+from zenml.zen_stores.execution_archive.models import (
+    ArchiveObjectKind,
+    ExecutionArchiveManifest,
+)
+from zenml.zen_stores.execution_archive.storage import (
+    BaseExecutionArchiveObjectStore,
+)
+from zenml.zen_stores.execution_archive.targets import ExecutionArchiveTargets
+
+DEFAULT_BATCH_SIZE = 500
+# A claim outlives any single batch by far; it is renewed after every one.
+DEFAULT_CLAIM_SECONDS = 15 * 60
+
+
+class ExecutionArchiver:
+    """Exports, compacts and restores one execution family at a time."""
+
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        targets: ExecutionArchiveTargets,
+        workspace_id: UUID,
+        writer_version: str,
+        writer_alembic_revision: str,
+        clock: Callable[[], datetime] = utc_now,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        claim_seconds: float = DEFAULT_CLAIM_SECONDS,
+        max_stored_bytes: int = (
+            DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_MAX_FAMILY_STORED_BYTES
+        ),
+    ) -> None:
+        """Initialize the archiver.
+
+        Args:
+            engine: The SQL store engine.
+            targets: The storage targets.
+            workspace_id: The workspace the archives belong to.
+            writer_version: The ZenML version writing archives.
+            writer_alembic_revision: The database revision written from.
+            clock: Source of the current time.
+            batch_size: Rows moved per transaction during compaction.
+            claim_seconds: How long a claim on a generation lasts.
+            max_stored_bytes: The largest payload that may be archived.
+        """
+        self._engine = engine
+        self._targets = targets
+        self._workspace_id = workspace_id
+        self._writer_version = writer_version
+        self._writer_alembic_revision = writer_alembic_revision
+        self._clock = clock
+        self._batch_size = batch_size
+        self._claim_seconds = claim_seconds
+        self._max_stored_bytes = max_stored_bytes
+        self._owner = f"{socket.gethostname()}:{os.getpid()}:{uuid4().hex[:8]}"
+        self._catalog = ExecutionArchiveCatalog(engine)
+        self._captures = ExecutionArchiveCapturer(
+            engine, max_stored_bytes=max_stored_bytes
+        )
+
+    def export(
+        self,
+        *,
+        project_id: UUID,
+        root_run_id: UUID,
+        older_than: timedelta,
+        capture: Optional[ExecutionArchiveCapture] = None,
+    ) -> ExecutionArchiveResponse:
+        """Write the family's objects and verify them against fresh SQL.
+
+        SQL payload is not touched. The generation ends `VERIFIED`, or
+        `FAILED` / `CORRUPT` with the error recorded. Exporting a verified
+        generation again re-reads and re-checks it; an authoritative one is
+        returned as it is.
+
+        Args:
+            project_id: The project of the family.
+            root_run_id: The root run of the family.
+            older_than: How long the family must have been unchanged.
+            capture: A capture of the family taken moments ago, to avoid
+                reading it again.
+
+        Returns:
+            The generation.
+
+        Raises:
+            ExecutionArchiveParityError: If the stored manifest or a fresh
+                capture differ from what was exported.
+            Exception: Whatever stopped the export, after it was recorded.
+        """
+        latest = self._catalog.latest_for_root(root_run_id)
+        if latest is not None and latest.state.is_authoritative:
+            return latest
+        capture = capture or self._captures.capture(
+            project_id=project_id, root_run_id=root_run_id
+        )
+        self._require_eligible(capture.family, older_than)
+        archive = self._catalog.begin_export(
+            project_id=project_id,
+            root_run_id=root_run_id,
+            generation=_next_generation(latest, capture.source_fingerprint),
+            source_fingerprint=capture.source_fingerprint,
+            storage_target_id=self._targets.current(),
+            stored_bytes=capture.family.stored_bytes,
+        )
+        self._claim(archive.id)
+        try:
+            store = self._targets.object_store(archive.storage_target_id)
+            if archive.state == ExecutionArchiveState.VERIFIED:
+                manifest = self._read_manifest(archive, store)
+            else:
+                manifest = self._export(archive, capture, store)
+                archive = self._catalog.require(archive.id)
+                if self._read_manifest(archive, store) != manifest:
+                    raise ExecutionArchiveParityError(
+                        "The stored manifest differs from the exported one."
+                    )
+            fresh = self._captures.capture(
+                project_id=project_id, root_run_id=root_run_id
+            )
+            if fresh.source_fingerprint != manifest.source_fingerprint:
+                raise ExecutionArchiveParityError(
+                    "The execution payload changed during the export."
+                )
+            self._catalog.mark_verified(archive.id)
+        except ChecksumMismatchError as e:
+            self._catalog.mark_failed(
+                archive.id, ExecutionArchiveState.CORRUPT, str(e)
+            )
+            raise
+        except ArchiveUnavailableError as e:
+            # The objects could not be read right now; a verified generation
+            # stays verified and is checked again on a later pass.
+            if archive.state == ExecutionArchiveState.VERIFIED:
+                self._catalog.record_error(archive.id, str(e))
+            else:
+                self._catalog.mark_failed(
+                    archive.id, ExecutionArchiveState.FAILED, str(e)
+                )
+            raise
+        except Exception as e:
+            self._catalog.mark_failed(
+                archive.id, ExecutionArchiveState.FAILED, str(e)
+            )
+            raise
+        finally:
+            self._catalog.release(archive.id, owner=self._owner)
+        return self._catalog.require(archive.id)
+
+    def _claim(self, archive_id: UUID) -> None:
+        self._catalog.claim(
+            archive_id, owner=self._owner, seconds=self._claim_seconds
+        )
+
+    def _export(
+        self,
+        archive: ExecutionArchiveResponse,
+        capture: ExecutionArchiveCapture,
+        store: BaseExecutionArchiveObjectStore,
+    ) -> ExecutionArchiveManifest:
+        """Write the payload objects and the manifest of a generation.
+
+        Args:
+            archive: The generation in `EXPORTING`.
+            capture: The captured family.
+            store: The object store of the generation's target.
+
+        Returns:
+            The manifest as written.
+
+        Raises:
+            ExecutionArchiveParityError: If the store returned references
+                other than the ones computed from the captured bytes.
+        """
+        execution = store.put_if_absent(
+            ArchiveObjectKind.EXECUTION,
+            archive.project_id,
+            capture.execution_compressed,
+        )
+        snapshots = store.put_if_absent(
+            ArchiveObjectKind.SNAPSHOT,
+            archive.project_id,
+            capture.snapshot_compressed,
+        )
+        if (execution, snapshots) != (
+            capture.execution_object,
+            capture.snapshot_object,
+        ):
+            raise ExecutionArchiveParityError(
+                "The stored payload objects differ from the captured ones."
+            )
+        family = capture.family
+        manifest = ExecutionArchiveManifest(
+            archive_id=archive.id,
+            workspace_id=self._workspace_id,
+            project_id=archive.project_id,
+            root_run_id=archive.root_run_id,
+            generation=archive.generation,
+            writer_version=self._writer_version,
+            writer_alembic_revision=self._writer_alembic_revision,
+            source_fingerprint=capture.source_fingerprint,
+            run_ids=family.run_ids,
+            step_run_ids=family.step_run_ids,
+            snapshot_ids=family.snapshot_ids,
+            static_configuration_ids=family.static_configuration_ids,
+            table_counts=family.table_counts,
+            storage_target_id=archive.storage_target_id,
+            execution_payload=execution,
+            snapshot_payload=snapshots,
+            created_at=self._clock(),
+        )
+        self._catalog.record_objects(
+            archive.id,
+            manifest=store.put_if_absent(
+                ArchiveObjectKind.MANIFEST,
+                archive.project_id,
+                canonical_json(manifest),
+            ),
+            execution=execution,
+            snapshots=snapshots,
+        )
+        return manifest
+
+    @staticmethod
+    def _read_manifest(
+        archive: ExecutionArchiveResponse,
+        store: BaseExecutionArchiveObjectStore,
+    ) -> ExecutionArchiveManifest:
+        if archive.manifest is None:
+            raise ExecutionArchiveStateError(
+                f"Execution archive {archive.id} has no manifest."
+            )
+        manifest = store.read_manifest(archive.project_id, archive.manifest)
+        if (
+            manifest.archive_id,
+            manifest.project_id,
+            manifest.root_run_id,
+            manifest.generation,
+            manifest.storage_target_id,
+        ) != (
+            archive.id,
+            archive.project_id,
+            archive.root_run_id,
+            archive.generation,
+            archive.storage_target_id,
+        ):
+            raise ExecutionArchiveParityError(
+                f"The manifest of execution archive {archive.id} describes a "
+                "different archive."
+            )
+        return manifest
+
+    def _require_eligible(
+        self, family: ExecutionArchiveFamily, older_than: timedelta
+    ) -> None:
+        eligibility = evaluate_eligibility(
+            family,
+            now=self._clock(),
+            older_than=older_than,
+            max_stored_bytes=self._max_stored_bytes,
+        )
+        if not eligibility.eligible:
+            raise ExecutionArchiveNotEligibleError(
+                "The execution family cannot be archived: "
+                + ", ".join(eligibility.blockers)
+                + "."
+            )
+
+
+def _next_generation(
+    latest: Optional[ExecutionArchiveResponse], source_fingerprint: str
+) -> int:
+    """Pick the generation to write: resume the latest one if it still fits.
+
+    Args:
+        latest: The latest generation of the family, if any.
+        source_fingerprint: The fingerprint of the family now.
+
+    Returns:
+        The generation number.
+    """
+    if latest is None:
+        return 1
+    if (
+        latest.state
+        in (
+            ExecutionArchiveState.RESTORED,
+            ExecutionArchiveState.CORRUPT,
+        )
+        or latest.source_fingerprint != source_fingerprint
+    ):
+        return latest.generation + 1
+    return latest.generation

--- a/src/zenml/zen_stores/execution_archive/cache.py
+++ b/src/zenml/zen_stores/execution_archive/cache.py
@@ -1,0 +1,91 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Byte-bounded cache of decoded, immutable archive objects."""
+
+import threading
+from collections import OrderedDict
+from typing import Callable, Dict, Generic, Tuple, TypeVar
+
+T = TypeVar("T")
+
+
+class ExecutionArchiveCache(Generic[T]):
+    """Thread-safe LRU cache keyed by object digest.
+
+    Objects are immutable, so an entry never goes stale. Entries are weighed
+    by the size the loader reports, which is the decoded size of the object,
+    not its compressed size on the store. Concurrent requests for the same
+    object share one load, so a burst of reads of a large cold family
+    decodes it once.
+    """
+
+    def __init__(self, max_bytes: int) -> None:
+        """Initialize the cache.
+
+        Args:
+            max_bytes: Maximum total weight of the cached entries.
+
+        Raises:
+            ValueError: If the limit is not positive.
+        """
+        if max_bytes <= 0:
+            raise ValueError("The archive cache size must be positive.")
+        self._max_bytes = max_bytes
+        self._size = 0
+        self._entries: "OrderedDict[str, Tuple[int, T]]" = OrderedDict()
+        self._lock = threading.Lock()
+        self._loading: Dict[str, threading.Lock] = {}
+
+    def get_or_load(
+        self, digest: str, loader: Callable[[], Tuple[T, int]]
+    ) -> T:
+        """Return the cached value or load, weigh and cache it.
+
+        Args:
+            digest: The object digest.
+            loader: Loads the object and returns it with its weight.
+
+        Returns:
+            The decoded object.
+        """
+        cached = self._get(digest)
+        if cached is not None:
+            return cached
+        with self._lock:
+            load_lock = self._loading.setdefault(digest, threading.Lock())
+        with load_lock:
+            cached = self._get(digest)
+            if cached is not None:
+                return cached
+            try:
+                value, weight = loader()
+            finally:
+                with self._lock:
+                    self._loading.pop(digest, None)
+            with self._lock:
+                if weight <= self._max_bytes:
+                    self._entries[digest] = (weight, value)
+                    self._size += weight
+                    while self._size > self._max_bytes:
+                        _, (evicted, _) = self._entries.popitem(last=False)
+                        self._size -= evicted
+            return value
+
+    def _get(self, digest: str) -> "T | None":
+        with self._lock:
+            entry = self._entries.get(digest)
+            if entry is None:
+                return None
+            self._entries.move_to_end(digest)
+            return entry[1]

--- a/src/zenml/zen_stores/execution_archive/hydrator.py
+++ b/src/zenml/zen_stores/execution_archive/hydrator.py
@@ -1,0 +1,520 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Hydration of archived payload onto loaded SQL rows.
+
+Rows are hydrated in batches right after they are loaded and before they
+are converted to response models, so conversion itself never touches the
+archive. Only rows that hold the archive placeholder in a payload column
+need anything: a batch without one costs no query and no object read, a
+value written after the archive was taken stays in SQL and wins, and a row
+the archive does not cover keeps the payload SQL holds for it.
+"""
+
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+from sqlmodel import Session, col, select
+
+from zenml.constants import DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_CACHE_BYTES
+from zenml.exceptions import ArchiveUnavailableError
+from zenml.models import ExecutionArchiveObject, ExecutionArchiveResponse
+from zenml.zen_stores.execution_archive.cache import ExecutionArchiveCache
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.models import ArchiveObjectKind
+from zenml.zen_stores.execution_archive.payload import (
+    ARCHIVED_CONFIGURATION_FIELDS,
+    ARCHIVED_PAYLOAD_PLACEHOLDER,
+    ARCHIVED_RUN_FIELDS,
+    ARCHIVED_SNAPSHOT_FIELDS,
+    ARCHIVED_STEP_FIELDS,
+    ArchivedPipelineRunPayload,
+    ArchivedPipelineSnapshotPayload,
+    ArchivedStepConfigurationPayload,
+    ArchivedStepRunPayload,
+    ExecutionPayload,
+    SnapshotPayload,
+)
+from zenml.zen_stores.execution_archive.targets import ExecutionArchiveTargets
+from zenml.zen_stores.execution_archive.utils import (
+    has_absent_fields,
+    is_loaded,
+    overlay_absent_fields,
+)
+from zenml.zen_stores.schemas.pipeline_run_schemas import PipelineRunSchema
+from zenml.zen_stores.schemas.pipeline_snapshot_schemas import (
+    PipelineSnapshotSchema,
+    StepConfigurationSchema,
+)
+from zenml.zen_stores.schemas.step_run_schemas import StepRunSchema
+
+# Decoded Pydantic objects take several times the memory of their JSON form;
+# weighing entries at four times the decompressed length keeps the budget
+# honest without serializing the object again.
+_DECODED_WEIGHT_FACTOR = 4
+
+
+class DecodedExecution(BaseModel):
+    """An execution payload indexed by row ID."""
+
+    runs: Dict[UUID, ArchivedPipelineRunPayload]
+    steps: Dict[UUID, ArchivedStepRunPayload]
+    configurations: Dict[UUID, ArchivedStepConfigurationPayload]
+
+    model_config = ConfigDict(frozen=True)
+
+    @classmethod
+    def from_payload(cls, payload: ExecutionPayload) -> "DecodedExecution":
+        """Index a payload.
+
+        Args:
+            payload: The execution payload.
+
+        Returns:
+            The indexed payload.
+        """
+        return cls(
+            runs={run.id: run for run in payload.runs},
+            steps={step.id: step for step in payload.steps},
+            configurations={c.id: c for c in payload.step_configurations},
+        )
+
+
+class DecodedSnapshots(BaseModel):
+    """A snapshot payload indexed by row ID."""
+
+    snapshots: Dict[UUID, ArchivedPipelineSnapshotPayload]
+    configurations: Dict[UUID, ArchivedStepConfigurationPayload]
+
+    model_config = ConfigDict(frozen=True)
+
+    @classmethod
+    def from_payload(cls, payload: SnapshotPayload) -> "DecodedSnapshots":
+        """Index a payload.
+
+        Args:
+            payload: The snapshot payload.
+
+        Returns:
+            The indexed payload.
+        """
+        return cls(
+            snapshots={
+                snapshot.id: snapshot for snapshot in payload.snapshots
+            },
+            configurations={c.id: c for c in payload.step_configurations},
+        )
+
+
+Decoded = Union[DecodedExecution, DecodedSnapshots]
+
+
+class ExecutionArchiveHydrator:
+    """Fills archived payload into loaded run, step and snapshot rows."""
+
+    def __init__(
+        self,
+        targets: ExecutionArchiveTargets,
+        *,
+        cache_bytes: int = DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_CACHE_BYTES,
+    ) -> None:
+        """Initialize the hydrator.
+
+        Args:
+            targets: Opens the object store of every readable target.
+            cache_bytes: Budget of the cache of decoded payload objects.
+        """
+        self._targets = targets
+        self._cache: ExecutionArchiveCache[Decoded] = ExecutionArchiveCache(
+            cache_bytes
+        )
+
+    def hydrate_runs(
+        self, session: Session, runs: Sequence[PipelineRunSchema]
+    ) -> None:
+        """Hydrate runs and their loaded snapshots.
+
+        Args:
+            session: The session the rows were loaded in.
+            runs: The runs.
+        """
+        self._hydrate(
+            session,
+            runs=list(runs),
+            snapshots=[
+                run.snapshot
+                for run in runs
+                if is_loaded(run, "snapshot") and run.snapshot is not None
+            ],
+        )
+
+    def hydrate_steps(
+        self, session: Session, steps: Sequence[StepRunSchema]
+    ) -> None:
+        """Hydrate step runs, their configurations and loaded snapshots.
+
+        Args:
+            session: The session the rows were loaded in.
+            steps: The step runs.
+        """
+        self._hydrate(
+            session,
+            steps=list(steps),
+            snapshots=[
+                step.snapshot
+                for step in steps
+                if is_loaded(step, "snapshot") and step.snapshot is not None
+            ],
+        )
+
+    def hydrate_snapshots(
+        self, session: Session, snapshots: Sequence[PipelineSnapshotSchema]
+    ) -> None:
+        """Hydrate snapshots and their step configurations.
+
+        Args:
+            session: The session the rows were loaded in.
+            snapshots: The snapshots.
+        """
+        self._hydrate(
+            session, snapshots=list(snapshots), load_configurations=True
+        )
+
+    def hydrate_family(self, session: Session, run: PipelineRunSchema) -> None:
+        """Hydrate a run with whatever of its family is already loaded.
+
+        Relationships the query did not load are left alone; loading every
+        step run of a run only to scan it would cost more than any
+        hydration saves.
+
+        Args:
+            session: The session the rows were loaded in.
+            run: The run.
+        """
+        self._hydrate(
+            session,
+            runs=[run],
+            steps=list(run.step_runs) if is_loaded(run, "step_runs") else [],
+            snapshots=[run.snapshot]
+            if is_loaded(run, "snapshot") and run.snapshot is not None
+            else [],
+        )
+
+    def _hydrate(
+        self,
+        session: Session,
+        *,
+        runs: Sequence[PipelineRunSchema] = (),
+        steps: Sequence[StepRunSchema] = (),
+        snapshots: Sequence[PipelineSnapshotSchema] = (),
+        load_configurations: bool = False,
+    ) -> None:
+        """Hydrate the rows that hold archived payload.
+
+        Args:
+            session: The session the rows were loaded in.
+            runs: The runs.
+            steps: The step runs.
+            snapshots: The snapshots.
+            load_configurations: Whether the snapshots are read for their
+                step configurations, which are then loaded and hydrated
+                even if the query did not load them.
+        """
+        runs = [run for run in runs if _run_needs_payload(run)]
+        steps = [step for step in steps if _step_needs_payload(step)]
+        snapshots = [
+            snapshot
+            for snapshot in snapshots
+            if _snapshot_needs_payload(snapshot, load_configurations)
+        ]
+        if not runs and not steps and not snapshots:
+            return
+
+        roots = _family_roots(session, runs, steps)
+        archives_by_id = {
+            archive.id: archive
+            for archive in ExecutionArchiveCatalog.authoritative(
+                session, root_run_ids=set(roots.values())
+            )
+        }
+        archives = {
+            archive.root_run_id: archive for archive in archives_by_id.values()
+        }
+        archives_by_id.update(
+            (archive.id, archive)
+            for archive in ExecutionArchiveCatalog.authoritative(
+                session,
+                archive_ids={
+                    snapshot.execution_archive_id
+                    for snapshot in snapshots
+                    if snapshot.execution_archive_id is not None
+                    and snapshot.execution_archive_id not in archives_by_id
+                },
+            )
+        )
+        try:
+            for run in runs:
+                archive = archives.get(roots[("run", run.id)])
+                if archive is not None:
+                    self._hydrate_run(run, archive)
+            for step in steps:
+                root = roots.get(("step", step.id))
+                archive = archives.get(root) if root is not None else None
+                if archive is not None:
+                    self._hydrate_step(step, archive)
+            for snapshot in snapshots:
+                if snapshot.execution_archive_id is None:
+                    continue
+                archive = archives_by_id.get(snapshot.execution_archive_id)
+                if archive is not None:
+                    self._hydrate_snapshot(
+                        snapshot, archive, load_configurations
+                    )
+        except (ValueError, OSError) as e:
+            # Undecodable or unreadable bytes; a bug in this module raises
+            # as itself so it is not mistaken for a storage outage.
+            raise ArchiveUnavailableError(
+                f"Archived execution payload is unavailable: {e}"
+            ) from e
+
+    def _hydrate_run(
+        self, run: PipelineRunSchema, archive: ExecutionArchiveResponse
+    ) -> None:
+        record = self._execution(archive).runs.get(run.id)
+        if record is not None:
+            overlay_absent_fields(run, record, ARCHIVED_RUN_FIELDS)
+
+    def _hydrate_step(
+        self, step: StepRunSchema, archive: ExecutionArchiveResponse
+    ) -> None:
+        dynamic_config = _loaded_dynamic_config(step)
+        if has_absent_fields(step, ARCHIVED_STEP_FIELDS) or (
+            dynamic_config is not None
+            and dynamic_config.config == ARCHIVED_PAYLOAD_PLACEHOLDER
+        ):
+            execution = self._execution(archive)
+            record = execution.steps.get(step.id)
+            if record is not None:
+                overlay_absent_fields(step, record, ARCHIVED_STEP_FIELDS)
+            if dynamic_config is not None:
+                _overlay_configuration(
+                    dynamic_config, execution.configurations
+                )
+        static_config = _loaded_static_config(step)
+        if static_config is not None:
+            _overlay_configuration(
+                static_config, self._snapshots(archive).configurations
+            )
+
+    def _hydrate_snapshot(
+        self,
+        snapshot: PipelineSnapshotSchema,
+        archive: ExecutionArchiveResponse,
+        load_configurations: bool,
+    ) -> None:
+        decoded = self._snapshots(archive)
+        record = decoded.snapshots.get(snapshot.id)
+        if record is not None:
+            overlay_absent_fields(snapshot, record, ARCHIVED_SNAPSHOT_FIELDS)
+        # Rows loaded later in the same session come from its identity map,
+        # so overlaying the relationship covers every later lookup too.
+        if load_configurations or is_loaded(snapshot, "step_configurations"):
+            for configuration in snapshot.step_configurations:
+                _overlay_configuration(configuration, decoded.configurations)
+
+    def _execution(
+        self, archive: ExecutionArchiveResponse
+    ) -> DecodedExecution:
+        def decode(raw: bytes) -> Decoded:
+            return DecodedExecution.from_payload(
+                ExecutionPayload.model_validate_json(raw)
+            )
+
+        return cast(
+            DecodedExecution,
+            self._load(
+                archive,
+                ArchiveObjectKind.EXECUTION,
+                archive.execution_payload,
+                decode,
+            ),
+        )
+
+    def _snapshots(
+        self, archive: ExecutionArchiveResponse
+    ) -> DecodedSnapshots:
+        def decode(raw: bytes) -> Decoded:
+            return DecodedSnapshots.from_payload(
+                SnapshotPayload.model_validate_json(raw)
+            )
+
+        return cast(
+            DecodedSnapshots,
+            self._load(
+                archive,
+                ArchiveObjectKind.SNAPSHOT,
+                archive.snapshot_payload,
+                decode,
+            ),
+        )
+
+    def _load(
+        self,
+        archive: ExecutionArchiveResponse,
+        kind: ArchiveObjectKind,
+        object_: Optional[ExecutionArchiveObject],
+        decode: Callable[[bytes], Decoded],
+    ) -> Decoded:
+        if object_ is None:
+            raise ArchiveUnavailableError(
+                f"Execution archive {archive.id} has no {kind.value} object."
+            )
+        reference = object_
+        store = self._targets.object_store(archive.storage_target_id)
+
+        def load() -> Tuple[Decoded, int]:
+            raw = store.get_decompressed(kind, archive.project_id, reference)
+            return decode(raw), _DECODED_WEIGHT_FACTOR * len(raw)
+
+        return self._cache.get_or_load(reference.sha256, load)
+
+
+def _run_needs_payload(run: PipelineRunSchema) -> bool:
+    return has_absent_fields(run, ARCHIVED_RUN_FIELDS)
+
+
+def _step_needs_payload(step: StepRunSchema) -> bool:
+    dynamic_config = _loaded_dynamic_config(step)
+    return (
+        has_absent_fields(step, ARCHIVED_STEP_FIELDS)
+        or (
+            dynamic_config is not None
+            and dynamic_config.config == ARCHIVED_PAYLOAD_PLACEHOLDER
+        )
+        or _loaded_static_config(step) is not None
+    )
+
+
+def _snapshot_needs_payload(
+    snapshot: PipelineSnapshotSchema, load_configurations: bool
+) -> bool:
+    """Whether a snapshot or its configurations hold the placeholder.
+
+    Only a snapshot an archive is authoritative for can hold archived
+    configurations, so the marker decides before the configuration rows
+    are ever loaded: a hot snapshot costs no query here.
+
+    Args:
+        snapshot: The snapshot.
+        load_configurations: Whether its configurations are read too.
+
+    Returns:
+        Whether archived payload is needed.
+    """
+    if has_absent_fields(snapshot, ARCHIVED_SNAPSHOT_FIELDS):
+        return True
+    if not is_loaded(snapshot, "step_configurations") and (
+        not load_configurations or snapshot.execution_archive_id is None
+    ):
+        return False
+    return any(
+        configuration.config == ARCHIVED_PAYLOAD_PLACEHOLDER
+        for configuration in snapshot.step_configurations
+    )
+
+
+def _loaded_dynamic_config(
+    step: StepRunSchema,
+) -> Optional[StepConfigurationSchema]:
+    return step.dynamic_config if is_loaded(step, "dynamic_config") else None
+
+
+def _loaded_static_config(
+    step: StepRunSchema,
+) -> Optional[StepConfigurationSchema]:
+    """The step's static configuration row, if loaded and archived.
+
+    Args:
+        step: The step run.
+
+    Returns:
+        The row holding the archive placeholder, or None.
+    """
+    if not is_loaded(step, "static_config"):
+        return None
+    static_config = step.static_config
+    if (
+        static_config is None
+        or static_config.config != ARCHIVED_PAYLOAD_PLACEHOLDER
+    ):
+        return None
+    return static_config
+
+
+def _overlay_configuration(
+    configuration: StepConfigurationSchema,
+    records: Dict[UUID, ArchivedStepConfigurationPayload],
+) -> None:
+    record = records.get(configuration.id)
+    if record is not None:
+        overlay_absent_fields(
+            configuration, record, ARCHIVED_CONFIGURATION_FIELDS
+        )
+
+
+def _family_roots(
+    session: Session,
+    runs: Sequence[PipelineRunSchema],
+    steps: Sequence[StepRunSchema],
+) -> Dict[Tuple[str, UUID], UUID]:
+    """Map runs and step runs to the root run of their execution family.
+
+    Runs know their root directly; step runs are resolved through the runs
+    that own them with one query. Snapshots carry their archive directly.
+
+    Args:
+        session: The SQL session.
+        runs: The runs.
+        steps: The step runs.
+
+    Returns:
+        The family root of every row, keyed by kind and row ID.
+    """
+    roots: Dict[Tuple[str, UUID], UUID] = {
+        ("run", run.id): run.root_run_id or run.id for run in runs
+    }
+    run_ids: Set[UUID] = {step.pipeline_run_id for step in steps}
+    known = {run.id: run.root_run_id or run.id for run in runs}
+    missing = [run_id for run_id in run_ids if run_id not in known]
+    if missing:
+        for run_id, root_run_id in session.exec(
+            select(PipelineRunSchema.id, PipelineRunSchema.root_run_id).where(
+                col(PipelineRunSchema.id).in_(missing)
+            )
+        ).all():
+            known[run_id] = root_run_id or run_id
+    for step in steps:
+        root = known.get(step.pipeline_run_id)
+        if root is not None:
+            roots[("step", step.id)] = root
+    return roots

--- a/src/zenml/zen_stores/execution_archive/maintenance.py
+++ b/src/zenml/zen_stores/execution_archive/maintenance.py
@@ -1,0 +1,358 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Bounded archive maintenance: preview, apply, restore, list."""
+
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, List, Optional
+from uuid import UUID
+
+from sqlmodel import Session, col, desc, select
+from sqlmodel.sql.expression import SelectOfScalar
+
+import zenml
+from zenml.constants import (
+    DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_MAX_FAMILY_STORED_BYTES,
+)
+from zenml.enums import ExecutionArchiveState, ExecutionStatus
+from zenml.logger import get_logger
+from zenml.models import (
+    ExecutionArchiveCandidate,
+    ExecutionArchiveMaintenanceRequest,
+    ExecutionArchiveResponse,
+)
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.execution_archive.archiver import ExecutionArchiver
+from zenml.zen_stores.execution_archive.capture import (
+    ExecutionArchiveCapturer,
+)
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.eligibility import (
+    evaluate_eligibility,
+    to_utc_naive,
+)
+from zenml.zen_stores.execution_archive.exceptions import (
+    ExecutionArchiveError,
+)
+from zenml.zen_stores.schemas import ExecutionArchiveSchema, PipelineRunSchema
+
+if TYPE_CHECKING:
+    from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+logger = get_logger(__name__)
+
+
+class ExecutionArchiveMaintainer:
+    """Finds eligible execution families and drives them through the archiver.
+
+    A preview reads identities and sizes only, never payload. An apply
+    runs the exact candidates a preview found, so a dry run always shows
+    what an apply would do.
+    """
+
+    def __init__(self, store: "SqlZenStore") -> None:
+        """Initialize maintenance.
+
+        Args:
+            store: The SQL store.
+        """
+        self._store = store
+        self._catalog = ExecutionArchiveCatalog(store.engine)
+        self._captures = ExecutionArchiveCapturer(store.engine)
+
+    def preview(
+        self, request: ExecutionArchiveMaintenanceRequest
+    ) -> List[ExecutionArchiveCandidate]:
+        """Report the eligibility of the requested families.
+
+        Args:
+            request: The project and, optionally, root runs to consider.
+
+        Returns:
+            One candidate per family.
+        """
+        now = utc_now()
+        return [
+            self._preview_family(root_run_id, request, now)
+            for root_run_id in self._root_run_ids(request, now)
+        ]
+
+    def apply(
+        self, request: ExecutionArchiveMaintenanceRequest
+    ) -> List[ExecutionArchiveCandidate]:
+        """Export and verify every eligible requested family.
+
+        Args:
+            request: The project and, optionally, root runs to consider.
+
+        Returns:
+            One candidate per family, with the archive it ended in.
+        """
+        now = utc_now()
+        older_than = timedelta(days=request.older_than_days)
+        archiver = self._archiver()
+        results = []
+        for root_run_id in self._root_run_ids(request, now):
+            candidate = self._preview_family(root_run_id, request, now)
+            if not candidate.eligible:
+                results.append(candidate)
+                continue
+            try:
+                archive = archiver.export(
+                    project_id=request.project,
+                    root_run_id=root_run_id,
+                    older_than=older_than,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to archive execution family {root_run_id}: {e}"
+                )
+                results.append(
+                    candidate.model_copy(
+                        update={"eligible": False, "blockers": [str(e)]}
+                    )
+                )
+                continue
+            results.append(
+                candidate.model_copy(
+                    update={
+                        "archive_id": archive.id,
+                        "archive_state": archive.state,
+                    }
+                )
+            )
+        return results
+
+    def get_archive(
+        self, archive_id: UUID, *, project_id: UUID
+    ) -> Optional[ExecutionArchiveResponse]:
+        """Load one generation of a project.
+
+        Args:
+            archive_id: The generation.
+            project_id: The project it must belong to.
+
+        Returns:
+            The generation, or None if it does not exist in the project.
+        """
+        return self._catalog.get(archive_id, project_id)
+
+    def list_archives(
+        self,
+        *,
+        project_id: UUID,
+        state: Optional[ExecutionArchiveState] = None,
+        limit: int = 100,
+    ) -> List[ExecutionArchiveResponse]:
+        """List the newest generations of a project.
+
+        Args:
+            project_id: The project.
+            state: Only generations in this state, if given.
+            limit: Maximum generations to return.
+
+        Returns:
+            The generations, newest first.
+        """
+        with Session(self._store.engine) as session:
+            statement = (
+                select(ExecutionArchiveSchema)
+                .where(col(ExecutionArchiveSchema.project_id) == project_id)
+                .order_by(
+                    desc(col(ExecutionArchiveSchema.created)),
+                    desc(col(ExecutionArchiveSchema.generation)),
+                )
+                .limit(limit)
+            )
+            if state is not None:
+                statement = statement.where(
+                    col(ExecutionArchiveSchema.state) == state.value
+                )
+            return [
+                schema.to_model() for schema in session.exec(statement).all()
+            ]
+
+    def _archiver(self) -> ExecutionArchiver:
+        return ExecutionArchiver(
+            self._store.engine,
+            targets=self._store.execution_archive_targets,
+            workspace_id=self._store.get_deployment_id(),
+            writer_version=zenml.__version__,
+            writer_alembic_revision=",".join(
+                self._store.alembic.current_revisions()
+            ),
+        )
+
+    def _root_run_ids(
+        self, request: ExecutionArchiveMaintenanceRequest, now: datetime
+    ) -> List[UUID]:
+        if request.root_run_ids:
+            return request.root_run_ids[: request.limit]
+        cutoff = to_utc_naive(now) - timedelta(days=request.older_than_days)
+        with Session(self._store.engine) as session:
+            return list(
+                session.exec(
+                    self._candidate_query(cutoff, request.project).limit(
+                        request.limit
+                    )
+                ).all()
+            )
+
+    def _preview_family(
+        self,
+        root_run_id: UUID,
+        request: ExecutionArchiveMaintenanceRequest,
+        now: datetime,
+    ) -> ExecutionArchiveCandidate:
+        """Evaluate one family without loading payload or touching storage.
+
+        Args:
+            root_run_id: The root run of the family.
+            request: The request being previewed.
+            now: The current time.
+
+        Returns:
+            The candidate.
+        """
+        archive = self._catalog.latest_for_root(root_run_id)
+        if archive is not None:
+            if archive.state == ExecutionArchiveState.COMPACTING:
+                # Compaction still pending: eligible so an apply resumes it.
+                return _candidate(root_run_id, archive, eligible=True)
+            if archive.state in (
+                ExecutionArchiveState.COLD,
+                ExecutionArchiveState.RESTORING,
+            ):
+                return _candidate(
+                    root_run_id,
+                    archive,
+                    eligible=False,
+                    blockers=[f"the archive is {archive.state.value}"],
+                )
+            if (
+                archive.state == ExecutionArchiveState.RESTORED
+                and archive.restored_at is not None
+            ):
+                eligible_at = to_utc_naive(archive.restored_at) + timedelta(
+                    days=request.older_than_days
+                )
+                if eligible_at > to_utc_naive(now):
+                    return _candidate(
+                        root_run_id,
+                        archive,
+                        eligible=False,
+                        eligible_at=eligible_at,
+                        blockers=["the family was restored recently"],
+                    )
+        try:
+            family = self._captures.inspect(
+                project_id=request.project, root_run_id=root_run_id
+            )
+        except ExecutionArchiveError as e:
+            return _candidate(
+                root_run_id, archive, eligible=False, blockers=[str(e)]
+            )
+        eligibility = evaluate_eligibility(
+            family,
+            now=now,
+            older_than=timedelta(days=request.older_than_days),
+            max_stored_bytes=(
+                DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_MAX_FAMILY_STORED_BYTES
+            ),
+        )
+        return _candidate(
+            root_run_id,
+            archive,
+            eligible=eligibility.eligible,
+            eligible_at=eligibility.eligible_at,
+            stored_bytes=family.stored_bytes,
+            blockers=list(eligibility.blockers),
+        )
+
+    @staticmethod
+    def _candidate_query(
+        cutoff: datetime, project_id: UUID
+    ) -> SelectOfScalar[UUID]:
+        """Completed root runs of a project old enough to archive, oldest first.
+
+        Families that are cold, being restored, or were restored after the
+        cutoff are excluded up front; families whose compaction is still
+        pending stay candidates so an apply can resume them.
+
+        Args:
+            cutoff: Runs last updated after this time are too recent.
+            project_id: The project.
+
+        Returns:
+            A query of root run IDs.
+        """
+        return (
+            select(PipelineRunSchema.id)
+            .where(col(PipelineRunSchema.project_id) == project_id)
+            .where(col(PipelineRunSchema.parent_run_id).is_(None))
+            .where(col(PipelineRunSchema.root_run_id).is_(None))
+            .where(
+                col(PipelineRunSchema.status)
+                == ExecutionStatus.COMPLETED.value
+            )
+            .where(col(PipelineRunSchema.updated) <= cutoff)
+            .where(
+                col(PipelineRunSchema.id).not_in(
+                    select(ExecutionArchiveSchema.root_run_id).where(
+                        col(ExecutionArchiveSchema.state).in_(
+                            [
+                                ExecutionArchiveState.COLD.value,
+                                ExecutionArchiveState.RESTORING.value,
+                            ]
+                        )
+                    )
+                )
+            )
+            .where(
+                col(PipelineRunSchema.id).not_in(
+                    select(ExecutionArchiveSchema.root_run_id)
+                    .where(
+                        col(ExecutionArchiveSchema.state)
+                        == ExecutionArchiveState.RESTORED.value
+                    )
+                    .where(col(ExecutionArchiveSchema.restored_at) > cutoff)
+                )
+            )
+            .order_by(
+                col(PipelineRunSchema.updated), col(PipelineRunSchema.id)
+            )
+        )
+
+
+def _candidate(
+    root_run_id: UUID,
+    archive: Optional[ExecutionArchiveResponse],
+    *,
+    eligible: bool,
+    eligible_at: Optional[datetime] = None,
+    stored_bytes: Optional[int] = None,
+    blockers: Optional[List[str]] = None,
+) -> ExecutionArchiveCandidate:
+    return ExecutionArchiveCandidate(
+        root_run_id=root_run_id,
+        eligible=eligible,
+        eligible_at=eligible_at,
+        stored_bytes=(
+            stored_bytes
+            if stored_bytes is not None
+            else (archive.stored_bytes if archive else None)
+        ),
+        blockers=blockers or [],
+        archive_id=archive.id if archive else None,
+        archive_state=archive.state if archive else None,
+    )

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -143,6 +143,7 @@ from zenml.constants import (
     DEFAULT_PASSWORD,
     DEFAULT_STACK_AND_COMPONENT_NAME,
     DEFAULT_USERNAME,
+    DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_CACHE_BYTES,
     ENV_ZENML_DEFAULT_USER_NAME,
     ENV_ZENML_DEFAULT_USER_PASSWORD,
     ENV_ZENML_DISABLE_DATABASE_MIGRATION,
@@ -481,12 +482,15 @@ if TYPE_CHECKING:
         TriggerExecutionInfo,
         UnScopedTriggerFilter,
     )
+    from zenml.zen_stores.execution_archive.hydrator import (
+        ExecutionArchiveHydrator,
+    )
     from zenml.zen_stores.execution_archive.targets import (
         ExecutionArchiveTargets,
     )
 
 AnyNamedSchema = TypeVar("AnyNamedSchema", bound=NamedSchema)
-# Guards the lazy construction of the execution archive components; the
+# Guards the lazy construction of the archive reader and its targets; the
 # reader builds on the targets, so the lock must be reentrant.
 _EXECUTION_ARCHIVE_INIT_LOCK = threading.RLock()
 AnySchema = TypeVar("AnySchema", bound=BaseSchema)
@@ -663,6 +667,8 @@ class SqlZenStoreConfiguration(StoreConfiguration):
             pool.
         max_overflow: The maximum number of connections to allow in the
             SQLAlchemy pool in addition to the pool_size.
+        execution_archive_cache_bytes: Budget of the in-memory cache of
+            decoded execution archive payload, per server process.
         pool_pre_ping: Enable emitting a test statement on the SQL connection
             at the start of each connection pool checkout, to test that the
             database connection is still viable.
@@ -690,6 +696,9 @@ class SqlZenStoreConfiguration(StoreConfiguration):
     pool_size: int = 20
     max_overflow: int = 20
     pool_pre_ping: bool = True
+    execution_archive_cache_bytes: int = Field(
+        default=DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_CACHE_BYTES, gt=0
+    )
 
     backup_strategy: DatabaseBackupStrategy = DatabaseBackupStrategy.IN_MEMORY
     custom_backup_engine: Optional[str] = None
@@ -1183,6 +1192,7 @@ class SqlZenStore(BaseZenStore):
     _default_user: Optional[UserResponse] = None
     _resource_pools: Optional[ResourcePoolsSQLStoreInterface] = None
     _execution_archive_targets: Optional["ExecutionArchiveTargets"] = None
+    _execution_archive_hydrator: Optional["ExecutionArchiveHydrator"] = None
 
     @property
     def secrets_store(self) -> "BaseSecretsStore":
@@ -1277,6 +1287,72 @@ class SqlZenStore(BaseZenStore):
 
                 self._execution_archive_targets = ExecutionArchiveTargets(self)
             return self._execution_archive_targets
+
+    @property
+    def execution_archive_hydrator(self) -> "ExecutionArchiveHydrator":
+        """The reader of archived execution payload.
+
+        Built once per store and consulted by every read that needs payload:
+        a batch without archived rows costs nothing, one with them costs one
+        catalog query and the object reads its cache does not cover.
+        Nothing is cached about which families are archived, so a replica
+        sees an archive the moment another replica makes it authoritative.
+
+        Returns:
+            The hydrator.
+        """
+        with _EXECUTION_ARCHIVE_INIT_LOCK:
+            if self._execution_archive_hydrator is None:
+                from zenml.zen_stores.execution_archive.hydrator import (
+                    ExecutionArchiveHydrator,
+                )
+
+                self._execution_archive_hydrator = ExecutionArchiveHydrator(
+                    self.execution_archive_targets,
+                    cache_bytes=self.config.execution_archive_cache_bytes,
+                )
+            return self._execution_archive_hydrator
+
+    def _hydrate_run_payload(
+        self, session: Session, run: PipelineRunSchema
+    ) -> None:
+        """Hydrate a run and its snapshot before code that parses payload.
+
+        Called right before the parse: a commit or refresh in between would
+        expire the row and drop the archived values again.
+
+        Args:
+            session: The session the run was loaded in.
+            run: The run.
+        """
+        from zenml.zen_stores.execution_archive.utils import is_loaded
+
+        # A commit or refresh expires the row; the pre-scan only looks at
+        # loaded columns, so an expired row must be loaded again first.
+        if not is_loaded(run, "orchestrator_environment"):
+            session.refresh(run)
+        hydrator = self.execution_archive_hydrator
+        hydrator.hydrate_runs(session, [run])
+        if run.snapshot is not None:
+            hydrator.hydrate_snapshots(session, [run.snapshot])
+
+    def _hydrate_step_payload(
+        self, session: Session, step: StepRunSchema
+    ) -> None:
+        """Hydrate a step run and its snapshot before code that parses payload.
+
+        Args:
+            session: The session the step run was loaded in.
+            step: The step run.
+        """
+        from zenml.zen_stores.execution_archive.utils import is_loaded
+
+        if not is_loaded(step, "source_code"):
+            session.refresh(step)
+        hydrator = self.execution_archive_hydrator
+        hydrator.hydrate_steps(session, [step])
+        if step.snapshot is not None:
+            hydrator.hydrate_snapshots(session, [step.snapshot])
 
     @property
     def db_backup_engine(self) -> BaseDatabaseBackupEngine:
@@ -1405,6 +1481,9 @@ class SqlZenStore(BaseZenStore):
                 Sequence[Any],
             ]
         ] = None,
+        pre_model_conversion: Optional[
+            Callable[[Sequence[AnySchema]], None]
+        ] = None,
         hydrate: bool = False,
         apply_query_options_from_schema: bool = False,
         query_options_kwargs: Optional[Dict[str, Any]] = None,
@@ -1426,6 +1505,8 @@ class SqlZenStore(BaseZenStore):
                 perform additional filtering). The callable should take a
                 `Session`, a `Select` query and a `BaseFilterModel` filter as
                 arguments and return a `List` of items.
+            pre_model_conversion: Optional batch hook run after fetching ORM
+                schemas and before converting them to response models.
             hydrate: Flag deciding whether to hydrate the output model(s)
                 by including metadata fields in the response.
             apply_query_options_from_schema: Flag deciding whether to apply
@@ -1518,6 +1599,9 @@ class SqlZenStore(BaseZenStore):
                 query.limit(filter_model.size).offset(filter_model.offset)
             )
             item_schemas = query_result.all()
+
+        if pre_model_conversion:
+            pre_model_conversion(item_schemas)
 
         # Convert this page of items from schemas to models.
         items: List[AnyResponse] = []
@@ -5486,6 +5570,10 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineSnapshotSchema,
                 session=session,
             )
+            if hydrate:
+                self.execution_archive_hydrator.hydrate_snapshots(
+                    session, [snapshot]
+                )
 
             return snapshot.to_model(
                 include_metadata=hydrate,
@@ -5522,6 +5610,15 @@ class SqlZenStore(BaseZenStore):
                 table=PipelineSnapshotSchema,
                 filter_model=snapshot_filter_model,
                 hydrate=hydrate,
+                pre_model_conversion=(
+                    lambda schemas: (
+                        self.execution_archive_hydrator.hydrate_snapshots(
+                            session, schemas
+                        )
+                        if hydrate
+                        else None
+                    )
+                ),
                 apply_query_options_from_schema=True,
             )
 
@@ -6424,6 +6521,7 @@ class SqlZenStore(BaseZenStore):
                 ],
             )
             assert run.snapshot is not None
+            self.execution_archive_hydrator.hydrate_family(session, run)
             snapshot = run.snapshot
             for condition in run.wait_conditions:
                 node_metadata: Dict[str, Any] = {
@@ -6990,6 +7088,9 @@ class SqlZenStore(BaseZenStore):
             pipeline_id=snapshot.pipeline_id, session=session
         )
 
+        # The heartbeat setting is read from the snapshot's configuration at
+        # the schema level; an archived snapshot holds it in the archive.
+        self.execution_archive_hydrator.hydrate_snapshots(session, [snapshot])
         new_run = PipelineRunSchema.from_request(
             pipeline_run,
             pipeline_id=snapshot.pipeline_id,
@@ -7058,6 +7159,9 @@ class SqlZenStore(BaseZenStore):
                     verify=False,
                 )
 
+        # Resolving the model version converts the run with its snapshot's
+        # configuration; an archived snapshot holds it in the archive.
+        self._hydrate_run_payload(session, new_run)
         try:
             model_version_id = self._get_or_create_model_version_for_run(
                 new_run
@@ -7086,6 +7190,7 @@ class SqlZenStore(BaseZenStore):
         )
 
         session.refresh(new_run)
+        self._hydrate_run_payload(session, new_run)
 
         return new_run.to_model(include_metadata=True, include_resources=True)
 
@@ -7121,6 +7226,8 @@ class SqlZenStore(BaseZenStore):
                     include_full_metadata=include_full_metadata,
                 ),
             )
+            if hydrate:
+                self.execution_archive_hydrator.hydrate_runs(session, [run])
             return run.to_model(
                 include_metadata=hydrate,
                 include_resources=True,
@@ -7444,13 +7551,21 @@ class SqlZenStore(BaseZenStore):
                 session=session,
             )
             query = select(PipelineRunSchema)
-
             return self.filter_and_paginate(
                 session=session,
                 query=query,
                 table=PipelineRunSchema,
                 filter_model=runs_filter_model,
                 hydrate=hydrate,
+                pre_model_conversion=(
+                    lambda schemas: (
+                        self.execution_archive_hydrator.hydrate_runs(
+                            session, schemas
+                        )
+                        if hydrate
+                        else None
+                    )
+                ),
                 custom_schema_to_model_conversion=lambda schema: (
                     schema.to_model(
                         include_metadata=hydrate,
@@ -7531,6 +7646,7 @@ class SqlZenStore(BaseZenStore):
                         reference_type="output artifact version",
                     )
 
+            self._hydrate_run_payload(session, existing_run)
             existing_run.update(run_update=run_update)
             session.add(existing_run)
             if run_update.outputs is not None:
@@ -7586,6 +7702,7 @@ class SqlZenStore(BaseZenStore):
             )
 
             session.refresh(existing_run)
+            self._hydrate_run_payload(session, existing_run)
 
             return existing_run.to_model(
                 include_metadata=True, include_resources=True
@@ -11653,6 +11770,12 @@ class SqlZenStore(BaseZenStore):
                 session=session,
                 reference_type="original step run",
             )
+            # The configuration lookup below reads the snapshot's payload at
+            # the schema level; an archived family holds it in the archive.
+            if run.snapshot is not None:
+                self.execution_archive_hydrator.hydrate_snapshots(
+                    session, [run.snapshot]
+                )
             step_config = (
                 step_run.dynamic_config
                 or run.get_step_configuration(step_name=step_run.name)
@@ -12051,6 +12174,9 @@ class SqlZenStore(BaseZenStore):
 
                 session.refresh(step_schema)
 
+            self.execution_archive_hydrator.hydrate_steps(
+                session, [step_schema]
+            )
             return step_schema.to_model(
                 include_metadata=True, include_resources=True
             )
@@ -12077,6 +12203,10 @@ class SqlZenStore(BaseZenStore):
                     include_metadata=hydrate, include_resources=True
                 ),
             )
+            if hydrate:
+                self.execution_archive_hydrator.hydrate_steps(
+                    session, [step_run]
+                )
             return step_run.to_model(
                 include_metadata=hydrate, include_resources=True
             )
@@ -12109,6 +12239,15 @@ class SqlZenStore(BaseZenStore):
                 table=StepRunSchema,
                 filter_model=step_run_filter_model,
                 hydrate=hydrate,
+                pre_model_conversion=(
+                    lambda schemas: (
+                        self.execution_archive_hydrator.hydrate_steps(
+                            session, schemas
+                        )
+                        if hydrate
+                        else None
+                    )
+                ),
                 apply_query_options_from_schema=True,
             )
 
@@ -12449,6 +12588,7 @@ class SqlZenStore(BaseZenStore):
                 step_run_update.status = ExecutionStatus.STOPPED
 
             # Update the step
+            self._hydrate_step_payload(session, existing_step_run)
             existing_step_run.update(step_run_update)
             session.add(existing_step_run)
 
@@ -12513,6 +12653,7 @@ class SqlZenStore(BaseZenStore):
                         verify=False,
                     )
 
+            self._hydrate_step_payload(session, existing_step_run)
             return existing_step_run.to_model(
                 include_metadata=True, include_resources=True
             )
@@ -12804,6 +12945,7 @@ class SqlZenStore(BaseZenStore):
             dispatcher = EventDispatcher()
             if dispatcher.has_handlers():
                 # Only convert to model if there are handlers to notify
+                self._hydrate_run_payload(session, pipeline_run)
                 dispatcher.handle_run_status_update(
                     run=pipeline_run.to_model(include_metadata=True)
                 )

--- a/tests/unit/zen_stores/execution_archive/service.py
+++ b/tests/unit/zen_stores/execution_archive/service.py
@@ -1,0 +1,112 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Helpers that drive the archiver in tests, with observable storage."""
+
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from tests.unit.zen_stores.execution_archive.utils import NOW
+from zenml.models import ExecutionArchiveObject
+from zenml.zen_stores.execution_archive.archiver import ExecutionArchiver
+from zenml.zen_stores.execution_archive.models import ArchiveObjectKind
+from zenml.zen_stores.execution_archive.storage import (
+    BaseExecutionArchiveObjectStore,
+)
+from zenml.zen_stores.execution_archive.targets import ExecutionArchiveTargets
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+class FaultyStores(ExecutionArchiveTargets):
+    """Wraps the configured target's object store to observe and inject."""
+
+    def __init__(
+        self,
+        store: SqlZenStore,
+        *,
+        before_manifest: Optional[Callable[[], None]] = None,
+    ) -> None:
+        """Wrap the targets of a store.
+
+        Args:
+            store: The store.
+            before_manifest: Runs once, right before the manifest is written.
+        """
+        super().__init__(store)
+        self._before_manifest = before_manifest
+        self.reads = 0
+
+    def object_store(self, target_id: UUID) -> BaseExecutionArchiveObjectStore:
+        """Wrap the object store of a target.
+
+        Args:
+            target_id: The target.
+
+        Returns:
+            The wrapped object store.
+        """
+        inner = super().object_store(target_id)
+        outer = self
+
+        class _Store(BaseExecutionArchiveObjectStore):
+            @property
+            def target_id(self) -> UUID:
+                return inner.target_id
+
+            def put_if_absent(
+                self, kind: ArchiveObjectKind, scope_id: UUID, payload: bytes
+            ) -> ExecutionArchiveObject:
+                if (
+                    kind is ArchiveObjectKind.MANIFEST
+                    and outer._before_manifest is not None
+                ):
+                    hook, outer._before_manifest = outer._before_manifest, None
+                    hook()
+                return inner.put_if_absent(kind, scope_id, payload)
+
+            def get_exact(
+                self,
+                kind: ArchiveObjectKind,
+                scope_id: UUID,
+                object_: ExecutionArchiveObject,
+            ) -> bytes:
+                outer.reads += 1
+                return inner.get_exact(kind, scope_id, object_)
+
+        return _Store()
+
+
+def archiver(
+    store: SqlZenStore,
+    stores: Optional[ExecutionArchiveTargets] = None,
+    **kwargs: Any,
+) -> ExecutionArchiver:
+    """An archiver writing to the store's configured target at `NOW`.
+
+    Args:
+        store: The store.
+        stores: Optional wrapped targets to observe or inject faults.
+        **kwargs: Further archiver arguments.
+
+    Returns:
+        The archiver.
+    """
+    return ExecutionArchiver(
+        store.engine,
+        targets=stores or store.execution_archive_targets,
+        workspace_id=store.get_deployment_id(),
+        writer_version="0.97.0",
+        writer_alembic_revision="ed9c52d0a1ff",
+        clock=lambda: NOW,
+        **kwargs,
+    )

--- a/tests/unit/zen_stores/execution_archive/test_export.py
+++ b/tests/unit/zen_stores/execution_archive/test_export.py
@@ -1,0 +1,220 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests of manual export, verification and maintenance passes.
+
+SQL stays authoritative throughout: an export ends `VERIFIED` and nothing
+clears payload from the database.
+"""
+
+from datetime import timedelta
+from typing import Optional
+
+import pytest
+from sqlmodel import Session, select
+
+from tests.unit.zen_stores.execution_archive.service import (
+    FaultyStores,
+    archiver,
+)
+from tests.unit.zen_stores.execution_archive.utils import (
+    OLD,
+    OLDER_THAN,
+    Family,
+    archive_row,
+    count_statements,
+    populate_family,
+)
+from zenml.enums import ExecutionArchiveState
+from zenml.models import (
+    ExecutionArchiveMaintenanceRequest,
+    ExecutionArchiveResponse,
+)
+from zenml.zen_stores.execution_archive import (
+    maintenance as maintenance_module,
+)
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.exceptions import (
+    ExecutionArchiveError,
+    ExecutionArchiveParityError,
+    ExecutionArchiveStateError,
+)
+from zenml.zen_stores.execution_archive.maintenance import (
+    ExecutionArchiveMaintainer,
+)
+from zenml.zen_stores.schemas import (
+    ExecutionArchiveSchema,
+    PipelineSnapshotSchema,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+def _export(
+    store: SqlZenStore,
+    family: Family,
+    stores: Optional[FaultyStores] = None,
+    **kwargs: object,
+) -> ExecutionArchiveResponse:
+    return archiver(store, stores, **kwargs).export(
+        project_id=family.project_id,
+        root_run_id=family.run_id,
+        older_than=OLDER_THAN,
+    )
+
+
+def _request(
+    family: Family, **kwargs: object
+) -> ExecutionArchiveMaintenanceRequest:
+    return ExecutionArchiveMaintenanceRequest(
+        project=family.project_id, root_run_ids=[family.run_id], **kwargs
+    )
+
+
+def test_export_verifies_objects_and_never_touches_sql(
+    sql_store: SqlZenStore,
+) -> None:
+    """Exports end verified and idempotent; SQL keeps its payload."""
+    family = populate_family(sql_store, steps=2)
+
+    first = _export(sql_store, family)
+    second = _export(sql_store, family)
+    assert first.id == second.id
+    assert second.state == ExecutionArchiveState.VERIFIED
+    assert second.manifest is not None
+    assert second.execution_payload is not None
+    assert second.snapshot_payload is not None
+    assert second.stored_bytes and second.stored_bytes > 0
+    assert archive_row(sql_store).compacted_at is None
+    with Session(sql_store.engine) as session:
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert snapshot is not None
+        assert snapshot.source_code == 'print("pipeline")'
+        assert snapshot.execution_archive_id is None
+
+    # An oversized family is refused before anything is read or written.
+    oversized = populate_family(sql_store, suffix="-oversized")
+    with pytest.raises(ExecutionArchiveError, match="too large"):
+        _export(sql_store, oversized, max_stored_bytes=16)
+    with Session(sql_store.engine) as session:
+        assert len(session.exec(select(ExecutionArchiveSchema)).all()) == 1
+
+
+def test_payload_change_during_export_fails_closed(
+    sql_store: SqlZenStore,
+) -> None:
+    """SQL edited between export and verification keeps its value."""
+    family = populate_family(sql_store)
+
+    def mutate() -> None:
+        with Session(sql_store.engine) as session:
+            snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+            assert snapshot is not None
+            snapshot.source_code = 'print("changed")'
+            snapshot.updated = OLD + timedelta(hours=1)
+            session.add(snapshot)
+            session.commit()
+
+    with pytest.raises(ExecutionArchiveParityError):
+        _export(
+            sql_store, family, FaultyStores(sql_store, before_manifest=mutate)
+        )
+
+    failed = archive_row(sql_store)
+    assert failed.state == ExecutionArchiveState.FAILED.value
+    assert failed.last_error
+    with Session(sql_store.engine) as session:
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert snapshot is not None
+        assert snapshot.source_code == 'print("changed")'
+
+    # The changed family is archived again as a new generation.
+    retried = _export(sql_store, family)
+    assert retried.state == ExecutionArchiveState.VERIFIED
+    assert retried.generation == 2
+
+
+def test_maintenance_previews_applies_and_lists(
+    sql_store: SqlZenStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dry run reads no payload; an apply ends verified, SQL untouched."""
+    family = populate_family(sql_store)
+    maintenance = ExecutionArchiveMaintainer(sql_store)
+
+    with count_statements(sql_store, "step_configuration") as statements:
+        [preview] = maintenance.preview(_request(family))
+    assert preview.eligible
+    assert preview.stored_bytes and preview.stored_bytes > 0
+    assert all(
+        "length(" in statement.lower()
+        for statement in statements
+        if "step_configuration.config" in statement
+    )
+    assert maintenance.list_archives(project_id=family.project_id) == []
+
+    [applied] = maintenance.apply(_request(family))
+    assert applied.archive_state == ExecutionArchiveState.VERIFIED
+    assert applied.archive_id is not None
+    with Session(sql_store.engine) as session:
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert snapshot is not None and snapshot.source_code is not None
+        assert snapshot.execution_archive_id is None
+
+    [again] = maintenance.apply(_request(family))
+    assert again.archive_id == applied.archive_id
+    listed = maintenance.list_archives(
+        project_id=family.project_id, state=ExecutionArchiveState.VERIFIED
+    )
+    assert [archive.id for archive in listed] == [applied.archive_id]
+    assert (
+        maintenance.get_archive(
+            applied.archive_id, project_id=family.project_id
+        )
+        == listed[0]
+    )
+    assert (
+        maintenance.get_archive(applied.archive_id, project_id=family.run_id)
+        is None
+    )
+    discovered = maintenance.preview(
+        ExecutionArchiveMaintenanceRequest(project=family.project_id)
+    )
+    assert [candidate.root_run_id for candidate in discovered] == [
+        family.run_id
+    ]
+
+    # A family too large to archive is reported, not attempted.
+    monkeypatch.setattr(
+        maintenance_module,
+        "DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_MAX_FAMILY_STORED_BYTES",
+        16,
+    )
+    big = populate_family(sql_store, suffix="-big")
+    [blocked] = maintenance.preview(_request(big))
+    assert not blocked.eligible
+    assert "too large" in " ".join(blocked.blockers)
+
+
+def test_a_claimed_generation_refuses_a_second_worker(
+    sql_store: SqlZenStore,
+) -> None:
+    """Workers claim a generation before touching it."""
+    family = populate_family(sql_store)
+    verified = _export(sql_store, family)
+    catalog = ExecutionArchiveCatalog(sql_store.engine)
+    catalog.claim(verified.id, owner="another-worker", seconds=600)
+
+    with pytest.raises(ExecutionArchiveStateError, match="processed"):
+        _export(sql_store, family)
+
+    catalog.release(verified.id, owner="another-worker")
+    assert _export(sql_store, family).state == ExecutionArchiveState.VERIFIED

--- a/tests/unit/zen_stores/execution_archive/test_reader.py
+++ b/tests/unit/zen_stores/execution_archive/test_reader.py
@@ -1,0 +1,344 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests of the archive reader.
+
+The reader is exercised on families made authoritative the way compaction
+does it: the marker set and the placeholder written into every payload
+column whose archived value is not empty.
+"""
+
+import threading
+from pathlib import Path
+from typing import Any, List, Tuple
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, col, select
+
+from tests.unit.zen_stores.execution_archive.service import (
+    FaultyStores,
+    archiver,
+)
+from tests.unit.zen_stores.execution_archive.utils import (
+    NOW,
+    OLDER_THAN,
+    Family,
+    archive_row,
+    count_statements,
+    populate_family,
+)
+from zenml.config.step_configurations import Step
+from zenml.enums import ExecutionArchiveState, ExecutionStatus
+from zenml.exceptions import ArchiveUnavailableError, EntityExistsError
+from zenml.models import (
+    PipelineRunFilter,
+    PipelineRunUpdate,
+    PipelineSnapshotFilter,
+    StepRunFilter,
+    StepRunRequest,
+    StepRunUpdate,
+)
+from zenml.zen_stores.execution_archive.cache import ExecutionArchiveCache
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.hydrator import (
+    ExecutionArchiveHydrator,
+)
+from zenml.zen_stores.execution_archive.payload import (
+    ARCHIVED_CONFIGURATION_FIELDS,
+    ARCHIVED_PAYLOAD_PLACEHOLDER,
+    ARCHIVED_RUN_FIELDS,
+    ARCHIVED_SNAPSHOT_FIELDS,
+    ARCHIVED_STEP_FIELDS,
+)
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    PipelineSnapshotSchema,
+    StepConfigurationSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+# Payload columns that are written once, at creation. `exception_info` and
+# `orchestrator_environment` may legitimately be written later; a later
+# value stays in SQL and wins over the archived one.
+IMMUTABLE_PAYLOAD_COLUMNS = (
+    "pipeline_configuration",
+    "client_environment",
+    "pipeline_spec",
+    "source_code",
+    "config",
+    "docstring",
+)
+
+
+def _export(store: SqlZenStore, family: Family, stores=None):  # type: ignore[no-untyped-def]
+    return archiver(store, stores).export(
+        project_id=family.project_id,
+        root_run_id=family.run_id,
+        older_than=OLDER_THAN,
+    )
+
+
+def _read_family(store: SqlZenStore, family: Family) -> Any:
+    return (
+        store.get_run(family.run_id, hydrate=True).metadata,
+        store.get_snapshot(family.snapshot_id, hydrate=True).metadata,
+        store.get_run_step(family.step_id, hydrate=True).metadata,
+        store.get_pipeline_run_dag(family.run_id),
+    )
+
+
+def _placeholder(row: Any, fields: Tuple[str, ...]) -> None:
+    for field in fields:
+        if getattr(row, field) is not None:
+            setattr(row, field, ARCHIVED_PAYLOAD_PLACEHOLDER)
+
+
+def _make_authoritative(store: SqlZenStore, family: Family) -> UUID:
+    """Do what the authority switch and compaction do, directly in SQL.
+
+    Args:
+        store: The store.
+        family: The exported family.
+
+    Returns:
+        The archive ID.
+    """
+    archive = archive_row(store)
+    with Session(store.engine) as session:
+        ExecutionArchiveCatalog.transition(
+            session,
+            archive.id,
+            ExecutionArchiveState.COMPACTING,
+            committed_at=NOW,
+        )
+        session.commit()
+    with Session(store.engine) as session:
+        ExecutionArchiveCatalog.transition(
+            session, archive.id, ExecutionArchiveState.COLD, compacted_at=NOW
+        )
+        run = session.get(PipelineRunSchema, family.run_id)
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert run is not None and snapshot is not None
+        _placeholder(run, ARCHIVED_RUN_FIELDS)
+        _placeholder(snapshot, ARCHIVED_SNAPSHOT_FIELDS)
+        snapshot.execution_archive_id = archive.id
+        for step_id in family.step_ids:
+            step = session.get(StepRunSchema, step_id)
+            assert step is not None
+            _placeholder(step, ARCHIVED_STEP_FIELDS)
+        for configuration in session.exec(
+            select(StepConfigurationSchema).where(
+                col(StepConfigurationSchema.snapshot_id) == family.snapshot_id
+            )
+        ).all():
+            _placeholder(configuration, ARCHIVED_CONFIGURATION_FIELDS)
+            session.add(configuration)
+        session.add_all([run, snapshot])
+        session.commit()
+    return archive.id
+
+
+def test_reader_costs_nothing_for_hot_rows(sql_store: SqlZenStore) -> None:
+    """Reads and writes of hot families do no archive work.
+
+    No catalog query, no object read — and the pre-scan itself loads no
+    relationship: an update of a hot step must not load every step
+    configuration of its snapshot.
+    """
+    family = populate_family(sql_store, steps=3)
+    stores = FaultyStores(sql_store)
+    sql_store._execution_archive_hydrator = ExecutionArchiveHydrator(stores)
+
+    with count_statements(sql_store, "FROM execution_archive") as statements:
+        _read_family(sql_store, family)
+        assert sql_store.list_run_steps(StepRunFilter(), hydrate=True).total
+        sql_store.update_run(
+            family.run_id, PipelineRunUpdate(status=ExecutionStatus.COMPLETED)
+        )
+        sql_store.update_run_step(family.step_id, StepRunUpdate(end_time=NOW))
+    assert statements == [] and stores.reads == 0
+
+    # The pre-scan must not force a load of every configuration of the
+    # snapshot: only targeted single-row lookups may touch the table.
+    with count_statements(sql_store, "FROM step_configuration") as statements:
+        sql_store.update_run_step(family.step_id, StepRunUpdate(end_time=NOW))
+        sql_store.update_run(
+            family.run_id, PipelineRunUpdate(status=ExecutionStatus.COMPLETED)
+        )
+    # The classic regression is a full relationship load filtered only by
+    # the snapshot: flag statements that name the snapshot column without
+    # any narrower predicate.
+    bulk = [
+        statement
+        for statement in statements
+        if "step_configuration.snapshot_id" in statement
+        and "step_configuration.name" not in statement
+        and "step_configuration.step_run_id" not in statement
+    ]
+    assert bulk == []
+
+
+def test_reader_serves_archived_rows_and_writers_keep_working(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """Placeholders are filled from two object reads; writers stay whole."""
+    family = populate_family(sql_store, steps=3)
+    stores = FaultyStores(sql_store)
+    sql_store._execution_archive_hydrator = ExecutionArchiveHydrator(stores)
+    hot = _read_family(sql_store, family)
+
+    _export(sql_store, family, stores)
+    _make_authoritative(sql_store, family)
+    stores.reads = 0
+    assert _read_family(sql_store, family) == hot
+    assert stores.reads == 2  # one execution and one snapshot object
+    with count_statements(sql_store, "FROM execution_archive") as statements:
+        assert sql_store.list_runs(PipelineRunFilter()).total == 1
+        assert sql_store.list_snapshots(PipelineSnapshotFilter()).total == 1
+        assert sql_store.list_run_steps(StepRunFilter()).total == 3
+    assert statements == []
+
+    # Updates of archived rows return real payload, never the placeholder.
+    updated_run = sql_store.update_run(
+        family.run_id, PipelineRunUpdate(status=ExecutionStatus.COMPLETED)
+    )
+    assert updated_run.config and updated_run.config.name
+    updated_step = sql_store.update_run_step(
+        family.step_id, StepRunUpdate(end_time=NOW)
+    )
+    assert updated_step.source_code == 'print("step-0")'
+    assert updated_step.docstring == "Docstring of step-0."
+    assert ARCHIVED_PAYLOAD_PLACEHOLDER not in updated_step.model_dump_json()
+
+    # A step that joined the family after the archive keeps its SQL payload.
+    late_step_id = uuid4()
+    with Session(sql_store.engine) as session:
+        step = session.get(StepRunSchema, family.step_id)
+        assert step is not None
+        session.add(
+            StepRunSchema(
+                id=late_step_id,
+                project_id=step.project_id,
+                user_id=step.user_id,
+                pipeline_run_id=step.pipeline_run_id,
+                snapshot_id=step.snapshot_id,
+                name="late-step",
+                start_time=step.start_time,
+                end_time=step.end_time,
+                status=step.status,
+                source_code='print("late")',
+                docstring="Late docstring.",
+                step_type=step.step_type,
+                substitutions=step.substitutions,
+                version=1,
+                is_retriable=False,
+                created=step.created,
+                updated=step.updated,
+            )
+        )
+        session.add(
+            StepConfigurationSchema(
+                snapshot_id=step.snapshot_id,
+                step_run_id=None,
+                index=3,
+                name="late-step",
+                config=Step.model_validate(
+                    {
+                        "spec": {
+                            "source": "module.step_class",
+                            "upstream_steps": [],
+                            "inputs": {},
+                        },
+                        "config": {"name": "late-step"},
+                    }
+                ).model_dump_json(exclude={"config"}),
+                created=step.created,
+                updated=step.updated,
+            )
+        )
+        session.commit()
+    late = sql_store.get_run_step(late_step_id, hydrate=True)
+    assert late.source_code == 'print("late")'
+    assert late.docstring == "Late docstring."
+
+    # Step creation reads the archived configuration instead of failing:
+    # the only thing wrong with this request is what would be wrong on a
+    # hot family too, the step already succeeded.
+    with pytest.raises(EntityExistsError, match="already exists"):
+        sql_store.create_run_step(
+            StepRunRequest(
+                name="step-0",
+                start_time=NOW,
+                status=ExecutionStatus.RUNNING,
+                pipeline_run_id=family.run_id,
+                project=family.project_id,
+            )
+        )
+
+    # A checksum mismatch never yields a partially hydrated row.
+    payload_file = next((tmp_path / "archive-primary").rglob("executions/*/*"))
+    payload_file.write_bytes(b"corrupt")
+    sql_store._execution_archive_hydrator = None
+    with pytest.raises(ArchiveUnavailableError):
+        sql_store.get_run(family.run_id, hydrate=True)
+
+
+def test_writers_never_touch_payload_columns(sql_store: SqlZenStore) -> None:
+    """Ordinary updates of runs and steps never write an immutable column."""
+    family = populate_family(sql_store)
+
+    with count_statements(sql_store, "UPDATE") as statements:
+        sql_store.update_run(
+            family.run_id, PipelineRunUpdate(status=ExecutionStatus.COMPLETED)
+        )
+        sql_store.update_run_step(family.step_id, StepRunUpdate(end_time=NOW))
+    assert any("step_run" in statement for statement in statements)
+    touched = [
+        column
+        for statement in statements
+        for column in IMMUTABLE_PAYLOAD_COLUMNS
+        if f"{column}=" in statement.replace(" ", "")
+    ]
+    assert touched == []
+
+
+def test_cache_shares_loads_and_recovers_from_failures() -> None:
+    """Concurrent readers share one load; a failing load leaves no trace."""
+    cache: ExecutionArchiveCache[str] = ExecutionArchiveCache(1024)
+    loads: List[int] = []
+    gate = threading.Barrier(8)
+
+    def loader() -> "tuple[str, int]":
+        loads.append(1)
+        return "value", 10
+
+    def read() -> None:
+        gate.wait()
+        assert cache.get_or_load("digest", loader) == "value"
+
+    workers = [threading.Thread(target=read) for _ in range(8)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+    assert len(loads) == 1
+
+    def failing() -> "tuple[str, int]":
+        raise OSError("read failed")
+
+    with pytest.raises(OSError):
+        cache.get_or_load("other", failing)
+    assert cache._loading == {}
+    assert cache.get_or_load("other", loader) == "value"


### PR DESCRIPTION
Part 2 of 3 of the execution-archive stack (DB growth initiative #7), stacked on #5176; #5198 follows. **The diff GitHub shows is against `feature/execution-archive-foundation`, not `develop`.** The terms (family, generation, bundle, capsule, manifest, fingerprint, placeholder, authoritative) and the state machine are defined in #5176's description.

## Problem

Two things have to be true before any release is allowed to clear payload from SQL. Every replica must already complete reads from an archive transparently — otherwise a rolling upgrade has replicas that return placeholders or fail parsing JSON. And operators must be able to prove, on their own data and with no risk, that an archive reproduces what the database serves. This PR ships both: the reader, and the manual export path that produces verified archives while SQL stays the source of truth.

## Changes

**The reader** — `hydrator.py`, `cache.py`, `SqlZenStore.execution_archive_hydrator` (constructed lazily, always installed). A hydration takes a batch of run, step or snapshot rows and first scans them for the placeholder. If none holds it — every hot family — nothing else happens: no catalog query, no object read, no allocation. Otherwise it resolves the rows' families (`root_run_id` of the run, or of the step's run), loads their authoritative generations with one catalog query (snapshots additionally by their `execution_archive_id` marker), reads the bundle and capsules it needs through the cache, and overlays *only the fields that hold the placeholder* with the archived values, using `set_committed_value` so SQLAlchemy never considers the row dirty. A value in SQL that is not the placeholder always wins, and rows the archive does not cover — a step that joined the family after it was archived — keep whatever SQL holds. The cache is an LRU keyed by object digest, bounded to 128 MiB of decoded weight per process, single-flight per digest so concurrent readers of one object share a single load.

Where it is wired: `filter_and_paginate` gained a `pre_model_conversion` hook called with a page's schemas before `to_model`; `list_runs`, `list_run_steps` and `list_snapshots` pass the hydrator; `get_run`, `get_run_step`, `get_snapshot` and `get_pipeline_run_dag` hydrate explicitly. Write paths that parse payload at the schema level hydrate before doing so: `create_run_step` (the step-configuration lookup and the final conversion), `update_run` and `update_run_step` (status transitions read `pipeline_spec`), `_create_run` (the heartbeat setting, model-version resolution, the final conversion). These are what allow part 3 to leave runs and steps unfenced; the test creates a step on a cold family and gets the ordinary "already exists" error instead of a crash.

Failure is closed: `ArchiveUnavailableError` (object missing, digest mismatch, target unreachable, integration not installed) maps to HTTP 503 with a message naming the archive; a row is never returned partially hydrated.

**Export** — `archiver.py`, `ExecutionArchiver.export(project_id, root_run_id, generation, policy, capture=None)`. Capture the family (or reuse the preview's capture), check eligibility, `begin_export`, upload bundle and capsules with `put_if_absent` (an object that already exists is read back and digest-checked, never trusted), write the manifest, `record_objects`, read the manifest back and compare it, capture the family again and compare fingerprints, `mark_verified`. A payload change between export and verification fails closed to `FAILED` and the family is archived again as a new generation on the next pass; a digest mismatch on any read ends in `CORRUPT`. Exporting a `VERIFIED` generation again re-reads and re-checks it instead of re-uploading. No SQL payload is touched and no marker is set.

**Maintenance** — `maintenance.py`; `POST /api/v1/archive?dry_run=`, `GET /api/v1/archive`. The request names a project, optionally `root_run_ids`, and a `limit`. A preview (`dry_run=true`, the default) evaluates each family with SQL only — capture, eligibility — and returns one candidate per family with `eligible`, `eligible_at`, `canonical_bytes`, `blockers`, and the existing `archive_id` / `archive_state` if any; the whole project's oldest completed root runs are scanned when no ids are given. An apply runs exactly those candidates through export, one family at a time, dropping each capture before the next, so a pass holds one family's payload at most. A non-dry-run runs on the maintenance executor (`submit_maintenance_task`; single worker; the same names and behavior as #5166 so the two merge without conflict) and answers immediately with a `task_id` bound to the log records; a second task while one runs is a 429. The generation to write is chosen from the latest one: resumed when policy version and fingerprint are unchanged, new otherwise and after `RESTORED` or `CORRUPT`.

**Shadow read** — `GET /api/v1/archive/{id}/shadow-read`. Converts every run, step and snapshot of the family to its API model twice — from SQL, and after `hydrate_from(archive, …)` replaced the payload in memory in a session that is never committed — compares the dumps and reports `differences` as `run:<id>` / `step:<id>` / `snapshot:<id>`. Nothing is written. This is the operator's evidence before enabling compaction in part 3; a family edited after its export shows the edited entity (test).

**Executor** — `zen_server/utils.py` gains `initialize_maintenance_executor` / `submit_maintenance_task` / `shutdown_maintenance_executor`, wired into the lifespan; identical to #5166's so whichever lands second drops its copy.

## Behavior and boundaries

- SQL remains authoritative. A `VERIFIED` archive changes nothing about any read; it is a checked copy.
- The reader recognizes only the placeholder. `NULL` and empty values are served as they are.
- Hot families cost nothing (asserted: no catalog statement, no object read). Cold families cost one catalog query per batch plus the object reads the cache does not hold.
- The cache size is a constant (`DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_CACHE_BYTES`) in this version, not a server setting.
- The shadow read compares API models, not bytes: response-level parity is what the product promises, and it is what the reader produces.
- Not here: anything that sets a marker or clears payload, the automatic pass, restore.

## Considered

- **Refusing writes to runs and steps of an archived family** instead of hydrating before use. Rejected: a fence turns an internal storage decision into a user-facing failure ("cannot add a step to this run"), and the places that need hydration are enumerable — they are the ones that parse a payload column.
- **A negative cache of "this family is hot"** to avoid catalog queries. Rejected for the pre-scan, which is free, never stale, and needs no invalidation.
- **Hydrating inside the schemas' `to_model`.** Rejected: `to_model` has no store access; the `filter_and_paginate` hook keeps hydration at the store boundary in one place.
- **A byte-level shadow read** (comparing canonical JSON). Rejected: it would fail on fields that are legitimately different at the API level (ordering, defaults) and would not prove what users see.

## Rollout

Deploy after #5176 to every replica. Enable the policy, run previews, then applies, on a project; list the archives; shadow-read a few families. Nothing changes for users; the only cost is object storage for the archives. Archives written through an integration flavor need that integration on every replica.

## Reviewing

Suggested order: `hydrator.py` (`_run_needs_payload` and friends are the pre-scan; `_hydrate` resolves families and generations; `_fill` is where archived values overlay rows); the `sql_zen_store.py` hunks — each hydrate call sits above a payload parse, and that is the claim to check; `archiver.py` `export` / `_export` / `_compare`; `maintenance.py`; the endpoints; the docs section on preview, apply and shadow read.

## Validation

- `tests/unit/zen_stores/execution_archive/test_reader.py`, seven scenario tests: exports end verified, are idempotent and never touch SQL, and an oversized family is refused before anything is written; a payload change during export fails closed; preview → apply → list → get, then target rotation keeps old archives readable; a shadow read agrees on an intact archive and names a later hot edit; the reader costs nothing for hot rows (no catalog statement, no object read), refills placeholders from one bundle and one capsule read, keeps a late row's SQL payload, still lets steps be created on an archived family, and fails closed on a corrupt object; ordinary run and step updates never write an immutable payload column; the cache loads an object once under concurrency. Families are made authoritative in these tests by writing the placeholder directly, the way part 3's compaction does.
- Regression: 684 passed / 35 skipped across the same suites as #5176.
- `ruff`, isolated `F401/F841`, `mypy`, `pydoclint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
