### PR TITLE
Clear standing CI reds: bump `mkdocs-material`, pin zizmor, skip Docker tests for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,15 @@ updates:
     cooldown:
       default-days: 7
     target-branch: develop
+  # Only the zizmor pin lives here; scoping to this directory keeps Dependabot
+  # away from the root pyproject.toml dependency tree.
+  - package-ecosystem: pip
+    directory: /.github/zizmor
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: Europe/Amsterdam
+    reviewers: [strickvl]
+    labels: [dependencies, internal, no-release-notes]
+    target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,8 @@ updates:
       timezone: Europe/Amsterdam
     reviewers: [strickvl]
     labels: [dependencies, internal, no-release-notes]
+    # Must exceed the 3-day `exclude-newer` window in pyproject.toml: uvx reads
+    # that config from the repo root, so a pin newer than 3 days is unresolvable.
+    cooldown:
+      default-days: 7
     target-branch: develop

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -73,7 +73,7 @@ jobs:
     # so we disable template updates for those PRs / branches
     if: github.event.pull_request.head.repo.full_name == 'zenml-io/zenml' && github.event.pull_request.draft
       == false
-    uses: $/.github/workflows/update-templates-to-examples.yml
+    uses: ./.github/workflows/update-templates-to-examples.yml
     with:
       python-version: '3.11'
       os: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: $/.github/workflows/linting.yml
+    uses: ./.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -102,7 +102,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -123,7 +123,7 @@ jobs:
         # Skip it there instead of burning six jobs per bot PR.
         test_environment: ${{ github.actor == 'dependabot[bot]' && fromJSON('["default"]') || fromJSON('["default", "docker-server-docker-orchestrator-mysql"]') }}
       fail-fast: false
-    uses: $/.github/workflows/integration-test-fast.yml
+    uses: ./.github/workflows/integration-test-fast.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -73,7 +73,7 @@ jobs:
     # so we disable template updates for those PRs / branches
     if: github.event.pull_request.head.repo.full_name == 'zenml-io/zenml' && github.event.pull_request.draft
       == false
-    uses: ./.github/workflows/update-templates-to-examples.yml
+    uses: $/.github/workflows/update-templates-to-examples.yml
     with:
       python-version: '3.11'
       os: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: ./.github/workflows/linting.yml
+    uses: $/.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -102,7 +102,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -123,7 +123,7 @@ jobs:
         # Skip it there instead of burning six jobs per bot PR.
         test_environment: ${{ github.actor == 'dependabot[bot]' && fromJSON('["default"]') || fromJSON('["default", "docker-server-docker-orchestrator-mysql"]') }}
       fail-fast: false
-    uses: ./.github/workflows/integration-test-fast.yml
+    uses: $/.github/workflows/integration-test-fast.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -73,7 +73,7 @@ jobs:
     # so we disable template updates for those PRs / branches
     if: github.event.pull_request.head.repo.full_name == 'zenml-io/zenml' && github.event.pull_request.draft
       == false
-    uses: ./.github/workflows/update-templates-to-examples.yml
+    uses: $/.github/workflows/update-templates-to-examples.yml
     with:
       python-version: '3.11'
       os: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: ./.github/workflows/linting.yml
+    uses: $/.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -102,7 +102,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -118,9 +118,12 @@ jobs:
         # here, please adjust the configuration of `ci-slow` accordingly.
         os: [ubuntu-latest]
         python-version: ['3.11']
-        test_environment: [default, docker-server-docker-orchestrator-mysql]
+        # Dependabot-triggered runs read the (empty) Dependabot secrets store,
+        # so the Docker Hub login this environment needs can never succeed.
+        # Skip it there instead of burning six jobs per bot PR.
+        test_environment: ${{ github.actor == 'dependabot[bot]' && fromJSON('["default"]') || fromJSON('["default", "docker-server-docker-orchestrator-mysql"]') }}
       fail-fast: false
-    uses: ./.github/workflows/integration-test-fast.yml
+    uses: $/.github/workflows/integration-test-fast.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -183,7 +183,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/linting.yml
+    uses: ./.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -196,7 +196,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -209,7 +209,7 @@ jobs:
         os: [windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/linting.yml
+    uses: ./.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -222,7 +222,7 @@ jobs:
         os: [windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
         os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/linting.yml
+    uses: ./.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -248,7 +248,7 @@ jobs:
         os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -264,7 +264,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         test_environment: [default]
       fail-fast: false
-    uses: $/.github/workflows/integration-test-slow.yml
+    uses: ./.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -279,7 +279,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         test_environment: [default]
       fail-fast: false
-    uses: $/.github/workflows/integration-test-slow.yml
+    uses: ./.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -315,7 +315,7 @@ jobs:
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.14'
       fail-fast: false
-    uses: $/.github/workflows/integration-test-slow.yml
+    uses: ./.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -324,7 +324,7 @@ jobs:
   vscode-tutorial-pipelines-test:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
-    uses: $/.github/workflows/vscode-tutorial-pipelines-test.yml
+    uses: ./.github/workflows/vscode-tutorial-pipelines-test.yml
     secrets: inherit
   ubuntu-base-package-functionality:
     needs: run-slow-ci-label-is-set
@@ -334,7 +334,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: $/.github/workflows/base-package-functionality.yml
+    uses: ./.github/workflows/base-package-functionality.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}

--- a/.github/workflows/ci-slow.yml
+++ b/.github/workflows/ci-slow.yml
@@ -183,7 +183,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/linting.yml
+    uses: $/.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -196,7 +196,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -209,7 +209,7 @@ jobs:
         os: [windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/linting.yml
+    uses: $/.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -222,7 +222,7 @@ jobs:
         os: [windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -235,7 +235,7 @@ jobs:
         os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/linting.yml
+    uses: $/.github/workflows/linting.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -248,7 +248,7 @@ jobs:
         os: [macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}
@@ -264,7 +264,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         test_environment: [default]
       fail-fast: false
-    uses: ./.github/workflows/integration-test-slow.yml
+    uses: $/.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -279,7 +279,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         test_environment: [default]
       fail-fast: false
-    uses: ./.github/workflows/integration-test-slow.yml
+    uses: $/.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -315,7 +315,7 @@ jobs:
           - test_environment: docker-server-docker-orchestrator-mariadb
             python-version: '3.14'
       fail-fast: false
-    uses: ./.github/workflows/integration-test-slow.yml
+    uses: $/.github/workflows/integration-test-slow.yml
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -324,7 +324,7 @@ jobs:
   vscode-tutorial-pipelines-test:
     if: github.event.pull_request.draft == false
     needs: run-slow-ci-label-is-set
-    uses: ./.github/workflows/vscode-tutorial-pipelines-test.yml
+    uses: $/.github/workflows/vscode-tutorial-pipelines-test.yml
     secrets: inherit
   ubuntu-base-package-functionality:
     needs: run-slow-ci-label-is-set
@@ -334,7 +334,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.11']
       fail-fast: false
-    uses: ./.github/workflows/base-package-functionality.yml
+    uses: $/.github/workflows/base-package-functionality.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}

--- a/.github/workflows/generate-test-duration.yml
+++ b/.github/workflows/generate-test-duration.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: develop
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: '3.10'
           os: ubuntu-latest

--- a/.github/workflows/generate-test-duration.yml
+++ b/.github/workflows/generate-test-duration.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: develop
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           python-version: '3.10'
           os: ubuntu-latest

--- a/.github/workflows/integration-test-fast-services.yml
+++ b/.github/workflows/integration-test-fast-services.yml
@@ -153,7 +153,7 @@ jobs:
           'docker') || contains(inputs.test_environment, 'kubeflow') || contains(inputs.test_environment,
           'airflow') || contains(inputs.test_environment, 'kubernetes'))
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-fast-services.yml
+++ b/.github/workflows/integration-test-fast-services.yml
@@ -153,7 +153,7 @@ jobs:
           'docker') || contains(inputs.test_environment, 'kubeflow') || contains(inputs.test_environment,
           'airflow') || contains(inputs.test_environment, 'kubernetes'))
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -203,7 +203,7 @@ jobs:
           'docker') || contains(inputs.test_environment, 'kubeflow') || contains(inputs.test_environment,
           'airflow') || contains(inputs.test_environment, 'kubernetes'))
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-fast.yml
+++ b/.github/workflows/integration-test-fast.yml
@@ -203,7 +203,7 @@ jobs:
           'docker') || contains(inputs.test_environment, 'kubeflow') || contains(inputs.test_environment,
           'airflow') || contains(inputs.test_environment, 'kubernetes'))
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-slow-services.yml
+++ b/.github/workflows/integration-test-slow-services.yml
@@ -144,7 +144,7 @@ jobs:
           install_components: gke-gcloud-auth-plugin
         if: contains(inputs.test_environment, 'gcp')
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-slow-services.yml
+++ b/.github/workflows/integration-test-slow-services.yml
@@ -144,7 +144,7 @@ jobs:
           install_components: gke-gcloud-auth-plugin
         if: contains(inputs.test_environment, 'gcp')
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -201,7 +201,7 @@ jobs:
           install_components: gke-gcloud-auth-plugin
         if: contains(inputs.test_environment, 'gcp')
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/integration-test-slow.yml
+++ b/.github/workflows/integration-test-slow.yml
@@ -201,7 +201,7 @@ jobs:
           install_components: gke-gcloud-auth-plugin
         if: contains(inputs.test_environment, 'gcp')
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           python-version: ${{ inputs.python-version }}
           os: ${{ inputs.os }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ inputs.os == 'macos-latest' || inputs.os == 'macos-13' }}
         run: brew install libomp
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -108,7 +108,7 @@ jobs:
         if: ${{ inputs.os == 'macos-latest' || inputs.os == 'macos-13' }}
         run: brew install libomp
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -7,7 +7,7 @@ on:
     - cron: 30 0 * * *
 jobs:
   setup-and-test:
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
       python-version: '3.11'
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'zenml-io/zenml'
   build-nightly-python-package:
     needs: setup-and-test
-    uses: $/.github/workflows/publish_to_pypi_nightly.yml
+    uses: ./.github/workflows/publish_to_pypi_nightly.yml
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'
   publish-nightly-python-package:
@@ -46,7 +46,7 @@ jobs:
   publish-docker-image:
     if: github.repository == 'zenml-io/zenml'
     needs: wait-for-package-release
-    uses: $/.github/workflows/publish_docker_image.yml
+    uses: ./.github/workflows/publish_docker_image.yml
     with:
       config_file: release-cloudbuild-nightly.yaml
       zenml_nightly: true

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -7,7 +7,7 @@ on:
     - cron: 30 0 * * *
 jobs:
   setup-and-test:
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
       python-version: '3.11'
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'zenml-io/zenml'
   build-nightly-python-package:
     needs: setup-and-test
-    uses: ./.github/workflows/publish_to_pypi_nightly.yml
+    uses: $/.github/workflows/publish_to_pypi_nightly.yml
     secrets: inherit
     if: github.repository == 'zenml-io/zenml'
   publish-nightly-python-package:
@@ -46,7 +46,7 @@ jobs:
   publish-docker-image:
     if: github.repository == 'zenml-io/zenml'
     needs: wait-for-package-release
-    uses: ./.github/workflows/publish_docker_image.yml
+    uses: $/.github/workflows/publish_docker_image.yml
     with:
       config_file: release-cloudbuild-nightly.yaml
       zenml_nightly: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   ZENML_ANALYTICS_OPT_IN: false
 jobs:
   setup-and-test:
-    uses: $/.github/workflows/unit-test.yml
+    uses: ./.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
       python-version: '3.11'
@@ -120,12 +120,12 @@ jobs:
   publish-docker-image:
     if: github.repository == 'zenml-io/zenml'
     needs: wait-for-package-release
-    uses: $/.github/workflows/publish_docker_image.yml
+    uses: ./.github/workflows/publish_docker_image.yml
     secrets: inherit
   publish-helm-chart:
     if: github.repository == 'zenml-io/zenml'
     needs: publish-docker-image
-    uses: $/.github/workflows/publish_helm_chart.yml
+    uses: ./.github/workflows/publish_helm_chart.yml
     secrets: inherit
   wait-for-package-release-again:
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
   publish-stack-templates:
     if: github.repository == 'zenml-io/zenml'
     needs: publish-python-package
-    uses: $/.github/workflows/publish_stack_templates.yml
+    uses: ./.github/workflows/publish_stack_templates.yml
     secrets: inherit
   # create a tag on the ZenML cloud plugins repo
   create_tag_on_cloud_plugins_repo:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   ZENML_ANALYTICS_OPT_IN: false
 jobs:
   setup-and-test:
-    uses: ./.github/workflows/unit-test.yml
+    uses: $/.github/workflows/unit-test.yml
     with:
       os: ubuntu-latest
       python-version: '3.11'
@@ -120,12 +120,12 @@ jobs:
   publish-docker-image:
     if: github.repository == 'zenml-io/zenml'
     needs: wait-for-package-release
-    uses: ./.github/workflows/publish_docker_image.yml
+    uses: $/.github/workflows/publish_docker_image.yml
     secrets: inherit
   publish-helm-chart:
     if: github.repository == 'zenml-io/zenml'
     needs: publish-docker-image
-    uses: ./.github/workflows/publish_helm_chart.yml
+    uses: $/.github/workflows/publish_helm_chart.yml
     secrets: inherit
   wait-for-package-release-again:
     runs-on: ubuntu-latest
@@ -137,7 +137,7 @@ jobs:
   publish-stack-templates:
     if: github.repository == 'zenml-io/zenml'
     needs: publish-python-package
-    uses: ./.github/workflows/publish_stack_templates.yml
+    uses: $/.github/workflows/publish_stack_templates.yml
     secrets: inherit
   # create a tag on the ZenML cloud plugins repo
   create_tag_on_cloud_plugins_repo:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ inputs.os == 'macos-latest' || inputs.os == 'macos-13' }}
         run: brew install libomp
       - name: Setup environment
-        uses: $/.github/actions/setup_environment
+        uses: ./.github/actions/setup_environment
         with:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ inputs.os == 'macos-latest' || inputs.os == 'macos-13' }}
         run: brew install libomp
       - name: Setup environment
-        uses: ./.github/actions/setup_environment
+        uses: $/.github/actions/setup_environment
         with:
           cache_version: ${{ secrets.GH_ACTIONS_CACHE_KEY }}
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,12 +3,13 @@ name: GitHub Actions Security Analysis
 on:
   push:
     branches: [main, develop]
-    paths: [.github/workflows/**, .github/zizmor.yml]
+    paths: [.github/workflows/**, .github/zizmor.yml, .github/zizmor/requirements.txt]
   pull_request:
     branches: [main, develop]
     paths:
       - .github/workflows/**
       - .github/zizmor.yml
+      - .github/zizmor/requirements.txt
   # Weekly safety net to catch drift (runs Monday 3am UTC)
   schedule:
     - cron: 0 3 * * 1
@@ -45,12 +46,12 @@ jobs:
           echo ""
           echo "📖 To run locally and see detailed output:"
           echo ""
-          echo "    GH_TOKEN=\$(gh auth token) uvx zizmor@1.30.0 --config=.github/zizmor.yml .github/workflows/"
+          echo "    GH_TOKEN=\$(gh auth token) uvx --constraints .github/zizmor/requirements.txt zizmor --config=.github/zizmor.yml .github/workflows/"
           echo ""
           echo "📖 Documentation: https://docs.zizmor.sh/"
           echo "📖 Config: .github/zizmor.yml"
           echo "============================================================"
           echo ""
-          uvx zizmor@1.30.0 --format=github --config=.github/zizmor.yml .github/workflows/
+          uvx --constraints .github/zizmor/requirements.txt zizmor --format=github --config=.github/zizmor.yml .github/workflows/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -45,12 +45,12 @@ jobs:
           echo ""
           echo "📖 To run locally and see detailed output:"
           echo ""
-          echo "    GH_TOKEN=\$(gh auth token) uvx zizmor --config=.github/zizmor.yml .github/workflows/"
+          echo "    GH_TOKEN=\$(gh auth token) uvx zizmor@1.30.0 --config=.github/zizmor.yml .github/workflows/"
           echo ""
           echo "📖 Documentation: https://docs.zizmor.sh/"
           echo "📖 Config: .github/zizmor.yml"
           echo "============================================================"
           echo ""
-          uvx zizmor --format=github --config=.github/zizmor.yml .github/workflows/
+          uvx zizmor@1.30.0 --format=github --config=.github/zizmor.yml .github/workflows/
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,10 @@ name: GitHub Actions Security Analysis
 on:
   push:
     branches: [main, develop]
-    paths: [.github/workflows/**, .github/zizmor.yml, .github/zizmor/requirements.txt]
+    paths:
+      - .github/workflows/**
+      - .github/zizmor.yml
+      - .github/zizmor/requirements.txt
   pull_request:
     branches: [main, develop]
     paths:

--- a/.github/zizmor/requirements.txt
+++ b/.github/zizmor/requirements.txt
@@ -1,0 +1,4 @@
+# Pin for the zizmor workflow scanner. Dependabot (pip ecosystem, scoped to
+# this directory) bumps it, so new audit rules arrive as reviewable PRs
+# instead of turning `develop` red on release day.
+zizmor==1.30.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,7 @@ dev = [
     "pytest-rerunfailures>=16.1,<17.0.0",
     "pytest-split>=0.11.0,<0.12.0",
     "mkdocs>=1.6.1,<2.0.0",
-    "mkdocs-material==9.6.8",
+    "mkdocs-material==9.7.7",
     "mkdocs-awesome-pages-plugin>=2.10.1,<3.0.0",
     "mkdocstrings[python]>=0.28.1,<1.0.0",
     "mkdocstrings-python",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -57,7 +57,7 @@ if [ "$SKIP_ZIZMOR" = false ] && [ -d ".github/workflows" ]; then
 
     if [ -n "$GH_TOKEN" ]; then
         export GH_TOKEN
-        uvx zizmor --config=.github/zizmor.yml .github/workflows/
+        uvx --constraints .github/zizmor/requirements.txt zizmor --config=.github/zizmor.yml .github/workflows/
     else
         echo "⚠️  Skipping zizmor check: no GH_TOKEN and gh CLI not authenticated."
         echo "   Run: GH_TOKEN=\$(gh auth token) bash scripts/lint.sh"


### PR DESCRIPTION
## Why

Triaging this week's Dependabot PRs (#5210, #5211, #5212) showed that most of their red checks are pre-existing on `develop` and not caused by any bump. This PR fixes the three that are fixable here. Each is independent; they share a PR because they're all small CI-hygiene changes with one root cause each.

## What

### 1. `Gate dependency audit result` — real vulnerability, blocked by a pin
- `pymdown-extensions` 10.21.3 has a **high-severity ReDoS** ([CVE-2026-67422](https://github.com/advisories/GHSA-gm37-52c6-37mw), fix in 11.0.1). A single hostile Markdown line under 50 bytes drives `markdown.markdown()` into unbounded CPU. Our exposure is the docs build only, but the audit gate has been red on `develop`'s schedule since at least Aug 3.
- The upgrade was blocked by `mkdocs-material==9.6.8`, which declares `pymdown-extensions~=10.2`. `mkdocs-material` 9.7.7 relaxes that to `>=10.2`, so bumping it lets the resolver pick `pymdown-extensions` 11.x (verified locally: 11.0.2; the audit on this PR went from 3 findings to 1).
- `mkdocs-material` 9.7 is its final feature release (project is in maintenance mode; Insiders features folded in). `api-docs-test` on this PR builds the site with the new version.
- Still red after this: the `click` 8.2.1 finding, whose severity the gate can't resolve (GitHub advisory API 404s) and whose fix is capped by our own `click<=8.2.1` pin. ZenML never calls `click.edit()`, so no real exposure — but it needs its own decision.

### 2. `Scan workflows with zizmor` — unpinned tool drift
- `uvx zizmor` was unpinned. zizmor 1.30.0 added the `self-repository` audit, which flags all 29 `uses: ./...` references to in-repo actions/reusable workflows. That alone has made the check red on every `develop` push since Aug 14.
- Applied zizmor's own safe fix: `./` → `$/`, GitHub's [self-repository syntax](https://docs.zizmor.sh/audits/#self-repository) (supported since July 2026). It resolves to the same commit as the workflow, but unlike `./` it can't be hijacked by a directory cloned at runtime in an earlier step, and GitHub treats it as "pinned" for policy purposes.
- **Pinned zizmor in a way Dependabot can see.** A version inside a shell line would go stale silently (Dependabot only reads manifests), so the pin lives in `.github/zizmor/requirements.txt`, consumed via `uvx --constraints`. A new `pip` Dependabot entry scoped to `directory: /.github/zizmor` bumps it weekly — scoping keeps Dependabot away from the root `pyproject.toml` dependency tree. The file is also added to the zizmor workflow's `paths` triggers, so each bump PR runs the scanner and shows exactly what any new audit rule flags, *before* it reaches `develop`. `scripts/lint.sh` consumes the same constraints file, so local and CI runs resolve the identical zizmor version.
- **The Dependabot entry has a 7-day `cooldown`** because `uvx` run from the repo root picks up `pyproject.toml`'s `[tool.uv] exclude-newer = "3 days"`. Without the cooldown, a zizmor release landing within three days of the Tuesday run would be pinned by Dependabot but unresolvable by uv, failing the very PR that bumps it (and uv reports that as "no compatible version", with no hint about the window).
- The `ref-version-mismatch` finding on `cardinalby/schema-validator-action` was fixed by #5211 (merged). zizmor is green on this PR.

### 3. Docker integration tests on Dependabot PRs — can never pass
- Dependabot-triggered workflows read the *Dependabot* secrets store, which is empty here (`Secret source: Dependabot` in the logs). `docker/login-action` fails "Username and password required" after ~2 min, six times per bot PR.
- `ci-fast.yml` now drops the `docker-server-docker-orchestrator-mysql` matrix entry when `github.actor == 'dependabot[bot]'`. Human PRs are unchanged.

## Reviewer notes
- The `./` → `$/` change touches 12 workflow files but is mechanical; the CI run on this PR exercises the reusable-workflow calls (`linting`, `unit-test`, `integration-test-fast`, `update-templates-to-examples`) via the new syntax, and they run fine.
- Commit history note: `706287066c` reverted `$/` back to `./` on the strength of a Codex review finding that turned out to be a false positive (its knowledge predates the July 2026 syntax); `8f3067eaea` reverts that revert. Net effect on the diff: none, `$/` throughout.
- `zizmor.yml`'s `paths` list is reformatted from inline to block style only because yamlfix's line-width limit kicked in once the third path was added.
- `integration-test-{fast,slow}-services.yml` are excluded from yamlfix in `scripts/lint.sh`; I only changed the `uses:` line there, no reformatting.
- Local `bash scripts/generate-docs.sh` fails identically with the old and new `mkdocs-material` pin (a `sys_modules_mock` vs numpy issue in my environment), so CI's `api-docs-test` is the verification for the docs build — it passed.

