### PR TITLE
Add ClickUp webhook provider

### DIFF
--- a/docs/book/getting-started/zenml-pro/toc.md
+++ b/docs/book/getting-started/zenml-pro/toc.md
@@ -39,6 +39,7 @@
 * [Triggers](triggers.md)
 * [Webhooks](webhooks.md)
   * [GitHub](webhooks/github.md)
+  * [ClickUp](webhooks/clickup.md)
   * [Custom webhooks](webhooks/custom.md)
 * [Resource Pools](resource-pools.md)
   * [Core Concepts](resource-pools-core-concepts.md)

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -725,9 +725,8 @@ Via the SDK, use the typed ClickUp configuration and event model:
 ```python
 from zenml.client import Client
 from zenml.webhooks.providers.clickup import (
-    ClickUpTargetEvent,
     ClickUpWebhookConfiguration,
-    ClickUpWebhookEvent,
+    TaskStatusUpdated,
 )
 
 client = Client()
@@ -736,8 +735,7 @@ trigger = client.create_webhook_trigger(
     webhook="clickup-ops",
     configuration=ClickUpWebhookConfiguration(
         target_events=[
-            ClickUpTargetEvent(
-                type=ClickUpWebhookEvent.TASK_STATUS_UPDATED,
+            TaskStatusUpdated(
                 list_id="162641285",
                 status="done",
             )

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -697,6 +697,64 @@ GitHub supports `merged_pull_request`, `workflow_run_completed`, `push`,
 for all fields, supported string-filter operators, and another configuration
 example.
 
+### ClickUp webhook triggers
+
+This example executes a pipeline snapshot when ClickUp reports that a task in
+one list moved to `done`. First, create and configure the ClickUp webhook by
+following [ClickUp webhooks](webhooks/clickup.md).
+
+Create `clickup-status.yaml`:
+
+```yaml
+target_events:
+  - type: taskStatusUpdated
+    list_id: "162641285"
+    status: done
+```
+
+Then create the trigger and select the owning webhook:
+
+```bash
+zenml trigger webhook create on-task-done \
+  --webhook clickup-ops \
+  --config clickup-status.yaml
+```
+
+Via the SDK, use the typed ClickUp configuration and event model:
+
+```python
+from zenml.client import Client
+from zenml.webhooks.providers.clickup import (
+    ClickUpTargetEvent,
+    ClickUpWebhookConfiguration,
+    ClickUpWebhookEvent,
+)
+
+client = Client()
+trigger = client.create_webhook_trigger(
+    name="on-task-done",
+    webhook="clickup-ops",
+    configuration=ClickUpWebhookConfiguration(
+        target_events=[
+            ClickUpTargetEvent(
+                type=ClickUpWebhookEvent.TASK_STATUS_UPDATED,
+                list_id="162641285",
+                status="done",
+            )
+        ]
+    ),
+)
+```
+
+ClickUp supports task and list semantic events such as `taskCreated`,
+`taskStatusUpdated`, and `listUpdated`. See the provider's
+[supported events and filters](webhooks/clickup.md#supported-events-and-filters)
+for all fields and supported string-filter operators.
+
+Attach the trigger to a snapshot as shown below, then follow the
+[signed ClickUp mock request](webhooks/clickup.md#mock-a-signed-clickup-delivery)
+to test the intake path.
+
 ### Attach the trigger to a snapshot
 
 A matching webhook trigger dispatches only the snapshots attached to it. In

--- a/docs/book/getting-started/zenml-pro/webhooks.md
+++ b/docs/book/getting-started/zenml-pro/webhooks.md
@@ -7,8 +7,8 @@ icon: webhook
 
 Webhooks connect external systems to ZenML so that your ZenML deployment can
 react to events that happen outside the platform. For example, you can receive
-an event when a pull request is merged in GitHub, when a GitHub Actions workflow
-finishes, or when an internal service publishes a new model version.
+an event when a pull request is merged in GitHub, when a ClickUp task changes
+status, or when an internal service publishes a new model version.
 
 When you create a webhook, ZenML exposes a project-scoped intake URL. Configure
 the external system to send signed HTTP requests to that URL.
@@ -21,9 +21,9 @@ For every delivery, the webhook endpoint:
 4. makes an accepted event available to configured consumers.
 
 Consumers define how ZenML reacts to accepted events. For example, a
-[webhook trigger](triggers.md#webhook-triggers) can filter GitHub events and
-execute attached pipeline snapshots when a pull request is merged or a branch
-is pushed.
+[webhook trigger](triggers.md#webhook-triggers) can filter GitHub or ClickUp
+events and execute attached pipeline snapshots when a pull request is merged
+or a task status changes.
 
 The endpoint returns an HTTP response to the sender. A valid delivery normally
 returns `202 Accepted`; an invalid signature, invalid payload, missing webhook,
@@ -36,6 +36,7 @@ that intake decision.
 | Provider | Type | Authentication | Event model |
 |----------|------|----------------|-------------|
 | [GitHub](webhooks/github.md) | `github` | GitHub HMAC-SHA256 signature | Curated semantic GitHub events and string filters |
+| [ClickUp](webhooks/clickup.md) | `clickup` | ClickUp HMAC-SHA256 signature | Curated ClickUp task and list events and string filters |
 | [Custom webhooks](webhooks/custom.md) | `custom` | ZenML HMAC-SHA256 signature | User-supplied event name and JSON object |
 
 Provider pages describe the headers, event model, external setup, and manual
@@ -69,9 +70,9 @@ webhook = result
 print(webhook.endpoint_url)
 ```
 
-Provider types are string identifiers. ZenML includes `github` and `custom`;
-servers may register additional provider implementations, and reject provider
-types that are not registered.
+Provider types are string identifiers. ZenML includes `github`, `clickup`, and
+`custom`; servers may register additional provider implementations, and reject
+provider types that are not registered.
 
 The provider type determines how deliveries are authenticated and interpreted
 and cannot be changed after creation. By default, ZenML also generates a
@@ -275,8 +276,8 @@ the signature changes those bytes and causes authentication to fail.
 
 Provider-specific early handling can refine this behavior. For example, GitHub
 deliveries with a non-empty but unsupported `X-GitHub-Event` value return `202`
-without resolving a webhook. See the [GitHub provider](webhooks/github.md) for
-details.
+without resolving a webhook. See the [GitHub](webhooks/github.md) and
+[ClickUp](webhooks/clickup.md) providers for details.
 
 ## Inspect intake statistics
 
@@ -307,5 +308,6 @@ publication, pipeline run creation, or run outcomes.
 ## Next steps
 
 - [Configure a GitHub webhook](webhooks/github.md)
+- [Configure a ClickUp webhook](webhooks/clickup.md)
 - [Send custom webhook events](webhooks/custom.md)
 - [Execute snapshots with webhook triggers](triggers.md#webhook-triggers)

--- a/docs/book/getting-started/zenml-pro/webhooks/clickup.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/clickup.md
@@ -52,18 +52,20 @@ secret-management and rotation options.
 
 ClickUp does not provide a repository-style webhook settings page. Create the
 subscription with the [Create Webhook](https://developer.clickup.com/reference/createwebhook)
-API using a personal API token and your Workspace ID (`team_id`).
+API using a personal API token and your ClickUp Workspace ID.
 
-1. In ClickUp, open **Settings** > **Apps** and create a personal API token.
-2. Copy the Workspace ID for the Workspace that should send events.
+1. In ClickUp, open **Settings** and create a personal API token.
+2. Copy the Workspace ID for the Workspace that should send events. You can
+   also list authorized Workspaces with `GET https://api.clickup.com/api/v2/team`
+   and use the `id` of the Workspace you want.
 3. Send a `POST` request that points ClickUp at the ZenML endpoint URL.
 
 ```bash
 export CLICKUP_TOKEN="<personal-api-token>"
-export CLICKUP_TEAM_ID="<workspace-id>"
+export CLICKUP_WORKSPACE_ID="<workspace-id>"
 export WEBHOOK_URL="<endpoint-url-from-zenml>"
 
-curl -s -X POST "https://api.clickup.com/api/v2/team/${CLICKUP_TEAM_ID}/webhook" \
+curl -s -X POST "https://api.clickup.com/api/v2/team/${CLICKUP_WORKSPACE_ID}/webhook" \
   -H "Authorization: $CLICKUP_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{

--- a/docs/book/getting-started/zenml-pro/webhooks/clickup.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/clickup.md
@@ -133,12 +133,15 @@ qualifying payloads to ZenML semantic events with the same names:
 
 Event names match ClickUp's camelCase identifiers. Resource IDs are compared
 as strings, even when ClickUp sends a numeric `list_id`, `space_id`, or
-`folder_id`.
+`folder_id`. Each event type has its own typed target class, such as
+`TaskStatusUpdated` or `ListCreated`, so filters that do not apply to that
+event are rejected at configuration time.
 
-`status` is the post-change value from the last `history_items` entry: a
-string `after` value, or `after.status` when `after` is an object. It is
-typically present for `taskStatusUpdated`. If you filter on `status` and the
-payload has no after-value, the event does not match.
+`status` is only available on `taskStatusUpdated`. It is the post-change value
+from the last `history_items` entry: a string `after` value, or `after.status`
+when `after` is an object. If you filter on `status` and the payload has no
+after-value, the event does not match. List events do not accept `task_id`,
+and task events other than `taskStatusUpdated` do not accept `status`.
 
 A ClickUp event that is missing from this catalog can still authenticate and
 return `202 Accepted`. It is not mapped to a semantic event, so webhook

--- a/docs/book/getting-started/zenml-pro/webhooks/clickup.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/clickup.md
@@ -1,0 +1,235 @@
+---
+description: Configure and test ClickUp webhook delivery to ZenML.
+---
+
+# ClickUp webhooks
+
+The ClickUp webhook provider authenticates Workspace webhook deliveries and
+maps supported ClickUp payloads to a small catalog of semantic events. Consumers
+can use this provider-owned event model instead of depending on ClickUp's raw
+payload structure. [Webhook triggers](../triggers.md#webhook-triggers) are the
+currently documented consumer that exposes this event configuration.
+
+ClickUp registers webhooks through its API and generates the signing secret
+itself. Create the ZenML webhook first so you have an intake URL, then store
+ClickUp's secret on the ZenML webhook.
+
+## Create the webhook in ZenML
+
+Create a ClickUp webhook in the active project:
+
+```bash
+zenml webhook create clickup-ops --type clickup
+```
+
+Describe the webhook and copy its endpoint URL:
+
+```bash
+zenml webhook describe clickup-ops
+```
+
+Via the SDK:
+
+```python
+from zenml.client import Client
+from zenml.webhooks.providers import BuiltinWebhookType
+
+client = Client()
+result = client.create_webhook(
+    name="clickup-ops",
+    webhook_type=BuiltinWebhookType.CLICKUP,
+)
+
+endpoint_url = result.endpoint_url
+```
+
+You can ignore the generated ZenML secret. ClickUp will issue a different
+shared secret when you register the endpoint, and that is the value ZenML must
+verify. See [Create a webhook](../webhooks.md#create-a-webhook) for
+secret-management and rotation options.
+
+## Register the webhook in ClickUp
+
+ClickUp does not provide a repository-style webhook settings page. Create the
+subscription with the [Create Webhook](https://developer.clickup.com/reference/createwebhook)
+API using a personal API token and your Workspace ID (`team_id`).
+
+1. In ClickUp, open **Settings** > **Apps** and create a personal API token.
+2. Copy the Workspace ID for the Workspace that should send events.
+3. Send a `POST` request that points ClickUp at the ZenML endpoint URL.
+
+```bash
+export CLICKUP_TOKEN="<personal-api-token>"
+export CLICKUP_TEAM_ID="<workspace-id>"
+export WEBHOOK_URL="<endpoint-url-from-zenml>"
+
+curl -s -X POST "https://api.clickup.com/api/v2/team/${CLICKUP_TEAM_ID}/webhook" \
+  -H "Authorization: $CLICKUP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"endpoint\": \"$WEBHOOK_URL\",
+    \"events\": [
+      \"taskCreated\",
+      \"taskUpdated\",
+      \"taskDeleted\",
+      \"taskStatusUpdated\",
+      \"taskMoved\",
+      \"taskAssigneeUpdated\",
+      \"taskCommentPosted\",
+      \"listCreated\",
+      \"listUpdated\",
+      \"listDeleted\"
+    ]
+  }"
+```
+
+Copy `webhook.secret` from the response. You can optionally include `space_id`,
+`folder_id`, `list_id`, or `task_id` so ClickUp only sends events from one
+location. ZenML trigger filters still apply to whatever ClickUp delivers.
+
+ClickUp sends an `X-Signature` header containing a raw hexadecimal HMAC-SHA256
+digest of the exact request body. There is no `sha256=` prefix. ZenML verifies
+this signature before it parses or forwards the delivery.
+
+## Store ClickUp's signing secret
+
+Rotate the ZenML webhook secret to the value ClickUp returned. Until this step
+succeeds, real ClickUp deliveries fail authentication with `401 Unauthorized`.
+ClickUp [suspends the webhook](https://developer.clickup.com/docs/webhookhealth)
+after that response.
+
+```bash
+zenml webhook rotate-secret clickup-ops --secret "$CLICKUP_WEBHOOK_SECRET"
+```
+
+Via the SDK:
+
+```python
+import os
+
+client.rotate_webhook_secret(
+    "clickup-ops",
+    secret=os.environ["CLICKUP_WEBHOOK_SECRET"],
+)
+```
+
+## Supported events and filters
+
+The provider reads the ClickUp event name from the JSON `event` field and maps
+qualifying payloads to ZenML semantic events with the same names:
+
+| ClickUp event | ZenML semantic event | Available filter fields |
+|---------------|----------------------|------------------------|
+| Task created | `taskCreated` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| Task updated | `taskUpdated` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| Task deleted | `taskDeleted` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| Task status updated | `taskStatusUpdated` | `task_id`, `list_id`, `space_id`, `folder_id`, `status` |
+| Task moved | `taskMoved` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| Task assignee updated | `taskAssigneeUpdated` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| Task comment posted | `taskCommentPosted` | `task_id`, `list_id`, `space_id`, `folder_id` |
+| List created | `listCreated` | `list_id`, `space_id`, `folder_id` |
+| List updated | `listUpdated` | `list_id`, `space_id`, `folder_id` |
+| List deleted | `listDeleted` | `list_id`, `space_id`, `folder_id` |
+
+Event names match ClickUp's camelCase identifiers. Resource IDs are compared
+as strings, even when ClickUp sends a numeric `list_id`, `space_id`, or
+`folder_id`.
+
+`status` is the post-change value from the last `history_items` entry: a
+string `after` value, or `after.status` when `after` is an object. It is
+typically present for `taskStatusUpdated`. If you filter on `status` and the
+payload has no after-value, the event does not match.
+
+A ClickUp event that is missing from this catalog can still authenticate and
+return `202 Accepted`. It is not mapped to a semantic event, so webhook
+triggers do not match it. A missing or empty `event` or `webhook_id` field
+returns `400 Bad Request`.
+
+### String filters
+
+Semantic event fields use ZenML string filters (`StringFilterOption`). You can
+use:
+
+- a plain string for exact equality, such as `list_id: "162641285"`;
+- `oneof:` with a non-empty JSON list for exact alternatives, such as
+  `status: 'oneof:["done","complete"]'`.
+
+ClickUp ID and status fields do not support `startswith:`. Values configured for
+the same field use OR logic; different populated fields use AND logic. Omitted
+fields match any value. If a configured field is absent from a delivery, it
+does not match.
+
+For example, this target matches status updates to `done` on one list:
+
+```yaml
+target_events:
+  - type: taskStatusUpdated
+    list_id: "162641285"
+    status: done
+```
+
+See [Webhook triggers](../triggers.md#clickup-webhook-triggers) for a complete
+example that uses this configuration to execute a pipeline snapshot.
+
+## Mock a signed ClickUp delivery
+
+You can test the endpoint without asking ClickUp to send a delivery. This
+example uses a minimal ClickUp-like status payload; the important part is
+signing and sending exactly the same bytes.
+
+Set the endpoint and the ClickUp signing secret stored on the ZenML webhook:
+
+```bash
+export WEBHOOK_URL="<endpoint-url-from-zenml>"
+export WEBHOOK_SECRET="<clickup-webhook-secret>"
+```
+
+Write the request body without adding a trailing newline:
+
+```bash
+printf '%s' '{"event":"taskStatusUpdated","webhook_id":"wh-1","task_id":"abc","list_id":"162641285","history_items":[{"id":"hist-1","after":"done"}]}' > clickup-status.json
+```
+
+Calculate the raw hexadecimal signature over the file's exact bytes:
+
+```bash
+export SIGNATURE="$(python -c 'import hashlib,hmac,os; body=open("clickup-status.json","rb").read(); print(hmac.new(os.environ["WEBHOOK_SECRET"].encode(), body, hashlib.sha256).hexdigest())')"
+```
+
+Send those same bytes with the ClickUp signature header:
+
+```bash
+curl -i -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIGNATURE" \
+  --data-binary @clickup-status.json
+```
+
+A valid delivery returns `202 Accepted`. This confirms webhook intake, not that
+a consumer matched or a pipeline run started.
+
+To confirm that signature verification is active, send the same body with an
+invalid signature:
+
+```bash
+curl -i -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: invalid" \
+  --data-binary @clickup-status.json
+```
+
+This request returns `401 Unauthorized`. If a calculated signature fails,
+verify that the bytes passed to `--data-binary` are the bytes used to calculate
+the digest; even a whitespace or newline change produces a different signature.
+Do not prefix the digest with `sha256=`.
+
+ClickUp [immediately suspends](https://developer.clickup.com/docs/webhookhealth)
+a webhook after an unauthorized response, so align the signing secret before
+ClickUp starts delivering events.
+
+## Related pages
+
+- [Webhooks](../webhooks.md)
+- [GitHub webhooks](github.md)
+- [Custom webhooks](custom.md)
+- [Webhook triggers](../triggers.md#clickup-webhook-triggers)

--- a/docs/book/getting-started/zenml-pro/webhooks/custom.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/custom.md
@@ -93,4 +93,5 @@ for the shared response contract.
 
 - [Webhooks](../webhooks.md)
 - [GitHub webhooks](github.md)
+- [ClickUp webhooks](clickup.md)
 - [Custom webhook triggers](../triggers.md#custom-webhook-triggers)

--- a/docs/book/getting-started/zenml-pro/webhooks/github.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/github.md
@@ -131,8 +131,8 @@ in the table, while `startswith:` is limited to `branch`, `target_branch`,
 `source_branch`, and `tag` fields. The issue title, number, and issue type are
 available in the propagated event but are not trigger filters.
 
-See [Webhook triggers](../triggers.md#webhook-triggers) for a complete example
-that uses this configuration to execute a pipeline snapshot.
+See [Webhook triggers](../triggers.md#github-webhook-triggers) for a complete
+example that uses this configuration to execute a pipeline snapshot.
 
 ## Mock a signed GitHub push
 
@@ -192,5 +192,6 @@ the digest; even a whitespace or newline change produces a different signature.
 ## Related pages
 
 - [Webhooks](../webhooks.md)
+- [ClickUp webhooks](clickup.md)
 - [Custom webhooks](custom.md)
-- [Webhook triggers](../triggers.md#webhook-triggers)
+- [Webhook triggers](../triggers.md#github-webhook-triggers)

--- a/src/zenml/webhooks/providers/base.py
+++ b/src/zenml/webhooks/providers/base.py
@@ -349,48 +349,38 @@ class BaseWebhookProvider(ABC):
 
 
 def authenticate_hmac_sha256(
-    *, body: bytes, headers: Mapping[str, str], secret: str, header: str
+    *,
+    body: bytes,
+    headers: Mapping[str, str],
+    secret: str,
+    header: str,
+    prefixed: bool = True,
 ) -> None:
-    """Authenticate a sha256-prefixed HMAC signature.
+    """Authenticate an HMAC-SHA256 signature.
 
     Args:
         body: The exact request body.
         headers: The request headers.
         secret: The signing secret.
         header: The signature header name.
+        prefixed: If `True`, require a `sha256=` prefix (GitHub-style). If
+            `False`, compare the raw hexadecimal digest (ClickUp-style).
 
     Raises:
         WebhookAuthenticationError: If the signature is invalid.
     """
     signature = headers.get(header)
-    if not signature or not signature.startswith("sha256="):
-        raise WebhookAuthenticationError(
-            f"Missing or malformed {header} header."
-        )
-    expected = (
-        "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    )
-    if not hmac.compare_digest(signature, expected):
-        raise WebhookAuthenticationError("Invalid webhook signature.")
-
-
-def authenticate_hmac_sha256_hex(
-    *, body: bytes, headers: Mapping[str, str], secret: str, header: str
-) -> None:
-    """Authenticate a raw hexadecimal HMAC-SHA256 signature.
-
-    Args:
-        body: The exact request body.
-        headers: The request headers.
-        secret: The signing secret.
-        header: The signature header name.
-
-    Raises:
-        WebhookAuthenticationError: If the signature is invalid.
-    """
-    signature = headers.get(header)
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    if prefixed:
+        if not signature or not signature.startswith("sha256="):
+            raise WebhookAuthenticationError(
+                f"Missing or malformed {header} header."
+            )
+        expected = "sha256=" + digest
+        if not hmac.compare_digest(signature, expected):
+            raise WebhookAuthenticationError("Invalid webhook signature.")
+        return
     if not signature:
         raise WebhookAuthenticationError(f"Missing {header} header.")
-    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    if not hmac.compare_digest(signature.lower(), expected.lower()):
+    if not hmac.compare_digest(signature.lower(), digest.lower()):
         raise WebhookAuthenticationError("Invalid webhook signature.")

--- a/src/zenml/webhooks/providers/base.py
+++ b/src/zenml/webhooks/providers/base.py
@@ -372,3 +372,25 @@ def authenticate_hmac_sha256(
     )
     if not hmac.compare_digest(signature, expected):
         raise WebhookAuthenticationError("Invalid webhook signature.")
+
+
+def authenticate_hmac_sha256_hex(
+    *, body: bytes, headers: Mapping[str, str], secret: str, header: str
+) -> None:
+    """Authenticate a raw hexadecimal HMAC-SHA256 signature.
+
+    Args:
+        body: The exact request body.
+        headers: The request headers.
+        secret: The signing secret.
+        header: The signature header name.
+
+    Raises:
+        WebhookAuthenticationError: If the signature is invalid.
+    """
+    signature = headers.get(header)
+    if not signature:
+        raise WebhookAuthenticationError(f"Missing {header} header.")
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(signature.lower(), expected.lower()):
+        raise WebhookAuthenticationError("Invalid webhook signature.")

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -94,7 +94,7 @@ def _matches_string_filter(
 
     if actual is None:
         return False
-    
+
     values = configured if isinstance(configured, list) else [configured]
     for value in values:
         if value.startswith("oneof:"):

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -1,0 +1,384 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""ClickUp webhook provider and semantic target event catalog."""
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import Field
+
+from zenml.models.v2.base.filter import StringFilterOption
+from zenml.utils.enum_utils import StrEnum
+from zenml.webhooks.providers.base import (
+    BaseWebhookProvider,
+    WebhookConfiguration,
+    WebhookPayloadError,
+    WebhookTargetEvent,
+    authenticate_hmac_sha256_hex,
+)
+from zenml.webhooks.providers.types import BuiltinWebhookType
+
+if TYPE_CHECKING:
+    from zenml.models import WebhookTriggerResponse
+    from zenml.webhooks.events import WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+CLICKUP_SIGNATURE_HEADER = "x-signature"
+
+_RESOURCE_KEYS = ("task_id", "list_id", "folder_id", "space_id")
+
+
+class ClickUpWebhookEvent(StrEnum):
+    """ClickUp events supported by webhook triggers."""
+
+    TASK_CREATED = "taskCreated"
+    TASK_UPDATED = "taskUpdated"
+    TASK_DELETED = "taskDeleted"
+    TASK_STATUS_UPDATED = "taskStatusUpdated"
+    TASK_MOVED = "taskMoved"
+    TASK_ASSIGNEE_UPDATED = "taskAssigneeUpdated"
+    TASK_COMMENT_POSTED = "taskCommentPosted"
+    LIST_CREATED = "listCreated"
+    LIST_UPDATED = "listUpdated"
+    LIST_DELETED = "listDeleted"
+
+
+class ClickUpTargetEvent(WebhookTargetEvent):
+    """Filters for a ClickUp webhook event."""
+
+    type: ClickUpWebhookEvent
+    list_id: StringFilterOption = None
+    task_id: StringFilterOption = None
+    space_id: StringFilterOption = None
+    folder_id: StringFilterOption = None
+    status: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix matching support for string filter fields.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            "list_id": False,
+            "task_id": False,
+            "space_id": False,
+            "folder_id": False,
+            "status": False,
+        }
+
+
+class ClickUpWebhookConfiguration(WebhookConfiguration):
+    """Typed configuration for a ClickUp webhook trigger."""
+
+    target_events: list[ClickUpTargetEvent] = Field(min_length=1)
+
+
+def _matches_string_filter(
+    *, actual: str | None, configured: str | list[str] | None
+) -> bool:
+    """Match an extracted value against a supported string filter.
+
+    Args:
+        actual: The value extracted from the webhook event.
+        configured: The configured exact, prefix, or alternatives filter.
+
+    Returns:
+        Whether the extracted value matches the configured filter.
+    """
+    if configured is None:
+        return True
+
+    if actual is None:
+        return False
+    
+    values = configured if isinstance(configured, list) else [configured]
+    for value in values:
+        if value.startswith("oneof:"):
+            if actual in json.loads(value.removeprefix("oneof:")):
+                return True
+        elif actual == value:
+            return True
+    return False
+
+
+def _id_string(payload: Mapping[str, Any], key: str) -> str | None:
+    """Extract an ID string from a ClickUp payload.
+
+    Args:
+        payload: The ClickUp payload.
+        key: The key to extract the ID from.
+
+    Returns:
+        The ID string, or `None` if the key is missing or empty.
+    """
+    value = payload.get(key)
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (str, int)) and str(value):
+        return str(value)
+    return None
+
+
+def _history_item_ids(payload: Mapping[str, Any]) -> list[str]:
+    """Extract history item IDs from a ClickUp payload.
+
+    Args:
+        payload: The ClickUp payload.
+
+    Returns:
+        The history item IDs, or an empty list if the history items are missing or empty.
+    """
+    items = payload.get("history_items")
+    if not isinstance(items, list):
+        return []
+    ids: list[str] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        item_id = item.get("id")
+        if isinstance(item_id, (str, int)) and str(item_id):
+            ids.append(str(item_id))
+    return sorted(ids)
+
+
+def _status_after(payload: Mapping[str, Any]) -> str | None:
+    """Extract the status after a change from a ClickUp payload.
+
+    Args:
+        payload: The ClickUp payload.
+
+    Returns:
+        The status after the change, or `None` if the history items are missing or empty.
+    """
+    items = payload.get("history_items")
+    if not isinstance(items, list) or not items:
+        return None
+    last = items[-1]
+    if not isinstance(last, Mapping):
+        return None
+    after = last.get("after")
+    if isinstance(after, str) and after:
+        return after
+    if isinstance(after, Mapping):
+        status = after.get("status")
+        if isinstance(status, str) and status:
+            return status
+    return None
+
+
+class ClickUpSemanticEvent:
+    """Normalized ClickUp event used for trigger matching."""
+
+    def __init__(
+        self,
+        *,
+        event_type: ClickUpWebhookEvent,
+        list_id: str | None,
+        task_id: str | None,
+        space_id: str | None,
+        folder_id: str | None,
+        status: str | None,
+    ) -> None:
+        """Initialize one normalized ClickUp event.
+
+        Args:
+            event_type: The ClickUp event name.
+            list_id: The list ID, if present.
+            task_id: The task ID, if present.
+            space_id: The space ID, if present.
+            folder_id: The folder ID, if present.
+            status: The status after the change, if present.
+        """
+        self.event_type = event_type
+        self.list_id = list_id
+        self.task_id = task_id
+        self.space_id = space_id
+        self.folder_id = folder_id
+        self.status = status
+
+    def matches(self, target: ClickUpTargetEvent) -> bool:
+        """Return whether this event matches a typed target.
+
+        Args:
+            target: The typed target event configuration.
+
+        Returns:
+            Whether this event matches the target.
+        """
+        if self.event_type != target.type:
+            return False
+        return all(
+            (
+                _matches_string_filter(
+                    actual=self.list_id, configured=target.list_id
+                ),
+                _matches_string_filter(
+                    actual=self.task_id, configured=target.task_id
+                ),
+                _matches_string_filter(
+                    actual=self.space_id, configured=target.space_id
+                ),
+                _matches_string_filter(
+                    actual=self.folder_id, configured=target.folder_id
+                ),
+                _matches_string_filter(
+                    actual=self.status, configured=target.status
+                ),
+            )
+        )
+
+
+class ClickUpWebhookProvider(BaseWebhookProvider):
+    """Provider for authenticated and semantically matched ClickUp webhooks."""
+
+    webhook_type = BuiltinWebhookType.CLICKUP
+    configuration_class = ClickUpWebhookConfiguration
+
+    def authenticate(
+        self, body: bytes, headers: Mapping[str, str], secret: str
+    ) -> None:
+        """Authenticate a ClickUp delivery.
+
+        Args:
+            body: The exact raw request body.
+            headers: The request headers.
+            secret: The webhook signing secret.
+        """
+        authenticate_hmac_sha256_hex(
+            body=body,
+            headers=headers,
+            secret=secret,
+            header=CLICKUP_SIGNATURE_HEADER,
+        )
+
+    def get_event_type(
+        self, payload: dict[str, Any], headers: Mapping[str, str]
+    ) -> str:
+        """Extract the ClickUp event name from the JSON body.
+
+        Args:
+            payload: The parsed ClickUp payload.
+            headers: The request headers.
+
+        Returns:
+            The ClickUp event name.
+
+        Raises:
+            WebhookPayloadError: If the event field is missing or empty.
+        """
+        event_type = payload.get("event")
+        if not isinstance(event_type, str) or not event_type:
+            raise WebhookPayloadError(
+                "Missing or empty ClickUp 'event' field."
+            )
+        return event_type
+
+    def get_delivery_id(
+        self, payload: dict[str, Any], headers: Mapping[str, str]
+    ) -> str | None:
+        """Build ClickUp's documented idempotency key.
+
+        Args:
+            payload: The parsed ClickUp payload.
+            headers: The request headers.
+
+        Returns:
+            The delivery ID, if the payload contains a webhook ID.
+
+        Raises:
+            WebhookPayloadError: If webhook_id is missing.
+        """
+        webhook_id = payload.get("webhook_id")
+        if not isinstance(webhook_id, str) or not webhook_id:
+            raise WebhookPayloadError(
+                "Missing or empty ClickUp 'webhook_id' field."
+            )
+        history_ids = _history_item_ids(payload)
+        if history_ids:
+            return f"{webhook_id}:{','.join(history_ids)}"
+        resource_id = next(
+            (
+                value
+                for key in _RESOURCE_KEYS
+                if (value := _id_string(payload, key)) is not None
+            ),
+            "unknown",
+        )
+        event_type = payload.get("event")
+        event_name = event_type if isinstance(event_type, str) else "unknown"
+        return f"{webhook_id}:{event_name}:{resource_id}"
+
+    def _cast_runtime_targets(
+        self, trigger: "WebhookTriggerResponse"
+    ) -> list[ClickUpTargetEvent]:
+        """Cast a webhook trigger configuration to a list of target events.
+
+        Args:
+            trigger: The webhook trigger configuration.
+
+        Returns:
+            The list of target events.
+        """
+        try:
+            configuration = self.validate_configuration(trigger.configuration)
+        except (TypeError, ValueError):
+            logger.exception(
+                "Skipping defective webhook trigger configuration %s",
+                trigger.id,
+            )
+            return []
+        return cast(ClickUpWebhookConfiguration, configuration).target_events
+
+    def match_triggers(
+        self,
+        *,
+        event: "WebhookEvent",
+        candidates: Sequence["WebhookTriggerResponse"],
+    ) -> list["WebhookTriggerResponse"]:
+        """Match ClickUp candidates while tolerating stale stored entries.
+
+        Args:
+            event: The trusted ClickUp webhook event.
+            candidates: The candidate webhook triggers.
+
+        Returns:
+            The candidates matching the semantic event.
+        """
+        semantic = self.parse_semantic_event(event)
+        if semantic is None:
+            return []
+        matches: list[WebhookTriggerResponse] = []
+        for trigger in candidates:
+            targets = self._cast_runtime_targets(trigger)
+            if any(semantic.matches(target) for target in targets):
+                matches.append(trigger)
+        return matches
+
+    def parse_semantic_event(
+        self, event: "WebhookEvent"
+    ) -> ClickUpSemanticEvent | None:
+        """Parse a trusted delivery into a normalized semantic event.
+
+        Args:
+            event: The trusted ClickUp webhook event.
+
+        Returns:
+            The normalized semantic event, or `None` for unsupported events.
+        """
+        try:
+            event_type = ClickUpWebhookEvent(event.event_type)
+        except ValueError:
+            return None
+        payload = event.payload
+        return ClickUpSemanticEvent(
+            event_type=event_type,
+            list_id=_id_string(payload, "list_id"),
+            task_id=_id_string(payload, "task_id"),
+            space_id=_id_string(payload, "space_id"),
+            folder_id=_id_string(payload, "folder_id"),
+            status=_status_after(payload),
+        )

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -1,7 +1,6 @@
 #  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 """ClickUp webhook provider and semantic target event catalog."""
 
-import json
 import logging
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
@@ -26,6 +25,7 @@ from zenml.webhooks.providers.base import (
     WebhookTargetEvent,
     WebhookTriggerMatch,
     authenticate_hmac_sha256,
+    matches_string_filter,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -213,34 +213,6 @@ class ClickUpWebhookConfiguration(WebhookConfiguration):
     target_events: list[ClickUpWebhookTargetEvent] = Field(min_length=1)
 
 
-def _matches_string_filter(
-    *, actual: str | None, configured: str | list[str] | None
-) -> bool:
-    """Match an extracted value against a supported string filter.
-
-    Args:
-        actual: The value extracted from the webhook event.
-        configured: The configured exact, prefix, or alternatives filter.
-
-    Returns:
-        Whether the extracted value matches the configured filter.
-    """
-    if configured is None:
-        return True
-
-    if actual is None:
-        return False
-
-    values = configured if isinstance(configured, list) else [configured]
-    for value in values:
-        if value.startswith("oneof:"):
-            if actual in json.loads(value.removeprefix("oneof:")):
-                return True
-        elif actual == value:
-            return True
-    return False
-
-
 def _matches_location_filters(
     *,
     list_id: str | None,
@@ -261,11 +233,9 @@ def _matches_location_filters(
     """
     return all(
         (
-            _matches_string_filter(actual=list_id, configured=target.list_id),
-            _matches_string_filter(
-                actual=space_id, configured=target.space_id
-            ),
-            _matches_string_filter(
+            matches_string_filter(actual=list_id, configured=target.list_id),
+            matches_string_filter(actual=space_id, configured=target.space_id),
+            matches_string_filter(
                 actual=folder_id, configured=target.folder_id
             ),
         )
@@ -294,7 +264,7 @@ def _matches_task_filters(
     """
     return all(
         (
-            _matches_string_filter(actual=task_id, configured=target.task_id),
+            matches_string_filter(actual=task_id, configured=target.task_id),
             _matches_location_filters(
                 list_id=list_id,
                 space_id=space_id,
@@ -500,7 +470,7 @@ class ClickUpTaskStatusUpdatedEvent(ClickUpTaskSemanticEvent):
                     folder_id=self.folder_id,
                     target=target,
                 ),
-                _matches_string_filter(
+                matches_string_filter(
                     actual=self.status, configured=target.status
                 ),
             )
@@ -561,25 +531,18 @@ class ClickUpListDeletedEvent(ClickUpListSemanticEvent):
     )
 
 
-_TASK_SEMANTIC_EVENTS: Mapping[
-    ClickUpWebhookEvent, type[ClickUpTaskSemanticEvent]
-] = {
-    ClickUpWebhookEvent.TASK_CREATED: ClickUpTaskCreatedEvent,
-    ClickUpWebhookEvent.TASK_UPDATED: ClickUpTaskUpdatedEvent,
-    ClickUpWebhookEvent.TASK_DELETED: ClickUpTaskDeletedEvent,
-    ClickUpWebhookEvent.TASK_STATUS_UPDATED: ClickUpTaskStatusUpdatedEvent,
-    ClickUpWebhookEvent.TASK_MOVED: ClickUpTaskMovedEvent,
-    ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED: ClickUpTaskAssigneeUpdatedEvent,
-    ClickUpWebhookEvent.TASK_COMMENT_POSTED: ClickUpTaskCommentPostedEvent,
-}
-
-_LIST_SEMANTIC_EVENTS: Mapping[
-    ClickUpWebhookEvent, type[ClickUpListSemanticEvent]
-] = {
-    ClickUpWebhookEvent.LIST_CREATED: ClickUpListCreatedEvent,
-    ClickUpWebhookEvent.LIST_UPDATED: ClickUpListUpdatedEvent,
-    ClickUpWebhookEvent.LIST_DELETED: ClickUpListDeletedEvent,
-}
+_SEMANTIC_EVENTS: list[type[ClickUpSemanticEvent]] = [
+    ClickUpTaskCreatedEvent,
+    ClickUpTaskUpdatedEvent,
+    ClickUpTaskDeletedEvent,
+    ClickUpTaskStatusUpdatedEvent,
+    ClickUpTaskMovedEvent,
+    ClickUpTaskAssigneeUpdatedEvent,
+    ClickUpTaskCommentPostedEvent,
+    ClickUpListCreatedEvent,
+    ClickUpListUpdatedEvent,
+    ClickUpListDeletedEvent,
+]
 
 
 class ClickUpWebhookProvider(BaseWebhookProvider):
@@ -731,8 +694,17 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         list_id = _id_string(payload, "list_id")
         space_id = _id_string(payload, "space_id")
         folder_id = _id_string(payload, "folder_id")
-        task_cls = _TASK_SEMANTIC_EVENTS.get(event_type)
-        if task_cls is ClickUpTaskStatusUpdatedEvent:
+        semantic_cls = next(
+            (
+                candidate
+                for candidate in _SEMANTIC_EVENTS
+                if candidate.model_fields["type"].default == event_type
+            ),
+            None,
+        )
+        if semantic_cls is None:
+            return None
+        if semantic_cls is ClickUpTaskStatusUpdatedEvent:
             return ClickUpTaskStatusUpdatedEvent(
                 type=event_type,
                 task_id=_id_string(payload, "task_id"),
@@ -741,20 +713,17 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
                 folder_id=folder_id,
                 status=_status_after(payload),
             )
-        if task_cls is not None:
-            return task_cls(
+        if issubclass(semantic_cls, ClickUpTaskSemanticEvent):
+            return semantic_cls(
                 type=event_type,
                 task_id=_id_string(payload, "task_id"),
                 list_id=list_id,
                 space_id=space_id,
                 folder_id=folder_id,
             )
-        list_cls = _LIST_SEMANTIC_EVENTS.get(event_type)
-        if list_cls is not None:
-            return list_cls(
-                type=event_type,
-                list_id=list_id,
-                space_id=space_id,
-                folder_id=folder_id,
-            )
-        return None
+        return semantic_cls(
+            type=event_type,
+            list_id=list_id,
+            space_id=space_id,
+            folder_id=folder_id,
+        )

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -3,10 +3,19 @@
 
 import json
 import logging
+from abc import abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Literal,
+    TypeAlias,
+    cast,
+)
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
@@ -45,15 +54,12 @@ class ClickUpWebhookEvent(StrEnum):
     LIST_DELETED = "listDeleted"
 
 
-class ClickUpTargetEvent(WebhookTargetEvent):
-    """Filters for a ClickUp webhook event."""
+class _ClickUpListTarget(WebhookTargetEvent):
+    """Shared location filters for ClickUp list events."""
 
-    type: ClickUpWebhookEvent
     list_id: StringFilterOption = None
-    task_id: StringFilterOption = None
     space_id: StringFilterOption = None
     folder_id: StringFilterOption = None
-    status: StringFilterOption = None
 
     @classmethod
     def get_prefix_matching_support(cls) -> Mapping[str, bool]:
@@ -64,17 +70,146 @@ class ClickUpTargetEvent(WebhookTargetEvent):
         """
         return {
             "list_id": False,
-            "task_id": False,
             "space_id": False,
             "folder_id": False,
+        }
+
+
+class _ClickUpTaskTarget(_ClickUpListTarget):
+    """Shared location and task filters for ClickUp task events."""
+
+    task_id: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix matching support for string filter fields.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            **super().get_prefix_matching_support(),
+            "task_id": False,
+        }
+
+
+class _ClickUpTaskStatusTarget(_ClickUpTaskTarget):
+    """Task filters plus the post-change status."""
+
+    status: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix matching support for string filter fields.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            **super().get_prefix_matching_support(),
             "status": False,
         }
+
+
+class TaskCreated(_ClickUpTaskTarget):
+    """Filters for a created ClickUp task."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_CREATED] = (
+        ClickUpWebhookEvent.TASK_CREATED
+    )
+
+
+class TaskUpdated(_ClickUpTaskTarget):
+    """Filters for an updated ClickUp task."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_UPDATED] = (
+        ClickUpWebhookEvent.TASK_UPDATED
+    )
+
+
+class TaskDeleted(_ClickUpTaskTarget):
+    """Filters for a deleted ClickUp task."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_DELETED] = (
+        ClickUpWebhookEvent.TASK_DELETED
+    )
+
+
+class TaskStatusUpdated(_ClickUpTaskStatusTarget):
+    """Filters for a ClickUp task status change."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_STATUS_UPDATED] = (
+        ClickUpWebhookEvent.TASK_STATUS_UPDATED
+    )
+
+
+class TaskMoved(_ClickUpTaskTarget):
+    """Filters for a ClickUp task moved to another list."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_MOVED] = (
+        ClickUpWebhookEvent.TASK_MOVED
+    )
+
+
+class TaskAssigneeUpdated(_ClickUpTaskTarget):
+    """Filters for a ClickUp task assignee change."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED] = (
+        ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED
+    )
+
+
+class TaskCommentPosted(_ClickUpTaskTarget):
+    """Filters for a comment posted on a ClickUp task."""
+
+    type: Literal[ClickUpWebhookEvent.TASK_COMMENT_POSTED] = (
+        ClickUpWebhookEvent.TASK_COMMENT_POSTED
+    )
+
+
+class ListCreated(_ClickUpListTarget):
+    """Filters for a created ClickUp list."""
+
+    type: Literal[ClickUpWebhookEvent.LIST_CREATED] = (
+        ClickUpWebhookEvent.LIST_CREATED
+    )
+
+
+class ListUpdated(_ClickUpListTarget):
+    """Filters for an updated ClickUp list."""
+
+    type: Literal[ClickUpWebhookEvent.LIST_UPDATED] = (
+        ClickUpWebhookEvent.LIST_UPDATED
+    )
+
+
+class ListDeleted(_ClickUpListTarget):
+    """Filters for a deleted ClickUp list."""
+
+    type: Literal[ClickUpWebhookEvent.LIST_DELETED] = (
+        ClickUpWebhookEvent.LIST_DELETED
+    )
+
+
+ClickUpWebhookTargetEvent: TypeAlias = Annotated[
+    TaskCreated
+    | TaskUpdated
+    | TaskDeleted
+    | TaskStatusUpdated
+    | TaskMoved
+    | TaskAssigneeUpdated
+    | TaskCommentPosted
+    | ListCreated
+    | ListUpdated
+    | ListDeleted,
+    Field(discriminator="type"),
+]
 
 
 class ClickUpWebhookConfiguration(WebhookConfiguration):
     """Typed configuration for a ClickUp webhook trigger."""
 
-    target_events: list[ClickUpTargetEvent] = Field(min_length=1)
+    target_events: list[ClickUpWebhookTargetEvent] = Field(min_length=1)
 
 
 def _matches_string_filter(
@@ -105,6 +240,70 @@ def _matches_string_filter(
     return False
 
 
+def _matches_location_filters(
+    *,
+    list_id: str | None,
+    space_id: str | None,
+    folder_id: str | None,
+    target: _ClickUpListTarget,
+) -> bool:
+    """Match shared ClickUp location filters.
+
+    Args:
+        list_id: The list ID extracted from the payload.
+        space_id: The space ID extracted from the payload.
+        folder_id: The folder ID extracted from the payload.
+        target: The typed target event configuration.
+
+    Returns:
+        Whether the extracted location matches the target filters.
+    """
+    return all(
+        (
+            _matches_string_filter(actual=list_id, configured=target.list_id),
+            _matches_string_filter(
+                actual=space_id, configured=target.space_id
+            ),
+            _matches_string_filter(
+                actual=folder_id, configured=target.folder_id
+            ),
+        )
+    )
+
+
+def _matches_task_filters(
+    *,
+    task_id: str | None,
+    list_id: str | None,
+    space_id: str | None,
+    folder_id: str | None,
+    target: _ClickUpTaskTarget,
+) -> bool:
+    """Match shared ClickUp task and location filters.
+
+    Args:
+        task_id: The task ID extracted from the payload.
+        list_id: The list ID extracted from the payload.
+        space_id: The space ID extracted from the payload.
+        folder_id: The folder ID extracted from the payload.
+        target: The typed target event configuration.
+
+    Returns:
+        Whether the extracted task matches the target filters.
+    """
+    return all(
+        (
+            _matches_string_filter(actual=task_id, configured=target.task_id),
+            _matches_location_filters(
+                list_id=list_id,
+                space_id=space_id,
+                folder_id=folder_id,
+                target=target,
+            ),
+        )
+    )
+
+
 def _id_string(payload: Mapping[str, Any], key: str) -> str | None:
     """Extract an ID string from a ClickUp payload.
 
@@ -130,7 +329,7 @@ def _history_item_ids(payload: Mapping[str, Any]) -> list[str]:
         payload: The ClickUp payload.
 
     Returns:
-        The history item IDs, or an empty list if the history items are missing or empty.
+        The history item IDs, or an empty list if they are missing.
     """
     items = payload.get("history_items")
     if not isinstance(items, list):
@@ -152,7 +351,7 @@ def _status_after(payload: Mapping[str, Any]) -> str | None:
         payload: The ClickUp payload.
 
     Returns:
-        The status after the change, or `None` if the history items are missing or empty.
+        The status after the change, or `None` if it is missing.
     """
     items = payload.get("history_items")
     if not isinstance(items, list) or not items:
@@ -170,38 +369,34 @@ def _status_after(payload: Mapping[str, Any]) -> str | None:
     return None
 
 
-class ClickUpSemanticEvent:
+class ClickUpSemanticEvent(BaseModel):
     """Normalized ClickUp event used for trigger matching."""
 
-    def __init__(
-        self,
-        *,
-        event_type: ClickUpWebhookEvent,
-        list_id: str | None,
-        task_id: str | None,
-        space_id: str | None,
-        folder_id: str | None,
-        status: str | None,
-    ) -> None:
-        """Initialize one normalized ClickUp event.
+    event_filter_type: ClassVar[type[WebhookTargetEvent]]
+
+    @abstractmethod
+    def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
+        """Return whether the semantic event matches its typed target.
 
         Args:
-            event_type: The ClickUp event name.
-            list_id: The list ID, if present.
-            task_id: The task ID, if present.
-            space_id: The space ID, if present.
-            folder_id: The folder ID, if present.
-            status: The status after the change, if present.
-        """
-        self.event_type = event_type
-        self.list_id = list_id
-        self.task_id = task_id
-        self.space_id = space_id
-        self.folder_id = folder_id
-        self.status = status
+            target: The typed target event configuration.
 
-    def matches(self, target: ClickUpTargetEvent) -> bool:
-        """Return whether this event matches a typed target.
+        Returns:
+            Whether the semantic event matches the target.
+        """
+
+
+class ClickUpTaskSemanticEvent(ClickUpSemanticEvent):
+    """Normalized ClickUp task event with shared location filters."""
+
+    event_filter_type: ClassVar[type[_ClickUpTaskTarget]]
+    task_id: str | None = None
+    list_id: str | None = None
+    space_id: str | None = None
+    folder_id: str | None = None
+
+    def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
+        """Return whether this event matches a typed task target.
 
         Args:
             target: The typed target event configuration.
@@ -209,27 +404,150 @@ class ClickUpSemanticEvent:
         Returns:
             Whether this event matches the target.
         """
-        if self.event_type != target.type:
+        if not isinstance(target, self.event_filter_type):
+            return False
+        return _matches_task_filters(
+            task_id=self.task_id,
+            list_id=self.list_id,
+            space_id=self.space_id,
+            folder_id=self.folder_id,
+            target=target,
+        )
+
+
+class ClickUpListSemanticEvent(ClickUpSemanticEvent):
+    """Normalized ClickUp list event with shared location filters."""
+
+    event_filter_type: ClassVar[type[_ClickUpListTarget]]
+    list_id: str | None = None
+    space_id: str | None = None
+    folder_id: str | None = None
+
+    def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
+        """Return whether this event matches a typed list target.
+
+        Args:
+            target: The typed target event configuration.
+
+        Returns:
+            Whether this event matches the target.
+        """
+        if not isinstance(target, self.event_filter_type):
+            return False
+        return _matches_location_filters(
+            list_id=self.list_id,
+            space_id=self.space_id,
+            folder_id=self.folder_id,
+            target=target,
+        )
+
+
+class ClickUpTaskCreatedEvent(ClickUpTaskSemanticEvent):
+    """Normalized created-task event."""
+
+    event_filter_type = TaskCreated
+
+
+class ClickUpTaskUpdatedEvent(ClickUpTaskSemanticEvent):
+    """Normalized updated-task event."""
+
+    event_filter_type = TaskUpdated
+
+
+class ClickUpTaskDeletedEvent(ClickUpTaskSemanticEvent):
+    """Normalized deleted-task event."""
+
+    event_filter_type = TaskDeleted
+
+
+class ClickUpTaskStatusUpdatedEvent(ClickUpTaskSemanticEvent):
+    """Normalized task-status-updated event."""
+
+    event_filter_type = TaskStatusUpdated
+    status: str | None = None
+
+    def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
+        """Return whether this event matches a status-updated target.
+
+        Args:
+            target: The typed target event configuration.
+
+        Returns:
+            Whether this event matches the target.
+        """
+        if not isinstance(target, TaskStatusUpdated):
             return False
         return all(
             (
-                _matches_string_filter(
-                    actual=self.list_id, configured=target.list_id
-                ),
-                _matches_string_filter(
-                    actual=self.task_id, configured=target.task_id
-                ),
-                _matches_string_filter(
-                    actual=self.space_id, configured=target.space_id
-                ),
-                _matches_string_filter(
-                    actual=self.folder_id, configured=target.folder_id
+                _matches_task_filters(
+                    task_id=self.task_id,
+                    list_id=self.list_id,
+                    space_id=self.space_id,
+                    folder_id=self.folder_id,
+                    target=target,
                 ),
                 _matches_string_filter(
                     actual=self.status, configured=target.status
                 ),
             )
         )
+
+
+class ClickUpTaskMovedEvent(ClickUpTaskSemanticEvent):
+    """Normalized moved-task event."""
+
+    event_filter_type = TaskMoved
+
+
+class ClickUpTaskAssigneeUpdatedEvent(ClickUpTaskSemanticEvent):
+    """Normalized task-assignee-updated event."""
+
+    event_filter_type = TaskAssigneeUpdated
+
+
+class ClickUpTaskCommentPostedEvent(ClickUpTaskSemanticEvent):
+    """Normalized task-comment-posted event."""
+
+    event_filter_type = TaskCommentPosted
+
+
+class ClickUpListCreatedEvent(ClickUpListSemanticEvent):
+    """Normalized created-list event."""
+
+    event_filter_type = ListCreated
+
+
+class ClickUpListUpdatedEvent(ClickUpListSemanticEvent):
+    """Normalized updated-list event."""
+
+    event_filter_type = ListUpdated
+
+
+class ClickUpListDeletedEvent(ClickUpListSemanticEvent):
+    """Normalized deleted-list event."""
+
+    event_filter_type = ListDeleted
+
+
+_TASK_SEMANTIC_EVENTS: Mapping[
+    ClickUpWebhookEvent, type[ClickUpTaskSemanticEvent]
+] = {
+    ClickUpWebhookEvent.TASK_CREATED: ClickUpTaskCreatedEvent,
+    ClickUpWebhookEvent.TASK_UPDATED: ClickUpTaskUpdatedEvent,
+    ClickUpWebhookEvent.TASK_DELETED: ClickUpTaskDeletedEvent,
+    ClickUpWebhookEvent.TASK_STATUS_UPDATED: ClickUpTaskStatusUpdatedEvent,
+    ClickUpWebhookEvent.TASK_MOVED: ClickUpTaskMovedEvent,
+    ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED: ClickUpTaskAssigneeUpdatedEvent,
+    ClickUpWebhookEvent.TASK_COMMENT_POSTED: ClickUpTaskCommentPostedEvent,
+}
+
+_LIST_SEMANTIC_EVENTS: Mapping[
+    ClickUpWebhookEvent, type[ClickUpListSemanticEvent]
+] = {
+    ClickUpWebhookEvent.LIST_CREATED: ClickUpListCreatedEvent,
+    ClickUpWebhookEvent.LIST_UPDATED: ClickUpListUpdatedEvent,
+    ClickUpWebhookEvent.LIST_DELETED: ClickUpListDeletedEvent,
+}
 
 
 class ClickUpWebhookProvider(BaseWebhookProvider):
@@ -314,7 +632,7 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
 
     def _cast_runtime_targets(
         self, trigger: "WebhookTriggerResponse"
-    ) -> list[ClickUpTargetEvent]:
+    ) -> list[ClickUpWebhookTargetEvent]:
         """Cast a webhook trigger configuration to a list of target events.
 
         Args:
@@ -374,11 +692,30 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         except ValueError:
             return None
         payload = event.payload
-        return ClickUpSemanticEvent(
-            event_type=event_type,
-            list_id=_id_string(payload, "list_id"),
-            task_id=_id_string(payload, "task_id"),
-            space_id=_id_string(payload, "space_id"),
-            folder_id=_id_string(payload, "folder_id"),
-            status=_status_after(payload),
-        )
+        list_id = _id_string(payload, "list_id")
+        space_id = _id_string(payload, "space_id")
+        folder_id = _id_string(payload, "folder_id")
+        task_cls = _TASK_SEMANTIC_EVENTS.get(event_type)
+        if task_cls is ClickUpTaskStatusUpdatedEvent:
+            return ClickUpTaskStatusUpdatedEvent(
+                task_id=_id_string(payload, "task_id"),
+                list_id=list_id,
+                space_id=space_id,
+                folder_id=folder_id,
+                status=_status_after(payload),
+            )
+        if task_cls is not None:
+            return task_cls(
+                task_id=_id_string(payload, "task_id"),
+                list_id=list_id,
+                space_id=space_id,
+                folder_id=folder_id,
+            )
+        list_cls = _LIST_SEMANTIC_EVENTS.get(event_type)
+        if list_cls is not None:
+            return list_cls(
+                list_id=list_id,
+                space_id=space_id,
+                folder_id=folder_id,
+            )
+        return None

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -24,6 +24,7 @@ from zenml.webhooks.providers.base import (
     WebhookConfiguration,
     WebhookPayloadError,
     WebhookTargetEvent,
+    WebhookTriggerMatch,
     authenticate_hmac_sha256,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
@@ -373,6 +374,7 @@ class ClickUpSemanticEvent(BaseModel):
     """Normalized ClickUp event used for trigger matching."""
 
     event_filter_type: ClassVar[type[WebhookTargetEvent]]
+    type: str
 
     @abstractmethod
     def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
@@ -446,24 +448,36 @@ class ClickUpTaskCreatedEvent(ClickUpTaskSemanticEvent):
     """Normalized created-task event."""
 
     event_filter_type = TaskCreated
+    type: Literal[ClickUpWebhookEvent.TASK_CREATED] = (
+        ClickUpWebhookEvent.TASK_CREATED
+    )
 
 
 class ClickUpTaskUpdatedEvent(ClickUpTaskSemanticEvent):
     """Normalized updated-task event."""
 
     event_filter_type = TaskUpdated
+    type: Literal[ClickUpWebhookEvent.TASK_UPDATED] = (
+        ClickUpWebhookEvent.TASK_UPDATED
+    )
 
 
 class ClickUpTaskDeletedEvent(ClickUpTaskSemanticEvent):
     """Normalized deleted-task event."""
 
     event_filter_type = TaskDeleted
+    type: Literal[ClickUpWebhookEvent.TASK_DELETED] = (
+        ClickUpWebhookEvent.TASK_DELETED
+    )
 
 
 class ClickUpTaskStatusUpdatedEvent(ClickUpTaskSemanticEvent):
     """Normalized task-status-updated event."""
 
     event_filter_type = TaskStatusUpdated
+    type: Literal[ClickUpWebhookEvent.TASK_STATUS_UPDATED] = (
+        ClickUpWebhookEvent.TASK_STATUS_UPDATED
+    )
     status: str | None = None
 
     def matches(self, target: ClickUpWebhookTargetEvent) -> bool:
@@ -497,36 +511,54 @@ class ClickUpTaskMovedEvent(ClickUpTaskSemanticEvent):
     """Normalized moved-task event."""
 
     event_filter_type = TaskMoved
+    type: Literal[ClickUpWebhookEvent.TASK_MOVED] = (
+        ClickUpWebhookEvent.TASK_MOVED
+    )
 
 
 class ClickUpTaskAssigneeUpdatedEvent(ClickUpTaskSemanticEvent):
     """Normalized task-assignee-updated event."""
 
     event_filter_type = TaskAssigneeUpdated
+    type: Literal[ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED] = (
+        ClickUpWebhookEvent.TASK_ASSIGNEE_UPDATED
+    )
 
 
 class ClickUpTaskCommentPostedEvent(ClickUpTaskSemanticEvent):
     """Normalized task-comment-posted event."""
 
     event_filter_type = TaskCommentPosted
+    type: Literal[ClickUpWebhookEvent.TASK_COMMENT_POSTED] = (
+        ClickUpWebhookEvent.TASK_COMMENT_POSTED
+    )
 
 
 class ClickUpListCreatedEvent(ClickUpListSemanticEvent):
     """Normalized created-list event."""
 
     event_filter_type = ListCreated
+    type: Literal[ClickUpWebhookEvent.LIST_CREATED] = (
+        ClickUpWebhookEvent.LIST_CREATED
+    )
 
 
 class ClickUpListUpdatedEvent(ClickUpListSemanticEvent):
     """Normalized updated-list event."""
 
     event_filter_type = ListUpdated
+    type: Literal[ClickUpWebhookEvent.LIST_UPDATED] = (
+        ClickUpWebhookEvent.LIST_UPDATED
+    )
 
 
 class ClickUpListDeletedEvent(ClickUpListSemanticEvent):
     """Normalized deleted-list event."""
 
     event_filter_type = ListDeleted
+    type: Literal[ClickUpWebhookEvent.LIST_DELETED] = (
+        ClickUpWebhookEvent.LIST_DELETED
+    )
 
 
 _TASK_SEMANTIC_EVENTS: Mapping[
@@ -657,25 +689,28 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         *,
         event: "WebhookEvent",
         candidates: Sequence["WebhookTriggerResponse"],
-    ) -> list["WebhookTriggerResponse"]:
-        """Match ClickUp candidates while tolerating stale stored entries.
+    ) -> "WebhookTriggerMatch[WebhookTriggerResponse]":
+        """Match ClickUp triggers and return the parsed semantic event.
 
         Args:
             event: The trusted ClickUp webhook event.
             candidates: The candidate webhook triggers.
 
         Returns:
-            The candidates matching the semantic event.
+            Matching triggers and their shared semantic event.
         """
         semantic = self.parse_semantic_event(event)
         if semantic is None:
-            return []
+            return WebhookTriggerMatch(triggers=[])
         matches: list[WebhookTriggerResponse] = []
         for trigger in candidates:
             targets = self._cast_runtime_targets(trigger)
             if any(semantic.matches(target) for target in targets):
                 matches.append(trigger)
-        return matches
+        return WebhookTriggerMatch(
+            triggers=matches,
+            event=semantic.model_dump(mode="json"),
+        )
 
     def parse_semantic_event(
         self, event: "WebhookEvent"
@@ -699,6 +734,7 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         task_cls = _TASK_SEMANTIC_EVENTS.get(event_type)
         if task_cls is ClickUpTaskStatusUpdatedEvent:
             return ClickUpTaskStatusUpdatedEvent(
+                type=event_type,
                 task_id=_id_string(payload, "task_id"),
                 list_id=list_id,
                 space_id=space_id,
@@ -707,6 +743,7 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
             )
         if task_cls is not None:
             return task_cls(
+                type=event_type,
                 task_id=_id_string(payload, "task_id"),
                 list_id=list_id,
                 space_id=space_id,
@@ -715,6 +752,7 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         list_cls = _LIST_SEMANTIC_EVENTS.get(event_type)
         if list_cls is not None:
             return list_cls(
+                type=event_type,
                 list_id=list_id,
                 space_id=space_id,
                 folder_id=folder_id,

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -24,7 +24,7 @@ from zenml.webhooks.providers.base import (
     WebhookConfiguration,
     WebhookPayloadError,
     WebhookTargetEvent,
-    authenticate_hmac_sha256_hex,
+    authenticate_hmac_sha256,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -566,11 +566,12 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
             headers: The request headers.
             secret: The webhook signing secret.
         """
-        authenticate_hmac_sha256_hex(
+        authenticate_hmac_sha256(
             body=body,
             headers=headers,
             secret=secret,
             header=CLICKUP_SIGNATURE_HEADER,
+            prefixed=False,
         )
 
     def get_event_type(

--- a/src/zenml/webhooks/providers/registry.py
+++ b/src/zenml/webhooks/providers/registry.py
@@ -87,11 +87,13 @@ class WebhookProviderRegistry:
             if self._builtins_registered:
                 return
 
+            from zenml.webhooks.providers.clickup import ClickUpWebhookProvider
             from zenml.webhooks.providers.custom import CustomWebhookProvider
             from zenml.webhooks.providers.github import GitHubWebhookProvider
 
             self.register(CustomWebhookProvider)
             self.register(GitHubWebhookProvider)
+            self.register(ClickUpWebhookProvider)
             self._builtins_registered = True
 
 

--- a/src/zenml/webhooks/providers/types.py
+++ b/src/zenml/webhooks/providers/types.py
@@ -21,3 +21,4 @@ class BuiltinWebhookType(StrEnum):
 
     CUSTOM = "custom"
     GITHUB = "github"
+    CLICKUP = "clickup"

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -772,6 +772,7 @@ def test_clickup_semantic_events_are_public_pydantic_models() -> None:
     assert isinstance(event, ClickUpSemanticEvent)
     assert event.event_filter_type is TaskStatusUpdated
     assert event.model_dump() == {
+        "type": "taskStatusUpdated",
         "task_id": "abc",
         "list_id": "162641285",
         "space_id": "space-1",
@@ -819,9 +820,14 @@ def test_clickup_match_filters_status_and_list() -> None:
         configuration={"target_events": [{"type": "taskCreated"}]},
     )
 
-    assert provider.match_triggers(
+    result = provider.match_triggers(
         event=event, candidates=[matching, other_list, other_event]
-    ) == [matching]
+    )
+    assert result.triggers == [matching]
+    assert result.event is not None
+    assert result.event["type"] == "taskStatusUpdated"
+    assert result.event["list_id"] == "162641285"
+    assert result.event["status"] == "done"
 
 
 def test_clickup_match_filters_list_events() -> None:
@@ -858,9 +864,13 @@ def test_clickup_match_filters_list_events() -> None:
         },
     )
 
-    assert provider.match_triggers(
+    result = provider.match_triggers(
         event=event, candidates=[matching, other_space, task_target]
-    ) == [matching]
+    )
+    assert result.triggers == [matching]
+    assert result.event is not None
+    assert result.event["type"] == "listCreated"
+    assert result.event["list_id"] == "162641285"
 
 
 def test_clickup_configuration_accepts_typed_configuration() -> None:

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -36,10 +36,13 @@ from zenml.webhooks.providers import (
 )
 from zenml.webhooks.providers.clickup import (
     CLICKUP_SIGNATURE_HEADER,
-    ClickUpTargetEvent,
+    ClickUpSemanticEvent,
+    ClickUpTaskStatusUpdatedEvent,
     ClickUpWebhookConfiguration,
-    ClickUpWebhookEvent,
     ClickUpWebhookProvider,
+    ListCreated,
+    TaskCreated,
+    TaskStatusUpdated,
 )
 from zenml.webhooks.providers.custom import (
     CUSTOM_DELIVERY_HEADER,
@@ -756,6 +759,27 @@ def test_clickup_parse_rejects_missing_event_or_webhook_id() -> None:
         )
 
 
+def test_clickup_semantic_events_are_public_pydantic_models() -> None:
+    """Normalized ClickUp events are available through the public models API."""
+    event = ClickUpTaskStatusUpdatedEvent(
+        task_id="abc",
+        list_id="162641285",
+        space_id="space-1",
+        folder_id=None,
+        status="done",
+    )
+
+    assert isinstance(event, ClickUpSemanticEvent)
+    assert event.event_filter_type is TaskStatusUpdated
+    assert event.model_dump() == {
+        "task_id": "abc",
+        "list_id": "162641285",
+        "space_id": "space-1",
+        "folder_id": None,
+        "status": "done",
+    }
+
+
 def test_clickup_match_filters_status_and_list() -> None:
     """ClickUp matching uses typed target events and resource filters."""
     provider = ClickUpWebhookProvider()
@@ -800,17 +824,79 @@ def test_clickup_match_filters_status_and_list() -> None:
     ) == [matching]
 
 
+def test_clickup_match_filters_list_events() -> None:
+    """List events match list filters and ignore task-only targets."""
+    provider = ClickUpWebhookProvider()
+    event = WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="clickup",
+        event_type="listCreated",
+        payload={
+            "event": "listCreated",
+            "webhook_id": "wh-1",
+            "list_id": "162641285",
+            "space_id": "space-1",
+        },
+    )
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [{"type": "listCreated", "list_id": "162641285"}]
+        },
+    )
+    other_space = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [{"type": "listCreated", "space_id": "space-9"}]
+        },
+    )
+    task_target = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [{"type": "taskCreated", "list_id": "162641285"}]
+        },
+    )
+
+    assert provider.match_triggers(
+        event=event, candidates=[matching, other_space, task_target]
+    ) == [matching]
+
+
 def test_clickup_configuration_accepts_typed_configuration() -> None:
     """Strict ClickUp validation accepts its public typed configuration."""
     provider = ClickUpWebhookProvider()
     configuration = ClickUpWebhookConfiguration(
         target_events=[
-            ClickUpTargetEvent(
-                type=ClickUpWebhookEvent.TASK_STATUS_UPDATED,
+            TaskStatusUpdated(
                 list_id="162641285",
                 status="done",
-            )
+            ),
+            ListCreated(list_id="162641285"),
+            TaskCreated(task_id="abc"),
         ]
     )
 
     assert provider.validate_configuration(configuration) is configuration
+
+
+def test_clickup_configuration_rejects_filters_for_other_events() -> None:
+    """Each ClickUp event type only accepts its own filter fields."""
+    provider = ClickUpWebhookProvider()
+
+    with pytest.raises(ValueError):
+        provider.validate_configuration(
+            {
+                "target_events": [
+                    {"type": "taskCreated", "status": "done"},
+                ]
+            }
+        )
+    with pytest.raises(ValueError):
+        provider.validate_configuration(
+            {
+                "target_events": [
+                    {"type": "listCreated", "task_id": "abc"},
+                ]
+            }
+        )

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -711,9 +711,7 @@ def test_clickup_authentication_uses_raw_hex_signature() -> None:
     """ClickUp HMAC uses a raw hex digest in X-Signature."""
     provider = ClickUpWebhookProvider()
     secret = "clickup-secret"
-    body = (
-        b'{"event":"taskStatusUpdated","webhook_id":"wh-1","task_id":"abc"}'
-    )
+    body = b'{"event":"taskStatusUpdated","webhook_id":"wh-1","task_id":"abc"}'
     headers = {CLICKUP_SIGNATURE_HEADER: _clickup_signature(secret, body)}
 
     provider.authenticate(body=body, headers=headers, secret=secret)
@@ -721,7 +719,10 @@ def test_clickup_authentication_uses_raw_hex_signature() -> None:
     with pytest.raises(WebhookAuthenticationError):
         provider.authenticate(
             body=body,
-            headers={CLICKUP_SIGNATURE_HEADER: "sha256=" + headers[CLICKUP_SIGNATURE_HEADER]},
+            headers={
+                CLICKUP_SIGNATURE_HEADER: "sha256="
+                + headers[CLICKUP_SIGNATURE_HEADER]
+            },
             secret=secret,
         )
 
@@ -786,9 +787,7 @@ def test_clickup_match_filters_status_and_list() -> None:
     other_list = SimpleNamespace(
         id=uuid4(),
         configuration={
-            "target_events": [
-                {"type": "taskStatusUpdated", "list_id": "999"}
-            ]
+            "target_events": [{"type": "taskStatusUpdated", "list_id": "999"}]
         },
     )
     other_event = SimpleNamespace(

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -34,6 +34,13 @@ from zenml.webhooks.providers import (
     WebhookTriggerMatch,
     get_webhook_provider,
 )
+from zenml.webhooks.providers.clickup import (
+    CLICKUP_SIGNATURE_HEADER,
+    ClickUpTargetEvent,
+    ClickUpWebhookConfiguration,
+    ClickUpWebhookEvent,
+    ClickUpWebhookProvider,
+)
 from zenml.webhooks.providers.custom import (
     CUSTOM_DELIVERY_HEADER,
     CUSTOM_EVENT_HEADER,
@@ -322,6 +329,7 @@ def _signature(secret: str, body: bytes) -> str:
 @pytest.mark.parametrize(
     "webhook_type, provider_type",
     [
+        (BuiltinWebhookType.CLICKUP, ClickUpWebhookProvider),
         (BuiltinWebhookType.GITHUB, GitHubWebhookProvider),
         (BuiltinWebhookType.CUSTOM, CustomWebhookProvider),
     ],
@@ -693,3 +701,117 @@ def test_runtime_empty_target_events_are_rejected() -> None:
         provider.match_triggers(event=event, candidates=[trigger]).triggers
         == []
     )
+
+
+def _clickup_signature(secret: str, body: bytes) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_clickup_authentication_uses_raw_hex_signature() -> None:
+    """ClickUp HMAC uses a raw hex digest in X-Signature."""
+    provider = ClickUpWebhookProvider()
+    secret = "clickup-secret"
+    body = (
+        b'{"event":"taskStatusUpdated","webhook_id":"wh-1","task_id":"abc"}'
+    )
+    headers = {CLICKUP_SIGNATURE_HEADER: _clickup_signature(secret, body)}
+
+    provider.authenticate(body=body, headers=headers, secret=secret)
+
+    with pytest.raises(WebhookAuthenticationError):
+        provider.authenticate(
+            body=body,
+            headers={CLICKUP_SIGNATURE_HEADER: "sha256=" + headers[CLICKUP_SIGNATURE_HEADER]},
+            secret=secret,
+        )
+
+
+def test_clickup_parse_extracts_event_and_history_delivery_id() -> None:
+    """ClickUp parsing reads event from the body and builds the idempotency key."""
+    provider = ClickUpWebhookProvider()
+    body = (
+        b'{"event":"taskStatusUpdated","webhook_id":"wh-1","task_id":"abc",'
+        b'"list_id":"162","history_items":[{"id":"hist-2"},{"id":"hist-1"}]}'
+    )
+
+    parsed = provider.parse(body=body, headers={})
+
+    assert parsed.event_type == "taskStatusUpdated"
+    assert parsed.delivery_id == "wh-1:hist-1,hist-2"
+    assert parsed.payload["task_id"] == "abc"
+
+
+def test_clickup_parse_rejects_missing_event_or_webhook_id() -> None:
+    """ClickUp parsing requires event and webhook_id in the JSON body."""
+    provider = ClickUpWebhookProvider()
+
+    with pytest.raises(WebhookPayloadError, match="event"):
+        provider.parse(
+            body=b'{"webhook_id":"wh-1","task_id":"abc"}', headers={}
+        )
+    with pytest.raises(WebhookPayloadError, match="webhook_id"):
+        provider.parse(
+            body=b'{"event":"taskCreated","task_id":"abc"}', headers={}
+        )
+
+
+def test_clickup_match_filters_status_and_list() -> None:
+    """ClickUp matching uses typed target events and resource filters."""
+    provider = ClickUpWebhookProvider()
+    event = WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="clickup",
+        event_type="taskStatusUpdated",
+        payload={
+            "event": "taskStatusUpdated",
+            "webhook_id": "wh-1",
+            "task_id": "abc",
+            "list_id": "162641285",
+            "history_items": [{"id": "hist-1", "after": "done"}],
+        },
+    )
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "taskStatusUpdated",
+                    "list_id": "162641285",
+                    "status": "done",
+                }
+            ]
+        },
+    )
+    other_list = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {"type": "taskStatusUpdated", "list_id": "999"}
+            ]
+        },
+    )
+    other_event = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "taskCreated"}]},
+    )
+
+    assert provider.match_triggers(
+        event=event, candidates=[matching, other_list, other_event]
+    ) == [matching]
+
+
+def test_clickup_configuration_accepts_typed_configuration() -> None:
+    """Strict ClickUp validation accepts its public typed configuration."""
+    provider = ClickUpWebhookProvider()
+    configuration = ClickUpWebhookConfiguration(
+        target_events=[
+            ClickUpTargetEvent(
+                type=ClickUpWebhookEvent.TASK_STATUS_UPDATED,
+                list_id="162641285",
+                status="done",
+            )
+        ]
+    )
+
+    assert provider.validate_configuration(configuration) is configuration


### PR DESCRIPTION
Adds a built-in clickup webhook provider that authenticates ClickUp deliveries (raw hex HMAC in X-Signature) and matches task/list events with string filters.

ClickUp generates the signing secret, so the documented setup is: create the ZenML webhook, register its URL in ClickUp, then rotate ZenML’s secret to ClickUp’s webhook.secret. Signature mismatches still return 401.