### PR TITLE
Mention Kitaru in the evals, tracing and agent-example docs

### DIFF
--- a/docs/book/reference/llms-txt.md
+++ b/docs/book/reference/llms-txt.md
@@ -227,4 +227,13 @@ For the best AI-assisted ZenML development experience, combine:
 
 This gives your AI assistant access to documentation, your actual ZenML data, and structured workflows for making changes.
 
+## Kitaru's coding-agent tooling
+
+Everything above covers ZenML pipelines. [Kitaru](https://docs.zenml.io/kitaru), ZenML's sibling project for recording and replaying AI agent runs, has its own equivalents, and they're worth installing separately if you work on agents: reviewing a session, freezing a cohort and running a replay experiment is a long loop that your coding assistant can drive end to end.
+
+- **MCP server** — `uv add "kitaru[mcp]"` gives you the `kitaru-mcp` executable, which exposes typed Kitaru operations to Claude Code, Cursor, and other MCP clients. Tools are gated by a capability mode (`read-only` by default, then `standard`, then `destructive`), so an assistant only sees the operations you've allowed.
+- **Agent Skills** — published from [`zenml-io/kitaru-skills`](https://github.com/zenml-io/kitaru-skills) and installable with `npx skills add zenml-io/kitaru-skills` or the Claude Code plugin marketplace. They cover the workflow itself: investigating sessions, running a replay experiment, and building an adapter or importer for an unsupported framework.
+
+See [Set up your coding agent](https://docs.zenml.io/kitaru/agent-native/setup) for the full setup, including the server URL and capability-mode settings that most often trip people up.
+
 <figure><img src="https://static.scarf.sh/a.png?x-pxid=f0b4f458-0a54-4fcd-aa95-d5ee424815bc" alt="ZenML Scarf"><figcaption></figcaption></figure>

--- a/docs/book/user-guide/llmops-guide/evaluation/README.md
+++ b/docs/book/user-guide/llmops-guide/evaluation/README.md
@@ -15,6 +15,8 @@ Our RAG pipeline is a whole system, moreover, not just a model, and evaluating i
 
 In the previous section we built out a basic RAG pipeline for our documentation question-and-answer use case. We'll use this pipeline to demonstrate how to evaluate the performance of your RAG pipeline.
 
+Everything that follows starts from a dataset you assembled and score offline, which is the right shape for a RAG pipeline. An agent already serving traffic gives you the opposite starting point: real runs, some of which went wrong. [Kitaru](https://docs.zenml.io/kitaru), ZenML's sibling project for agents, replays one of those recorded runs against your real code with a single thing changed — a cheaper model, a different prompt — and diffs the pair, so a failure you saw once becomes a check you can rerun. See [building a regression suite from production](https://docs.zenml.io/kitaru/guides/regression-suite) for that workflow and [evaluators](https://docs.zenml.io/kitaru/concepts/evaluators) for how Kitaru scores sessions.
+
 {% hint style="info" %}
 If you were running this in a production setting, you might want to set up evaluation to check the performance of a raw LLM model (i.e. without any retrieval / RAG components) as a baseline, and then compare this to the performance of your RAG pipeline. This will help you understand how much value the retrieval and generation components are adding to your system. We won't cover this here, but it's a good practice to keep in mind.
 {% endhint %}

--- a/docs/book/user-guide/llmops-guide/finetuning-llms/evaluation-for-finetuning.md
+++ b/docs/book/user-guide/llmops-guide/finetuning-llms/evaluation-for-finetuning.md
@@ -110,6 +110,8 @@ As part of this, implementing comprehensive logging from the early stages of dev
 - [langfuse](https://langfuse.com/)
 - [braintrust](https://www.braintrust.dev/)
 
+If your inference calls come from an agent rather than a single model call, the traces you collect in these tools don't have to stay read-only. [Kitaru](https://docs.zenml.io/kitaru) ships importers for Langfuse, LangSmith, Braintrust, Logfire and Arize Phoenix that turn those traces into sessions you can replay against your real code; see [importing your traces](https://docs.zenml.io/kitaru/getting-started/import-your-traces).
+
 Alongside collecting the raw data and viewing it periodically, creating simple
 dashboards that display core metrics reflecting your model's performance is an
 effective way to visualize and monitor progress. These metrics should align with

--- a/examples/agent_comparison/README.md
+++ b/examples/agent_comparison/README.md
@@ -305,6 +305,7 @@ To make this production-ready:
 5. **Scale Testing**: Run on larger datasets and more architectures
 6. **Add Monitoring**: Track performance degradation over time with Langfuse dashboards
 7. **Implement A/B Testing**: Gradually roll out winning architectures with proper monitoring
+8. **Replay Real Runs**: Import the Langfuse traces of the winning architecture into [Kitaru](https://docs.zenml.io/kitaru) with `kitaru-langfuse-importer` and replay them against your real code with one thing changed, instead of comparing architectures on sample data only ([importing Langfuse traces](https://docs.zenml.io/kitaru/guides/import-langfuse-traces))
 
 ## 🔗 Related Examples
 

--- a/examples/agent_framework_integrations/README.md
+++ b/examples/agent_framework_integrations/README.md
@@ -197,6 +197,15 @@ ZenML is an extensible, open-source MLOps framework for creating production-read
 - 🌐 **Real-time APIs**: Deploy agents as HTTP services instantly
 - 🚀 **Pipeline deployments**: Transform batch workflows into live services
 
+## 🔁 Recording Production Runs with Kitaru
+
+These pipelines run agents as batch or deployed workloads. Once an agent serves real traffic, [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — records each run as a session you can replay against your real code with one thing changed (a cheaper model, a different prompt) and diff against the original.
+
+There are two ways in, depending on your framework:
+
+- **Adapters** wrap the agent you already have. Kitaru ships Python adapters for [PydanticAI](https://docs.zenml.io/kitaru/adapters/pydantic-ai), [LangGraph](https://docs.zenml.io/kitaru/adapters/langgraph) (which also covers LangChain agents built with `create_agent`, since those factories return LangGraph runnables) and the [OpenAI Agents SDK](https://docs.zenml.io/kitaru/adapters/openai-agents). For anything else, see [writing a custom adapter](https://docs.zenml.io/kitaru/adapters/custom).
+- **Importers** need no adapter at all: if you already collect traces in Langfuse, LangSmith, Braintrust, Logfire or Arize Phoenix, [import them as sessions](https://docs.zenml.io/kitaru/getting-started/import-your-traces).
+
 ## 📖 Learn More
 
 | Resource | Description |
@@ -207,6 +216,7 @@ ZenML is an extensible, open-source MLOps framework for creating production-read
 | 📓 **[Documentation]** | Full ZenML documentation |
 | 📒 **[API Reference]** | Detailed API documentation |
 | ⚽ **[Examples]** | More ZenML examples |
+| 🔁 **[Kitaru Docs]** | Record, replay and evaluate agent runs in production |
 
 [ZenML 101]: https://docs.zenml.io/user-guides/starter-guide
 [Core Concepts]: https://docs.zenml.io/getting-started/core-concepts
@@ -214,6 +224,7 @@ ZenML is an extensible, open-source MLOps framework for creating production-read
 [Documentation]: https://docs.zenml.io/
 [SDK Reference]: https://sdkdocs.zenml.io/
 [Examples]: https://github.com/zenml-io/zenml/tree/main/examples
+[Kitaru Docs]: https://docs.zenml.io/kitaru
 
 ---
 

--- a/examples/agent_framework_integrations/langchain/README.md
+++ b/examples/agent_framework_integrations/langchain/README.md
@@ -46,3 +46,7 @@ curl -X POST http://localhost:8000/invoke \
 - **Agent Framework**: LangChain's agent paradigm for reasoning
 - **Real-time Deployment**: Deploy as HTTP API for instant responses
 - **ZenML Orchestration**: Full pipeline tracking and artifact management
+
+## 🔁 Recording runs with Kitaru
+
+This example is an LCEL chain rather than an agent loop. Once you move to a LangChain agent (`langchain.agents.create_agent`), [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — records its production runs through the [LangGraph adapter](https://docs.zenml.io/kitaru/adapters/langgraph), since those factories return LangGraph runnables. Each recorded run can then be replayed against your real code with a single change and diffed against the original.

--- a/examples/agent_framework_integrations/langgraph/README.md
+++ b/examples/agent_framework_integrations/langgraph/README.md
@@ -46,3 +46,7 @@ curl -X POST http://localhost:8000/invoke \
 - **Built-in Tools**: Search and calculation capabilities
 - **Real-time Deployment**: Deploy as HTTP API for instant responses
 - **ZenML Orchestration**: Full pipeline tracking and artifact management
+
+## 🔁 Recording runs with Kitaru
+
+This example builds its agent with `langchain.agents.create_agent`, which is exactly the shape [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — records in production: install `kitaru-langgraph` and pass `create_agent` itself, plus the arguments this example gives it, to `KitaruGraphRunner.from_agent_factory(...)`. Every run becomes a session you can replay against your real code with one thing changed — a cheaper model, a different prompt — and diff against the original. Going through the factory is what buys model and prompt substitution; wrapping an already compiled graph records but replays less. See the [LangGraph adapter docs](https://docs.zenml.io/kitaru/adapters/langgraph) for the capability matrix.

--- a/examples/agent_framework_integrations/openai_agents_sdk/README.md
+++ b/examples/agent_framework_integrations/openai_agents_sdk/README.md
@@ -72,3 +72,7 @@ curl -X POST http://localhost:8000/invoke \
 - **Tracing & Monitoring**: Comprehensive execution tracking
 - **Real-time Deployment**: Deploy as HTTP API for instant responses
 - **ZenML Orchestration**: Full pipeline tracking and artifact management
+
+## 🔁 Recording runs with Kitaru
+
+The pipeline invokes the agent through the SDK's `Runner`. In production, swap it for `KitaruRunner` from the `kitaru-openai-agents` package and every run is recorded as a replayable session by [Kitaru](https://docs.zenml.io/kitaru), ZenML's sibling project for agents — then replay a real run against your real code with one thing changed and diff the pair. See the [OpenAI Agents SDK adapter docs](https://docs.zenml.io/kitaru/adapters/openai-agents).

--- a/examples/agent_framework_integrations/pydanticai/README.md
+++ b/examples/agent_framework_integrations/pydanticai/README.md
@@ -46,3 +46,7 @@ curl -X POST http://localhost:8000/invoke \
 - **Tool Integration**: Built-in support for function calling
 - **Real-time Deployment**: Deploy as HTTP API for instant responses
 - **ZenML Orchestration**: Full pipeline tracking and artifact management
+
+## 🔁 Recording runs with Kitaru
+
+This pipeline runs the agent for a batch workload. When the same agent runs in production, [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — can record every run as a replayable session: install `kitaru-pydantic-ai` and wrap the agent in `KitaruAgent`, which is a transparent wrapper (`run_sync`, tools, and output types behave exactly as before). You can then replay a real run against your real code with one thing changed — a cheaper model, a different prompt — and diff the pair. See the [PydanticAI adapter docs](https://docs.zenml.io/kitaru/adapters/pydantic-ai).

--- a/examples/agent_outer_loop/README.md
+++ b/examples/agent_outer_loop/README.md
@@ -185,6 +185,7 @@ quickstart/
 This quickstart shows the foundation. In production, you might:
 
 - **Collect real conversation data** from agent interactions via tracing tools like Langfuse, Datadog, etc.
+- **Turn those traces into tests** with [Kitaru](https://docs.zenml.io/kitaru), ZenML's sibling project for agents: `kitaru-langfuse-importer` imports Langfuse traces as sessions you can replay against your real code with one thing changed, so a failure you saw in production becomes a check you can rerun ([importing your traces](https://docs.zenml.io/kitaru/getting-started/import-your-traces))
 - **Fine-tune larger models** (DistilBERT, small LLMs) for better accuracy
 - **A/B test model versions** by deploying different tagged artifacts
 - **Deploy to any cloud infrastructure** with [stacks](https://docs.zenml.io/stacks)

--- a/examples/deploying_agent/README.md
+++ b/examples/deploying_agent/README.md
@@ -198,6 +198,8 @@ examples/minimal_agent_production/
 
 This is the same **steps → pipeline → artifacts** pattern you use for classic ML, now applied to an LLM workflow. You get deployable endpoints, reproducibility, and dashboard artifacts without building a bespoke web service.
 
+Once the endpoint is live, ZenML gives you a run and its artifacts for every request. If the workflow grows past a single LLM call into an agent loop with tools and multiple turns, [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — is the other half: it records each agent run as a session you can replay against your real code with one thing changed, and diff the pair. It has adapters for PydanticAI, LangGraph and the OpenAI Agents SDK, and importers if you already send traces to Langfuse, LangSmith, Braintrust, Logfire or Arize Phoenix.
+
 ---
 
 **Want to learn more?**
@@ -205,5 +207,6 @@ This is the same **steps → pipeline → artifacts** pattern you use for classi
 - 📖 [Full ZenML Documentation](https://docs.zenml.io/)
 - 🔗 [ZenML Pipelines](https://docs.zenml.io/concepts/steps_and_pipelines)
 - 🚀 [Pipeline Deployments](https://docs.zenml.io/concepts/deployment)
+- 🔁 [Kitaru](https://docs.zenml.io/kitaru) — record and replay agent runs
 - 💬 [Join our Community](https://zenml.io/slack)
 - 🏢 [ZenML Pro](https://zenml.io/pro)

--- a/examples/sandbox_pydantic_ai/README.md
+++ b/examples/sandbox_pydantic_ai/README.md
@@ -100,6 +100,10 @@ print(run.steps["reducer_step"].outputs["final_answer"][0].load())
 - **Make subagents independent.** The planner's system prompt insists on no shared state; if you write a leading query that implies a pipeline, the planner may still produce dependent subtasks and you'll see "file not found" errors from subagents 2+.
 - **Richer base image.** The default Modal image is `python:3.11-slim` — bare Python. The agent's system prompt teaches it to `pip install` on demand, and `prep_step` does this once and snapshots. To skip the snapshot dance, pass a pre-built sci-py image in `ModalSandboxSettings(image="ghcr.io/your-org/scipy-base:latest")` on the relevant step.
 
+## Recording runs with Kitaru
+
+The agents here run inside a pipeline, which is the right shape for a batch fan-out. If the same PydanticAI agent runs in production, [Kitaru](https://docs.zenml.io/kitaru) — ZenML's sibling project for agents — records each run as a replayable session: install `kitaru-pydantic-ai` and wrap the agent in `KitaruAgent`, a transparent wrapper that leaves `run_sync`, tools and output types untouched. A recorded run can then be replayed against your real code with one thing changed, and a [tool policy](https://docs.zenml.io/kitaru/guides/tool-policies) decides whether each tool call is answered from the session or executed live — worth setting deliberately when the tools write files and run shell commands, as they do here. See the [PydanticAI adapter docs](https://docs.zenml.io/kitaru/adapters/pydantic-ai).
+
 ## Cloud orchestrators
 
 The default `orchestrator: default` runs the agent steps on your local Python. To run on a remote orchestrator (Kubernetes, SageMaker, Vertex…), the pipeline's `DockerSettings` bakes the example's requirements into the step image. No extra env wiring is needed for the OpenAI key: the `--secret=openai` attached to the sandbox component is resolved into the step environment at runtime, on any orchestrator.


### PR DESCRIPTION
## Describe changes

Docs-only. Kitaru is already visible at the top of the funnel (introduction, Learn overview, first AI pipeline, component guide, README). This adds mid-funnel pointers in the places where a reader is already doing the thing Kitaru does, and nowhere else — no mentions were added to the RAG/reranking/embedding pages, where they would read as an ad.

Docs (`docs/book/`):

- `user-guide/llmops-guide/evaluation/README.md` — the section is entirely offline evals on a dataset you assembled. One paragraph names the other starting point (production runs that went wrong) and links Kitaru's regression-suite guide and evaluators.
- `user-guide/llmops-guide/finetuning-llms/evaluation-for-finetuning.md` — the page already lists LangSmith/Langfuse/Braintrust/Weave; one paragraph notes Kitaru has importers for exactly those and links `getting-started/import-your-traces`.
- `reference/llms-txt.md` — new "Kitaru's coding-agent tooling" subsection covering `uv add "kitaru[mcp]"` / `kitaru-mcp` (with its capability modes) and `zenml-io/kitaru-skills`, next to the existing ZenML MCP + Agent Skills material.

Examples: no boilerplate pasted across all 22 agent examples. Each mention is specific to what that example actually builds, appended to its existing closing section.

- Exact adapter exists → `pydanticai` (`KitaruAgent`), `langgraph` (`KitaruGraphRunner.from_agent_factory` with the same `create_agent` factory), `openai_agents_sdk` (`KitaruRunner`), `sandbox_pydantic_ai` (adds the tool-policy caveat, since those tools write files and run shell commands), and `langchain` (LCEL today, so the note says the LangGraph adapter is the path once it becomes an agent).
- Already wires up Langfuse → `agent_comparison` and `agent_outer_loop` get the `kitaru-langfuse-importer` line rather than a generic blurb.
- Everything else → one section in the parent `agent_framework_integrations/README.md` explaining the two ways in (adapters vs. importers, plus custom adapters for unsupported frameworks) and a Kitaru row in its Learn More table, instead of repeating it in each unsupported framework's README. `deploying_agent` gets a note since it is the deployed-agent example.

Every claim and URL was checked against the Kitaru docs source (adapter entry points, importer package names, MCP capability modes, skills install commands, page paths). No ToC changes — no pages added or removed.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (documentation only)


Link to Devin session: https://app.devin.ai/sessions/231a5be02a214e03966285ae7b315c52
Open in Devin Desktop: https://app.devin.ai/desktop/session/231a5be02a214e03966285ae7b315c52?variant=devin
Requested by: @strickvl