### PR TITLE
[DB growth initiative #7, 3/4] Compact and restore execution history

### DIFF
--- a/docs/book/how-to/manage-zenml-server/archive-execution-history.md
+++ b/docs/book/how-to/manage-zenml-server/archive-execution-history.md
@@ -18,10 +18,9 @@ relationships, and other workspace tables remain in the metadata database and
 continue to grow normally.
 
 {% hint style="warning" %}
-The export endpoint in this release is a non-destructive administrator tool.
-It creates a verified object but does not remove or replace any SQL payload.
-SQL remains authoritative until compaction support is enabled in a later
-release.
+Export is always non-destructive. Compaction is a separate administrator
+operation and is disabled by default. Deploy the archive-aware version to
+every server replica before enabling it.
 {% endhint %}
 
 ## Configure the storage tier
@@ -34,6 +33,8 @@ prefix on every server replica. For example:
 export ZENML_SERVER_EXECUTION_ARCHIVE_FLAVOR=s3
 export ZENML_SERVER_EXECUTION_ARCHIVE_CONFIGURATION='{"path":"s3://example-history"}'
 export ZENML_SERVER_EXECUTION_ARCHIVE_PATH_PREFIX=execution-archive
+# Enable only after every replica runs this archive-aware release.
+export ZENML_SERVER_EXECUTION_ARCHIVE_COMPACTION_ENABLED=true
 ```
 
 The server builds the existing ZenML artifact-store implementation directly.
@@ -50,8 +51,8 @@ entry; restore and purge existing generations before deliberately moving the
 archive tier.
 
 Use object-store encryption, versioning, retention, and lifecycle controls
-appropriate for your environment. Once SQL is compacted in a later release,
-historical payload availability also depends on this destination.
+appropriate for your environment. Once SQL is compacted, historical payload
+availability depends on this destination.
 
 ## Export one execution tree
 
@@ -96,15 +97,57 @@ List generations with
 Get one generation with
 `GET /api/v1/archive/<ARCHIVE-ID>?project_id=<PROJECT-ID>`.
 
-## Current read and downgrade behavior
+## Compact and restore one generation
+
+After a generation reaches `verified`, an administrator can make its archive
+authoritative:
+
+```text
+POST /api/v1/archive/<ARCHIVE-ID>/compact?project_id=<PROJECT-ID>
+```
+
+The server reads and validates the object again immediately before the
+authority switch. It then locks the complete execution tree, compares its
+current semantic fingerprint with the object, and atomically marks all of its
+runs and snapshots as archived. Only after this fence commits does it replace
+the covered SQL payload fields in bounded, resumable batches. The lifecycle is
+`verified` → `compacting` → `cold`.
+
+There is no transparent object-store hydration. Payload-free list summaries
+remain available for cold history, while a request that needs compacted
+payload returns HTTP 409 with the archive ID to restore. Restore explicitly:
+
+```text
+POST /api/v1/archive/<ARCHIVE-ID>/restore?project_id=<PROJECT-ID>
+```
+
+Restoration verifies the object, writes payload back in bounded, resumable
+batches, and clears the run and snapshot fences only after every surviving row
+has been restored. Rows deleted while the generation was cold are skipped.
+The lifecycle is `cold` → `restoring` → `restored`.
+
+An interrupted compaction or restoration is safe to call again. A fenced
+worker whose lease was taken over cannot commit another batch. A checksum or
+format failure becomes `corrupt`; when it occurs after authority moved, the
+generation continues to require restoration and the server fails closed.
+
+The three source reads serve different safety boundaries: the first builds the
+export, the second detects changes made while the object was uploaded, and the
+third runs under row locks immediately before SQL authority moves. Removing
+one would leave a different concurrent-write window unchecked.
+
+## Read and downgrade behavior
 
 Ordinary hot reads do not contact archive storage. This release never writes
-archive markers, so existing reads and writes retain their current behavior.
-The schema already contains fail-closed conversion guards needed by later
-compaction support: if a future compacted row is encountered, a full-payload
-request returns a typed HTTP 409 that names the archive to restore, while
-payload-free list summaries remain available.
+archive markers unless an administrator explicitly calls the compact endpoint
+and the deployment gate is enabled. A full-payload request for cold history
+returns a typed HTTP 409 that names the archive to restore. New runs, steps,
+operational snapshot references, and updates are fenced from modifying a cold
+execution tree until it is restored. Deleting an individual cold run or
+snapshot is also refused: partial deletion would break the tree closure and
+make restoration semantics ambiguous. Restore the tree first, perform the
+deletion, and archive the remaining history again if needed.
 
-The database migration refuses to downgrade while any future archive is
-authoritative. Verified-only generations do not block downgrade because SQL
-still contains their full payload.
+The database migration refuses to downgrade while any archive is authoritative.
+Verified-only and restored generations do not block downgrade because SQL
+contains their full payload.

--- a/src/zenml/config/server_config.py
+++ b/src/zenml/config/server_config.py
@@ -284,6 +284,9 @@ class ServerConfiguration(BaseModel):
             its own identity; credentials do not belong here.
         execution_archive_path_prefix: Directory below the artifact store
             path that holds every archive object.
+        execution_archive_compaction_enabled: Deployment-level safety gate.
+            Archived objects can be exported while this is false, but SQL
+            payload cannot be compacted until every replica enables it.
         dashboard_files_path: The path to the dashboard files directory. If not
             specified, the built-in dashboard files will be used.
         otel_exporter_otlp_endpoint: Base OTLP/HTTP collector endpoint URL for
@@ -430,6 +433,7 @@ class ServerConfiguration(BaseModel):
         default_factory=dict
     )
     execution_archive_path_prefix: str = "execution-archive"
+    execution_archive_compaction_enabled: bool = False
 
     max_request_body_size_in_bytes: int = (
         DEFAULT_ZENML_SERVER_MAX_REQUEST_BODY_SIZE_IN_BYTES

--- a/src/zenml/zen_server/routers/execution_archive_endpoints.py
+++ b/src/zenml/zen_server/routers/execution_archive_endpoints.py
@@ -40,6 +40,9 @@ from zenml.zen_stores.execution_archive.archiver import (
 from zenml.zen_stores.execution_archive.catalog import (
     ExecutionArchiveCatalog,
 )
+from zenml.zen_stores.execution_archive.compactor import (
+    ExecutionArchiveAuthority,
+)
 
 router = APIRouter(
     prefix=API + VERSION_1 + "/archive",
@@ -102,6 +105,68 @@ def export_execution_archive(
     return ExecutionArchiveExporter(store=zen_store()).export(
         project_id=request.project_id,
         root_run_id=request.root_run_id,
+    )
+
+
+@router.post(
+    "/{archive_id}/compact",
+    responses={404: error_response, 409: error_response, 503: error_response},
+)
+@async_fastapi_endpoint_wrapper
+def compact_execution_archive(
+    archive_id: UUID,
+    project_id: UUID,
+    auth_context: AuthContext = Security(authorize),
+) -> ExecutionArchiveResponse:
+    """Move SQL authority to one verified archive generation.
+
+    Args:
+        archive_id: Generation to compact.
+        project_id: Project that must own the generation.
+        auth_context: Authenticated caller.
+
+    Returns:
+        Cold archive generation.
+    """
+    _authorize_execution_archive(
+        auth_context,
+        action="compact execution history",
+        permission=Action.UPDATE,
+        project_id=project_id,
+    )
+    return ExecutionArchiveAuthority(store=zen_store()).compact(
+        archive_id=archive_id, project_id=project_id
+    )
+
+
+@router.post(
+    "/{archive_id}/restore",
+    responses={404: error_response, 409: error_response, 503: error_response},
+)
+@async_fastapi_endpoint_wrapper
+def restore_execution_archive(
+    archive_id: UUID,
+    project_id: UUID,
+    auth_context: AuthContext = Security(authorize),
+) -> ExecutionArchiveResponse:
+    """Restore one generation's payload and return authority to SQL.
+
+    Args:
+        archive_id: Generation to restore.
+        project_id: Project that must own the generation.
+        auth_context: Authenticated caller.
+
+    Returns:
+        Restored archive generation.
+    """
+    _authorize_execution_archive(
+        auth_context,
+        action="restore execution history",
+        permission=Action.UPDATE,
+        project_id=project_id,
+    )
+    return ExecutionArchiveAuthority(store=zen_store()).restore(
+        archive_id=archive_id, project_id=project_id
     )
 
 

--- a/src/zenml/zen_stores/execution_archive/capture.py
+++ b/src/zenml/zen_stores/execution_archive/capture.py
@@ -243,7 +243,8 @@ class ExecutionArchiveCapturer:
             project_id: Project that must own the execution tree.
             root_run_id: Root run of the execution tree.
             session: Existing transaction, if any.
-            for_update: Whether to lock the family until transaction end.
+            for_update: Whether to lock the execution tree until transaction
+                end.
 
         Returns:
             Complete archive source records.

--- a/src/zenml/zen_stores/execution_archive/catalog.py
+++ b/src/zenml/zen_stores/execution_archive/catalog.py
@@ -45,7 +45,9 @@ _TRANSITIONS: Dict[S, FrozenSet[S]] = {
     S.COLD: frozenset({S.COLD, S.RESTORING, S.CORRUPT}),
     S.RESTORING: frozenset({S.RESTORING, S.RESTORED, S.COLD, S.CORRUPT}),
     S.RESTORED: frozenset(),
-    S.CORRUPT: frozenset(),
+    # A cold object can be repaired out of band and restored. The service
+    # only permits this transition when the generation still owns SQL.
+    S.CORRUPT: frozenset({S.RESTORING}),
 }
 _RESUMABLE_EXPORT_STATES = frozenset({S.EXPORTING, S.FAILED})
 _PURGEABLE_SUPERSEDED_STATES = frozenset(
@@ -270,6 +272,37 @@ class ExecutionArchiveCatalog:
             )
             session.commit()
             return renewed
+
+    def claim(
+        self,
+        archive_id: UUID,
+        *,
+        owner: str,
+        lease_seconds: float,
+    ) -> ExecutionArchiveClaim:
+        """Claim an existing generation with a new fencing token.
+
+        Args:
+            archive_id: Generation to claim.
+            owner: Unique worker identity.
+            lease_seconds: Initial ownership lease duration.
+
+        Returns:
+            Claimed generation and its fencing token.
+        """
+        with Session(self._engine) as session:
+            schema = self._lock(session, archive_id)
+            token = self._acquire(
+                schema, owner=owner, lease_seconds=lease_seconds
+            )
+            schema.updated = utc_now()
+            session.add(schema)
+            session.flush()
+            claim = ExecutionArchiveClaim(
+                archive=schema.to_model(), owner=owner, token=token
+            )
+            session.commit()
+            return claim
 
     def mark_verified(
         self,
@@ -520,6 +553,21 @@ class ExecutionArchiveCatalog:
         schema.updated = utc_now()
         session.add(schema)
         return schema
+
+    @staticmethod
+    def require_claimed(
+        session: Session, claim: ExecutionArchiveClaim
+    ) -> ExecutionArchiveSchema:
+        """Lock a generation and validate its live fencing token.
+
+        Args:
+            session: SQL transaction.
+            claim: Current fenced ownership.
+
+        Returns:
+            Locked catalog row.
+        """
+        return ExecutionArchiveCatalog._claimed(session, claim)
 
     @staticmethod
     def _claimed(

--- a/src/zenml/zen_stores/execution_archive/compactor.py
+++ b/src/zenml/zen_stores/execution_archive/compactor.py
@@ -1,0 +1,453 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Fenced, resumable compaction and restoration of execution archives."""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Optional, Sequence
+from uuid import UUID
+
+from sqlmodel import Session, col, select, update
+
+from zenml.config.server_config import ServerConfiguration
+from zenml.constants import (
+    DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_LEASE_SECONDS,
+)
+from zenml.enums import ExecutionArchiveState
+from zenml.exceptions import (
+    ArchiveUnavailableError,
+    DoesNotExistException,
+    ExecutionArchiveParityError,
+    ExecutionArchiveStateError,
+)
+from zenml.logger import get_logger
+from zenml.models import ExecutionArchiveResponse
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.execution_archive.archiver import load_archive_payload
+from zenml.zen_stores.execution_archive.capture import (
+    ExecutionArchiveCapturer,
+    chunked_ids,
+)
+from zenml.zen_stores.execution_archive.catalog import (
+    ExecutionArchiveCatalog,
+    ExecutionArchiveClaim,
+)
+from zenml.zen_stores.execution_archive.exceptions import (
+    ArchiveObjectInvalidError,
+    ChecksumMismatchError,
+)
+from zenml.zen_stores.execution_archive.payload import ExecutionArchivePayload
+from zenml.zen_stores.execution_archive.payload_mover import (
+    ExecutionArchivePayloadMover,
+)
+from zenml.zen_stores.execution_archive.storage import (
+    ExecutionArchiveStorage,
+    build_execution_archive_storage,
+)
+from zenml.zen_stores.execution_archive.worker import (
+    new_execution_archive_worker_id,
+)
+from zenml.zen_stores.schemas import PipelineRunSchema, PipelineSnapshotSchema
+
+if TYPE_CHECKING:
+    from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+logger = get_logger(__name__)
+
+_DEFAULT_BATCH_SIZE = 500
+
+
+class ExecutionArchiveAuthority:
+    """Move SQL authority to and from one verified archive object."""
+
+    def __init__(
+        self,
+        *,
+        store: "SqlZenStore",
+        config: Optional[ServerConfiguration] = None,
+        storage: Optional[ExecutionArchiveStorage] = None,
+        clock: Callable[[], datetime] = utc_now,
+        owner: Optional[str] = None,
+        lease_seconds: float = (
+            DEFAULT_ZENML_SERVER_EXECUTION_ARCHIVE_LEASE_SECONDS
+        ),
+        batch_size: int = _DEFAULT_BATCH_SIZE,
+        compaction_enabled: Optional[bool] = None,
+    ) -> None:
+        """Initialize the authority service.
+
+        Args:
+            store: SQL Zen store containing execution history.
+            config: Deployment archive configuration.
+            storage: Injected archive storage, primarily for testing.
+            clock: Source of lifecycle timestamps.
+            owner: Unique worker identity.
+            lease_seconds: Duration of each fenced ownership lease.
+            batch_size: Maximum payload rows changed per transaction.
+            compaction_enabled: Optional deployment-gate override.
+
+        Raises:
+            ValueError: If the batch size is not positive.
+        """
+        if batch_size <= 0:
+            raise ValueError(
+                "The execution archive batch size must be positive."
+            )
+        config = config or ServerConfiguration.get_server_config()
+        self._store = store
+        self._workspace_id = store.get_deployment_id()
+        self._storage = storage or build_execution_archive_storage(
+            config, workspace_id=self._workspace_id
+        )
+        self._clock = clock
+        self._lease_seconds = lease_seconds
+        self._batch_size = batch_size
+        self._compaction_enabled = (
+            config.execution_archive_compaction_enabled
+            if compaction_enabled is None
+            else compaction_enabled
+        )
+        self._owner = owner or new_execution_archive_worker_id()
+        self._catalog = ExecutionArchiveCatalog(store.engine)
+        self._capturer = ExecutionArchiveCapturer(store.engine)
+
+    def compact(
+        self, *, archive_id: UUID, project_id: UUID
+    ) -> ExecutionArchiveResponse:
+        """Make a verified archive authoritative and compact SQL payload.
+
+        Args:
+            archive_id: Generation to compact.
+            project_id: Project that must own the generation.
+
+        Returns:
+            Cold archive generation.
+
+        Raises:
+            ExecutionArchiveStateError: If compaction is disabled or the
+                generation cannot be compacted.
+            ExecutionArchiveParityError: If SQL changed after verification.
+            ArchiveUnavailableError: If the archive object cannot be trusted.
+            Exception: Any storage or SQL failure after its safe catalog
+                outcome is recorded.
+        """
+        archive = self._require_archive(archive_id, project_id)
+        if archive.state == ExecutionArchiveState.COLD:
+            return archive
+        if (
+            archive.state == ExecutionArchiveState.VERIFIED
+            and not self._compaction_enabled
+        ):
+            raise ExecutionArchiveStateError(
+                "Execution archive compaction is disabled on this server."
+            )
+        if archive.state not in {
+            ExecutionArchiveState.VERIFIED,
+            ExecutionArchiveState.COMPACTING,
+        }:
+            raise ExecutionArchiveStateError(
+                f"Execution archive {archive_id} is {archive.state.value}; "
+                "only a verified or interrupted compacting generation can "
+                "be compacted."
+            )
+        claim = self._catalog.claim(
+            archive_id,
+            owner=self._owner,
+            lease_seconds=self._lease_seconds,
+        )
+        authoritative = claim.archive.requires_restore
+        try:
+            if claim.archive.state not in {
+                ExecutionArchiveState.VERIFIED,
+                ExecutionArchiveState.COMPACTING,
+                ExecutionArchiveState.COLD,
+            }:
+                raise ExecutionArchiveStateError(
+                    f"Execution archive {archive_id} is "
+                    f"{claim.archive.state.value}; only a verified or "
+                    "interrupted compacting generation can be compacted."
+                )
+            if claim.archive.state == ExecutionArchiveState.COLD:
+                return claim.archive
+            payload = self._load_payload(claim.archive)
+            claim = self._renew(claim)
+            if claim.archive.state == ExecutionArchiveState.VERIFIED:
+                self._commit_authority(claim, payload)
+                authoritative = True
+            self._mover().compact(claim, payload)
+            return self._catalog.require(archive_id)
+        except (ArchiveObjectInvalidError, ChecksumMismatchError) as error:
+            self._catalog.try_record_failure(
+                claim, error, state=ExecutionArchiveState.CORRUPT
+            )
+            raise ArchiveUnavailableError(
+                f"Execution archive {archive_id} is corrupt: {error}"
+            ) from error
+        except ExecutionArchiveParityError as error:
+            self._catalog.try_record_failure(
+                claim,
+                error,
+                state=None if authoritative else ExecutionArchiveState.FAILED,
+            )
+            raise
+        except ExecutionArchiveStateError:
+            raise
+        except Exception as error:
+            self._catalog.try_record_failure(claim, error)
+            raise
+        finally:
+            self._catalog.release(claim)
+
+    def restore(
+        self, *, archive_id: UUID, project_id: UUID
+    ) -> ExecutionArchiveResponse:
+        """Restore SQL payload and return authority to SQL.
+
+        Args:
+            archive_id: Generation to restore.
+            project_id: Project that must own the generation.
+
+        Returns:
+            Restored archive generation.
+
+        Raises:
+            ExecutionArchiveStateError: If the generation owns no SQL payload.
+            ArchiveUnavailableError: If the archive object cannot be trusted.
+            Exception: Any storage or SQL failure after its safe catalog
+                outcome is recorded.
+        """
+        archive = self._require_archive(archive_id, project_id)
+        if archive.state == ExecutionArchiveState.RESTORED:
+            return archive
+        if not archive.requires_restore:
+            raise ExecutionArchiveStateError(
+                f"Execution archive {archive_id} is {archive.state.value} "
+                "and owns no SQL payload to restore."
+            )
+        claim = self._catalog.claim(
+            archive_id,
+            owner=self._owner,
+            lease_seconds=self._lease_seconds,
+        )
+        try:
+            if not claim.archive.requires_restore:
+                raise ExecutionArchiveStateError(
+                    f"Execution archive {archive_id} no longer requires "
+                    "restoration."
+                )
+            payload = self._load_payload(claim.archive)
+            claim = self._renew(claim)
+            self._start_restore(claim)
+            self._mover().restore(claim, payload)
+            self._finish_restore(claim, payload)
+            return self._catalog.require(archive_id)
+        except (ArchiveObjectInvalidError, ChecksumMismatchError) as error:
+            self._catalog.try_record_failure(
+                claim, error, state=ExecutionArchiveState.CORRUPT
+            )
+            raise ArchiveUnavailableError(
+                f"Execution archive {archive_id} is corrupt: {error}"
+            ) from error
+        except ExecutionArchiveStateError:
+            raise
+        except Exception as error:
+            self._catalog.try_record_failure(claim, error)
+            raise
+        finally:
+            self._catalog.release(claim)
+
+    def _require_archive(
+        self, archive_id: UUID, project_id: UUID
+    ) -> ExecutionArchiveResponse:
+        archive = self._catalog.get(archive_id, project_id=project_id)
+        if archive is None:
+            raise DoesNotExistException(
+                f"Execution archive {archive_id} does not exist in project "
+                f"{project_id}."
+            )
+        return archive
+
+    def _load_payload(
+        self, archive: ExecutionArchiveResponse
+    ) -> ExecutionArchivePayload:
+        return load_archive_payload(
+            storage=self._storage,
+            object_key=self._catalog.object_key(archive.id),
+            archive=archive,
+            workspace_id=self._workspace_id,
+        )
+
+    def _renew(self, claim: ExecutionArchiveClaim) -> ExecutionArchiveClaim:
+        return self._catalog.renew(claim, lease_seconds=self._lease_seconds)
+
+    def _mover(self) -> "ExecutionArchivePayloadMover":
+        return ExecutionArchivePayloadMover(
+            self._store.engine,
+            catalog=self._catalog,
+            batch_size=self._batch_size,
+            lease_seconds=self._lease_seconds,
+            clock=self._clock,
+        )
+
+    def _commit_authority(
+        self,
+        claim: ExecutionArchiveClaim,
+        payload: ExecutionArchivePayload,
+    ) -> None:
+        with Session(self._store.engine) as session:
+            schema = self._catalog.require_claimed(session, claim)
+            if schema.archive_state != ExecutionArchiveState.VERIFIED:
+                raise ExecutionArchiveStateError(
+                    f"Execution archive {schema.id} is {schema.state}; "
+                    "authority can only move from a verified generation."
+                )
+            capture = self._capturer.capture(
+                project_id=schema.project_id,
+                root_run_id=schema.root_run_id,
+                session=session,
+                for_update=True,
+            )
+            if capture.source_fingerprint != payload.source_fingerprint:
+                raise ExecutionArchiveParityError(
+                    "The execution tree changed after its archive was "
+                    "verified. Export a new generation before compacting."
+                )
+            _require_unmarked_tree(
+                session,
+                archive_id=schema.id,
+                run_ids=capture.family.run_ids,
+                snapshot_ids=capture.family.snapshot_ids,
+            )
+            for ids in chunked_ids(capture.family.run_ids):
+                session.execute(
+                    update(PipelineRunSchema)
+                    .where(col(PipelineRunSchema.id).in_(ids))
+                    .values(execution_archive_id=schema.id)
+                )
+            for ids in chunked_ids(capture.family.snapshot_ids):
+                session.execute(
+                    update(PipelineSnapshotSchema)
+                    .where(col(PipelineSnapshotSchema.id).in_(ids))
+                    .values(execution_archive_id=schema.id)
+                )
+            self._catalog.transition(
+                session,
+                claim,
+                ExecutionArchiveState.COMPACTING,
+                committed_at=self._clock(),
+            )
+            session.commit()
+
+    def _start_restore(self, claim: ExecutionArchiveClaim) -> None:
+        with Session(self._store.engine) as session:
+            self._catalog.transition(
+                session, claim, ExecutionArchiveState.RESTORING
+            )
+            session.commit()
+
+    def _finish_restore(
+        self,
+        claim: ExecutionArchiveClaim,
+        payload: ExecutionArchivePayload,
+    ) -> None:
+        run_ids = [record.id for record in payload.runs]
+        snapshot_ids = [record.id for record in payload.snapshots]
+        with Session(self._store.engine) as session:
+            schema = self._catalog.require_claimed(session, claim)
+            if schema.archive_state != ExecutionArchiveState.RESTORING:
+                raise ExecutionArchiveStateError(
+                    f"Execution archive {schema.id} is {schema.state}; "
+                    "restoration cannot be completed."
+                )
+            _require_owned_markers(
+                session,
+                archive_id=schema.id,
+                run_ids=run_ids,
+                snapshot_ids=snapshot_ids,
+            )
+            for ids in chunked_ids(run_ids):
+                session.execute(
+                    update(PipelineRunSchema)
+                    .where(col(PipelineRunSchema.id).in_(ids))
+                    .where(
+                        col(PipelineRunSchema.execution_archive_id)
+                        == schema.id
+                    )
+                    .values(execution_archive_id=None)
+                )
+            for ids in chunked_ids(snapshot_ids):
+                session.execute(
+                    update(PipelineSnapshotSchema)
+                    .where(col(PipelineSnapshotSchema.id).in_(ids))
+                    .where(
+                        col(PipelineSnapshotSchema.execution_archive_id)
+                        == schema.id
+                    )
+                    .values(execution_archive_id=None)
+                )
+            self._catalog.transition(
+                session,
+                claim,
+                ExecutionArchiveState.RESTORED,
+                restored_at=self._clock(),
+            )
+            session.commit()
+
+
+def _require_unmarked_tree(
+    session: Session,
+    *,
+    archive_id: UUID,
+    run_ids: Sequence[UUID],
+    snapshot_ids: Sequence[UUID],
+) -> None:
+    for table, ids in (
+        (PipelineSnapshotSchema, snapshot_ids),
+        (PipelineRunSchema, run_ids),
+    ):
+        for chunk in chunked_ids(ids):
+            marker = session.exec(
+                select(table.execution_archive_id)
+                .where(col(table.id).in_(chunk))
+                .where(col(table.execution_archive_id).is_not(None))
+                .limit(1)
+            ).first()
+            if marker is not None:
+                raise ExecutionArchiveStateError(
+                    "Another archive already owns part of execution archive "
+                    f"{archive_id}."
+                )
+
+
+def _require_owned_markers(
+    session: Session,
+    *,
+    archive_id: UUID,
+    run_ids: Sequence[UUID],
+    snapshot_ids: Sequence[UUID],
+) -> None:
+    for table, ids in (
+        (PipelineSnapshotSchema, snapshot_ids),
+        (PipelineRunSchema, run_ids),
+    ):
+        for chunk in chunked_ids(ids):
+            markers = session.exec(
+                select(table.execution_archive_id)
+                .where(col(table.id).in_(chunk))
+                .with_for_update()
+            ).all()
+            if any(marker != archive_id for marker in markers):
+                raise ExecutionArchiveStateError(
+                    f"Execution archive {archive_id} lost one of its SQL "
+                    "markers."
+                )

--- a/src/zenml/zen_stores/execution_archive/payload_mover.py
+++ b/src/zenml/zen_stores/execution_archive/payload_mover.py
@@ -1,0 +1,280 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Bounded SQL payload movement for authoritative execution archives."""
+
+import json
+from datetime import datetime
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.base import ExecutableOption
+from sqlmodel import Session, col, select
+
+from zenml.enums import ExecutionArchiveState
+from zenml.exceptions import (
+    ExecutionArchiveParityError,
+    ExecutionArchiveStateError,
+)
+from zenml.zen_stores.execution_archive.catalog import (
+    ExecutionArchiveCatalog,
+    ExecutionArchiveClaim,
+)
+from zenml.zen_stores.execution_archive.payload import (
+    ARCHIVED_CONFIGURATION_FIELDS,
+    ARCHIVED_RUN_FIELDS,
+    ARCHIVED_SNAPSHOT_FIELDS,
+    ARCHIVED_STEP_FIELDS,
+    ExecutionArchivePayload,
+)
+from zenml.zen_stores.execution_archive_utils import (
+    archived_payload_placeholder,
+)
+from zenml.zen_stores.schemas import (
+    BaseSchema,
+    PipelineRunSchema,
+    PipelineSnapshotSchema,
+    StepConfigurationSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.schemas.utils import jl_arg
+
+S = TypeVar("S", bound=BaseSchema)
+
+
+class ExecutionArchivePayloadMover:
+    """Replace and restore archived fields in bounded transactions."""
+
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        catalog: ExecutionArchiveCatalog,
+        batch_size: int,
+        lease_seconds: float,
+        clock: Callable[[], datetime],
+    ) -> None:
+        """Initialize the payload mover.
+
+        Args:
+            engine: SQL store engine.
+            catalog: Archive catalog owning state transitions.
+            batch_size: Maximum rows changed per transaction.
+            lease_seconds: Claim renewal duration.
+            clock: Source of lifecycle timestamps.
+        """
+        self._engine = engine
+        self._catalog = catalog
+        self._batch_size = batch_size
+        self._lease_seconds = lease_seconds
+        self._clock = clock
+
+    def compact(
+        self, claim: ExecutionArchiveClaim, payload: ExecutionArchivePayload
+    ) -> None:
+        """Replace the generation's payload fields with typed placeholders.
+
+        Args:
+            claim: Current fenced ownership.
+            payload: Verified source payload.
+        """
+        self._move(
+            claim,
+            payload,
+            state=ExecutionArchiveState.COMPACTING,
+            compact=True,
+        )
+        with Session(self._engine) as session:
+            self._catalog.transition(
+                session,
+                claim,
+                ExecutionArchiveState.COLD,
+                compacted_at=self._clock(),
+            )
+            session.commit()
+
+    def restore(
+        self, claim: ExecutionArchiveClaim, payload: ExecutionArchivePayload
+    ) -> None:
+        """Restore the generation's payload fields from its object.
+
+        Rows deleted after compaction are intentionally skipped.
+
+        Args:
+            claim: Current fenced ownership.
+            payload: Verified source payload.
+        """
+        self._move(
+            claim,
+            payload,
+            state=ExecutionArchiveState.RESTORING,
+            compact=False,
+        )
+
+    def _move(
+        self,
+        claim: ExecutionArchiveClaim,
+        payload: ExecutionArchivePayload,
+        *,
+        state: ExecutionArchiveState,
+        compact: bool,
+    ) -> None:
+        write = _compact_fields if compact else _restore_fields
+        self._write_rows(
+            claim,
+            state,
+            StepRunSchema,
+            {record.id: record for record in payload.steps},
+            ARCHIVED_STEP_FIELDS,
+            write,
+            before=_store_step_projection if compact else None,
+            options=(
+                selectinload(jl_arg(StepRunSchema.snapshot)),
+                selectinload(jl_arg(StepRunSchema.static_config)),
+                selectinload(jl_arg(StepRunSchema.dynamic_config)),
+                selectinload(jl_arg(StepRunSchema.pipeline_run)),
+            ),
+        )
+        self._write_rows(
+            claim,
+            state,
+            PipelineRunSchema,
+            {record.id: record for record in payload.runs},
+            ARCHIVED_RUN_FIELDS,
+            write,
+        )
+        self._write_rows(
+            claim,
+            state,
+            StepConfigurationSchema,
+            {record.id: record for record in payload.step_configurations},
+            ARCHIVED_CONFIGURATION_FIELDS,
+            write,
+        )
+        self._write_rows(
+            claim,
+            state,
+            PipelineSnapshotSchema,
+            {record.id: record for record in payload.snapshots},
+            ARCHIVED_SNAPSHOT_FIELDS,
+            write,
+        )
+
+    def _write_rows(
+        self,
+        claim: ExecutionArchiveClaim,
+        state: ExecutionArchiveState,
+        table: Type[S],
+        records: Dict[UUID, BaseModel],
+        fields: Sequence[str],
+        write: Callable[[BaseSchema, BaseModel, Sequence[str], UUID], None],
+        *,
+        before: Optional[Callable[[S], None]] = None,
+        options: Sequence[ExecutableOption] = (),
+    ) -> None:
+        for ids in _batches(records, self._batch_size):
+            with Session(self._engine) as session:
+                schema = self._catalog.require_claimed(session, claim)
+                if schema.archive_state != state:
+                    raise ExecutionArchiveStateError(
+                        f"Execution archive {schema.id} is {schema.state}; "
+                        f"expected {state.value}."
+                    )
+                rows = session.exec(
+                    select(table)
+                    .where(col(table.id).in_(ids))
+                    .options(*options)
+                    .with_for_update()
+                ).all()
+                for row in rows:
+                    if before is not None:
+                        before(row)
+                    write(row, records[row.id], fields, claim.archive_id)
+                    session.add(row)
+                session.commit()
+            self._catalog.renew(claim, lease_seconds=self._lease_seconds)
+
+
+def _compact_fields(
+    row: BaseSchema,
+    record: BaseModel,
+    fields: Sequence[str],
+    archive_id: UUID,
+) -> None:
+    placeholder = archived_payload_placeholder(archive_id)
+    for field in fields:
+        current = getattr(row, field)
+        expected = getattr(record, field)
+        if current == placeholder or current is None and expected is None:
+            continue
+        if current != expected:
+            raise ExecutionArchiveParityError(
+                f"{type(row).__name__} {row.id} field '{field}' changed "
+                "after the archive authority switch."
+            )
+        setattr(row, field, placeholder)
+
+
+def _restore_fields(
+    row: BaseSchema,
+    record: BaseModel,
+    fields: Sequence[str],
+    archive_id: UUID,
+) -> None:
+    placeholder = archived_payload_placeholder(archive_id)
+    for field in fields:
+        current = getattr(row, field)
+        expected = getattr(record, field)
+        if current == expected:
+            continue
+        if current != placeholder:
+            raise ExecutionArchiveParityError(
+                f"{type(row).__name__} {row.id} field '{field}' does not "
+                "belong to execution archive restoration."
+            )
+        setattr(row, field, expected)
+
+
+def _store_step_projection(step: StepRunSchema) -> None:
+    if step.step_type is not None and step.substitutions is not None:
+        return
+    configuration = step.get_step_configuration()
+    if step.step_type is None:
+        step.step_type = (
+            configuration.config.step_type.value
+            if configuration.config.step_type
+            else None
+        )
+    if step.substitutions is None:
+        step.substitutions = json.dumps(
+            configuration.config.substitutions, sort_keys=True
+        )
+
+
+def _batches(values: Iterable[UUID], size: int) -> List[List[UUID]]:
+    ordered = list(values)
+    return [
+        ordered[index : index + size] for index in range(0, len(ordered), size)
+    ]

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -2777,6 +2777,10 @@ class SqlZenStore(BaseZenStore):
                 reference_id=service.pipeline_run_id,
                 session=session,
             )
+            if service.pipeline_run_id is not None:
+                self._assert_run_history_writable(
+                    session=session, run_id=service.pipeline_run_id
+                )
 
             self._get_reference_schema_by_id(
                 resource=service,
@@ -2863,6 +2867,11 @@ class SqlZenStore(BaseZenStore):
                 schema_class=ServiceSchema,
                 session=session,
             )
+            if existing_service.pipeline_run_id is not None:
+                self._assert_run_history_writable(
+                    session=session,
+                    run_id=existing_service.pipeline_run_id,
+                )
 
             self._get_reference_schema_by_id(
                 resource=existing_service,
@@ -5365,6 +5374,11 @@ class SqlZenStore(BaseZenStore):
                 reference_id=snapshot.source_snapshot,
                 session=session,
             )
+            if snapshot.source_snapshot is not None:
+                self._assert_execution_history_writable(
+                    session=session,
+                    snapshot_id=snapshot.source_snapshot,
+                )
 
             if isinstance(snapshot.name, str):
                 validate_name(snapshot)
@@ -5525,6 +5539,9 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineSnapshotSchema,
                 session=session,
             )
+            self._assert_execution_history_writable(
+                session=session, snapshot_id=snapshot.id
+            )
 
             if isinstance(snapshot_update.name, str):
                 validate_name(snapshot_update)
@@ -5591,6 +5608,9 @@ class SqlZenStore(BaseZenStore):
                 resource_id=snapshot_id,
                 schema_class=PipelineSnapshotSchema,
                 session=session,
+            )
+            self._assert_execution_history_writable(
+                session=session, snapshot_id=snapshot.id
             )
 
             session.delete(snapshot)
@@ -5701,6 +5721,9 @@ class SqlZenStore(BaseZenStore):
                 reference_schema=PipelineSnapshotSchema,
                 reference_id=deployment.snapshot_id,
                 session=session,
+            )
+            self._assert_execution_history_writable(
+                session=session, snapshot_id=deployment.snapshot_id
             )
             self._get_reference_schema_by_id(
                 resource=deployment,
@@ -6157,6 +6180,9 @@ class SqlZenStore(BaseZenStore):
                 reference_schema=PipelineSnapshotSchema,
                 reference_id=template.source_snapshot_id,
                 session=session,
+            )
+            self._assert_execution_history_writable(
+                session=session, snapshot_id=snapshot.id
             )
 
             template_utils.validate_snapshot_is_templatable(snapshot)
@@ -6876,6 +6902,72 @@ class SqlZenStore(BaseZenStore):
             f"For more information on run naming, see: https://docs.zenml.io/concepts/steps_and_pipelines/yaml_configuration#run-name"
         )
 
+    @staticmethod
+    def _assert_execution_history_writable(
+        *,
+        session: Session,
+        snapshot_id: Optional[UUID],
+        run_id: Optional[UUID] = None,
+    ) -> None:
+        """Lock execution fences and reject writes to compacted history.
+
+        Snapshot then run is the shared lock order used by step creation and
+        the archive authority switch. Holding these locks through the caller's
+        write makes the marker check race-free under MySQL REPEATABLE READ.
+
+        Args:
+            session: Transaction that will perform the write.
+            snapshot_id: Snapshot referenced or changed by the write, if any.
+            run_id: Existing run referenced or changed by the write.
+
+        Raises:
+            IllegalOperationError: If an execution archive owns either row.
+        """
+        if snapshot_id is not None:
+            snapshot_archive_id = session.exec(
+                select(PipelineSnapshotSchema.execution_archive_id)
+                .where(col(PipelineSnapshotSchema.id) == snapshot_id)
+                .with_for_update()
+            ).one_or_none()
+            if snapshot_archive_id is not None:
+                raise IllegalOperationError(
+                    "This execution history is compacted in archive "
+                    f"{snapshot_archive_id}. Restore it before modifying or "
+                    "reusing its snapshot."
+                )
+        if run_id is None:
+            return
+        run_archive_id = session.exec(
+            select(PipelineRunSchema.execution_archive_id)
+            .where(col(PipelineRunSchema.id) == run_id)
+            .with_for_update()
+        ).one_or_none()
+        if run_archive_id is not None:
+            raise IllegalOperationError(
+                "This execution history is compacted in archive "
+                f"{run_archive_id}. Restore it before modifying or extending "
+                "the run."
+            )
+
+    @classmethod
+    def _assert_run_history_writable(
+        cls, *, session: Session, run_id: UUID
+    ) -> None:
+        """Resolve a run's snapshot and apply the ordered archive fence.
+
+        Args:
+            session: Transaction that will perform the write.
+            run_id: Existing run referenced or changed by the write.
+        """
+        snapshot_id = session.exec(
+            select(PipelineRunSchema.snapshot_id).where(
+                col(PipelineRunSchema.id) == run_id
+            )
+        ).one_or_none()
+        cls._assert_execution_history_writable(
+            session=session, snapshot_id=snapshot_id, run_id=run_id
+        )
+
     def _get_next_run_index(self, pipeline_id: UUID, session: Session) -> int:
         """Get the next run index for a pipeline.
 
@@ -6962,6 +7054,13 @@ class SqlZenStore(BaseZenStore):
 
         index = self._get_next_run_index(
             pipeline_id=snapshot.pipeline_id, session=session
+        )
+        # `_get_next_run_index` commits twice. Recheck the archive markers
+        # under the locks held by the run insert after that transaction gap.
+        self._assert_execution_history_writable(
+            session=session,
+            snapshot_id=snapshot.id,
+            run_id=pipeline_run.parent_run_id,
         )
 
         new_run = PipelineRunSchema.from_request(
@@ -7462,6 +7561,11 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineRunSchema,
                 session=session,
             )
+            self._assert_execution_history_writable(
+                session=session,
+                snapshot_id=existing_run.snapshot_id,
+                run_id=existing_run.id,
+            )
 
             if run_update.status is not None:
                 self._update_pipeline_run_status(
@@ -7578,6 +7682,11 @@ class SqlZenStore(BaseZenStore):
                 schema_class=PipelineRunSchema,
                 session=session,
             )
+            self._assert_execution_history_writable(
+                session=session,
+                snapshot_id=existing_run.snapshot_id,
+                run_id=existing_run.id,
+            )
 
             # Delete the pipeline run
             session.delete(existing_run)
@@ -7669,16 +7778,16 @@ class SqlZenStore(BaseZenStore):
                 request_model=run_wait_condition,
                 session=session,
             )
-            session.exec(
-                select(PipelineRunSchema.id)
-                .with_for_update()
-                .where(PipelineRunSchema.id == run_wait_condition.run)
-            ).one()
             run_schema = self._get_reference_schema_by_id(
                 resource=run_wait_condition,
                 reference_schema=PipelineRunSchema,
                 reference_id=run_wait_condition.run,
                 session=session,
+            )
+            self._assert_execution_history_writable(
+                session=session,
+                snapshot_id=run_schema.snapshot_id,
+                run_id=run_schema.id,
             )
             if not run_schema.snapshot or not run_schema.snapshot.is_dynamic:
                 raise IllegalOperationError(
@@ -8461,6 +8570,9 @@ class SqlZenStore(BaseZenStore):
                     f"Can not attach snapshot {snapshot_id} to archived trigger {trigger_id}."
                 )
 
+            self._assert_execution_history_writable(
+                session=session, snapshot_id=snapshot_id
+            )
             new_assoc = TriggerSnapshotSchema(
                 trigger_id=trigger_id,
                 snapshot_id=snapshot_id,
@@ -11636,18 +11748,13 @@ class SqlZenStore(BaseZenStore):
             # try to acquire more exclusive locks
             session.commit()
 
-            # Acquire exclusive lock on the snapshot and run to prevent
-            # deadlocks during insertion
-            assert run.snapshot_id
-            session.exec(
-                select(PipelineSnapshotSchema.id)
-                .with_for_update()
-                .where(PipelineSnapshotSchema.id == run.snapshot_id)
-            )
-            session.exec(
-                select(PipelineRunSchema.id)
-                .with_for_update()
-                .where(PipelineRunSchema.id == step_run.pipeline_run_id)
+            # Acquire the existing snapshot/run locks in their shared order
+            # and refuse the insert if archive authority moved while the
+            # earlier transaction was being committed.
+            self._assert_execution_history_writable(
+                session=session,
+                snapshot_id=run.snapshot_id,
+                run_id=step_run.pipeline_run_id,
             )
 
             existing_step_runs = session.exec(
@@ -12111,6 +12218,9 @@ class SqlZenStore(BaseZenStore):
                 reference_id=hook_invocation.pipeline_run_id,
                 session=session,
             )
+            self._assert_run_history_writable(
+                session=session, run_id=hook_invocation.pipeline_run_id
+            )
             # Check that the step run exists (if set).
             self._get_reference_schema_by_id(
                 resource=hook_invocation,
@@ -12380,6 +12490,11 @@ class SqlZenStore(BaseZenStore):
                 resource_id=step_run_id,
                 schema_class=StepRunSchema,
                 session=session,
+            )
+            self._assert_execution_history_writable(
+                session=session,
+                snapshot_id=existing_step_run.snapshot_id,
+                run_id=existing_step_run.pipeline_run_id,
             )
 
             if step_run_update.status:

--- a/tests/unit/zen_stores/execution_archive/service.py
+++ b/tests/unit/zen_stores/execution_archive/service.py
@@ -23,6 +23,9 @@ from zenml.models import ExecutionArchiveObject
 from zenml.zen_stores.execution_archive.archiver import (
     ExecutionArchiveExporter,
 )
+from zenml.zen_stores.execution_archive.compactor import (
+    ExecutionArchiveAuthority,
+)
 from zenml.zen_stores.execution_archive.storage import (
     ExecutionArchiveStorage,
     build_execution_archive_storage,
@@ -169,4 +172,39 @@ def exporter(
         clock=lambda: NOW,
         owner=owner,
         lease_seconds=lease_seconds,
+    )
+
+
+def authority(
+    store: SqlZenStore,
+    root: Path,
+    *,
+    storage: Optional[ExecutionArchiveStorage] = None,
+    owner: str = "test-worker",
+    lease_seconds: float = 600,
+    batch_size: int = 2,
+    compaction_enabled: bool = True,
+) -> ExecutionArchiveAuthority:
+    """Build a deterministic authority service backed by local storage.
+
+    Args:
+        store: SQL store.
+        root: Local artifact-store root.
+        storage: Optional observable storage wrapper.
+        owner: Worker identity.
+        lease_seconds: Fenced lease duration.
+        batch_size: Maximum changed rows per transaction.
+        compaction_enabled: Deployment-gate value.
+
+    Returns:
+        Configured authority service.
+    """
+    return ExecutionArchiveAuthority(
+        store=store,
+        storage=storage or local_storage(store, root),
+        clock=lambda: NOW,
+        owner=owner,
+        lease_seconds=lease_seconds,
+        batch_size=batch_size,
+        compaction_enabled=compaction_enabled,
     )

--- a/tests/unit/zen_stores/execution_archive/test_authority.py
+++ b/tests/unit/zen_stores/execution_archive/test_authority.py
@@ -1,0 +1,289 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for explicit execution archive authority changes."""
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, col, select
+
+from tests.unit.zen_stores.execution_archive.service import (
+    authority,
+    exporter,
+)
+from tests.unit.zen_stores.execution_archive.utils import populate_family
+from zenml.enums import ExecutionArchiveState, ExecutionStatus
+from zenml.exceptions import (
+    ArchiveUnavailableError,
+    ExecutionArchiveParityError,
+    ExecutionArchiveRestoreRequiredError,
+    ExecutionArchiveStateError,
+    IllegalOperationError,
+)
+from zenml.models import (
+    PipelineRunUpdate,
+    PipelineSnapshotUpdate,
+    StepRunUpdate,
+)
+from zenml.zen_stores.execution_archive.capture import ExecutionArchiveCapturer
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.execution_archive.payload_mover import (
+    ExecutionArchivePayloadMover,
+)
+from zenml.zen_stores.execution_archive_utils import archived_payload_id
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    PipelineSnapshotSchema,
+    StepConfigurationSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+def test_compact_and_restore_round_trip(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """Compaction is explicit, bounded, fail-closed, and reversible."""
+    family = populate_family(sql_store, steps=3, with_projection=False)
+    original = ExecutionArchiveCapturer(sql_store.engine).capture(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+
+    cold = authority(sql_store, tmp_path).compact(
+        archive_id=archive.id, project_id=family.project_id
+    )
+
+    assert cold.state == ExecutionArchiveState.COLD
+    assert cold.requires_restore
+    with Session(sql_store.engine) as session:
+        run = session.get(PipelineRunSchema, family.run_id)
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        step = session.get(StepRunSchema, family.step_id)
+        configuration = session.exec(
+            select(StepConfigurationSchema).where(
+                col(StepConfigurationSchema.snapshot_id) == family.snapshot_id
+            )
+        ).first()
+        assert run is not None and run.execution_archive_id == archive.id
+        assert snapshot is not None
+        assert snapshot.execution_archive_id == archive.id
+        assert step is not None and step.substitutions is not None
+        assert configuration is not None
+        for value in (
+            run.orchestrator_environment,
+            snapshot.pipeline_configuration,
+            step.source_code,
+            configuration.config,
+        ):
+            assert archived_payload_id(value) == archive.id
+
+    assert sql_store.get_run(family.run_id, hydrate=False).metadata is None
+    assert (
+        sql_store.get_run_step(family.step_id, hydrate=False).metadata is None
+    )
+    with pytest.raises(ExecutionArchiveRestoreRequiredError):
+        sql_store.get_run(family.run_id)
+    with pytest.raises(ExecutionArchiveRestoreRequiredError):
+        sql_store.get_run_step(family.step_id)
+
+    restored = authority(sql_store, tmp_path).restore(
+        archive_id=archive.id, project_id=family.project_id
+    )
+
+    assert restored.state == ExecutionArchiveState.RESTORED
+    assert not restored.requires_restore
+    recaptured = ExecutionArchiveCapturer(sql_store.engine).capture(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    assert recaptured.source_fingerprint == original.source_fingerprint
+    with Session(sql_store.engine) as session:
+        run = session.get(PipelineRunSchema, family.run_id)
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert run is not None and run.execution_archive_id is None
+        assert snapshot is not None and snapshot.execution_archive_id is None
+
+
+def test_compaction_requires_the_deployment_gate(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """Verified export remains non-destructive while compaction is disabled."""
+    family = populate_family(sql_store)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+
+    with pytest.raises(ExecutionArchiveStateError, match="disabled"):
+        authority(sql_store, tmp_path, compaction_enabled=False).compact(
+            archive_id=archive.id, project_id=family.project_id
+        )
+
+    assert (
+        ExecutionArchiveCatalog(sql_store.engine).require(archive.id).state
+        == ExecutionArchiveState.VERIFIED
+    )
+    assert sql_store.get_run(family.run_id).id == family.run_id
+
+
+def test_interrupted_compaction_resumes_after_the_gate_is_disabled(
+    sql_store: SqlZenStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning off new compaction never strands authoritative SQL payload."""
+    family = populate_family(sql_store)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+
+    def interrupt(
+        mover: ExecutionArchivePayloadMover, *args: object, **kwargs: object
+    ) -> None:
+        del mover, args, kwargs
+        raise RuntimeError("interrupted after authority moved")
+
+    with monkeypatch.context() as context:
+        context.setattr(ExecutionArchivePayloadMover, "compact", interrupt)
+        with pytest.raises(RuntimeError, match="interrupted"):
+            authority(sql_store, tmp_path).compact(
+                archive_id=archive.id, project_id=family.project_id
+            )
+
+    assert (
+        ExecutionArchiveCatalog(sql_store.engine).require(archive.id).state
+        == ExecutionArchiveState.COMPACTING
+    )
+    resumed = authority(sql_store, tmp_path, compaction_enabled=False).compact(
+        archive_id=archive.id, project_id=family.project_id
+    )
+    assert resumed.state == ExecutionArchiveState.COLD
+
+
+def test_compaction_refuses_sql_changed_after_verification(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """The locked authority switch never trusts a stale verified object."""
+    family = populate_family(sql_store)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    with Session(sql_store.engine) as session:
+        snapshot = session.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert snapshot is not None
+        snapshot.source_code = 'print("changed after verification")'
+        session.add(snapshot)
+        session.commit()
+
+    with pytest.raises(ExecutionArchiveParityError, match="changed"):
+        authority(sql_store, tmp_path).compact(
+            archive_id=archive.id, project_id=family.project_id
+        )
+
+    failed = ExecutionArchiveCatalog(sql_store.engine).require(archive.id)
+    assert failed.state == ExecutionArchiveState.FAILED
+    assert not failed.requires_restore
+    assert sql_store.get_run(family.run_id).id == family.run_id
+
+
+def test_cold_corruption_keeps_restore_required(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """A damaged authoritative object never makes incomplete SQL readable."""
+    family = populate_family(sql_store)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    service = authority(sql_store, tmp_path)
+    service.compact(archive_id=archive.id, project_id=family.project_id)
+    Path(
+        ExecutionArchiveCatalog(sql_store.engine).object_key(archive.id)
+    ).write_bytes(b"corrupt")
+
+    with pytest.raises(ArchiveUnavailableError, match="corrupt"):
+        service.restore(archive_id=archive.id, project_id=family.project_id)
+
+    failed = ExecutionArchiveCatalog(sql_store.engine).require(archive.id)
+    assert failed.state == ExecutionArchiveState.CORRUPT
+    assert failed.requires_restore
+    with pytest.raises(ExecutionArchiveRestoreRequiredError):
+        sql_store.get_run(family.run_id)
+
+
+def test_cold_execution_writes_are_fenced_until_restore(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """Run, step, and snapshot mutations cannot cross archive authority."""
+    family = populate_family(sql_store)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    service = authority(sql_store, tmp_path)
+    service.compact(archive_id=archive.id, project_id=family.project_id)
+
+    with pytest.raises(IllegalOperationError, match="Restore"):
+        sql_store.update_snapshot(
+            family.snapshot_id,
+            PipelineSnapshotUpdate(description="changed"),
+        )
+    with pytest.raises(IllegalOperationError, match="Restore"):
+        sql_store.update_run(
+            family.run_id,
+            PipelineRunUpdate(status=ExecutionStatus.COMPLETED),
+        )
+    with pytest.raises(IllegalOperationError, match="Restore"):
+        sql_store.update_run_step(
+            family.step_id,
+            StepRunUpdate(status=ExecutionStatus.COMPLETED),
+        )
+    with pytest.raises(IllegalOperationError, match="Restore"):
+        sql_store.delete_run(family.run_id)
+    with pytest.raises(IllegalOperationError, match="Restore"):
+        sql_store.delete_snapshot(family.snapshot_id)
+
+    service.restore(archive_id=archive.id, project_id=family.project_id)
+    updated = sql_store.update_snapshot(
+        family.snapshot_id,
+        PipelineSnapshotUpdate(description="changed"),
+    )
+    assert updated.metadata is not None
+    assert updated.metadata.description == "changed"
+
+
+def test_restore_skips_rows_deleted_while_cold(
+    sql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """User-deleted rows do not strand restoration or its family markers."""
+    family = populate_family(sql_store, steps=2)
+    archive = exporter(sql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    service = authority(sql_store, tmp_path)
+    service.compact(archive_id=archive.id, project_id=family.project_id)
+    with Session(sql_store.engine) as session:
+        step = session.get(StepRunSchema, family.step_id)
+        assert step is not None
+        session.delete(step)
+        session.commit()
+
+    restored = service.restore(
+        archive_id=archive.id, project_id=family.project_id
+    )
+
+    assert restored.state == ExecutionArchiveState.RESTORED
+    with Session(sql_store.engine) as session:
+        assert session.get(StepRunSchema, family.step_id) is None
+        run = session.get(PipelineRunSchema, family.run_id)
+        assert run is not None and run.execution_archive_id is None

--- a/tests/unit/zen_stores/execution_archive/test_mysql_concurrency.py
+++ b/tests/unit/zen_stores/execution_archive/test_mysql_concurrency.py
@@ -1,0 +1,148 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Two-connection authority-switch tests for MySQL locking semantics.
+
+SQLite serializes writers and ignores ``SELECT ... FOR UPDATE``. Set
+``ZENML_TEST_EXECUTION_ARCHIVE_MYSQL_URL`` to a MySQL server URL whose user may
+create temporary databases to exercise the real race; otherwise these tests
+are skipped.
+"""
+
+import os
+import threading
+from pathlib import Path
+from typing import Iterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+from sqlmodel import Session, col, select
+
+from tests.unit.zen_stores.execution_archive.service import authority, exporter
+from tests.unit.zen_stores.execution_archive.utils import populate_family
+from zenml.enums import ExecutionArchiveState
+from zenml.zen_stores.execution_archive.catalog import ExecutionArchiveCatalog
+from zenml.zen_stores.schemas import PipelineSnapshotSchema
+from zenml.zen_stores.sql_zen_store import (
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+MYSQL_URL = os.environ.get("ZENML_TEST_EXECUTION_ARCHIVE_MYSQL_URL")
+
+pytestmark = pytest.mark.skipif(
+    not MYSQL_URL, reason="ZENML_TEST_EXECUTION_ARCHIVE_MYSQL_URL is not set"
+)
+
+
+@pytest.fixture
+def mysql_store() -> Iterator[SqlZenStore]:
+    """Yield a store backed by a fresh disposable MySQL database."""
+    assert MYSQL_URL
+    database = f"zenml_archive_test_{uuid4().hex[:12]}"
+    url = make_url(MYSQL_URL)
+    if url.drivername == "mysql":
+        url = url.set(drivername="mysql+pymysql")
+    admin_url = url.set(database=None)
+    admin = create_engine(admin_url)
+    with admin.connect() as connection:
+        connection.execute(text(f"CREATE DATABASE {database}"))
+        connection.commit()
+    store_url = url.set(database=database).render_as_string(
+        hide_password=False
+    )
+    store: SqlZenStore | None = None
+    try:
+        store = SqlZenStore(
+            config=SqlZenStoreConfiguration(url=store_url),
+            skip_default_registrations=False,
+        )
+        yield store
+    finally:
+        if store is not None:
+            store.engine.dispose()
+        with admin.connect() as connection:
+            connection.execute(text(f"DROP DATABASE {database}"))
+            connection.commit()
+        admin.dispose()
+
+
+def test_authority_switch_waits_for_writer_and_rechecks_source(
+    mysql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """A writer that commits first makes the waiting switch fail parity."""
+    family = populate_family(mysql_store)
+    archive = exporter(mysql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+    service = authority(mysql_store, tmp_path)
+    outcome: dict[str, str] = {}
+
+    with Session(mysql_store.engine) as writer:
+        snapshot = writer.exec(
+            select(PipelineSnapshotSchema)
+            .where(col(PipelineSnapshotSchema.id) == family.snapshot_id)
+            .with_for_update()
+        ).one()
+
+        def compact() -> None:
+            try:
+                service.compact(
+                    archive_id=archive.id, project_id=family.project_id
+                )
+                outcome["result"] = "committed"
+            except Exception as error:
+                outcome["result"] = f"{type(error).__name__}: {error}"
+
+        worker = threading.Thread(target=compact)
+        worker.start()
+        worker.join(timeout=2)
+        assert worker.is_alive(), "the authority switch did not wait"
+
+        snapshot.source_code = 'print("writer won")'
+        writer.add(snapshot)
+        writer.commit()
+        worker.join(timeout=30)
+
+    assert not worker.is_alive(), "the authority switch did not finish"
+    assert outcome["result"].startswith("ExecutionArchiveParityError")
+    failed = ExecutionArchiveCatalog(mysql_store.engine).require(archive.id)
+    assert failed.state == ExecutionArchiveState.FAILED
+    assert not failed.requires_restore
+
+
+def test_locking_fence_sees_authority_committed_after_consistent_read(
+    mysql_store: SqlZenStore, tmp_path: Path
+) -> None:
+    """A locking read sees the marker even after an older consistent read."""
+    family = populate_family(mysql_store)
+    archive = exporter(mysql_store, tmp_path).export(
+        project_id=family.project_id, root_run_id=family.run_id
+    )
+
+    with Session(mysql_store.engine) as writer:
+        snapshot = writer.get(PipelineSnapshotSchema, family.snapshot_id)
+        assert snapshot is not None and snapshot.execution_archive_id is None
+
+        authority(mysql_store, tmp_path).compact(
+            archive_id=archive.id, project_id=family.project_id
+        )
+        marker = writer.exec(
+            select(PipelineSnapshotSchema.execution_archive_id)
+            .where(col(PipelineSnapshotSchema.id) == family.snapshot_id)
+            .with_for_update()
+        ).one()
+
+    assert marker == archive.id


### PR DESCRIPTION
> **Stack (3/4):** #5176 -> #5200 -> this PR -> #5198. This PR targets `feature/execution-archive-export`.

## Outcome

This PR adds explicit, restore-on-demand authority movement. A verified generation can be compacted in bounded batches and later restored in bounded batches. There is deliberately no transparent object-store hydration: summary reads remain hot, while payload-bearing reads return a typed HTTP 409 naming the archive that must be restored.

## Compaction safety protocol

1. Require the deployment compaction gate; it is disabled by default.
2. Claim the generation and checksum/decode the object again.
3. In one transaction, lock archive and execution-tree rows in writer order, capture the tree under those locks, and recheck semantic parity.
4. Atomically set every run/snapshot marker and transition to `compacting`.
5. Replace only still-matching payload values with typed markers in bounded batches, renewing the fenced claim after each batch.
6. Transition to `cold` only after every covered surviving row is compacted.

All marker reads and writes are chunked at 500 IDs. V1 refuses trees above 10,000 payload-bearing rows, bounding the authority-switch transaction and lock footprint. Normal writers take the same tree fences and refuse changes to cold history. An expired worker cannot commit a later batch. Interrupted `compacting` work resumes even if the deployment gate is subsequently disabled; the gate prevents new destructive work, not recovery of an authority switch already in progress.

## Restore protocol

Restore revalidates the object, writes archived values back only where the marker still exists, tolerates rows removed by broader lifecycle cleanup, and clears all tree markers only after every surviving row is restored. Interrupted `restoring` work is resumable. A corrupt object after authority moved remains restore-required and fails closed.

V1 deliberately requires restore before deleting an individual cold run or snapshot. Arbitrary partial deletion would break execution-tree closure and make restoration semantics ambiguous.

## API in this PR

- `POST /api/v1/archive/{archive_id}/compact`
- `POST /api/v1/archive/{archive_id}/restore`

Without RBAC, callers must be administrators. With RBAC enabled, both operations require the normal project-scoped pipeline-run update permission. Product policy, scheduling, status, Python client, CLI, and purge arrive in PR 4.

## Review focus

1. The locked authority transaction and snapshot -> run -> step -> configuration lock order.
2. Chunked tree-marker operations and the 10,000-row limit.
3. `payload_mover.py`: conditional, idempotent batched writes.
4. Writer fences in `SqlZenStore`, including run/step creation, snapshot references, and deletion.
5. Recovery semantics for expired claims, crashes, corruption, and missing rows.
6. `test_mysql_concurrency.py`: the two-connection races that SQLite cannot prove.

## Verification

- 28 focused tests cover hot -> verified -> compacting -> cold -> restoring -> restored, late mutations, interrupted batches, missing rows, stale/corrupt objects, writer fences, chunked markers, scoped RBAC, and typed restore-required reads.
- The two real MySQL concurrency tests remain skipped without a disposable MySQL URL and are an explicit external rehearsal gate.
- Ruff, Ruff format, pydoclint, targeted mypy, and `git diff --check` pass.
