### PR TITLE
Slack webhook provider

### DIFF
--- a/docs/book/getting-started/zenml-pro/toc.md
+++ b/docs/book/getting-started/zenml-pro/toc.md
@@ -38,6 +38,7 @@
 * [Snapshots](snapshots.md)
 * [Triggers](triggers.md)
 * [Webhooks](webhooks.md)
+  * [Slack](webhooks/slack.md)
   * [GitHub](webhooks/github.md)
   * [ClickUp](webhooks/clickup.md)
   * [Custom webhooks](webhooks/custom.md)

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -752,6 +752,68 @@ for all fields and supported string-filter operators.
 Attach the trigger to a snapshot as shown below, then follow the
 [signed ClickUp mock request](webhooks/clickup.md#mock-a-signed-clickup-delivery)
 to test the intake path.
+### Slack webhook triggers
+
+Slack webhook triggers support a curated set of events suited to automation:
+app mentions, ordinary human messages, reactions being added or removed,
+message metadata being posted or updated, and files being shared. First,
+configure the Slack app, event subscriptions, and webhook by following
+[Slack webhooks](webhooks/slack.md).
+
+Create `slack-automation.yaml`:
+
+```yaml
+target_events:
+  - type: message_posted
+    channel_id: 'oneof:["C0123456789","C9876543210"]'
+    text: "startswith:deploy production"
+  - type: reaction_added
+    channel_id: C0123456789
+    reaction: rocket
+```
+
+Then create the trigger:
+
+```bash
+zenml trigger webhook create on-slack-automation \
+  --webhook slack-events \
+  --config slack-automation.yaml
+```
+
+Via the SDK:
+
+```python
+from zenml.client import Client
+from zenml.webhooks.providers.slack import (
+    MessagePostedEventFilter,
+    ReactionAddedEventFilter,
+    SlackWebhookConfiguration,
+)
+
+client = Client()
+trigger = client.create_webhook_trigger(
+    name="on-slack-automation",
+    webhook="slack-events",
+    configuration=SlackWebhookConfiguration(
+        target_events=[
+            MessagePostedEventFilter(
+                channel_id='oneof:["C0123456789","C9876543210"]',
+                text="startswith:deploy production",
+            ),
+            ReactionAddedEventFilter(
+                channel_id="C0123456789",
+                reaction="rocket",
+            ),
+        ]
+    ),
+)
+```
+
+Each event filter has event-specific optional fields. Exact, list, and
+`oneof:` string matching are supported throughout; `startswith:` is also
+available for message text and message-metadata event types. See the Slack
+provider's [supported events and filters](webhooks/slack.md#supported-events-and-filters)
+for the complete event catalog, subscription scopes, and matching behavior.
 
 ### Attach the trigger to a snapshot
 

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -755,7 +755,7 @@ to test the intake path.
 ### Slack webhook triggers
 
 Slack webhook triggers support seven semantic event types suited to automation:
-`app_mention`, `message_posted`, `reaction_added`, `reaction_removed`,
+`app_mention`, `message`, `reaction_added`, `reaction_removed`,
 `message_metadata_posted`, `message_metadata_updated`, and `file_shared`.
 First, configure the Slack app, event subscriptions, and webhook by following
 [Slack webhooks](webhooks/slack.md).
@@ -764,7 +764,10 @@ Create `slack-automation.yaml`:
 
 ```yaml
 target_events:
-  - type: message_posted
+  - type: app_mention
+    channel_id: C0123456789
+    text: "startswith:<@U0123456789> deploy production"
+  - type: message
     channel_id: 'oneof:["C0123456789","C9876543210"]'
     text: "startswith:deploy production"
   - type: reaction_added
@@ -785,7 +788,8 @@ Via the SDK:
 ```python
 from zenml.client import Client
 from zenml.webhooks.providers.slack import (
-    MessagePostedEventFilter,
+    AppMentionEventFilter,
+    MessageEventFilter,
     ReactionAddedEventFilter,
     SlackWebhookConfiguration,
 )
@@ -796,7 +800,11 @@ trigger = client.create_webhook_trigger(
     webhook="slack-events",
     configuration=SlackWebhookConfiguration(
         target_events=[
-            MessagePostedEventFilter(
+            AppMentionEventFilter(
+                channel_id="C0123456789",
+                text="startswith:<@U0123456789> deploy production",
+            ),
+            MessageEventFilter(
                 channel_id='oneof:["C0123456789","C9876543210"]',
                 text="startswith:deploy production",
             ),
@@ -811,8 +819,9 @@ trigger = client.create_webhook_trigger(
 
 Each event filter has event-specific optional fields. Exact, list, and
 `oneof:` string matching are supported throughout; `startswith:` is also
-available for message text and message-metadata event types. See the Slack
-provider's [supported events and filters](webhooks/slack.md#supported-events-and-filters)
+available for app-mention text, message text, and message-metadata event types.
+See the Slack provider's
+[supported events and filters](webhooks/slack.md#supported-events-and-filters)
 for the complete event catalog, subscription scopes, and matching behavior.
 
 ### Attach the trigger to a snapshot

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -644,6 +644,41 @@ fields. The SDK accepts a mapping or a typed provider configuration model; the
 typed models are recommended because they validate and document the available
 fields.
 
+### String filter operators
+
+Every provider-defined string field in a webhook event filter supports the same
+case-sensitive operators:
+
+| Syntax | Matches when |
+|--------|--------------|
+| `value` or `equals:value` | The field equals `value` |
+| `notequals:value` | The field does not equal `value` |
+| `contains:value` | The field contains `value` |
+| `notcontains:value` | The field does not contain `value` |
+| `startswith:value` | The field starts with `value` |
+| `endswith:value` | The field ends with `value` |
+| `oneof:["a","b"]` | The field equals one of the JSON-list values |
+| `notoneof:["a","b"]` | The field equals none of the JSON-list values |
+
+A YAML list combines multiple expressions for one field with OR. Use
+`notoneof:` instead of a list of `notequals:` expressions when excluding
+several exact values:
+
+```yaml
+target_events:
+  - type: push
+    branch:
+      - main
+      - "startswith:release/"
+    actor: 'notoneof:["dependabot[bot]","renovate[bot]"]'
+```
+
+Different populated fields on one target event combine with AND, while
+multiple target events combine with OR. An absent event field does not satisfy
+a configured filter, including a negative filter. For collection-valued event
+fields such as GitHub labels, positive operators match any item and negative
+operators require every item to satisfy the expression.
+
 ### GitHub webhook triggers
 
 This example executes a pipeline snapshot when GitHub reports a push to the
@@ -766,7 +801,7 @@ Create `slack-automation.yaml`:
 target_events:
   - type: app_mention
     channel_id: C0123456789
-    text: "startswith:<@U0123456789> deploy production"
+    text: "contains:deploy production"
   - type: message
     channel_id: 'oneof:["C0123456789","C9876543210"]'
     text: "startswith:deploy production"
@@ -802,7 +837,7 @@ trigger = client.create_webhook_trigger(
         target_events=[
             AppMentionEventFilter(
                 channel_id="C0123456789",
-                text="startswith:<@U0123456789> deploy production",
+                text="contains:deploy production",
             ),
             MessageEventFilter(
                 channel_id='oneof:["C0123456789","C9876543210"]',
@@ -817,11 +852,9 @@ trigger = client.create_webhook_trigger(
 )
 ```
 
-Each event filter has event-specific optional fields. Exact, list, and
-`oneof:` string matching are supported throughout; `startswith:` is also
-available for app-mention text, message text, and message-metadata event types.
-See the Slack provider's
-[supported events and filters](webhooks/slack.md#supported-events-and-filters)
+Each event filter has event-specific optional fields, and all string fields use
+the shared [string filter operators](#string-filter-operators). See the Slack
+provider's [supported events and filters](webhooks/slack.md#supported-events-and-filters)
 for the complete event catalog, subscription scopes, and matching behavior.
 
 ### Attach the trigger to a snapshot

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -754,10 +754,10 @@ Attach the trigger to a snapshot as shown below, then follow the
 to test the intake path.
 ### Slack webhook triggers
 
-Slack webhook triggers support a curated set of events suited to automation:
-app mentions, ordinary human messages, reactions being added or removed,
-message metadata being posted or updated, and files being shared. First,
-configure the Slack app, event subscriptions, and webhook by following
+Slack webhook triggers support seven semantic event types suited to automation:
+`app_mention`, `message_posted`, `reaction_added`, `reaction_removed`,
+`message_metadata_posted`, `message_metadata_updated`, and `file_shared`.
+First, configure the Slack app, event subscriptions, and webhook by following
 [Slack webhooks](webhooks/slack.md).
 
 Create `slack-automation.yaml`:
@@ -839,10 +839,11 @@ client.attach_trigger_to_snapshot(
 The trigger's `concurrency` setting controls what happens when another matching
 delivery arrives while a run for an attached snapshot is already active.
 
-Push to the configured branch in GitHub, or use the
-[signed GitHub mock request](webhooks/github.md#mock-a-signed-github-push) to
-test the intake path. Remember that `202 Accepted` confirms webhook intake; use
-trigger dispatch state and pipeline runs to verify downstream execution.
+Send an event from the configured provider, or test the intake path with a
+[signed GitHub mock request](webhooks/github.md#mock-a-signed-github-push) or
+[signed Slack mock request](webhooks/slack.md#mock-a-signed-slack-message).
+Remember that a successful `200` or `202` response confirms webhook intake;
+use trigger dispatch state and pipeline runs to verify downstream execution.
 
 ### Access the upstream webhook event
 

--- a/docs/book/getting-started/zenml-pro/webhooks.md
+++ b/docs/book/getting-started/zenml-pro/webhooks.md
@@ -8,7 +8,8 @@ icon: webhook
 Webhooks connect external systems to ZenML so that your ZenML deployment can
 react to events that happen outside the platform. For example, you can receive
 an event when a pull request is merged in GitHub, when a ClickUp task changes
-status, or when an internal service publishes a new model version.
+status, when someone requests a deployment in Slack, or when an internal service
+publishes a new model version.
 
 When you create a webhook, ZenML exposes a project-scoped intake URL. Configure
 the external system to send signed HTTP requests to that URL.
@@ -23,9 +24,10 @@ For every delivery, the webhook endpoint:
    task after the response is sent.
 
 Consumers define how ZenML reacts to accepted events. For example, a
-[webhook trigger](triggers.md#webhook-triggers) can filter GitHub or ClickUp
+[webhook trigger](triggers.md#webhook-triggers) can filter GitHub, ClickUp or Slack
 events and execute attached pipeline snapshots when a pull request is merged
-or a task status changes.
+or a task status changes, a deployment message is posted, or an approval reaction
+is added.
 
 The endpoint returns an HTTP response selected by the provider. GitHub and
 custom deliveries normally return `202 Accepted`; Slack returns `200 OK`. An
@@ -283,6 +285,10 @@ Provider-specific early handling can refine this behavior. For example, GitHub
 deliveries with a non-empty but unsupported `X-GitHub-Event` value return `202`
 without resolving a webhook. See the [GitHub](webhooks/github.md) and
 [ClickUp](webhooks/clickup.md) providers for details.
+Slack authenticates and acknowledges URL-verification and rate-limit
+control deliveries with `200`, but does not create events for consumers. See
+the [Slack provider](webhooks/slack.md#authentication-and-accepted-envelopes)
+for its complete envelope behavior.
 
 Successful intake schedules event handlers in an in-process background task.
 It does not guarantee that a handler starts or completes, and the handoff is not
@@ -316,6 +322,7 @@ publication, pipeline run creation, or run outcomes.
 
 ## Next steps
 
+- [Configure a Slack webhook](webhooks/slack.md)
 - [Configure a GitHub webhook](webhooks/github.md)
 - [Configure a ClickUp webhook](webhooks/clickup.md)
 - [Send custom webhook events](webhooks/custom.md)

--- a/docs/book/getting-started/zenml-pro/webhooks.md
+++ b/docs/book/getting-started/zenml-pro/webhooks.md
@@ -18,23 +18,27 @@ For every delivery, the webhook endpoint:
 1. verifies the request signature using the webhook's signing secret;
 2. validates the headers and JSON payload required by that webhook type;
 3. records intake statistics for accepted and rejected deliveries; and
-4. makes an accepted event available to configured consumers.
+4. sends the provider-selected successful response; and
+5. makes any accepted event available to configured consumers in a background
+   task after the response is sent.
 
 Consumers define how ZenML reacts to accepted events. For example, a
 [webhook trigger](triggers.md#webhook-triggers) can filter GitHub or ClickUp
 events and execute attached pipeline snapshots when a pull request is merged
 or a task status changes.
 
-The endpoint returns an HTTP response to the sender. A valid delivery normally
-returns `202 Accepted`; an invalid signature, invalid payload, missing webhook,
-or inactive webhook returns an appropriate `4xx` response. The response reports
-the result of webhook intake. Any work performed by consumers happens after
-that intake decision.
+The endpoint returns an HTTP response selected by the provider. GitHub and
+custom deliveries normally return `202 Accepted`; Slack returns `200 OK`. An
+invalid signature, invalid payload, missing webhook, or inactive webhook returns
+an appropriate `4xx` response. The response reports the result of webhook
+intake. Any work performed by consumers happens in an in-process background task
+after the response is sent.
 
 ## Available providers
 
 | Provider | Type | Authentication | Event model |
 |----------|------|----------------|-------------|
+| [Slack](webhooks/slack.md) | `slack` | Slack request signature and timestamp | Curated semantic Slack automation events and typed filters |
 | [GitHub](webhooks/github.md) | `github` | GitHub HMAC-SHA256 signature | Curated semantic GitHub events and string filters |
 | [ClickUp](webhooks/clickup.md) | `clickup` | ClickUp HMAC-SHA256 signature | Curated ClickUp task and list events and string filters |
 | [Custom webhooks](webhooks/custom.md) | `custom` | ZenML HMAC-SHA256 signature | User-supplied event name and JSON object |
@@ -70,7 +74,7 @@ webhook = result
 print(webhook.endpoint_url)
 ```
 
-Provider types are string identifiers. ZenML includes `github`, `clickup`, and
+Provider types are string identifiers. ZenML includes `github`, `clickup`, `slack`, and
 `custom`; servers may register additional provider implementations, and reject
 provider types that are not registered.
 
@@ -264,6 +268,7 @@ Webhook endpoints return intake-level responses:
 
 | Status | Meaning |
 |--------|---------|
+| `200 OK` | The provider accepted the delivery and selected an immediate success response. Slack uses this for event and control deliveries. |
 | `202 Accepted` | The delivery was accepted for processing, or the provider intentionally ignored an unsupported event before webhook lookup. |
 | `400 Bad Request` | Required provider metadata is missing, or the body is not a valid top-level JSON object. |
 | `401 Unauthorized` | The signature does not match the exact request body. |
@@ -278,6 +283,10 @@ Provider-specific early handling can refine this behavior. For example, GitHub
 deliveries with a non-empty but unsupported `X-GitHub-Event` value return `202`
 without resolving a webhook. See the [GitHub](webhooks/github.md) and
 [ClickUp](webhooks/clickup.md) providers for details.
+
+Successful intake schedules event handlers in an in-process background task.
+It does not guarantee that a handler starts or completes, and the handoff is not
+durable if the server process stops after sending the response.
 
 ## Inspect intake statistics
 

--- a/docs/book/getting-started/zenml-pro/webhooks/clickup.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/clickup.md
@@ -156,13 +156,18 @@ Semantic event fields use ZenML string filters (`StringFilterOption`). You can
 use:
 
 - a plain string for exact equality, such as `list_id: "162641285"`;
+- `equals:`, `notequals:`, `contains:`, `notcontains:`, `startswith:`, and
+  `endswith:` expressions;
 - `oneof:` with a non-empty JSON list for exact alternatives, such as
-  `status: 'oneof:["done","complete"]'`.
+  `status: 'oneof:["done","complete"]'`;
+- `notoneof:` with a non-empty JSON list for exclusions; and
+- a YAML list to OR multiple expressions for one field.
 
-ClickUp ID and status fields do not support `startswith:`. Values configured for
-the same field use OR logic; different populated fields use AND logic. Omitted
-fields match any value. If a configured field is absent from a delivery, it
-does not match.
+All filter fields in the table support these generic webhook string operators.
+Values configured for the same field use OR logic; different populated fields
+use AND logic. Omitted fields match any value. If a configured field is absent
+from a delivery, it does not match. See the complete
+[string filter operator reference](../triggers.md#string-filter-operators).
 
 For example, this target matches status updates to `done` on one list:
 

--- a/docs/book/getting-started/zenml-pro/webhooks/custom.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/custom.md
@@ -92,6 +92,7 @@ for the shared response contract.
 ## Related pages
 
 - [Webhooks](../webhooks.md)
+- [Slack webhooks](slack.md)
 - [GitHub webhooks](github.md)
 - [ClickUp webhooks](clickup.md)
 - [Custom webhook triggers](../triggers.md#custom-webhook-triggers)

--- a/docs/book/getting-started/zenml-pro/webhooks/github.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/github.md
@@ -193,5 +193,6 @@ the digest; even a whitespace or newline change produces a different signature.
 
 - [Webhooks](../webhooks.md)
 - [ClickUp webhooks](clickup.md)
+- [Slack webhooks](slack.md)
 - [Custom webhooks](custom.md)
 - [Webhook triggers](../triggers.md#github-webhook-triggers)

--- a/docs/book/getting-started/zenml-pro/webhooks/github.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/github.md
@@ -88,17 +88,21 @@ Semantic event fields use ZenML string filters (`StringFilterOption`). You can
 use:
 
 - a plain string for exact equality, such as `repo: acme/ml-pipelines`;
+- an explicit operator such as `notequals:dependabot[bot]`,
+  `contains:release`, `notcontains:draft`, `startswith:release/`, or
+  `endswith:-production`;
 - `oneof:` with a non-empty JSON list for exact alternatives, such as
   `conclusion: 'oneof:["success","neutral"]'`;
-- `startswith:` for branch-, tag-, and ref-like fields, such as
-  `branch: startswith:release/`.
+- `notoneof:` with a non-empty JSON list for exclusions; and
+- a YAML list to OR multiple expressions for one field.
 
 Values configured for the same field use OR logic; different populated fields
 use AND logic. Omitted fields match any value. If a configured field is absent
 from a delivery, it does not match.
 
-For the collection-valued `labels` and `assignees` fields, a filter matches if
-any value on the issue matches any configured value. For example, this target
+For the collection-valued `labels` and `assignees` fields, positive filters
+match if any value on the issue satisfies the expression. Negative filters
+match only if every value satisfies the expression. For example, this target
 matches an issue carrying either the `bug` or `priority-high` label:
 
 ```yaml
@@ -126,10 +130,10 @@ target_events:
       - "startswith:release/"
 ```
 
-Not every operator applies to every field. `oneof:` is supported by the fields
-in the table, while `startswith:` is limited to `branch`, `target_branch`,
-`source_branch`, and `tag` fields. The issue title, number, and issue type are
-available in the propagated event but are not trigger filters.
+All filter fields in the table support the generic webhook string operators.
+The issue title, number, and issue type are available in the propagated event
+but are not trigger filters. See the complete
+[string filter operator reference](../triggers.md#string-filter-operators).
 
 See [Webhook triggers](../triggers.md#github-webhook-triggers) for a complete
 example that uses this configuration to execute a pipeline snapshot.

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -15,9 +15,10 @@ the Slack app's signing secret to authenticate callbacks sent to ZenML.
 
 ## Create a Slack webhook
 
-Create a Slack app in the workspace you want to connect. A free Slack workspace
-is sufficient. In the app configuration, open **Basic Information**, find
-**App Credentials**, and copy the **Signing Secret**.
+Create a [Slack app](https://api.slack.com/apps) in the workspace you want to
+connect. A free Slack workspace is sufficient. In the app configuration, open
+**Basic Information**, find **App Credentials**, and copy the **Signing
+Secret**.
 
 Pass that Slack-owned secret when creating the ZenML webhook:
 
@@ -87,9 +88,10 @@ channel.
 
 ## Subscribe to automation events
 
-Slack controls which callbacks reach ZenML through the app's bot event
-subscriptions, OAuth scopes, and channel visibility. Under **Subscribe to bot
-events**, add only the source events needed by your automations:
+Slack controls which callbacks reach ZenML through the app's
+[event subscriptions](https://docs.slack.dev/apis/events-api/), OAuth scopes,
+and channel visibility. Under **Subscribe to bot events**, add only the source
+events needed by your automations:
 
 | Slack bot event subscription | ZenML semantic event | Required bot scope |
 |------------------------------|----------------------|--------------------|
@@ -111,7 +113,9 @@ The four Slack message subscriptions all arrive with the raw inner event type
 Message-metadata subscriptions have one additional source-side control. In the
 app manifest, add `settings.event_subscriptions.metadata_subscriptions` entries
 that select an `app_id` and metadata `event_type`. Slack permits one of those
-values, but not both, to be `*`; prefer explicit values when possible.
+values, but not both, to be `*`; prefer explicit values when possible. See
+Slack's [message metadata documentation](https://docs.slack.dev/messaging/message-metadata/)
+for the manifest format.
 
 Install or reinstall the app when Slack asks you to apply scope changes. Invite
 the app to any channel from which it should receive events, then perform one of
@@ -131,17 +135,20 @@ message text, sender, channel, reaction name, or file ID.
 ## Supported events and filters
 
 ZenML supports the following curated automation events. Every filter field is
-optional; populated fields on one event filter combine with AND.
+optional; populated fields on one event filter combine with AND. Every
+normalized event includes `type`, `event_id`, `team_id`, `channel_id`,
+`user_id`, `event_time`, and `event_ts`; fields unavailable in a particular
+Slack callback are `null`.
 
-| Event filter `type` | Available fields |
-|---------------------|-------------------|
-| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` |
-| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` |
-| `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` |
-| `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` |
-| `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` |
-| `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` |
-| `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` |
+| Event filter `type` | Destination filter fields | Additional normalized event fields |
+|---------------------|---------------------------|------------------------------------|
+| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` | `message_ts`, `thread_ts` |
+| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` | `channel_type`, `text`, `message_ts`, `thread_ts` |
+| `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
+| `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
+| `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `app_id`, `bot_id`, `message_ts`, `metadata` (`event_type`, `event_payload`) |
+| `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `app_id`, `bot_id`, `message_ts`, `metadata`, `previous_metadata` |
+| `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` | `file_id` |
 
 String filters support exact values, YAML lists, and the `oneof:` expression.
 `text` and `metadata_event_type` additionally support `startswith:`. Prefix
@@ -154,8 +161,9 @@ ZenML applies a few semantic qualifications and normalizations:
   subtypes, bot messages, and malformed messages are ignored. Root messages and
   thread replies can be selected with `threaded`.
 - Reactions can reference a `message`, `file`, or `file_comment`. `item_type`
-  selects that shape and `item_id` is respectively the message timestamp, file
-  ID, or file-comment ID. `channel_id` is only present when Slack includes it.
+  selects `item.type`, and `item_id` selects `item.id`. The normalized ID is
+  respectively the message timestamp, file ID, or file-comment ID.
+  `channel_id` is only present when Slack includes it.
 - Message-metadata events expose the metadata's declared event type for
   filtering. The complete metadata payload, and the previous metadata on
   updates, remain in the normalized event but are not JSON-path filters.
@@ -244,7 +252,9 @@ or matching.
 Slack signs the exact raw request body with the app signing secret. ZenML
 requires `X-Slack-Signature` with the `v0=` version and
 `X-Slack-Request-Timestamp`, rejects timestamps more than five minutes from the
-server time, and compares signatures in constant time.
+server time, and compares signatures in constant time. The implementation
+follows Slack's
+[request-signing procedure](https://docs.slack.dev/authentication/verifying-requests-from-slack/).
 
 The provider accepts these top-level envelopes:
 
@@ -263,10 +273,66 @@ authentication metadata returns `401 Unauthorized`.
 Slack may retry deliveries. The current intake path does not provide
 cross-delivery idempotency or a durable handoff to background handlers.
 
+## Mock a signed Slack message
+
+You can test the endpoint without asking Slack to send a delivery. This example
+uses a minimal Slack-like `message` callback and computes the `v0` signature
+over Slack's timestamp-prefixed signature base.
+
+Set the endpoint and the Slack signing secret used when you created the
+webhook:
+
+```bash
+export WEBHOOK_URL="<endpoint-url-from-zenml>"
+export WEBHOOK_SECRET="<slack-signing-secret>"
+export SLACK_TIMESTAMP="$(date +%s)"
+```
+
+Write the body without adding a trailing newline:
+
+```bash
+printf '%s' '{"type":"event_callback","team_id":"T0123456789","event":{"type":"message","channel":"C0123456789","channel_type":"channel","user":"U0123456789","text":"deploy production","ts":"1788300000.000100","event_ts":"1788300000.000100"},"event_id":"Ev0123456789","event_time":1788300000}' > slack-message.json
+```
+
+Calculate the signature over the exact body bytes and current timestamp:
+
+```bash
+export SIGNATURE="$(python -c 'import hashlib,hmac,os; body=open("slack-message.json","rb").read(); timestamp=os.environ["SLACK_TIMESTAMP"]; base=f"v0:{timestamp}:".encode()+body; print("v0="+hmac.new(os.environ["WEBHOOK_SECRET"].encode(),base,hashlib.sha256).hexdigest())')"
+```
+
+Send those same bytes with the Slack authentication headers:
+
+```bash
+curl -i -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Slack-Request-Timestamp: $SLACK_TIMESTAMP" \
+  -H "X-Slack-Signature: $SIGNATURE" \
+  --data-binary @slack-message.json
+```
+
+A valid delivery returns `200 OK`. This confirms webhook intake, not that a
+trigger matched or a pipeline run started.
+
+To confirm that signature verification is active, resend the same body and
+timestamp with an invalid signature:
+
+```bash
+curl -i -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Slack-Request-Timestamp: $SLACK_TIMESTAMP" \
+  -H "X-Slack-Signature: v0=invalid" \
+  --data-binary @slack-message.json
+```
+
+This request returns `401 Unauthorized`. Generate a new timestamp and signature
+if more than five minutes have passed. If a calculated signature fails, verify
+that the body passed to `--data-binary` is byte-for-byte identical to the body
+used to calculate the digest.
+
 ## Related pages
 
 - [Webhooks](../webhooks.md)
-- [Webhook triggers](../triggers.md#webhook-triggers)
+- [Slack webhook triggers](../triggers.md#slack-webhook-triggers)
 - [GitHub webhooks](github.md)
 - [Custom webhooks](custom.md)
 - [Slack alerter](../../../component-guide/alerters/slack.md)

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -152,23 +152,22 @@ except for reaction `channel_id`, which Slack omits for files and file comments.
 | `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `channel_id`, `app_id`, `bot_id`, `message_ts`, `metadata`, `previous_metadata` |
 | `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` | `channel_id`, `file_id` |
 
-String filters support exact values, YAML lists, and the `oneof:` expression.
-The `text` filters on `app_mention` and `message`, as well as
-`metadata_event_type`, additionally support `startswith:`. Prefix matching is
-intentionally unavailable for opaque Slack IDs, reaction names, channel types,
-message subtypes, and reaction item types. `threaded` and `include_subtypes`
-are boolean filters. Slack preserves the app mention in `text` as a user-ID
-token such as `<@U0123456789>`, so include that token when matching from the
-beginning of the complete message.
+All string fields support exact values, YAML lists, `equals:`, `notequals:`,
+`contains:`, `notcontains:`, `startswith:`, `endswith:`, `oneof:`, and
+`notoneof:`. Matching is case-sensitive; see the complete
+[string filter operator reference](../triggers.md#string-filter-operators).
+`threaded` and `include_subtypes` are boolean filters. Slack preserves an app
+mention in `text` as a user-ID token such as `<@U0123456789>`, so
+`contains:deploy production` can match the command without requiring that app
+user ID in the filter.
 
 ZenML applies a few semantic qualifications and normalizations:
 
 - `message` matches regular, non-bot messages by default. Set
   `include_subtypes: true` to include all message subtypes and bot-authored
-  messages, or configure `subtype` with an exact value, YAML list, or `oneof:`
-  expression to select named subtypes. `include_subtypes` and `subtype` cannot
-  be combined. Root messages and thread replies can be selected with
-  `threaded`.
+  messages, or configure `subtype` with any string filter expression to select
+  named subtypes. `include_subtypes` and `subtype` cannot be combined. Root
+  messages and thread replies can be selected with `threaded`.
 - Slack subtype payloads are not uniform. For example, message edits carry the
   current content in a nested `message` object, while deletions may omit user
   and text fields. ZenML normalizes nested content when available; a configured
@@ -196,7 +195,7 @@ other filtered webhook providers. Multiple event filters combine with OR. Create
 target_events:
   - type: app_mention
     channel_id: C0123456789
-    text: "startswith:<@U0123456789> deploy production"
+    text: "contains:deploy production"
     threaded: false
   - type: message
     channel_id: C0123456789
@@ -248,7 +247,7 @@ trigger = client.create_webhook_trigger(
         target_events=[
             AppMentionEventFilter(
                 channel_id="C0123456789",
-                text="startswith:<@U0123456789> deploy production",
+                text="contains:deploy production",
                 threaded=False,
             ),
             MessageEventFilter(

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -317,7 +317,7 @@ export SLACK_TIMESTAMP="$(date +%s)"
 Write the body without adding a trailing newline:
 
 ```bash
-printf '%s' '{"type":"event_callback","team_id":"T0123456789","event":{"type":"message","channel":"C0123456789","channel_type":"channel","user":"U0123456789","text":"deploy production","ts":"1788300000.000100","event_ts":"1788300000.000100"},"event_id":"Ev0123456789","event_time":1788300000}' > slack-message.json
+printf '%s' '{"type":"event_callback","team_id":"T0123456789","event":{"type":"message","channel":"C0123456789","channel_type":"channel","user":"U0123456789","text":"deploy production","ts":"1788300000.000100","event_ts":"1788300000.000100"},"event_id":"Ev0123456788","event_time":1788300000}' > slack-message.json
 ```
 
 Calculate the signature over the exact body bytes and current timestamp:

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -136,19 +136,20 @@ message text, sender, channel, reaction name, or file ID.
 
 ZenML supports the following curated automation events. Every filter field is
 optional; populated fields on one event filter combine with AND. Every
-normalized event includes `type`, `event_id`, `team_id`, `channel_id`,
-`user_id`, `event_time`, and `event_ts`; fields unavailable in a particular
-Slack callback are `null`.
+normalized event includes the non-null fields `type`, `event_id`, `team_id`,
+`user_id`, `event_time`, and `event_ts`. The event-specific `channel_id` is
+non-null except for reactions to files and file comments, where Slack does not
+include a channel.
 
 | Event filter `type` | Destination filter fields | Additional normalized event fields |
 |---------------------|---------------------------|------------------------------------|
-| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` | `message_ts`, `thread_ts` |
-| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` | `channel_type`, `text`, `message_ts`, `thread_ts` |
-| `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
-| `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
-| `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `app_id`, `bot_id`, `message_ts`, `metadata` (`event_type`, `event_payload`) |
-| `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `app_id`, `bot_id`, `message_ts`, `metadata`, `previous_metadata` |
-| `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` | `file_id` |
+| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` | `channel_id`, `message_ts`, `thread_ts` |
+| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` | `channel_id`, `channel_type`, `text`, `message_ts`, `thread_ts` |
+| `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `channel_id`, `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
+| `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `channel_id`, `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
+| `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `channel_id`, `app_id`, `bot_id`, `message_ts`, `metadata` (`event_type`, `event_payload`) |
+| `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `channel_id`, `app_id`, `bot_id`, `message_ts`, `metadata`, `previous_metadata` |
+| `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` | `channel_id`, `file_id` |
 
 String filters support exact values, YAML lists, and the `oneof:` expression.
 `text` and `metadata_event_type` additionally support `startswith:`. Prefix

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -96,10 +96,10 @@ events needed by your automations:
 | Slack bot event subscription | ZenML semantic event | Required bot scope |
 |------------------------------|----------------------|--------------------|
 | `app_mention` | `app_mention` | `app_mentions:read` |
-| `message.channels` | `message_posted` in public channels | `channels:history` |
-| `message.groups` | `message_posted` in private channels | `groups:history` |
-| `message.im` | `message_posted` in direct messages | `im:history` |
-| `message.mpim` | `message_posted` in group direct messages | `mpim:history` |
+| `message.channels` | `message` in public channels | `channels:history` |
+| `message.groups` | `message` in private channels | `groups:history` |
+| `message.im` | `message` in direct messages | `im:history` |
+| `message.mpim` | `message` in group direct messages | `mpim:history` |
 | `reaction_added` | `reaction_added` | `reactions:read` |
 | `reaction_removed` | `reaction_removed` | `reactions:read` |
 | `message_metadata_posted` | `message_metadata_posted` | `metadata.message:read` |
@@ -107,8 +107,8 @@ events needed by your automations:
 | `file_shared` | `file_shared` | `files:read` |
 
 The four Slack message subscriptions all arrive with the raw inner event type
-`message`. ZenML exposes qualifying messages as the more precise semantic event
-`message_posted`.
+`message`. ZenML uses the same type for message trigger filters and exposes the
+optional Slack `subtype` for more precise matching.
 
 Message-metadata subscriptions have one additional source-side control. In the
 app manifest, add `settings.event_subscriptions.metadata_subscriptions` entries
@@ -137,14 +137,15 @@ message text, sender, channel, reaction name, or file ID.
 ZenML supports the following curated automation events. Every filter field is
 optional; populated fields on one event filter combine with AND. Every
 normalized event includes the non-null fields `type`, `event_id`, `team_id`,
-`user_id`, `event_time`, and `event_ts`. The event-specific `channel_id` is
-non-null except for reactions to files and file comments, where Slack does not
-include a channel.
+`event_time`, and `event_ts`. Message fields such as `user_id`, `channel_id`,
+`text`, and `message_ts` are optional because Slack message subtypes have
+different payload shapes. Other event-specific identifiers remain non-null
+except for reaction `channel_id`, which Slack omits for files and file comments.
 
 | Event filter `type` | Destination filter fields | Additional normalized event fields |
 |---------------------|---------------------------|------------------------------------|
-| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` | `channel_id`, `message_ts`, `thread_ts` |
-| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` | `channel_id`, `channel_type`, `text`, `message_ts`, `thread_ts` |
+| `app_mention` | `team_id`, `channel_id`, `user_id`, `text`, `threaded` | `channel_id`, `text`, `message_ts`, `thread_ts` |
+| `message` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `subtype`, `include_subtypes`, `threaded` | `channel_id`, `channel_type`, `user_id`, `text`, `subtype`, `bot_authored`, `message_ts`, `thread_ts` |
 | `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `channel_id`, `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
 | `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` | `channel_id`, `reaction`, `item_user_id`, `item` (`type`, `id`, `channel_id`, `file_id`) |
 | `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` | `channel_id`, `app_id`, `bot_id`, `message_ts`, `metadata` (`event_type`, `event_payload`) |
@@ -152,15 +153,26 @@ include a channel.
 | `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` | `channel_id`, `file_id` |
 
 String filters support exact values, YAML lists, and the `oneof:` expression.
-`text` and `metadata_event_type` additionally support `startswith:`. Prefix
-matching is intentionally unavailable for opaque Slack IDs, reaction names,
-channel types, and reaction item types. `threaded` is a boolean filter.
+The `text` filters on `app_mention` and `message`, as well as
+`metadata_event_type`, additionally support `startswith:`. Prefix matching is
+intentionally unavailable for opaque Slack IDs, reaction names, channel types,
+message subtypes, and reaction item types. `threaded` and `include_subtypes`
+are boolean filters. Slack preserves the app mention in `text` as a user-ID
+token such as `<@U0123456789>`, so include that token when matching from the
+beginning of the complete message.
 
 ZenML applies a few semantic qualifications and normalizations:
 
-- `message_posted` accepts only ordinary human-authored messages. Message
-  subtypes, bot messages, and malformed messages are ignored. Root messages and
-  thread replies can be selected with `threaded`.
+- `message` matches regular, non-bot messages by default. Set
+  `include_subtypes: true` to include all message subtypes and bot-authored
+  messages, or configure `subtype` with an exact value, YAML list, or `oneof:`
+  expression to select named subtypes. `include_subtypes` and `subtype` cannot
+  be combined. Root messages and thread replies can be selected with
+  `threaded`.
+- Slack subtype payloads are not uniform. For example, message edits carry the
+  current content in a nested `message` object, while deletions may omit user
+  and text fields. ZenML normalizes nested content when available; a configured
+  filter does not match when its corresponding event field is unavailable.
 - Reactions can reference a `message`, `file`, or `file_comment`. `item_type`
   selects `item.type`, and `item_id` selects `item.id`. The normalized ID is
   respectively the message timestamp, file ID, or file-comment ID.
@@ -184,8 +196,9 @@ other filtered webhook providers. Multiple event filters combine with OR. Create
 target_events:
   - type: app_mention
     channel_id: C0123456789
+    text: "startswith:<@U0123456789> deploy production"
     threaded: false
-  - type: message_posted
+  - type: message
     channel_id: C0123456789
     text: "startswith:deploy production"
   - type: reaction_added
@@ -204,13 +217,25 @@ zenml trigger webhook create on-slack-automation \
   --config slack-automation.yaml
 ```
 
+The default `message` target above matches regular non-bot messages only. To
+match every message variant, use `include_subtypes: true`. To select particular
+subtypes instead, provide one value or a YAML list:
+
+```yaml
+target_events:
+  - type: message
+    subtype:
+      - message_changed
+      - message_deleted
+```
+
 Via the SDK, use the typed Slack configuration:
 
 ```python
 from zenml.client import Client
 from zenml.webhooks.providers.slack import (
     AppMentionEventFilter,
-    MessagePostedEventFilter,
+    MessageEventFilter,
     ReactionAddedEventFilter,
     SlackWebhookConfiguration,
 )
@@ -223,9 +248,10 @@ trigger = client.create_webhook_trigger(
         target_events=[
             AppMentionEventFilter(
                 channel_id="C0123456789",
+                text="startswith:<@U0123456789> deploy production",
                 threaded=False,
             ),
-            MessagePostedEventFilter(
+            MessageEventFilter(
                 channel_id="C0123456789",
                 text="startswith:deploy production",
             ),

--- a/docs/book/getting-started/zenml-pro/webhooks/slack.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/slack.md
@@ -1,0 +1,272 @@
+---
+description: Connect the Slack Events API to a ZenML webhook endpoint.
+---
+
+# Slack webhooks
+
+The Slack webhook provider receives and authenticates callbacks from the Slack
+Events API. Use it to verify a Slack app's Request URL and turn selected Slack
+collaboration events into ZenML automation triggers.
+
+This inbound provider is separate from the
+[Slack alerter](../../../component-guide/alerters/slack.md). The alerter uses a
+Slack OAuth token to send messages from a pipeline; the webhook provider uses
+the Slack app's signing secret to authenticate callbacks sent to ZenML.
+
+## Create a Slack webhook
+
+Create a Slack app in the workspace you want to connect. A free Slack workspace
+is sufficient. In the app configuration, open **Basic Information**, find
+**App Credentials**, and copy the **Signing Secret**.
+
+Pass that Slack-owned secret when creating the ZenML webhook:
+
+```bash
+export SLACK_SIGNING_SECRET="<signing-secret-from-slack>"
+
+zenml webhook create slack-events \
+  --type slack \
+  --secret "$SLACK_SIGNING_SECRET"
+```
+
+Then describe the webhook and copy its endpoint URL:
+
+```bash
+zenml webhook describe slack-events
+```
+
+Via the SDK:
+
+```python
+import os
+
+from zenml.client import Client
+from zenml.webhooks.providers import BuiltinWebhookType
+
+result = Client().create_webhook(
+    name="slack-events",
+    webhook_type=BuiltinWebhookType.SLACK,
+    secret=os.environ["SLACK_SIGNING_SECRET"],
+)
+
+endpoint_url = result.endpoint_url
+```
+
+ZenML still permits omission of `--secret` and will generate a value as it does
+for other providers. That generated value cannot authenticate Slack callbacks:
+Slack owns the signing secret used for this integration.
+
+## Verify the Events API Request URL
+
+Your ZenML endpoint must be reachable from Slack over public HTTPS.
+Slack **Socket Mode must be disabled**: Socket Mode delivers Events API
+callbacks over a WebSocket connection instead of sending them to the ZenML
+HTTP endpoint.
+
+1. In the Slack app configuration, open **Event Subscriptions**.
+2. Turn on **Enable Events**.
+3. Paste the ZenML webhook endpoint into **Request URL**.
+4. Wait for Slack to show **Verified**.
+
+Slack sends a signed `url_verification` delivery during this flow. ZenML first
+verifies the Slack signature and timestamp, then returns the challenge as
+`200 OK` plaintext. The control delivery increments accepted intake statistics
+but does not create a `WebhookEvent`.
+
+If verification fails, check that:
+
+- the endpoint is publicly reachable over HTTPS;
+- **Socket Mode** is disabled;
+- the ZenML webhook was created with this Slack app's signing secret; and
+- the server clock is accurate enough for Slack's five-minute request window.
+
+If URL verification succeeds but subscribed events do not increment the
+webhook's `received_count`, also confirm that Socket Mode remains disabled, the
+app was reinstalled after its scopes changed, and the app belongs to the test
+channel.
+
+## Subscribe to automation events
+
+Slack controls which callbacks reach ZenML through the app's bot event
+subscriptions, OAuth scopes, and channel visibility. Under **Subscribe to bot
+events**, add only the source events needed by your automations:
+
+| Slack bot event subscription | ZenML semantic event | Required bot scope |
+|------------------------------|----------------------|--------------------|
+| `app_mention` | `app_mention` | `app_mentions:read` |
+| `message.channels` | `message_posted` in public channels | `channels:history` |
+| `message.groups` | `message_posted` in private channels | `groups:history` |
+| `message.im` | `message_posted` in direct messages | `im:history` |
+| `message.mpim` | `message_posted` in group direct messages | `mpim:history` |
+| `reaction_added` | `reaction_added` | `reactions:read` |
+| `reaction_removed` | `reaction_removed` | `reactions:read` |
+| `message_metadata_posted` | `message_metadata_posted` | `metadata.message:read` |
+| `message_metadata_updated` | `message_metadata_updated` | `metadata.message:read` |
+| `file_shared` | `file_shared` | `files:read` |
+
+The four Slack message subscriptions all arrive with the raw inner event type
+`message`. ZenML exposes qualifying messages as the more precise semantic event
+`message_posted`.
+
+Message-metadata subscriptions have one additional source-side control. In the
+app manifest, add `settings.event_subscriptions.metadata_subscriptions` entries
+that select an `app_id` and metadata `event_type`. Slack permits one of those
+values, but not both, to be `*`; prefer explicit values when possible.
+
+Install or reinstall the app when Slack asks you to apply scope changes. Invite
+the app to any channel from which it should receive events, then perform one of
+the subscribed actions.
+
+An authenticated `event_callback` returns an empty `200 OK`. ZenML maps the
+inner Slack event's `type` to `WebhookEvent.event_type`, maps Slack's `event_id`
+to `WebhookEvent.delivery_id`, and preserves the complete outer payload. Event
+handlers run in an in-process background task after the HTTP response is sent.
+
+Slack's subscriptions are the source-side filter: they determine which event
+families and visible conversations Slack sends. ZenML event filters are the
+destination-side control: they select which accepted callbacks launch a given
+automation. The Events API does not provide arbitrary source-side filters for
+message text, sender, channel, reaction name, or file ID.
+
+## Supported events and filters
+
+ZenML supports the following curated automation events. Every filter field is
+optional; populated fields on one event filter combine with AND.
+
+| Event filter `type` | Available fields |
+|---------------------|-------------------|
+| `app_mention` | `team_id`, `channel_id`, `user_id`, `threaded` |
+| `message_posted` | `team_id`, `channel_id`, `user_id`, `channel_type`, `text`, `threaded` |
+| `reaction_added` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` |
+| `reaction_removed` | `team_id`, `channel_id`, `reaction`, `user_id`, `item_user_id`, `item_type`, `item_id` |
+| `message_metadata_posted` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` |
+| `message_metadata_updated` | `team_id`, `channel_id`, `app_id`, `user_id`, `bot_id`, `metadata_event_type` |
+| `file_shared` | `team_id`, `channel_id`, `user_id`, `file_id` |
+
+String filters support exact values, YAML lists, and the `oneof:` expression.
+`text` and `metadata_event_type` additionally support `startswith:`. Prefix
+matching is intentionally unavailable for opaque Slack IDs, reaction names,
+channel types, and reaction item types. `threaded` is a boolean filter.
+
+ZenML applies a few semantic qualifications and normalizations:
+
+- `message_posted` accepts only ordinary human-authored messages. Message
+  subtypes, bot messages, and malformed messages are ignored. Root messages and
+  thread replies can be selected with `threaded`.
+- Reactions can reference a `message`, `file`, or `file_comment`. `item_type`
+  selects that shape and `item_id` is respectively the message timestamp, file
+  ID, or file-comment ID. `channel_id` is only present when Slack includes it.
+- Message-metadata events expose the metadata's declared event type for
+  filtering. The complete metadata payload, and the previous metadata on
+  updates, remain in the normalized event but are not JSON-path filters.
+- `file_shared` exposes the IDs delivered by Slack. ZenML does not call Slack's
+  Web API to enrich the file during intake.
+
+Other valid Slack event callbacks can still be accepted by intake, but they do
+not match a trigger.
+
+## Create a Slack trigger
+
+Slack trigger configuration follows the same typed `target_events` shape as
+other filtered webhook providers. Multiple event filters combine with OR. Create
+`slack-automation.yaml`:
+
+```yaml
+target_events:
+  - type: app_mention
+    channel_id: C0123456789
+    threaded: false
+  - type: message_posted
+    channel_id: C0123456789
+    text: "startswith:deploy production"
+  - type: reaction_added
+    channel_id: C0123456789
+    reaction: rocket
+    item_type: message
+  - type: message_metadata_posted
+    metadata_event_type: "startswith:zenml.pipeline."
+```
+
+Create the trigger for the Slack webhook:
+
+```bash
+zenml trigger webhook create on-slack-automation \
+  --webhook slack-events \
+  --config slack-automation.yaml
+```
+
+Via the SDK, use the typed Slack configuration:
+
+```python
+from zenml.client import Client
+from zenml.webhooks.providers.slack import (
+    AppMentionEventFilter,
+    MessagePostedEventFilter,
+    ReactionAddedEventFilter,
+    SlackWebhookConfiguration,
+)
+
+client = Client()
+trigger = client.create_webhook_trigger(
+    name="on-slack-automation",
+    webhook="slack-events",
+    configuration=SlackWebhookConfiguration(
+        target_events=[
+            AppMentionEventFilter(
+                channel_id="C0123456789",
+                threaded=False,
+            ),
+            MessagePostedEventFilter(
+                channel_id="C0123456789",
+                text="startswith:deploy production",
+            ),
+            ReactionAddedEventFilter(
+                channel_id="C0123456789",
+                reaction="rocket",
+                item_type="message",
+            ),
+        ]
+    ),
+)
+```
+
+Attach the trigger to a pipeline snapshot before testing it. See
+[Webhook triggers](../triggers.md#webhook-triggers) for attachment and runtime
+inspection commands.
+
+The normalized events retain useful non-filterable context such as Slack's
+`event_id`, event timestamp, message timestamp, thread timestamp, and metadata
+payload. ZenML does not call Slack to resolve message permalinks during intake
+or matching.
+
+## Authentication and accepted envelopes
+
+Slack signs the exact raw request body with the app signing secret. ZenML
+requires `X-Slack-Signature` with the `v0=` version and
+`X-Slack-Request-Timestamp`, rejects timestamps more than five minutes from the
+server time, and compares signatures in constant time.
+
+The provider accepts these top-level envelopes:
+
+| Slack delivery type | ZenML behavior |
+|---------------------|----------------|
+| `event_callback` | Returns empty `200` and schedules one trusted `WebhookEvent` |
+| `url_verification` | Returns `200 text/plain` with the challenge and schedules no event |
+| `app_rate_limited` | Returns empty `200` and schedules no event |
+
+Malformed JSON, malformed known envelopes, and unsupported top-level delivery
+types return `400 Bad Request`. For `app_rate_limited`, ZenML validates Slack's
+`team_id`, `api_app_id`, and integer `minute_rate_limited` fields before
+acknowledging the control delivery. Missing, invalid, stale, or future-dated
+authentication metadata returns `401 Unauthorized`.
+
+Slack may retry deliveries. The current intake path does not provide
+cross-delivery idempotency or a durable handoff to background handlers.
+
+## Related pages
+
+- [Webhooks](../webhooks.md)
+- [Webhook triggers](../triggers.md#webhook-triggers)
+- [GitHub webhooks](github.md)
+- [Custom webhooks](custom.md)
+- [Slack alerter](../../../component-guide/alerters/slack.md)

--- a/src/zenml/webhooks/AGENTS.md
+++ b/src/zenml/webhooks/AGENTS.md
@@ -6,8 +6,9 @@ handlers perform downstream work after intake.
 
 ## Architecture
 
-- `providers/base.py` defines the stateless provider contract, configuration,
-  target-event filters, and shared authentication helpers.
+- `providers/base.py` defines the stateless provider contract, parsed delivery
+  and intake response models, configuration, target-event filters, and shared
+  authentication helpers.
 - `providers/<provider>.py` owns provider-specific authentication, parsing,
   typed trigger configuration, semantic events, and matching.
 - `providers/registry.py` lazily registers bundled providers.
@@ -19,24 +20,28 @@ handlers perform downstream work after intake.
 
 The intake order is significant: pre-validate cheap header metadata, resolve
 the webhook, authenticate the exact raw body, verify that it is active, parse
-the payload, record acceptance, then dispatch a `WebhookEvent`. Never expose an
-unauthenticated payload to handlers or perform provider side effects in intake.
+the delivery, record acceptance, then return the provider-owned response with
+any `WebhookEvent` dispatch attached as an in-process background task. Never
+expose an unauthenticated payload to handlers or perform provider side effects
+in intake.
 
 A successful `2XX` intake response means only that ZenML accepted the trusted
-delivery. The exact success status may vary by integration. It does not confirm
-trigger matching, queuing, or snapshot execution. Preserve this boundary:
-return after intake and keep downstream handler failures isolated and
-observable through handler logs and dispatch state. A handler failure must not
-change an accepted delivery into an HTTP intake failure or cause the provider
-to retry it.
+delivery. The exact success status and payload may vary by integration. It does
+not confirm trigger matching, queuing, or snapshot execution. Preserve this
+boundary: return after intake and keep downstream handler failures isolated and
+observable through handler logs and dispatch state. The background handoff is
+not durable. A handler failure must not change an accepted delivery into an HTTP
+intake failure or cause the provider to retry it.
 
 ## Adding a Provider
 
 1. Add a provider module with a `WebhookConfiguration` subclass and a
    `BaseWebhookProvider` implementation.
 2. Implement authentication, event-type extraction, optional delivery-ID
-   extraction, and trigger matching. Override `parse` or `pre_validate` only
-   when the generic behavior is insufficient.
+   extraction, and trigger matching. Override `parse_delivery`, `parse`, or
+   `pre_validate` only when the generic behavior is insufficient. Use
+   `parse_delivery` for successful control deliveries without events or
+   provider-specific success responses.
 3. Add bundled provider identifiers to `BuiltinWebhookType` and lazy
    registration to `WebhookProviderRegistry`. The enum is intentionally not an
    exhaustive list of externally registered provider types.
@@ -44,8 +49,9 @@ to retry it.
    provider-specific configuration and event classes from their provider
    module, not from `zenml.models`.
 5. Cover registry lookup, authentication over exact bytes, malformed payloads,
-   event metadata, configuration validation, and trigger matching in
-   `tests/unit/webhooks/test_providers.py`.
+   event metadata, configuration validation, and trigger matching in a focused
+   provider test module. Integration-specific providers may keep this coverage
+   under `tests/integration/functional/webhooks/`.
 6. Update webhook and trigger SDK/CLI documentation and signed request examples.
 
 Providers must be stateless: the registry creates a fresh instance for each

--- a/src/zenml/webhooks/__init__.py
+++ b/src/zenml/webhooks/__init__.py
@@ -18,8 +18,11 @@ from zenml.webhooks.handler import WebhookEventHandler
 from zenml.webhooks.intake import WebhookIntakeConfig
 from zenml.webhooks.providers import (
     BaseWebhookProvider,
+    ParsedWebhookDelivery,
+    ParsedWebhookEvent,
     WebhookAuthenticationError,
     WebhookConfiguration,
+    WebhookIntakeResponse,
     WebhookPayloadError,
     WebhookPreValidationResult,
     WebhookProviderRegistry,
@@ -31,11 +34,14 @@ from zenml.webhooks.providers import (
 
 __all__ = [
     "BaseWebhookProvider",
+    "ParsedWebhookDelivery",
+    "ParsedWebhookEvent",
     "WebhookConfiguration",
     "WebhookAuthenticationError",
     "WebhookEvent",
     "WebhookEventHandler",
     "WebhookIntakeConfig",
+    "WebhookIntakeResponse",
     "WebhookPayloadError",
     "WebhookPreValidationResult",
     "WebhookProviderRegistry",

--- a/src/zenml/webhooks/providers/__init__.py
+++ b/src/zenml/webhooks/providers/__init__.py
@@ -3,8 +3,11 @@
 
 from zenml.webhooks.providers.base import (
     BaseWebhookProvider,
+    ParsedWebhookDelivery,
+    ParsedWebhookEvent,
     WebhookAuthenticationError,
     WebhookConfiguration,
+    WebhookIntakeResponse,
     WebhookPayloadError,
     WebhookPreValidationResult,
     WebhookTargetEvent,
@@ -20,8 +23,11 @@ from zenml.webhooks.providers.types import BuiltinWebhookType
 __all__ = [
     "BaseWebhookProvider",
     "BuiltinWebhookType",
+    "ParsedWebhookDelivery",
+    "ParsedWebhookEvent",
     "WebhookConfiguration",
     "WebhookAuthenticationError",
+    "WebhookIntakeResponse",
     "WebhookPayloadError",
     "WebhookPreValidationResult",
     "WebhookProviderRegistry",

--- a/src/zenml/webhooks/providers/base.py
+++ b/src/zenml/webhooks/providers/base.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from zenml.exceptions import CredentialsNotValid
 from zenml.models.v2.base.filter import StringFilterOption
@@ -208,6 +208,23 @@ class WebhookTriggerMatch(BaseModel, Generic[WebhookTriggerT]):
     event: dict[str, Any] | None = None
 
 
+class WebhookIntakeResponse(BaseModel):
+    """Provider-owned successful webhook intake response."""
+
+    status_code: int = Field(default=202, ge=200, lt=300)
+    body: str | None = None
+    media_type: str | None = None
+
+
+class ParsedWebhookDelivery(BaseModel):
+    """A successful provider delivery and its intake response."""
+
+    event: ParsedWebhookEvent | None
+    response: WebhookIntakeResponse = Field(
+        default_factory=WebhookIntakeResponse
+    )
+
+
 class BaseWebhookProvider(ABC):
     """Stateless provider behavior used by intake and trigger matching."""
 
@@ -273,6 +290,23 @@ class BaseWebhookProvider(ABC):
             delivery_id=self.get_delivery_id(payload=payload, headers=headers),
             payload=payload,
         )
+
+    def parse_delivery(
+        self, body: bytes, headers: Mapping[str, str]
+    ) -> ParsedWebhookDelivery:
+        """Parse a successful delivery and select its intake response.
+
+        Existing providers can continue to implement :meth:`parse`; providers
+        with control deliveries or custom responses can override this method.
+
+        Args:
+            body: The raw request body.
+            headers: The request headers.
+
+        Returns:
+            The parsed delivery and provider-owned response.
+        """
+        return ParsedWebhookDelivery(event=self.parse(body, headers))
 
     @abstractmethod
     def get_event_type(

--- a/src/zenml/webhooks/providers/base.py
+++ b/src/zenml/webhooks/providers/base.py
@@ -9,10 +9,11 @@ import hmac
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from zenml.enums import GenericFilterOps
 from zenml.exceptions import CredentialsNotValid
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
@@ -24,6 +25,22 @@ if TYPE_CHECKING:
 
 
 WebhookTriggerT = TypeVar("WebhookTriggerT")
+
+_WEBHOOK_STRING_FILTER_OPERATORS = {
+    GenericFilterOps.EQUALS,
+    GenericFilterOps.NOT_EQUALS,
+    GenericFilterOps.CONTAINS,
+    GenericFilterOps.NOT_CONTAINS,
+    GenericFilterOps.STARTSWITH,
+    GenericFilterOps.ENDSWITH,
+    GenericFilterOps.ONEOF,
+    GenericFilterOps.NOT_ONEOF,
+}
+_WEBHOOK_NEGATIVE_STRING_FILTER_OPERATORS = {
+    GenericFilterOps.NOT_EQUALS,
+    GenericFilterOps.NOT_CONTAINS,
+    GenericFilterOps.NOT_ONEOF,
+}
 
 
 class WebhookAuthenticationError(CredentialsNotValid):
@@ -48,28 +65,17 @@ class WebhookTargetEvent(BaseModel):
 
     type: str
 
-    @classmethod
-    @abstractmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-
     @staticmethod
     def _validate_filter(
         value: StringFilterOption,
         *,
         field_name: str,
-        allow_startswith: bool,
     ) -> StringFilterOption:
         """Validate one webhook event string filter.
 
         Args:
             value: The filter value to validate.
             field_name: The name of the filtered event field.
-            allow_startswith: Whether the field supports prefix matching.
 
         Returns:
             The validated filter value.
@@ -79,9 +85,6 @@ class WebhookTargetEvent(BaseModel):
         """
         if value is None:
             return None
-        allowed = {"oneof"}
-        if allow_startswith:
-            allowed.add("startswith")
         for item in value if isinstance(value, list) else [value]:
             if not item:
                 raise ValueError(
@@ -90,7 +93,7 @@ class WebhookTargetEvent(BaseModel):
             if ":" not in item:
                 continue
             operator, operand = item.split(":", 1)
-            if operator not in allowed:
+            if operator not in _WEBHOOK_STRING_FILTER_OPERATORS:
                 raise ValueError(
                     f"Webhook event filter '{field_name}' does not support "
                     f"the '{operator}' operator."
@@ -100,13 +103,16 @@ class WebhookTargetEvent(BaseModel):
                     f"Webhook event filter '{field_name}' has an empty "
                     "operand."
                 )
-            if operator == "oneof":
+            if operator in {
+                GenericFilterOps.ONEOF,
+                GenericFilterOps.NOT_ONEOF,
+            }:
                 try:
                     choices = json.loads(operand)
                 except json.JSONDecodeError as error:
                     raise ValueError(
                         f"Webhook event filter '{field_name}' requires a "
-                        "JSON-formatted list for 'oneof'."
+                        f"JSON-formatted list for '{operator}'."
                     ) from error
                 if (
                     not isinstance(choices, list)
@@ -118,7 +124,7 @@ class WebhookTargetEvent(BaseModel):
                 ):
                     raise ValueError(
                         f"Webhook event filter '{field_name}' requires a "
-                        "non-empty JSON list of strings for 'oneof'."
+                        f"non-empty JSON list of strings for '{operator}'."
                     )
         return value
 
@@ -129,14 +135,61 @@ class WebhookTargetEvent(BaseModel):
         Returns:
             The validated target event.
         """
-        prefix_matching_support = self.get_prefix_matching_support()
-        for field_name, allow_startswith in prefix_matching_support.items():
+        for field_name, field in type(self).model_fields.items():
+            if cast(Any, field.annotation) != StringFilterOption:
+                continue
             self._validate_filter(
                 getattr(self, field_name),
                 field_name=field_name,
-                allow_startswith=allow_startswith,
             )
         return self
+
+
+def _matches_string_filter_value(*, actual: str, configured: str) -> bool:
+    """Match one actual string against one configured filter expression.
+
+    Args:
+        actual: The value extracted from the webhook event.
+        configured: One validated string filter expression.
+
+    Returns:
+        Whether the actual value satisfies the expression.
+    """
+    if ":" not in configured:
+        return actual == configured
+    operator, operand = configured.split(":", 1)
+    if operator == GenericFilterOps.EQUALS:
+        return actual == operand
+    if operator == GenericFilterOps.NOT_EQUALS:
+        return actual != operand
+    if operator == GenericFilterOps.CONTAINS:
+        return operand in actual
+    if operator == GenericFilterOps.NOT_CONTAINS:
+        return operand not in actual
+    if operator == GenericFilterOps.STARTSWITH:
+        return actual.startswith(operand)
+    if operator == GenericFilterOps.ENDSWITH:
+        return actual.endswith(operand)
+    if operator == GenericFilterOps.ONEOF:
+        return actual in json.loads(operand)
+    if operator == GenericFilterOps.NOT_ONEOF:
+        return actual not in json.loads(operand)
+    return False
+
+
+def _is_negative_string_filter(configured: str) -> bool:
+    """Return whether a string filter expression uses a negative operator.
+
+    Args:
+        configured: One validated string filter expression.
+
+    Returns:
+        Whether the expression negates a match.
+    """
+    operator, separator, _ = configured.partition(":")
+    return bool(
+        separator and operator in _WEBHOOK_NEGATIVE_STRING_FILTER_OPERATORS
+    )
 
 
 def matches_string_filter(
@@ -146,7 +199,7 @@ def matches_string_filter(
 
     Args:
         actual: The value extracted from the webhook event.
-        configured: The configured exact, prefix, or alternatives filter.
+        configured: The configured string filter or OR-list of filters.
 
     Returns:
         Whether the extracted value matches the configured filter.
@@ -155,36 +208,46 @@ def matches_string_filter(
         return True
     if actual is None:
         return False
-    for value in configured if isinstance(configured, list) else [configured]:
-        if value.startswith("oneof:"):
-            if actual in json.loads(value.removeprefix("oneof:")):
-                return True
-        elif value.startswith("startswith:"):
-            if actual.startswith(value.removeprefix("startswith:")):
-                return True
-        elif actual == value:
-            return True
-    return False
+    configured_values = (
+        configured if isinstance(configured, list) else [configured]
+    )
+    return any(
+        _matches_string_filter_value(actual=actual, configured=value)
+        for value in configured_values
+    )
 
 
 def matches_string_collection_filter(
     *, actual: Sequence[str], configured: StringFilterOption
 ) -> bool:
-    """Match when any actual collection item satisfies a string filter.
+    """Match a collection against a configured string filter.
 
     Args:
         actual: Values extracted from the webhook event.
-        configured: The configured exact value or alternatives.
+        configured: The configured string filter or OR-list of filters.
 
     Returns:
-        Whether at least one actual value matches the configured filter.
+        Whether any value satisfies a positive filter or every value satisfies
+        a negative filter.
     """
     if configured is None:
         return True
-    return any(
-        matches_string_filter(actual=value, configured=configured)
-        for value in actual
-    )
+    if not actual:
+        return False
+    for configured_value in (
+        configured if isinstance(configured, list) else [configured]
+    ):
+        aggregate = (
+            all if _is_negative_string_filter(configured_value) else any
+        )
+        if aggregate(
+            _matches_string_filter_value(
+                actual=actual_value, configured=configured_value
+            )
+            for actual_value in actual
+        ):
+            return True
+    return False
 
 
 class WebhookConfiguration(YAMLSerializationMixin):

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -62,54 +62,17 @@ class _ClickUpListTarget(WebhookTargetEvent):
     space_id: StringFilterOption = None
     folder_id: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            "list_id": False,
-            "space_id": False,
-            "folder_id": False,
-        }
-
 
 class _ClickUpTaskTarget(_ClickUpListTarget):
     """Shared location and task filters for ClickUp task events."""
 
     task_id: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            **super().get_prefix_matching_support(),
-            "task_id": False,
-        }
-
 
 class _ClickUpTaskStatusTarget(_ClickUpTaskTarget):
     """Task filters plus the post-change status."""
 
     status: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            **super().get_prefix_matching_support(),
-            "status": False,
-        }
 
 
 class TaskCreated(_ClickUpTaskTarget):

--- a/src/zenml/webhooks/providers/github.py
+++ b/src/zenml/webhooks/providers/github.py
@@ -73,20 +73,6 @@ class MergedPullRequest(WebhookTargetEvent):
     source_branch: StringFilterOption = None
     author: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            "repo": False,
-            "target_branch": True,
-            "source_branch": True,
-            "author": False,
-        }
-
 
 class WorkflowRunCompleted(WebhookTargetEvent):
     """Filters for a completed GitHub workflow run."""
@@ -98,15 +84,6 @@ class WorkflowRunCompleted(WebhookTargetEvent):
     conclusion: StringFilterOption = None
     actor: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {"workflow": False, "conclusion": False, "actor": False}
-
 
 class PushEvent(WebhookTargetEvent):
     """Filters for a GitHub branch push."""
@@ -115,15 +92,6 @@ class PushEvent(WebhookTargetEvent):
     repo: StringFilterOption = None
     branch: StringFilterOption = None
     actor: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {"repo": False, "branch": True, "actor": False}
 
 
 class ReleasePublished(WebhookTargetEvent):
@@ -136,20 +104,6 @@ class ReleasePublished(WebhookTargetEvent):
     tag: StringFilterOption = None
     target_branch: StringFilterOption = None
     actor: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            "repo": False,
-            "tag": True,
-            "target_branch": True,
-            "actor": False,
-        }
 
 
 class IssueOpened(WebhookTargetEvent):
@@ -164,22 +118,6 @@ class IssueOpened(WebhookTargetEvent):
     labels: StringFilterOption = None
     assignees: StringFilterOption = None
     milestone: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix matching support for string filter fields.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            "repo": False,
-            "author": False,
-            "author_association": False,
-            "labels": False,
-            "assignees": False,
-            "milestone": False,
-        }
 
 
 GitHubWebhookTargetEvent: TypeAlias = Annotated[

--- a/src/zenml/webhooks/providers/registry.py
+++ b/src/zenml/webhooks/providers/registry.py
@@ -90,10 +90,12 @@ class WebhookProviderRegistry:
             from zenml.webhooks.providers.clickup import ClickUpWebhookProvider
             from zenml.webhooks.providers.custom import CustomWebhookProvider
             from zenml.webhooks.providers.github import GitHubWebhookProvider
+            from zenml.webhooks.providers.slack import SlackWebhookProvider
 
             self.register(CustomWebhookProvider)
             self.register(GitHubWebhookProvider)
             self.register(ClickUpWebhookProvider)
+            self.register(SlackWebhookProvider)
             self._builtins_registered = True
 
 

--- a/src/zenml/webhooks/providers/slack.py
+++ b/src/zenml/webhooks/providers/slack.py
@@ -1,0 +1,1118 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Slack Events API webhook provider."""
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from collections.abc import Mapping, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    ClassVar,
+    Literal,
+    TypeAlias,
+    cast,
+)
+
+from pydantic import BaseModel, Field
+
+from zenml.models.v2.base.filter import StringFilterOption
+from zenml.utils.enum_utils import StrEnum
+from zenml.webhooks.providers.base import (
+    BaseWebhookProvider,
+    ParsedWebhookDelivery,
+    ParsedWebhookEvent,
+    WebhookAuthenticationError,
+    WebhookConfiguration,
+    WebhookIntakeResponse,
+    WebhookPayloadError,
+    WebhookTargetEvent,
+    WebhookTriggerMatch,
+    matches_string_filter,
+)
+from zenml.webhooks.providers.types import BuiltinWebhookType
+
+if TYPE_CHECKING:
+    from zenml.models import WebhookTriggerResponse
+    from zenml.webhooks.events import WebhookEvent
+
+logger = logging.getLogger(__name__)
+
+SLACK_SIGNATURE_HEADER = "x-slack-signature"
+SLACK_REQUEST_TIMESTAMP_HEADER = "x-slack-request-timestamp"
+SLACK_SIGNATURE_VERSION = "v0"
+SLACK_TIMESTAMP_TOLERANCE_SECONDS = 5 * 60
+
+SLACK_EVENT_CALLBACK = "event_callback"
+SLACK_URL_VERIFICATION = "url_verification"
+SLACK_APP_RATE_LIMITED = "app_rate_limited"
+
+
+class SlackWebhookEventType(StrEnum):
+    """Raw Slack event families used by supported semantic events."""
+
+    APP_MENTION = "app_mention"
+    MESSAGE = "message"
+    REACTION_ADDED = "reaction_added"
+    REACTION_REMOVED = "reaction_removed"
+    MESSAGE_METADATA_POSTED = "message_metadata_posted"
+    MESSAGE_METADATA_UPDATED = "message_metadata_updated"
+    FILE_SHARED = "file_shared"
+
+
+class SlackWebhookEvent(StrEnum):
+    """Semantic Slack events supported by webhook triggers."""
+
+    APP_MENTION = "app_mention"
+    MESSAGE_POSTED = "message_posted"
+    REACTION_ADDED = "reaction_added"
+    REACTION_REMOVED = "reaction_removed"
+    MESSAGE_METADATA_POSTED = "message_metadata_posted"
+    MESSAGE_METADATA_UPDATED = "message_metadata_updated"
+    FILE_SHARED = "file_shared"
+
+
+class SlackEventFilter(WebhookTargetEvent):
+    """Base filters shared by Slack target events."""
+
+    team_id: StringFilterOption = None
+    channel_id: StringFilterOption = None
+    user_id: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for shared Slack filters.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {"team_id": False, "channel_id": False, "user_id": False}
+
+
+class AppMentionEventFilter(SlackEventFilter):
+    """Filters for a Slack app mention."""
+
+    type: Literal[SlackWebhookEvent.APP_MENTION] = (
+        SlackWebhookEvent.APP_MENTION
+    )
+    threaded: bool | None = None
+
+
+class MessagePostedEventFilter(SlackEventFilter):
+    """Filters for an ordinary human-authored Slack message."""
+
+    type: Literal[SlackWebhookEvent.MESSAGE_POSTED] = (
+        SlackWebhookEvent.MESSAGE_POSTED
+    )
+    channel_type: StringFilterOption = None
+    text: StringFilterOption = None
+    threaded: bool | None = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for message filters.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            **super().get_prefix_matching_support(),
+            "channel_type": False,
+            "text": True,
+        }
+
+
+class _ReactionEventFilter(SlackEventFilter):
+    """Shared filters for a Slack reaction event."""
+
+    reaction: StringFilterOption = None
+    item_user_id: StringFilterOption = None
+    item_type: StringFilterOption = None
+    item_id: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for reaction filters.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            **super().get_prefix_matching_support(),
+            "reaction": False,
+            "item_user_id": False,
+            "item_type": False,
+            "item_id": False,
+        }
+
+
+class ReactionAddedEventFilter(_ReactionEventFilter):
+    """Filters for a Slack reaction being added."""
+
+    type: Literal[SlackWebhookEvent.REACTION_ADDED] = (
+        SlackWebhookEvent.REACTION_ADDED
+    )
+
+
+class ReactionRemovedEventFilter(_ReactionEventFilter):
+    """Filters for a Slack reaction being removed."""
+
+    type: Literal[SlackWebhookEvent.REACTION_REMOVED] = (
+        SlackWebhookEvent.REACTION_REMOVED
+    )
+
+
+class _MessageMetadataEventFilter(SlackEventFilter):
+    """Shared filters for a Slack message-metadata event."""
+
+    app_id: StringFilterOption = None
+    bot_id: StringFilterOption = None
+    metadata_event_type: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for message-metadata filters.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {
+            **super().get_prefix_matching_support(),
+            "app_id": False,
+            "bot_id": False,
+            "metadata_event_type": True,
+        }
+
+
+class MessageMetadataPostedEventFilter(_MessageMetadataEventFilter):
+    """Filters for Slack message metadata being posted."""
+
+    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_POSTED] = (
+        SlackWebhookEvent.MESSAGE_METADATA_POSTED
+    )
+
+
+class MessageMetadataUpdatedEventFilter(_MessageMetadataEventFilter):
+    """Filters for Slack message metadata being updated."""
+
+    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_UPDATED] = (
+        SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+    )
+
+
+class FileSharedEventFilter(SlackEventFilter):
+    """Filters for a Slack file being shared."""
+
+    type: Literal[SlackWebhookEvent.FILE_SHARED] = (
+        SlackWebhookEvent.FILE_SHARED
+    )
+    file_id: StringFilterOption = None
+
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for file-share filters.
+
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {**super().get_prefix_matching_support(), "file_id": False}
+
+
+SlackWebhookEventFilter: TypeAlias = Annotated[
+    AppMentionEventFilter
+    | MessagePostedEventFilter
+    | ReactionAddedEventFilter
+    | ReactionRemovedEventFilter
+    | MessageMetadataPostedEventFilter
+    | MessageMetadataUpdatedEventFilter
+    | FileSharedEventFilter,
+    Field(discriminator="type"),
+]
+
+
+class SlackWebhookConfiguration(WebhookConfiguration):
+    """Typed configuration for a Slack webhook trigger."""
+
+    target_events: list[SlackWebhookEventFilter] = Field(min_length=1)
+
+
+def _matches_bool(*, actual: bool, configured: bool | None) -> bool:
+    """Match a boolean value against an optional configured filter.
+
+    Args:
+        actual: The value extracted from the Slack event.
+        configured: The configured value, or `None` to match either value.
+
+    Returns:
+        Whether the value matches the configured filter.
+    """
+    return configured is None or actual is configured
+
+
+class SlackSemanticEvent(BaseModel):
+    """Provider event normalized for semantic trigger matching."""
+
+    event_filter_type: ClassVar[type[SlackEventFilter]]
+
+    event_id: str | None = None
+    team_id: str | None = None
+    channel_id: str | None = None
+    user_id: str | None = None
+    event_time: int | None = None
+    event_ts: str | None = None
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Match identifiers shared by all Slack semantic events.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether the event's team, channel, and user match the target.
+        """
+        return all(
+            (
+                matches_string_filter(
+                    actual=self.team_id, configured=target.team_id
+                ),
+                matches_string_filter(
+                    actual=self.channel_id, configured=target.channel_id
+                ),
+                matches_string_filter(
+                    actual=self.user_id, configured=target.user_id
+                ),
+            )
+        )
+
+
+class SlackAppMentionEvent(SlackSemanticEvent):
+    """Normalized Slack app mention."""
+
+    event_filter_type = AppMentionEventFilter
+    type: Literal[SlackWebhookEvent.APP_MENTION] = (
+        SlackWebhookEvent.APP_MENTION
+    )
+    channel_id: str
+    user_id: str
+    message_ts: str | None = None
+    thread_ts: str | None = None
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Return whether this mention matches an app-mention target.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether this mention matches the target.
+        """
+        if not isinstance(target, AppMentionEventFilter):
+            return False
+        return all(
+            (
+                super().matches(target),
+                _matches_bool(
+                    actual=self.thread_ts is not None,
+                    configured=target.threaded,
+                ),
+            )
+        )
+
+
+class SlackMessagePostedEvent(SlackSemanticEvent):
+    """Normalized ordinary human-authored Slack message."""
+
+    event_filter_type = MessagePostedEventFilter
+    type: Literal[SlackWebhookEvent.MESSAGE_POSTED] = (
+        SlackWebhookEvent.MESSAGE_POSTED
+    )
+    channel_id: str
+    user_id: str
+    channel_type: str | None = None
+    text: str | None = None
+    message_ts: str
+    thread_ts: str | None = None
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Return whether this message matches a message target.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether this message matches the target.
+        """
+        if not isinstance(target, MessagePostedEventFilter):
+            return False
+        return all(
+            (
+                super().matches(target),
+                matches_string_filter(
+                    actual=self.channel_type, configured=target.channel_type
+                ),
+                matches_string_filter(
+                    actual=self.text, configured=target.text
+                ),
+                _matches_bool(
+                    actual=self.thread_ts is not None,
+                    configured=target.threaded,
+                ),
+            )
+        )
+
+
+class SlackReactionItem(BaseModel):
+    """Normalized item referenced by a Slack reaction event."""
+
+    type: Literal["message", "file", "file_comment"]
+    id: str
+    channel_id: str | None = None
+    file_id: str | None = None
+
+
+class SlackReactionEvent(SlackSemanticEvent):
+    """Shared normalized fields for a Slack reaction event."""
+
+    reaction: str
+    user_id: str
+    item_user_id: str | None = None
+    item: SlackReactionItem
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Return whether this reaction matches its reaction target.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether this reaction matches the target.
+        """
+        if not isinstance(target, self.event_filter_type):
+            return False
+        reaction_target = cast(_ReactionEventFilter, target)
+        return all(
+            (
+                super().matches(target),
+                matches_string_filter(
+                    actual=self.reaction, configured=reaction_target.reaction
+                ),
+                matches_string_filter(
+                    actual=self.item_user_id,
+                    configured=reaction_target.item_user_id,
+                ),
+                matches_string_filter(
+                    actual=self.item.type,
+                    configured=reaction_target.item_type,
+                ),
+                matches_string_filter(
+                    actual=self.item.id, configured=reaction_target.item_id
+                ),
+            )
+        )
+
+
+class SlackReactionAddedEvent(SlackReactionEvent):
+    """Normalized Slack reaction-added event."""
+
+    event_filter_type = ReactionAddedEventFilter
+    type: Literal[SlackWebhookEvent.REACTION_ADDED] = (
+        SlackWebhookEvent.REACTION_ADDED
+    )
+
+
+class SlackReactionRemovedEvent(SlackReactionEvent):
+    """Normalized Slack reaction-removed event."""
+
+    event_filter_type = ReactionRemovedEventFilter
+    type: Literal[SlackWebhookEvent.REACTION_REMOVED] = (
+        SlackWebhookEvent.REACTION_REMOVED
+    )
+
+
+class SlackMessageMetadata(BaseModel):
+    """Structured metadata attached to a Slack message."""
+
+    event_type: str
+    event_payload: dict[str, Any]
+
+
+class SlackMessageMetadataEvent(SlackSemanticEvent):
+    """Shared normalized fields for a Slack message-metadata event."""
+
+    channel_id: str
+    app_id: str
+    user_id: str | None = None
+    bot_id: str | None = None
+    message_ts: str
+    metadata: SlackMessageMetadata
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Return whether this metadata event matches its typed target.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether this metadata event matches the target.
+        """
+        if not isinstance(target, self.event_filter_type):
+            return False
+        metadata_target = cast(_MessageMetadataEventFilter, target)
+        return all(
+            (
+                super().matches(target),
+                matches_string_filter(
+                    actual=self.app_id, configured=metadata_target.app_id
+                ),
+                matches_string_filter(
+                    actual=self.bot_id, configured=metadata_target.bot_id
+                ),
+                matches_string_filter(
+                    actual=self.metadata.event_type,
+                    configured=metadata_target.metadata_event_type,
+                ),
+            )
+        )
+
+
+class SlackMessageMetadataPostedEvent(SlackMessageMetadataEvent):
+    """Normalized Slack message-metadata-posted event."""
+
+    event_filter_type = MessageMetadataPostedEventFilter
+    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_POSTED] = (
+        SlackWebhookEvent.MESSAGE_METADATA_POSTED
+    )
+
+
+class SlackMessageMetadataUpdatedEvent(SlackMessageMetadataEvent):
+    """Normalized Slack message-metadata-updated event."""
+
+    event_filter_type = MessageMetadataUpdatedEventFilter
+    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_UPDATED] = (
+        SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+    )
+    previous_metadata: SlackMessageMetadata
+
+
+class SlackFileSharedEvent(SlackSemanticEvent):
+    """Normalized Slack file-shared event."""
+
+    event_filter_type = FileSharedEventFilter
+    type: Literal[SlackWebhookEvent.FILE_SHARED] = (
+        SlackWebhookEvent.FILE_SHARED
+    )
+    channel_id: str
+    user_id: str
+    file_id: str
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Return whether this file share matches a file-share target.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether this file share matches the target.
+        """
+        if not isinstance(target, FileSharedEventFilter):
+            return False
+        return all(
+            (
+                super().matches(target),
+                matches_string_filter(
+                    actual=self.file_id, configured=target.file_id
+                ),
+            )
+        )
+
+
+class SlackWebhookProvider(BaseWebhookProvider):
+    """Provider for signed Slack Events API deliveries."""
+
+    webhook_type = BuiltinWebhookType.SLACK
+    configuration_class = SlackWebhookConfiguration
+
+    def authenticate(
+        self, body: bytes, headers: Mapping[str, str], secret: str
+    ) -> None:
+        """Authenticate a Slack delivery using its exact raw body.
+
+        Args:
+            body: The raw request body.
+            headers: The request headers.
+            secret: The Slack app signing secret.
+
+        Raises:
+            WebhookAuthenticationError: If the request cannot be authenticated.
+        """
+        signature = headers.get(SLACK_SIGNATURE_HEADER)
+        if not signature or not signature.startswith(
+            f"{SLACK_SIGNATURE_VERSION}="
+        ):
+            raise WebhookAuthenticationError(
+                f"Missing or malformed {SLACK_SIGNATURE_HEADER} header."
+            )
+
+        timestamp = headers.get(SLACK_REQUEST_TIMESTAMP_HEADER)
+        if (
+            not timestamp
+            or not timestamp.isascii()
+            or not timestamp.isdigit()
+            or len(timestamp) > 20
+        ):
+            raise WebhookAuthenticationError(
+                "Missing or malformed "
+                f"{SLACK_REQUEST_TIMESTAMP_HEADER} header."
+            )
+        if (
+            abs(time.time() - int(timestamp))
+            > SLACK_TIMESTAMP_TOLERANCE_SECONDS
+        ):
+            raise WebhookAuthenticationError(
+                "Slack request timestamp is outside the allowed tolerance."
+            )
+
+        signature_base = (
+            f"{SLACK_SIGNATURE_VERSION}:{timestamp}:".encode() + body
+        )
+        expected = (
+            f"{SLACK_SIGNATURE_VERSION}="
+            + hmac.new(
+                secret.encode(), signature_base, hashlib.sha256
+            ).hexdigest()
+        )
+        if not hmac.compare_digest(signature, expected):
+            raise WebhookAuthenticationError("Invalid webhook signature.")
+
+    def parse_delivery(
+        self, body: bytes, headers: Mapping[str, str]
+    ) -> ParsedWebhookDelivery:
+        """Parse a Slack event or control delivery.
+
+        Args:
+            body: The raw request body.
+            headers: The request headers.
+
+        Returns:
+            The optional event and Slack-compatible response.
+
+        Raises:
+            WebhookPayloadError: If the Slack envelope is malformed.
+        """
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise WebhookPayloadError(
+                "Request body must be valid JSON."
+            ) from error
+        if not isinstance(payload, dict):
+            raise WebhookPayloadError(
+                "Request body must contain a top-level JSON object."
+            )
+
+        delivery_type = payload.get("type")
+        if delivery_type == SLACK_EVENT_CALLBACK:
+            return self._parse_event_callback(payload)
+        if delivery_type == SLACK_URL_VERIFICATION:
+            challenge = payload.get("challenge")
+            if not isinstance(challenge, str) or not challenge:
+                raise WebhookPayloadError(
+                    "Slack URL verification requires a non-empty challenge."
+                )
+            return ParsedWebhookDelivery(
+                event=None,
+                response=WebhookIntakeResponse(
+                    status_code=200,
+                    body=challenge,
+                    media_type="text/plain",
+                ),
+            )
+        if delivery_type == SLACK_APP_RATE_LIMITED:
+            self._validate_rate_limited_delivery(payload)
+            return ParsedWebhookDelivery(
+                event=None,
+                response=WebhookIntakeResponse(status_code=200),
+            )
+        raise WebhookPayloadError(
+            "Unsupported Slack delivery type."
+            if isinstance(delivery_type, str) and delivery_type
+            else "Slack delivery requires a non-empty type."
+        )
+
+    def _parse_event_callback(
+        self, payload: dict[str, Any]
+    ) -> ParsedWebhookDelivery:
+        """Parse one Slack event callback envelope.
+
+        Args:
+            payload: The parsed Slack envelope.
+
+        Returns:
+            The trusted provider-neutral event and response.
+
+        Raises:
+            WebhookPayloadError: If required event metadata is malformed.
+        """
+        event = payload.get("event")
+        if not isinstance(event, dict):
+            raise WebhookPayloadError(
+                "Slack event callback requires an event object."
+            )
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or not event_type:
+            raise WebhookPayloadError(
+                "Slack event callback requires a non-empty event type."
+            )
+        event_id = payload.get("event_id")
+        if not isinstance(event_id, str) or not event_id:
+            raise WebhookPayloadError(
+                "Slack event callback requires a non-empty event_id."
+            )
+        return ParsedWebhookDelivery(
+            event=ParsedWebhookEvent(
+                event_type=event_type,
+                delivery_id=event_id,
+                payload=payload,
+            ),
+            response=WebhookIntakeResponse(status_code=200),
+        )
+
+    @staticmethod
+    def _validate_rate_limited_delivery(payload: Mapping[str, Any]) -> None:
+        """Validate and log a Slack rate-limit notification.
+
+        Args:
+            payload: The parsed Slack control delivery.
+
+        Raises:
+            WebhookPayloadError: If required rate-limit fields are malformed.
+        """
+        team_id = payload.get("team_id")
+        api_app_id = payload.get("api_app_id")
+        minute_rate_limited = payload.get("minute_rate_limited")
+        if not isinstance(team_id, str) or not team_id:
+            raise WebhookPayloadError(
+                "Slack rate-limit notification requires a non-empty team_id."
+            )
+        if not isinstance(api_app_id, str) or not api_app_id:
+            raise WebhookPayloadError(
+                "Slack rate-limit notification requires a non-empty api_app_id."
+            )
+        if not isinstance(minute_rate_limited, int) or isinstance(
+            minute_rate_limited, bool
+        ):
+            raise WebhookPayloadError(
+                "Slack rate-limit notification requires an integer "
+                "minute_rate_limited."
+            )
+        logger.warning(
+            "Slack Events API delivery is rate limited for team %s and app %s "
+            "as of minute %s.",
+            team_id,
+            api_app_id,
+            minute_rate_limited,
+        )
+
+    def get_event_type(
+        self, payload: dict[str, Any], headers: Mapping[str, str]
+    ) -> str:
+        """Reject direct event parsing in favor of delivery parsing.
+
+        Args:
+            payload: The parsed Slack payload.
+            headers: The request headers.
+
+        Returns:
+            This method never returns successfully.
+
+        Raises:
+            NotImplementedError: Always, because Slack has control deliveries.
+        """
+        raise NotImplementedError(
+            "Slack deliveries must be parsed with parse_delivery()."
+        )
+
+    def _cast_runtime_targets(
+        self, trigger: "WebhookTriggerResponse"
+    ) -> list[SlackWebhookEventFilter]:
+        """Load one trigger's targets while tolerating stale stored data.
+
+        Args:
+            trigger: The candidate Slack webhook trigger.
+
+        Returns:
+            The validated targets, or an empty list for defective stored data.
+        """
+        try:
+            configuration = self.validate_configuration(trigger.configuration)
+        except (TypeError, ValueError):
+            logger.exception(
+                "Skipping defective webhook trigger configuration %s",
+                trigger.id,
+            )
+            return []
+        return cast(SlackWebhookConfiguration, configuration).target_events
+
+    def match_triggers(
+        self,
+        *,
+        event: "WebhookEvent",
+        candidates: Sequence["WebhookTriggerResponse"],
+    ) -> "WebhookTriggerMatch[WebhookTriggerResponse]":
+        """Match candidates and return the parsed semantic event.
+
+        Args:
+            event: The trusted webhook event.
+            candidates: Triggers selected by generic orchestration.
+
+        Returns:
+            The matching triggers and any parsed semantic event.
+        """
+        semantic = self.parse_semantic_event(event)
+        if semantic is None:
+            return WebhookTriggerMatch(triggers=[])
+        matches: list[WebhookTriggerResponse] = []
+        for trigger in candidates:
+            targets = self._cast_runtime_targets(trigger)
+            if any(semantic.matches(target) for target in targets):
+                matches.append(trigger)
+        return WebhookTriggerMatch(
+            triggers=matches,
+            event=semantic.model_dump(mode="json"),
+        )
+
+    def parse_semantic_event(
+        self, event: "WebhookEvent"
+    ) -> SlackSemanticEvent | None:
+        """Normalize a trusted Slack event for trigger matching.
+
+        Args:
+            event: The trusted Slack webhook event.
+
+        Returns:
+            The normalized supported event, or `None` if it is not matchable.
+        """
+        payload = event.payload.get("event")
+        if not isinstance(payload, Mapping):
+            return None
+        if event.event_type == SlackWebhookEventType.APP_MENTION:
+            return self._parse_app_mention(event, payload)
+        if event.event_type == SlackWebhookEventType.MESSAGE:
+            return self._parse_message_posted(event, payload)
+        if event.event_type == SlackWebhookEventType.REACTION_ADDED:
+            return self._parse_reaction(
+                event, payload, SlackReactionAddedEvent
+            )
+        if event.event_type == SlackWebhookEventType.REACTION_REMOVED:
+            return self._parse_reaction(
+                event, payload, SlackReactionRemovedEvent
+            )
+        if event.event_type == SlackWebhookEventType.MESSAGE_METADATA_POSTED:
+            fields = self._parse_message_metadata_fields(event, payload)
+            return (
+                SlackMessageMetadataPostedEvent(**fields)
+                if fields is not None
+                else None
+            )
+        if event.event_type == SlackWebhookEventType.MESSAGE_METADATA_UPDATED:
+            return self._parse_message_metadata_updated(event, payload)
+        if event.event_type == SlackWebhookEventType.FILE_SHARED:
+            return self._parse_file_shared(event, payload)
+        return None
+
+    def _parse_app_mention(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> SlackAppMentionEvent | None:
+        """Normalize an app-mention callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            The normalized mention, or `None` if it is not matchable.
+        """
+        channel_id = self._optional_string(payload.get("channel"))
+        user_id = self._optional_string(payload.get("user"))
+        if channel_id is None or user_id is None:
+            return None
+        if self._is_bot_message(payload):
+            return None
+        return SlackAppMentionEvent(
+            **self._common_event_fields(event, payload),
+            channel_id=channel_id,
+            user_id=user_id,
+            message_ts=self._optional_string(payload.get("ts")),
+            thread_ts=self._optional_string(payload.get("thread_ts")),
+        )
+
+    def _parse_message_posted(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> SlackMessagePostedEvent | None:
+        """Normalize an ordinary human-authored message callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            The normalized message, or `None` for bot and subtype variants.
+        """
+        if payload.get("subtype") is not None or self._is_bot_message(payload):
+            return None
+        channel_id = self._optional_string(payload.get("channel"))
+        user_id = self._optional_string(payload.get("user"))
+        message_ts = self._optional_string(payload.get("ts"))
+        if channel_id is None or user_id is None or message_ts is None:
+            return None
+        return SlackMessagePostedEvent(
+            **self._common_event_fields(event, payload),
+            channel_id=channel_id,
+            user_id=user_id,
+            channel_type=self._optional_string(payload.get("channel_type")),
+            text=self._optional_string(payload.get("text")),
+            message_ts=message_ts,
+            thread_ts=self._optional_string(payload.get("thread_ts")),
+        )
+
+    def _parse_reaction(
+        self,
+        event: "WebhookEvent",
+        payload: Mapping[str, Any],
+        event_class: type[SlackReactionEvent],
+    ) -> SlackReactionEvent | None:
+        """Normalize a reaction callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+            event_class: The reaction semantic model to instantiate.
+
+        Returns:
+            The normalized reaction, or `None` if required fields are missing.
+        """
+        reaction = self._optional_string(payload.get("reaction"))
+        user_id = self._optional_string(payload.get("user"))
+        item_payload = payload.get("item")
+        if (
+            reaction is None
+            or user_id is None
+            or not isinstance(item_payload, Mapping)
+        ):
+            return None
+        item = self._parse_reaction_item(item_payload)
+        if item is None:
+            return None
+        return event_class(
+            **self._common_event_fields(event, payload),
+            channel_id=item.channel_id,
+            reaction=reaction,
+            user_id=user_id,
+            item_user_id=self._optional_string(payload.get("item_user")),
+            item=item,
+        )
+
+    def _parse_reaction_item(
+        self, payload: Mapping[str, Any]
+    ) -> SlackReactionItem | None:
+        """Normalize one documented Slack reaction item shape.
+
+        Args:
+            payload: The embedded Slack reaction item.
+
+        Returns:
+            The normalized item, or `None` for unknown or malformed shapes.
+        """
+        item_type = payload.get("type")
+        if item_type == "message":
+            item_id = self._optional_string(payload.get("ts"))
+        elif item_type == "file":
+            item_id = self._optional_string(payload.get("file"))
+        elif item_type == "file_comment":
+            item_id = self._optional_string(payload.get("file_comment"))
+        else:
+            return None
+        if item_id is None:
+            return None
+        return SlackReactionItem(
+            type=item_type,
+            id=item_id,
+            channel_id=self._optional_string(payload.get("channel")),
+            file_id=self._optional_string(payload.get("file")),
+        )
+
+    def _parse_message_metadata_fields(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> dict[str, Any] | None:
+        """Extract normalized fields from a message-metadata callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            Semantic model fields, or `None` if required fields are missing.
+        """
+        channel_id = self._optional_string(payload.get("channel_id"))
+        app_id = self._optional_string(payload.get("app_id"))
+        message_ts = self._optional_string(payload.get("message_ts"))
+        metadata_payload = payload.get("metadata")
+        if (
+            channel_id is None
+            or app_id is None
+            or message_ts is None
+            or not isinstance(metadata_payload, Mapping)
+        ):
+            return None
+        metadata = self._parse_metadata(metadata_payload)
+        if metadata is None:
+            return None
+        return {
+            **self._common_event_fields(event, payload),
+            "channel_id": channel_id,
+            "app_id": app_id,
+            "user_id": self._optional_string(payload.get("user_id")),
+            "bot_id": self._optional_string(payload.get("bot_id")),
+            "message_ts": message_ts,
+            "metadata": metadata,
+        }
+
+    def _parse_message_metadata_updated(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> SlackMessageMetadataUpdatedEvent | None:
+        """Normalize a message-metadata-updated callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            The normalized update, or `None` if either metadata value is invalid.
+        """
+        fields = self._parse_message_metadata_fields(event, payload)
+        previous_payload = payload.get("previous_metadata")
+        if fields is None or not isinstance(previous_payload, Mapping):
+            return None
+        previous_metadata = self._parse_metadata(previous_payload)
+        if previous_metadata is None:
+            return None
+        return SlackMessageMetadataUpdatedEvent(
+            **fields, previous_metadata=previous_metadata
+        )
+
+    def _parse_file_shared(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> SlackFileSharedEvent | None:
+        """Normalize a file-shared callback.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            The normalized file share, or `None` if required fields are missing.
+        """
+        channel_id = self._optional_string(payload.get("channel_id"))
+        user_id = self._optional_string(payload.get("user_id"))
+        file_id = self._optional_string(payload.get("file_id"))
+        if channel_id is None or user_id is None or file_id is None:
+            return None
+        return SlackFileSharedEvent(
+            **self._common_event_fields(event, payload),
+            channel_id=channel_id,
+            user_id=user_id,
+            file_id=file_id,
+        )
+
+    def _common_event_fields(
+        self, event: "WebhookEvent", payload: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Extract metadata shared by normalized Slack events.
+
+        Args:
+            event: The trusted Slack webhook event.
+            payload: The inner Slack event payload.
+
+        Returns:
+            Keyword arguments for a `SlackSemanticEvent` model.
+        """
+        return {
+            "event_id": event.delivery_id,
+            "team_id": self._optional_string(event.payload.get("team_id"))
+            or self._optional_string(payload.get("team_id")),
+            "event_time": self._optional_int(event.payload.get("event_time")),
+            "event_ts": self._optional_string(payload.get("event_ts")),
+        }
+
+    @staticmethod
+    def _parse_metadata(
+        payload: Mapping[str, Any],
+    ) -> SlackMessageMetadata | None:
+        """Normalize structured Slack message metadata.
+
+        Args:
+            payload: The Slack metadata object.
+
+        Returns:
+            The normalized metadata, or `None` if it is malformed.
+        """
+        event_type = SlackWebhookProvider._optional_string(
+            payload.get("event_type")
+        )
+        event_payload = payload.get("event_payload")
+        if event_type is None or not isinstance(event_payload, Mapping):
+            return None
+        return SlackMessageMetadata(
+            event_type=event_type,
+            event_payload=dict(event_payload),
+        )
+
+    @staticmethod
+    def _is_bot_message(payload: Mapping[str, Any]) -> bool:
+        """Return whether a Slack message payload was authored by a bot.
+
+        Args:
+            payload: The inner Slack event payload.
+
+        Returns:
+            Whether Slack identifies the message as bot-authored.
+        """
+        return any(
+            (
+                SlackWebhookProvider._optional_string(payload.get("bot_id"))
+                is not None,
+                isinstance(payload.get("bot_profile"), Mapping),
+                payload.get("subtype") == "bot_message",
+            )
+        )
+
+    @staticmethod
+    def _optional_string(value: Any) -> str | None:
+        """Return a non-empty string or `None` for optional metadata.
+
+        Args:
+            value: The untrusted payload value.
+
+        Returns:
+            The value if it is a non-empty string, otherwise `None`.
+        """
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _optional_int(value: Any) -> int | None:
+        """Return a non-boolean integer or `None` for optional metadata.
+
+        Args:
+            value: The untrusted payload value.
+
+        Returns:
+            The value if it is an integer, otherwise `None`.
+        """
+        return (
+            value
+            if isinstance(value, int) and not isinstance(value, bool)
+            else None
+        )

--- a/src/zenml/webhooks/providers/slack.py
+++ b/src/zenml/webhooks/providers/slack.py
@@ -71,15 +71,6 @@ class SlackEventFilter(WebhookTargetEvent):
     channel_id: StringFilterOption = None
     user_id: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for shared Slack filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {"team_id": False, "channel_id": False, "user_id": False}
-
 
 class AppMentionEventFilter(SlackEventFilter):
     """Filters for a Slack app mention."""
@@ -89,15 +80,6 @@ class AppMentionEventFilter(SlackEventFilter):
     )
     text: StringFilterOption = None
     threaded: bool | None = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for app-mention filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {**super().get_prefix_matching_support(), "text": True}
 
 
 class MessageEventFilter(SlackEventFilter):
@@ -111,20 +93,6 @@ class MessageEventFilter(SlackEventFilter):
     subtype: StringFilterOption = None
     include_subtypes: bool = False
     threaded: bool | None = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for message filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            **super().get_prefix_matching_support(),
-            "channel_type": False,
-            "text": True,
-            "subtype": False,
-        }
 
     @model_validator(mode="after")
     def validate_subtype_filters(self) -> "MessageEventFilter":
@@ -152,21 +120,6 @@ class _ReactionEventFilter(SlackEventFilter):
     item_type: StringFilterOption = None
     item_id: StringFilterOption = None
 
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for reaction filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            **super().get_prefix_matching_support(),
-            "reaction": False,
-            "item_user_id": False,
-            "item_type": False,
-            "item_id": False,
-        }
-
 
 class ReactionAddedEventFilter(_ReactionEventFilter):
     """Filters for a Slack reaction being added."""
@@ -190,20 +143,6 @@ class _MessageMetadataEventFilter(SlackEventFilter):
     app_id: StringFilterOption = None
     bot_id: StringFilterOption = None
     metadata_event_type: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for message-metadata filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {
-            **super().get_prefix_matching_support(),
-            "app_id": False,
-            "bot_id": False,
-            "metadata_event_type": True,
-        }
 
 
 class MessageMetadataPostedEventFilter(_MessageMetadataEventFilter):
@@ -229,15 +168,6 @@ class FileSharedEventFilter(SlackEventFilter):
         SlackWebhookEventType.FILE_SHARED
     )
     file_id: StringFilterOption = None
-
-    @classmethod
-    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
-        """Get prefix-matching support for file-share filters.
-
-        Returns:
-            Filter fields mapped to whether they allow `startswith`.
-        """
-        return {**super().get_prefix_matching_support(), "file_id": False}
 
 
 SlackWebhookEventFilter: TypeAlias = Annotated[

--- a/src/zenml/webhooks/providers/slack.py
+++ b/src/zenml/webhooks/providers/slack.py
@@ -18,7 +18,7 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
@@ -53,22 +53,10 @@ SLACK_APP_RATE_LIMITED = "app_rate_limited"
 
 
 class SlackWebhookEventType(StrEnum):
-    """Raw Slack event families used by supported semantic events."""
+    """Slack event types used during intake and semantic matching."""
 
     APP_MENTION = "app_mention"
     MESSAGE = "message"
-    REACTION_ADDED = "reaction_added"
-    REACTION_REMOVED = "reaction_removed"
-    MESSAGE_METADATA_POSTED = "message_metadata_posted"
-    MESSAGE_METADATA_UPDATED = "message_metadata_updated"
-    FILE_SHARED = "file_shared"
-
-
-class SlackWebhookEvent(StrEnum):
-    """Semantic Slack events supported by webhook triggers."""
-
-    APP_MENTION = "app_mention"
-    MESSAGE_POSTED = "message_posted"
     REACTION_ADDED = "reaction_added"
     REACTION_REMOVED = "reaction_removed"
     MESSAGE_METADATA_POSTED = "message_metadata_posted"
@@ -96,20 +84,32 @@ class SlackEventFilter(WebhookTargetEvent):
 class AppMentionEventFilter(SlackEventFilter):
     """Filters for a Slack app mention."""
 
-    type: Literal[SlackWebhookEvent.APP_MENTION] = (
-        SlackWebhookEvent.APP_MENTION
+    type: Literal[SlackWebhookEventType.APP_MENTION] = (
+        SlackWebhookEventType.APP_MENTION
     )
+    text: StringFilterOption = None
     threaded: bool | None = None
 
+    @classmethod
+    def get_prefix_matching_support(cls) -> Mapping[str, bool]:
+        """Get prefix-matching support for app-mention filters.
 
-class MessagePostedEventFilter(SlackEventFilter):
-    """Filters for an ordinary human-authored Slack message."""
+        Returns:
+            Filter fields mapped to whether they allow `startswith`.
+        """
+        return {**super().get_prefix_matching_support(), "text": True}
 
-    type: Literal[SlackWebhookEvent.MESSAGE_POSTED] = (
-        SlackWebhookEvent.MESSAGE_POSTED
+
+class MessageEventFilter(SlackEventFilter):
+    """Filters for a Slack message event."""
+
+    type: Literal[SlackWebhookEventType.MESSAGE] = (
+        SlackWebhookEventType.MESSAGE
     )
     channel_type: StringFilterOption = None
     text: StringFilterOption = None
+    subtype: StringFilterOption = None
+    include_subtypes: bool = False
     threaded: bool | None = None
 
     @classmethod
@@ -123,7 +123,25 @@ class MessagePostedEventFilter(SlackEventFilter):
             **super().get_prefix_matching_support(),
             "channel_type": False,
             "text": True,
+            "subtype": False,
         }
+
+    @model_validator(mode="after")
+    def validate_subtype_filters(self) -> "MessageEventFilter":
+        """Reject competing broad and targeted subtype selection.
+
+        Returns:
+            The validated message event filter.
+
+        Raises:
+            ValueError: If all subtypes and named subtypes are both selected.
+        """
+        if self.include_subtypes and self.subtype is not None:
+            raise ValueError(
+                "Slack message filters cannot combine 'include_subtypes' "
+                "with 'subtype'."
+            )
+        return self
 
 
 class _ReactionEventFilter(SlackEventFilter):
@@ -153,16 +171,16 @@ class _ReactionEventFilter(SlackEventFilter):
 class ReactionAddedEventFilter(_ReactionEventFilter):
     """Filters for a Slack reaction being added."""
 
-    type: Literal[SlackWebhookEvent.REACTION_ADDED] = (
-        SlackWebhookEvent.REACTION_ADDED
+    type: Literal[SlackWebhookEventType.REACTION_ADDED] = (
+        SlackWebhookEventType.REACTION_ADDED
     )
 
 
 class ReactionRemovedEventFilter(_ReactionEventFilter):
     """Filters for a Slack reaction being removed."""
 
-    type: Literal[SlackWebhookEvent.REACTION_REMOVED] = (
-        SlackWebhookEvent.REACTION_REMOVED
+    type: Literal[SlackWebhookEventType.REACTION_REMOVED] = (
+        SlackWebhookEventType.REACTION_REMOVED
     )
 
 
@@ -191,24 +209,24 @@ class _MessageMetadataEventFilter(SlackEventFilter):
 class MessageMetadataPostedEventFilter(_MessageMetadataEventFilter):
     """Filters for Slack message metadata being posted."""
 
-    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_POSTED] = (
-        SlackWebhookEvent.MESSAGE_METADATA_POSTED
+    type: Literal[SlackWebhookEventType.MESSAGE_METADATA_POSTED] = (
+        SlackWebhookEventType.MESSAGE_METADATA_POSTED
     )
 
 
 class MessageMetadataUpdatedEventFilter(_MessageMetadataEventFilter):
     """Filters for Slack message metadata being updated."""
 
-    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_UPDATED] = (
-        SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+    type: Literal[SlackWebhookEventType.MESSAGE_METADATA_UPDATED] = (
+        SlackWebhookEventType.MESSAGE_METADATA_UPDATED
     )
 
 
 class FileSharedEventFilter(SlackEventFilter):
     """Filters for a Slack file being shared."""
 
-    type: Literal[SlackWebhookEvent.FILE_SHARED] = (
-        SlackWebhookEvent.FILE_SHARED
+    type: Literal[SlackWebhookEventType.FILE_SHARED] = (
+        SlackWebhookEventType.FILE_SHARED
     )
     file_id: StringFilterOption = None
 
@@ -224,7 +242,7 @@ class FileSharedEventFilter(SlackEventFilter):
 
 SlackWebhookEventFilter: TypeAlias = Annotated[
     AppMentionEventFilter
-    | MessagePostedEventFilter
+    | MessageEventFilter
     | ReactionAddedEventFilter
     | ReactionRemovedEventFilter
     | MessageMetadataPostedEventFilter
@@ -245,7 +263,6 @@ class _SlackCommonEventFields(TypedDict):
 
     event_id: str
     team_id: str
-    user_id: str
     event_time: int
     event_ts: str
 
@@ -270,7 +287,6 @@ class SlackSemanticEvent(BaseModel):
 
     event_id: str
     team_id: str
-    user_id: str
     event_time: int
     event_ts: str
 
@@ -281,13 +297,30 @@ class SlackSemanticEvent(BaseModel):
             target: The typed Slack target event.
 
         Returns:
+            Whether the event's team matches the target.
+        """
+        return matches_string_filter(
+            actual=self.team_id, configured=target.team_id
+        )
+
+
+class SlackUserEvent(SlackSemanticEvent):
+    """Base event with a required Slack user identifier."""
+
+    user_id: str
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Match the required user identifier.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
             Whether the event's team and user match the target.
         """
         return all(
             (
-                matches_string_filter(
-                    actual=self.team_id, configured=target.team_id
-                ),
+                super().matches(target),
                 matches_string_filter(
                     actual=self.user_id, configured=target.user_id
                 ),
@@ -295,7 +328,7 @@ class SlackSemanticEvent(BaseModel):
         )
 
 
-class SlackChannelEvent(SlackSemanticEvent):
+class SlackChannelEvent(SlackUserEvent):
     """Base event with a required Slack channel identifier."""
 
     channel_id: str
@@ -323,9 +356,10 @@ class SlackAppMentionEvent(SlackChannelEvent):
     """Normalized Slack app mention."""
 
     event_filter_type = AppMentionEventFilter
-    type: Literal[SlackWebhookEvent.APP_MENTION] = (
-        SlackWebhookEvent.APP_MENTION
+    type: Literal[SlackWebhookEventType.APP_MENTION] = (
+        SlackWebhookEventType.APP_MENTION
     )
+    text: str | None = None
     message_ts: str | None = None
     thread_ts: str | None = None
 
@@ -343,6 +377,9 @@ class SlackAppMentionEvent(SlackChannelEvent):
         return all(
             (
                 super().matches(target),
+                matches_string_filter(
+                    actual=self.text, configured=target.text
+                ),
                 _matches_bool(
                     actual=self.thread_ts is not None,
                     configured=target.threaded,
@@ -351,16 +388,20 @@ class SlackAppMentionEvent(SlackChannelEvent):
         )
 
 
-class SlackMessagePostedEvent(SlackChannelEvent):
-    """Normalized ordinary human-authored Slack message."""
+class SlackMessageEvent(SlackSemanticEvent):
+    """Normalized Slack message event."""
 
-    event_filter_type = MessagePostedEventFilter
-    type: Literal[SlackWebhookEvent.MESSAGE_POSTED] = (
-        SlackWebhookEvent.MESSAGE_POSTED
+    event_filter_type = MessageEventFilter
+    type: Literal[SlackWebhookEventType.MESSAGE] = (
+        SlackWebhookEventType.MESSAGE
     )
+    user_id: str | None = None
+    channel_id: str | None = None
     channel_type: str | None = None
     text: str | None = None
-    message_ts: str
+    subtype: str | None = None
+    bot_authored: bool = False
+    message_ts: str | None = None
     thread_ts: str | None = None
 
     def matches(self, target: SlackWebhookEventFilter) -> bool:
@@ -372,17 +413,32 @@ class SlackMessagePostedEvent(SlackChannelEvent):
         Returns:
             Whether this message matches the target.
         """
-        if not isinstance(target, MessagePostedEventFilter):
+        if not isinstance(target, MessageEventFilter):
             return False
+        if target.subtype is not None:
+            subtype_matches = matches_string_filter(
+                actual=self.subtype, configured=target.subtype
+            )
+        elif target.include_subtypes:
+            subtype_matches = True
+        else:
+            subtype_matches = self.subtype is None and not self.bot_authored
         return all(
             (
                 super().matches(target),
+                matches_string_filter(
+                    actual=self.user_id, configured=target.user_id
+                ),
+                matches_string_filter(
+                    actual=self.channel_id, configured=target.channel_id
+                ),
                 matches_string_filter(
                     actual=self.channel_type, configured=target.channel_type
                 ),
                 matches_string_filter(
                     actual=self.text, configured=target.text
                 ),
+                subtype_matches,
                 _matches_bool(
                     actual=self.thread_ts is not None,
                     configured=target.threaded,
@@ -400,7 +456,7 @@ class SlackReactionItem(BaseModel):
     file_id: str | None = None
 
 
-class SlackReactionEvent(SlackSemanticEvent):
+class SlackReactionEvent(SlackUserEvent):
     """Shared normalized fields for a Slack reaction event."""
 
     channel_id: str | None = None
@@ -448,8 +504,8 @@ class SlackReactionAddedEvent(SlackReactionEvent):
     """Normalized Slack reaction-added event."""
 
     event_filter_type = ReactionAddedEventFilter
-    type: Literal[SlackWebhookEvent.REACTION_ADDED] = (
-        SlackWebhookEvent.REACTION_ADDED
+    type: Literal[SlackWebhookEventType.REACTION_ADDED] = (
+        SlackWebhookEventType.REACTION_ADDED
     )
 
 
@@ -457,8 +513,8 @@ class SlackReactionRemovedEvent(SlackReactionEvent):
     """Normalized Slack reaction-removed event."""
 
     event_filter_type = ReactionRemovedEventFilter
-    type: Literal[SlackWebhookEvent.REACTION_REMOVED] = (
-        SlackWebhookEvent.REACTION_REMOVED
+    type: Literal[SlackWebhookEventType.REACTION_REMOVED] = (
+        SlackWebhookEventType.REACTION_REMOVED
     )
 
 
@@ -510,8 +566,8 @@ class SlackMessageMetadataPostedEvent(SlackMessageMetadataEvent):
     """Normalized Slack message-metadata-posted event."""
 
     event_filter_type = MessageMetadataPostedEventFilter
-    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_POSTED] = (
-        SlackWebhookEvent.MESSAGE_METADATA_POSTED
+    type: Literal[SlackWebhookEventType.MESSAGE_METADATA_POSTED] = (
+        SlackWebhookEventType.MESSAGE_METADATA_POSTED
     )
 
 
@@ -519,8 +575,8 @@ class SlackMessageMetadataUpdatedEvent(SlackMessageMetadataEvent):
     """Normalized Slack message-metadata-updated event."""
 
     event_filter_type = MessageMetadataUpdatedEventFilter
-    type: Literal[SlackWebhookEvent.MESSAGE_METADATA_UPDATED] = (
-        SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+    type: Literal[SlackWebhookEventType.MESSAGE_METADATA_UPDATED] = (
+        SlackWebhookEventType.MESSAGE_METADATA_UPDATED
     )
     previous_metadata: SlackMessageMetadata
 
@@ -529,8 +585,8 @@ class SlackFileSharedEvent(SlackChannelEvent):
     """Normalized Slack file-shared event."""
 
     event_filter_type = FileSharedEventFilter
-    type: Literal[SlackWebhookEvent.FILE_SHARED] = (
-        SlackWebhookEvent.FILE_SHARED
+    type: Literal[SlackWebhookEventType.FILE_SHARED] = (
+        SlackWebhookEventType.FILE_SHARED
     )
     file_id: str
 
@@ -830,7 +886,7 @@ class SlackWebhookProvider(BaseWebhookProvider):
         if event.event_type == SlackWebhookEventType.APP_MENTION:
             return self._parse_app_mention(payload, common_fields)
         if event.event_type == SlackWebhookEventType.MESSAGE:
-            return self._parse_message_posted(payload, common_fields)
+            return self._parse_message(payload, common_fields)
         if event.event_type == SlackWebhookEventType.REACTION_ADDED:
             return self._parse_reaction(
                 payload, common_fields, SlackReactionAddedEvent
@@ -869,44 +925,67 @@ class SlackWebhookProvider(BaseWebhookProvider):
             The normalized mention, or `None` if it is not matchable.
         """
         channel_id = self._optional_string(payload.get("channel"))
-        if channel_id is None:
+        user_id = self._event_user_id(payload)
+        if channel_id is None or user_id is None:
             return None
         if self._is_bot_message(payload):
             return None
         return SlackAppMentionEvent(
             **common_fields,
             channel_id=channel_id,
+            user_id=user_id,
+            text=self._optional_string(payload.get("text")),
             message_ts=self._optional_string(payload.get("ts")),
             thread_ts=self._optional_string(payload.get("thread_ts")),
         )
 
-    def _parse_message_posted(
+    def _parse_message(
         self,
         payload: Mapping[str, Any],
         common_fields: _SlackCommonEventFields,
-    ) -> SlackMessagePostedEvent | None:
-        """Normalize an ordinary human-authored message callback.
+    ) -> SlackMessageEvent | None:
+        """Normalize a Slack message callback.
 
         Args:
             payload: The inner Slack event payload.
             common_fields: Validated fields shared by all semantic events.
 
         Returns:
-            The normalized message, or `None` for bot and subtype variants.
+            The normalized message event, or `None` if a regular message is
+            missing its stable identity fields.
         """
-        if payload.get("subtype") is not None or self._is_bot_message(payload):
+        content = self._message_content(payload)
+        user_id = self._event_user_id(payload, content)
+        channel_id = self._optional_string(
+            payload.get("channel")
+        ) or self._optional_string(content.get("channel"))
+        subtype = self._optional_string(payload.get("subtype"))
+        bot_authored = self._is_bot_message(payload) or self._is_bot_message(
+            content
+        )
+        message_ts = self._optional_string(
+            content.get("ts")
+        ) or self._optional_string(payload.get("deleted_ts"))
+        if message_ts is None:
+            message_ts = self._optional_string(payload.get("ts"))
+        if (
+            subtype is None
+            and not bot_authored
+            and (user_id is None or channel_id is None or message_ts is None)
+        ):
             return None
-        channel_id = self._optional_string(payload.get("channel"))
-        message_ts = self._optional_string(payload.get("ts"))
-        if channel_id is None or message_ts is None:
-            return None
-        return SlackMessagePostedEvent(
+        return SlackMessageEvent(
             **common_fields,
+            user_id=user_id,
             channel_id=channel_id,
-            channel_type=self._optional_string(payload.get("channel_type")),
-            text=self._optional_string(payload.get("text")),
+            channel_type=self._optional_string(payload.get("channel_type"))
+            or self._optional_string(content.get("channel_type")),
+            text=self._optional_string(content.get("text")),
+            subtype=subtype,
+            bot_authored=bot_authored,
             message_ts=message_ts,
-            thread_ts=self._optional_string(payload.get("thread_ts")),
+            thread_ts=self._optional_string(content.get("thread_ts"))
+            or self._optional_string(payload.get("thread_ts")),
         )
 
     def _parse_reaction(
@@ -926,14 +1005,20 @@ class SlackWebhookProvider(BaseWebhookProvider):
             The normalized reaction, or `None` if required fields are missing.
         """
         reaction = self._optional_string(payload.get("reaction"))
+        user_id = self._event_user_id(payload)
         item_payload = payload.get("item")
-        if reaction is None or not isinstance(item_payload, Mapping):
+        if (
+            reaction is None
+            or user_id is None
+            or not isinstance(item_payload, Mapping)
+        ):
             return None
         item = self._parse_reaction_item(item_payload)
         if item is None:
             return None
         return event_class(
             **common_fields,
+            user_id=user_id,
             channel_id=item.channel_id,
             reaction=reaction,
             item_user_id=self._optional_string(payload.get("item_user")),
@@ -985,11 +1070,13 @@ class SlackWebhookProvider(BaseWebhookProvider):
         """
         channel_id = self._optional_string(payload.get("channel_id"))
         app_id = self._optional_string(payload.get("app_id"))
+        user_id = self._event_user_id(payload)
         message_ts = self._optional_string(payload.get("message_ts"))
         metadata_payload = payload.get("metadata")
         if (
             channel_id is None
             or app_id is None
+            or user_id is None
             or message_ts is None
             or not isinstance(metadata_payload, Mapping)
         ):
@@ -999,6 +1086,7 @@ class SlackWebhookProvider(BaseWebhookProvider):
             return None
         return {
             **common_fields,
+            "user_id": user_id,
             "channel_id": channel_id,
             "app_id": app_id,
             "bot_id": self._optional_string(payload.get("bot_id")),
@@ -1047,11 +1135,13 @@ class SlackWebhookProvider(BaseWebhookProvider):
         """
         channel_id = self._optional_string(payload.get("channel_id"))
         file_id = self._optional_string(payload.get("file_id"))
-        if channel_id is None or file_id is None:
+        user_id = self._event_user_id(payload)
+        if channel_id is None or user_id is None or file_id is None:
             return None
         return SlackFileSharedEvent(
             **common_fields,
             channel_id=channel_id,
+            user_id=user_id,
             file_id=file_id,
         )
 
@@ -1071,15 +1161,11 @@ class SlackWebhookProvider(BaseWebhookProvider):
         team_id = self._optional_string(
             event.payload.get("team_id")
         ) or self._optional_string(payload.get("team_id"))
-        user_id = self._optional_string(
-            payload.get("user")
-        ) or self._optional_string(payload.get("user_id"))
         event_time = self._optional_int(event.payload.get("event_time"))
         event_ts = self._optional_string(payload.get("event_ts"))
         if (
             event_id is None
             or team_id is None
-            or user_id is None
             or event_time is None
             or event_ts is None
         ):
@@ -1087,7 +1173,6 @@ class SlackWebhookProvider(BaseWebhookProvider):
         return {
             "event_id": event_id,
             "team_id": team_id,
-            "user_id": user_id,
             "event_time": event_time,
             "event_ts": event_ts,
         }
@@ -1114,6 +1199,48 @@ class SlackWebhookProvider(BaseWebhookProvider):
             event_type=event_type,
             event_payload=dict(event_payload),
         )
+
+    @staticmethod
+    def _message_content(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Select the message object containing content fields.
+
+        Args:
+            payload: The inner Slack message event payload.
+
+        Returns:
+            The nested current or previous message when present, otherwise the
+            event payload itself.
+        """
+        message = payload.get("message")
+        if isinstance(message, Mapping):
+            return message
+        previous_message = payload.get("previous_message")
+        if isinstance(previous_message, Mapping):
+            return previous_message
+        return payload
+
+    @staticmethod
+    def _event_user_id(
+        payload: Mapping[str, Any],
+        fallback: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        """Extract a Slack user identifier from an event payload.
+
+        Args:
+            payload: The primary Slack event payload.
+            fallback: An optional nested message payload.
+
+        Returns:
+            The first non-empty documented user identifier.
+        """
+        user_id = SlackWebhookProvider._optional_string(
+            payload.get("user")
+        ) or SlackWebhookProvider._optional_string(payload.get("user_id"))
+        if user_id is not None or fallback is None:
+            return user_id
+        return SlackWebhookProvider._optional_string(
+            fallback.get("user")
+        ) or SlackWebhookProvider._optional_string(fallback.get("user_id"))
 
     @staticmethod
     def _is_bot_message(payload: Mapping[str, Any]) -> bool:

--- a/src/zenml/webhooks/providers/slack.py
+++ b/src/zenml/webhooks/providers/slack.py
@@ -14,6 +14,7 @@ from typing import (
     ClassVar,
     Literal,
     TypeAlias,
+    TypedDict,
     cast,
 )
 
@@ -239,6 +240,16 @@ class SlackWebhookConfiguration(WebhookConfiguration):
     target_events: list[SlackWebhookEventFilter] = Field(min_length=1)
 
 
+class _SlackCommonEventFields(TypedDict):
+    """Required fields shared by every supported Slack semantic event."""
+
+    event_id: str
+    team_id: str
+    user_id: str
+    event_time: int
+    event_ts: str
+
+
 def _matches_bool(*, actual: bool, configured: bool | None) -> bool:
     """Match a boolean value against an optional configured filter.
 
@@ -257,12 +268,11 @@ class SlackSemanticEvent(BaseModel):
 
     event_filter_type: ClassVar[type[SlackEventFilter]]
 
-    event_id: str | None = None
-    team_id: str | None = None
-    channel_id: str | None = None
-    user_id: str | None = None
-    event_time: int | None = None
-    event_ts: str | None = None
+    event_id: str
+    team_id: str
+    user_id: str
+    event_time: int
+    event_ts: str
 
     def matches(self, target: SlackWebhookEventFilter) -> bool:
         """Match identifiers shared by all Slack semantic events.
@@ -271,15 +281,12 @@ class SlackSemanticEvent(BaseModel):
             target: The typed Slack target event.
 
         Returns:
-            Whether the event's team, channel, and user match the target.
+            Whether the event's team and user match the target.
         """
         return all(
             (
                 matches_string_filter(
                     actual=self.team_id, configured=target.team_id
-                ),
-                matches_string_filter(
-                    actual=self.channel_id, configured=target.channel_id
                 ),
                 matches_string_filter(
                     actual=self.user_id, configured=target.user_id
@@ -288,15 +295,37 @@ class SlackSemanticEvent(BaseModel):
         )
 
 
-class SlackAppMentionEvent(SlackSemanticEvent):
+class SlackChannelEvent(SlackSemanticEvent):
+    """Base event with a required Slack channel identifier."""
+
+    channel_id: str
+
+    def matches(self, target: SlackWebhookEventFilter) -> bool:
+        """Match the required channel identifier.
+
+        Args:
+            target: The typed Slack target event.
+
+        Returns:
+            Whether the event's team, user, and channel match the target.
+        """
+        return all(
+            (
+                super().matches(target),
+                matches_string_filter(
+                    actual=self.channel_id, configured=target.channel_id
+                ),
+            )
+        )
+
+
+class SlackAppMentionEvent(SlackChannelEvent):
     """Normalized Slack app mention."""
 
     event_filter_type = AppMentionEventFilter
     type: Literal[SlackWebhookEvent.APP_MENTION] = (
         SlackWebhookEvent.APP_MENTION
     )
-    channel_id: str
-    user_id: str
     message_ts: str | None = None
     thread_ts: str | None = None
 
@@ -322,15 +351,13 @@ class SlackAppMentionEvent(SlackSemanticEvent):
         )
 
 
-class SlackMessagePostedEvent(SlackSemanticEvent):
+class SlackMessagePostedEvent(SlackChannelEvent):
     """Normalized ordinary human-authored Slack message."""
 
     event_filter_type = MessagePostedEventFilter
     type: Literal[SlackWebhookEvent.MESSAGE_POSTED] = (
         SlackWebhookEvent.MESSAGE_POSTED
     )
-    channel_id: str
-    user_id: str
     channel_type: str | None = None
     text: str | None = None
     message_ts: str
@@ -376,8 +403,8 @@ class SlackReactionItem(BaseModel):
 class SlackReactionEvent(SlackSemanticEvent):
     """Shared normalized fields for a Slack reaction event."""
 
+    channel_id: str | None = None
     reaction: str
-    user_id: str
     item_user_id: str | None = None
     item: SlackReactionItem
 
@@ -396,6 +423,9 @@ class SlackReactionEvent(SlackSemanticEvent):
         return all(
             (
                 super().matches(target),
+                matches_string_filter(
+                    actual=self.channel_id, configured=target.channel_id
+                ),
                 matches_string_filter(
                     actual=self.reaction, configured=reaction_target.reaction
                 ),
@@ -439,12 +469,10 @@ class SlackMessageMetadata(BaseModel):
     event_payload: dict[str, Any]
 
 
-class SlackMessageMetadataEvent(SlackSemanticEvent):
+class SlackMessageMetadataEvent(SlackChannelEvent):
     """Shared normalized fields for a Slack message-metadata event."""
 
-    channel_id: str
     app_id: str
-    user_id: str | None = None
     bot_id: str | None = None
     message_ts: str
     metadata: SlackMessageMetadata
@@ -497,15 +525,13 @@ class SlackMessageMetadataUpdatedEvent(SlackMessageMetadataEvent):
     previous_metadata: SlackMessageMetadata
 
 
-class SlackFileSharedEvent(SlackSemanticEvent):
+class SlackFileSharedEvent(SlackChannelEvent):
     """Normalized Slack file-shared event."""
 
     event_filter_type = FileSharedEventFilter
     type: Literal[SlackWebhookEvent.FILE_SHARED] = (
         SlackWebhookEvent.FILE_SHARED
     )
-    channel_id: str
-    user_id: str
     file_id: str
 
     def matches(self, target: SlackWebhookEventFilter) -> bool:
@@ -798,65 +824,72 @@ class SlackWebhookProvider(BaseWebhookProvider):
         payload = event.payload.get("event")
         if not isinstance(payload, Mapping):
             return None
+        common_fields = self._common_event_fields(event, payload)
+        if common_fields is None:
+            return None
         if event.event_type == SlackWebhookEventType.APP_MENTION:
-            return self._parse_app_mention(event, payload)
+            return self._parse_app_mention(payload, common_fields)
         if event.event_type == SlackWebhookEventType.MESSAGE:
-            return self._parse_message_posted(event, payload)
+            return self._parse_message_posted(payload, common_fields)
         if event.event_type == SlackWebhookEventType.REACTION_ADDED:
             return self._parse_reaction(
-                event, payload, SlackReactionAddedEvent
+                payload, common_fields, SlackReactionAddedEvent
             )
         if event.event_type == SlackWebhookEventType.REACTION_REMOVED:
             return self._parse_reaction(
-                event, payload, SlackReactionRemovedEvent
+                payload, common_fields, SlackReactionRemovedEvent
             )
         if event.event_type == SlackWebhookEventType.MESSAGE_METADATA_POSTED:
-            fields = self._parse_message_metadata_fields(event, payload)
+            fields = self._parse_message_metadata_fields(
+                payload, common_fields
+            )
             return (
                 SlackMessageMetadataPostedEvent(**fields)
                 if fields is not None
                 else None
             )
         if event.event_type == SlackWebhookEventType.MESSAGE_METADATA_UPDATED:
-            return self._parse_message_metadata_updated(event, payload)
+            return self._parse_message_metadata_updated(payload, common_fields)
         if event.event_type == SlackWebhookEventType.FILE_SHARED:
-            return self._parse_file_shared(event, payload)
+            return self._parse_file_shared(payload, common_fields)
         return None
 
     def _parse_app_mention(
-        self, event: "WebhookEvent", payload: Mapping[str, Any]
+        self,
+        payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
     ) -> SlackAppMentionEvent | None:
         """Normalize an app-mention callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
 
         Returns:
             The normalized mention, or `None` if it is not matchable.
         """
         channel_id = self._optional_string(payload.get("channel"))
-        user_id = self._optional_string(payload.get("user"))
-        if channel_id is None or user_id is None:
+        if channel_id is None:
             return None
         if self._is_bot_message(payload):
             return None
         return SlackAppMentionEvent(
-            **self._common_event_fields(event, payload),
+            **common_fields,
             channel_id=channel_id,
-            user_id=user_id,
             message_ts=self._optional_string(payload.get("ts")),
             thread_ts=self._optional_string(payload.get("thread_ts")),
         )
 
     def _parse_message_posted(
-        self, event: "WebhookEvent", payload: Mapping[str, Any]
+        self,
+        payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
     ) -> SlackMessagePostedEvent | None:
         """Normalize an ordinary human-authored message callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
 
         Returns:
             The normalized message, or `None` for bot and subtype variants.
@@ -864,14 +897,12 @@ class SlackWebhookProvider(BaseWebhookProvider):
         if payload.get("subtype") is not None or self._is_bot_message(payload):
             return None
         channel_id = self._optional_string(payload.get("channel"))
-        user_id = self._optional_string(payload.get("user"))
         message_ts = self._optional_string(payload.get("ts"))
-        if channel_id is None or user_id is None or message_ts is None:
+        if channel_id is None or message_ts is None:
             return None
         return SlackMessagePostedEvent(
-            **self._common_event_fields(event, payload),
+            **common_fields,
             channel_id=channel_id,
-            user_id=user_id,
             channel_type=self._optional_string(payload.get("channel_type")),
             text=self._optional_string(payload.get("text")),
             message_ts=message_ts,
@@ -880,37 +911,31 @@ class SlackWebhookProvider(BaseWebhookProvider):
 
     def _parse_reaction(
         self,
-        event: "WebhookEvent",
         payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
         event_class: type[SlackReactionEvent],
     ) -> SlackReactionEvent | None:
         """Normalize a reaction callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
             event_class: The reaction semantic model to instantiate.
 
         Returns:
             The normalized reaction, or `None` if required fields are missing.
         """
         reaction = self._optional_string(payload.get("reaction"))
-        user_id = self._optional_string(payload.get("user"))
         item_payload = payload.get("item")
-        if (
-            reaction is None
-            or user_id is None
-            or not isinstance(item_payload, Mapping)
-        ):
+        if reaction is None or not isinstance(item_payload, Mapping):
             return None
         item = self._parse_reaction_item(item_payload)
         if item is None:
             return None
         return event_class(
-            **self._common_event_fields(event, payload),
+            **common_fields,
             channel_id=item.channel_id,
             reaction=reaction,
-            user_id=user_id,
             item_user_id=self._optional_string(payload.get("item_user")),
             item=item,
         )
@@ -945,13 +970,15 @@ class SlackWebhookProvider(BaseWebhookProvider):
         )
 
     def _parse_message_metadata_fields(
-        self, event: "WebhookEvent", payload: Mapping[str, Any]
+        self,
+        payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
     ) -> dict[str, Any] | None:
         """Extract normalized fields from a message-metadata callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
 
         Returns:
             Semantic model fields, or `None` if required fields are missing.
@@ -971,28 +998,29 @@ class SlackWebhookProvider(BaseWebhookProvider):
         if metadata is None:
             return None
         return {
-            **self._common_event_fields(event, payload),
+            **common_fields,
             "channel_id": channel_id,
             "app_id": app_id,
-            "user_id": self._optional_string(payload.get("user_id")),
             "bot_id": self._optional_string(payload.get("bot_id")),
             "message_ts": message_ts,
             "metadata": metadata,
         }
 
     def _parse_message_metadata_updated(
-        self, event: "WebhookEvent", payload: Mapping[str, Any]
+        self,
+        payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
     ) -> SlackMessageMetadataUpdatedEvent | None:
         """Normalize a message-metadata-updated callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
 
         Returns:
             The normalized update, or `None` if either metadata value is invalid.
         """
-        fields = self._parse_message_metadata_fields(event, payload)
+        fields = self._parse_message_metadata_fields(payload, common_fields)
         previous_payload = payload.get("previous_metadata")
         if fields is None or not isinstance(previous_payload, Mapping):
             return None
@@ -1004,32 +1032,32 @@ class SlackWebhookProvider(BaseWebhookProvider):
         )
 
     def _parse_file_shared(
-        self, event: "WebhookEvent", payload: Mapping[str, Any]
+        self,
+        payload: Mapping[str, Any],
+        common_fields: _SlackCommonEventFields,
     ) -> SlackFileSharedEvent | None:
         """Normalize a file-shared callback.
 
         Args:
-            event: The trusted Slack webhook event.
             payload: The inner Slack event payload.
+            common_fields: Validated fields shared by all semantic events.
 
         Returns:
             The normalized file share, or `None` if required fields are missing.
         """
         channel_id = self._optional_string(payload.get("channel_id"))
-        user_id = self._optional_string(payload.get("user_id"))
         file_id = self._optional_string(payload.get("file_id"))
-        if channel_id is None or user_id is None or file_id is None:
+        if channel_id is None or file_id is None:
             return None
         return SlackFileSharedEvent(
-            **self._common_event_fields(event, payload),
+            **common_fields,
             channel_id=channel_id,
-            user_id=user_id,
             file_id=file_id,
         )
 
     def _common_event_fields(
         self, event: "WebhookEvent", payload: Mapping[str, Any]
-    ) -> dict[str, Any]:
+    ) -> _SlackCommonEventFields | None:
         """Extract metadata shared by normalized Slack events.
 
         Args:
@@ -1037,14 +1065,31 @@ class SlackWebhookProvider(BaseWebhookProvider):
             payload: The inner Slack event payload.
 
         Returns:
-            Keyword arguments for a `SlackSemanticEvent` model.
+            Required common fields, or `None` if any field is missing.
         """
+        event_id = self._optional_string(event.delivery_id)
+        team_id = self._optional_string(
+            event.payload.get("team_id")
+        ) or self._optional_string(payload.get("team_id"))
+        user_id = self._optional_string(
+            payload.get("user")
+        ) or self._optional_string(payload.get("user_id"))
+        event_time = self._optional_int(event.payload.get("event_time"))
+        event_ts = self._optional_string(payload.get("event_ts"))
+        if (
+            event_id is None
+            or team_id is None
+            or user_id is None
+            or event_time is None
+            or event_ts is None
+        ):
+            return None
         return {
-            "event_id": event.delivery_id,
-            "team_id": self._optional_string(event.payload.get("team_id"))
-            or self._optional_string(payload.get("team_id")),
-            "event_time": self._optional_int(event.payload.get("event_time")),
-            "event_ts": self._optional_string(payload.get("event_ts")),
+            "event_id": event_id,
+            "team_id": team_id,
+            "user_id": user_id,
+            "event_time": event_time,
+            "event_ts": event_ts,
         }
 
     @staticmethod

--- a/src/zenml/webhooks/providers/types.py
+++ b/src/zenml/webhooks/providers/types.py
@@ -22,3 +22,4 @@ class BuiltinWebhookType(StrEnum):
     CUSTOM = "custom"
     GITHUB = "github"
     CLICKUP = "clickup"
+    SLACK = "slack"

--- a/src/zenml/zen_server/routers/webhook_endpoints.py
+++ b/src/zenml/zen_server/routers/webhook_endpoints.py
@@ -24,6 +24,7 @@ from fastapi import (
     status,
 )
 from fastapi.responses import Response
+from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import Headers
 
@@ -353,7 +354,7 @@ def _receive_webhook_event(
         )
 
     try:
-        parsed_event = provider.parse(body=body, headers=headers)
+        parsed_delivery = provider.parse_delivery(body=body, headers=headers)
     except WebhookPayloadError as error:
         zen_store().record_webhook_event(
             webhook_id,
@@ -369,13 +370,25 @@ def _receive_webhook_event(
     zen_store().record_webhook_event(
         webhook_id, WebhookEventStatsUpdate(accepted=True)
     )
-    event = WebhookEvent(
-        project_id=config.project_id,
-        webhook_id=webhook_id,
-        webhook_type=webhook_type,
-        event_type=parsed_event.event_type,
-        delivery_id=parsed_event.delivery_id,
-        payload=parsed_event.payload,
+    background_task = None
+    if parsed_delivery.event is not None:
+        parsed_event = parsed_delivery.event
+        event = WebhookEvent(
+            project_id=config.project_id,
+            webhook_id=webhook_id,
+            webhook_type=webhook_type,
+            event_type=parsed_event.event_type,
+            delivery_id=parsed_event.delivery_id,
+            payload=parsed_event.payload,
+        )
+        background_task = BackgroundTask(
+            EventDispatcher().dispatch_event, event
+        )
+
+    intake_response = parsed_delivery.response
+    return Response(
+        content=intake_response.body,
+        status_code=intake_response.status_code,
+        media_type=intake_response.media_type,
+        background=background_task,
     )
-    EventDispatcher().dispatch_event(event)
-    return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/tests/integration/functional/webhooks/test_slack.py
+++ b/tests/integration/functional/webhooks/test_slack.py
@@ -62,6 +62,9 @@ from zenml.webhooks.providers.slack import (
 )
 from zenml.zen_server.routers import webhook_endpoints as endpoints
 
+SLACK_EVENT_TIME = 1788300000
+SLACK_EVENT_TS = "1788300000.000000"
+
 
 def _slack_signature(secret: str, timestamp: str, body: bytes) -> str:
     signature_base = f"v0:{timestamp}:".encode() + body
@@ -442,7 +445,8 @@ def _slack_webhook_event(
         "text": "<@APP123> investigate this",
     }
     if event_payload is not None:
-        inner_event = event_payload
+        inner_event = dict(event_payload)
+    inner_event.setdefault("event_ts", SLACK_EVENT_TS)
     return WebhookEvent(
         project_id=uuid4(),
         webhook_id=uuid4(),
@@ -453,6 +457,7 @@ def _slack_webhook_event(
             "type": "event_callback",
             "team_id": "T123",
             "event_id": "Ev123",
+            "event_time": SLACK_EVENT_TIME,
             "event": inner_event,
         },
     )
@@ -475,6 +480,8 @@ def test_slack_parses_semantic_app_mention() -> None:
     assert semantic == SlackAppMentionEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
+        event_ts=SLACK_EVENT_TS,
         channel_id="C123",
         user_id="U123",
         message_ts="1788300000.000002",
@@ -482,6 +489,36 @@ def test_slack_parses_semantic_app_mention() -> None:
     )
     assert semantic.event_filter_type is AppMentionEventFilter
     assert semantic.type == SlackWebhookEvent.APP_MENTION
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["event_id", "team_id", "user_id", "event_time", "event_ts"],
+)
+def test_slack_ignores_events_missing_common_fields(
+    missing_field: str,
+) -> None:
+    """Every semantic event requires the common Slack callback fields.
+
+    Args:
+        missing_field: The required common field to omit.
+    """
+    event = _slack_webhook_event()
+    if missing_field == "event_id":
+        event = event.model_copy(update={"delivery_id": None})
+    else:
+        payload = dict(event.payload)
+        if missing_field in {"user_id", "event_ts"}:
+            inner_event = dict(payload["event"])
+            inner_event.pop(
+                "user" if missing_field == "user_id" else missing_field
+            )
+            payload["event"] = inner_event
+        else:
+            payload.pop(missing_field)
+        event = event.model_copy(update={"payload": payload})
+
+    assert SlackWebhookProvider().parse_semantic_event(event) is None
 
 
 def test_slack_matches_app_mention_targets() -> None:
@@ -579,6 +616,7 @@ def test_slack_parses_and_matches_human_message_posts() -> None:
     assert semantic == SlackMessagePostedEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
         event_ts="1788300000.000003",
         channel_id="C123",
         channel_type="channel",
@@ -712,6 +750,7 @@ def test_slack_parses_all_documented_reaction_items(
     assert semantic == SlackReactionAddedEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
         channel_id=expected_item.channel_id,
         event_ts="1788300000.000002",
         reaction="rocket",
@@ -811,6 +850,8 @@ def test_slack_parses_and_matches_posted_message_metadata() -> None:
     assert semantic == SlackMessageMetadataPostedEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
+        event_ts=SLACK_EVENT_TS,
         channel_id="C123",
         app_id="A123",
         bot_id="B123",
@@ -856,6 +897,8 @@ def test_slack_parses_and_matches_updated_message_metadata() -> None:
     assert semantic == SlackMessageMetadataUpdatedEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
+        event_ts=SLACK_EVENT_TS,
         channel_id="C123",
         app_id="A123",
         user_id="U123",
@@ -932,6 +975,7 @@ def test_slack_parses_and_matches_shared_files() -> None:
     assert semantic == SlackFileSharedEvent(
         event_id="Ev123",
         team_id="T123",
+        event_time=SLACK_EVENT_TIME,
         event_ts="1788300000.000001",
         channel_id="C123",
         user_id="U123",

--- a/tests/integration/functional/webhooks/test_slack.py
+++ b/tests/integration/functional/webhooks/test_slack.py
@@ -42,22 +42,22 @@ from zenml.webhooks.providers.slack import (
     SLACK_SIGNATURE_HEADER,
     AppMentionEventFilter,
     FileSharedEventFilter,
+    MessageEventFilter,
     MessageMetadataPostedEventFilter,
     MessageMetadataUpdatedEventFilter,
-    MessagePostedEventFilter,
     ReactionAddedEventFilter,
     ReactionRemovedEventFilter,
     SlackAppMentionEvent,
     SlackFileSharedEvent,
+    SlackMessageEvent,
     SlackMessageMetadata,
     SlackMessageMetadataPostedEvent,
     SlackMessageMetadataUpdatedEvent,
-    SlackMessagePostedEvent,
     SlackReactionAddedEvent,
     SlackReactionItem,
     SlackReactionRemovedEvent,
     SlackWebhookConfiguration,
-    SlackWebhookEvent,
+    SlackWebhookEventType,
     SlackWebhookProvider,
 )
 from zenml.zen_server.routers import webhook_endpoints as endpoints
@@ -120,6 +120,11 @@ def test_slack_provider_is_registered() -> None:
 
     assert isinstance(provider, SlackWebhookProvider)
     assert provider.webhook_type == BuiltinWebhookType.SLACK
+
+
+def test_slack_message_event_types_preserve_wire_and_semantic_names() -> None:
+    """Slack intake and ZenML triggers share the Slack message name."""
+    assert SlackWebhookEventType.MESSAGE == "message"
 
 
 def test_slack_pre_validation_always_processes() -> None:
@@ -355,12 +360,14 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                     "type": "app_mention",
                     "channel_id": ["C123", "C456"],
                     "user_id": 'oneof:["U123","U456"]',
+                    "text": "startswith:<@APP123> deploy ",
                     "threaded": True,
                 },
                 {
-                    "type": "message_posted",
+                    "type": "message",
                     "text": "startswith:deploy ",
                     "channel_type": "channel",
+                    "subtype": ["message_changed", "message_deleted"],
                 },
                 {"type": "reaction_added", "reaction": "rocket"},
                 {"type": "reaction_removed", "item_type": "message"},
@@ -383,10 +390,13 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
             AppMentionEventFilter(
                 channel_id=["C123", "C456"],
                 user_id='oneof:["U123","U456"]',
+                text="startswith:<@APP123> deploy ",
                 threaded=True,
             ),
-            MessagePostedEventFilter(
-                text="startswith:deploy ", channel_type="channel"
+            MessageEventFilter(
+                text="startswith:deploy ",
+                channel_type="channel",
+                subtype=["message_changed", "message_deleted"],
             ),
             ReactionAddedEventFilter(reaction="rocket"),
             ReactionRemovedEventFilter(item_type="message"),
@@ -411,8 +421,27 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                 {"type": "app_mention", "channel_id": "startswith:C"}
             ]
         },
+        {
+            "target_events": [
+                {"type": "app_mention", "text": "contains:deploy"}
+            ]
+        },
         {"target_events": [{"type": "app_mention", "user_id": "oneof:[]"}]},
         {"target_events": [{"type": "app_mention", "workspace_id": "T123"}]},
+        {
+            "target_events": [
+                {"type": "message", "subtype": "startswith:message_"}
+            ]
+        },
+        {
+            "target_events": [
+                {
+                    "type": "message",
+                    "subtype": "message_changed",
+                    "include_subtypes": True,
+                }
+            ]
+        },
         {
             "target_events": [
                 {"type": "reaction_added", "reaction": "startswith:approve"}
@@ -470,6 +499,7 @@ def test_slack_parses_semantic_app_mention() -> None:
             "type": "app_mention",
             "channel": "C123",
             "user": "U123",
+            "text": "<@APP123> investigate this",
             "ts": "1788300000.000002",
             "thread_ts": "1788300000.000001",
         }
@@ -484,21 +514,22 @@ def test_slack_parses_semantic_app_mention() -> None:
         event_ts=SLACK_EVENT_TS,
         channel_id="C123",
         user_id="U123",
+        text="<@APP123> investigate this",
         message_ts="1788300000.000002",
         thread_ts="1788300000.000001",
     )
     assert semantic.event_filter_type is AppMentionEventFilter
-    assert semantic.type == SlackWebhookEvent.APP_MENTION
+    assert semantic.type == SlackWebhookEventType.APP_MENTION
 
 
 @pytest.mark.parametrize(
     "missing_field",
     ["event_id", "team_id", "user_id", "event_time", "event_ts"],
 )
-def test_slack_ignores_events_missing_common_fields(
+def test_slack_app_mentions_require_common_and_user_fields(
     missing_field: str,
 ) -> None:
-    """Every semantic event requires the common Slack callback fields.
+    """App mentions require common Slack callback and user fields.
 
     Args:
         missing_field: The required common field to omit.
@@ -536,6 +567,7 @@ def test_slack_matches_app_mention_targets() -> None:
                     "type": "app_mention",
                     "channel_id": ["C999", "C123"],
                     "user_id": 'oneof:["U123","U456"]',
+                    "text": "startswith:<@APP123> investigate",
                 }
             ]
         },
@@ -567,6 +599,14 @@ def test_slack_matches_app_mention_targets() -> None:
             ]
         },
     )
+    wrong_text = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {"type": "app_mention", "text": "startswith:deploy "}
+            ]
+        },
+    )
     empty_channel_list = SimpleNamespace(
         id=uuid4(),
         configuration={
@@ -582,6 +622,7 @@ def test_slack_matches_app_mention_targets() -> None:
             matching_alternative,
             wrong_channel,
             wrong_user,
+            wrong_text,
             empty_channel_list,
         ],
     )
@@ -592,11 +633,12 @@ def test_slack_matches_app_mention_targets() -> None:
         matching_alternative,
     ]
     assert matches.event is not None
-    assert matches.event["type"] == SlackWebhookEvent.APP_MENTION
+    assert matches.event["type"] == SlackWebhookEventType.APP_MENTION
+    assert matches.event["text"] == "<@APP123> investigate this"
 
 
-def test_slack_parses_and_matches_human_message_posts() -> None:
-    """Ordinary root messages and replies support semantic filtering."""
+def test_slack_parses_and_matches_regular_messages() -> None:
+    """Regular root messages and replies support semantic filtering."""
     event = _slack_webhook_event(
         event_type="message",
         event_payload={
@@ -613,7 +655,7 @@ def test_slack_parses_and_matches_human_message_posts() -> None:
 
     semantic = SlackWebhookProvider().parse_semantic_event(event)
 
-    assert semantic == SlackMessagePostedEvent(
+    assert semantic == SlackMessageEvent(
         event_id="Ev123",
         team_id="T123",
         event_time=SLACK_EVENT_TIME,
@@ -622,11 +664,13 @@ def test_slack_parses_and_matches_human_message_posts() -> None:
         channel_type="channel",
         user_id="U123",
         text="deploy production",
+        subtype=None,
+        bot_authored=False,
         message_ts="1788300000.000002",
         thread_ts="1788300000.000001",
     )
     assert semantic.matches(
-        MessagePostedEventFilter(
+        MessageEventFilter(
             team_id="T123",
             channel_id="C123",
             channel_type="channel",
@@ -635,15 +679,13 @@ def test_slack_parses_and_matches_human_message_posts() -> None:
             threaded=True,
         )
     )
-    assert semantic.type == SlackWebhookEvent.MESSAGE_POSTED
-    assert not semantic.matches(MessagePostedEventFilter(threaded=False))
+    assert semantic.type == SlackWebhookEventType.MESSAGE
+    assert not semantic.matches(MessageEventFilter(threaded=False))
 
     matching = SimpleNamespace(
         id=uuid4(),
         configuration={
-            "target_events": [
-                {"type": "message_posted", "text": "deploy production"}
-            ]
+            "target_events": [{"type": "message", "text": "deploy production"}]
         },
     )
     wrong_event = SimpleNamespace(
@@ -655,41 +697,123 @@ def test_slack_parses_and_matches_human_message_posts() -> None:
     )
     assert match.triggers == [matching]
     assert match.event is not None
-    assert match.event["type"] == SlackWebhookEvent.MESSAGE_POSTED
+    assert match.event["type"] == SlackWebhookEventType.MESSAGE
 
 
 @pytest.mark.parametrize(
-    "payload",
+    "payload, expected_subtype, expected_bot_authored",
     [
-        {
-            "type": "message",
-            "channel": "C123",
-            "user": "U123",
-            "ts": "1.1",
-            "subtype": "message_changed",
-        },
-        {
-            "type": "message",
-            "channel": "C123",
-            "user": "U123",
-            "ts": "1.1",
-            "bot_id": "B123",
-        },
-        {
-            "type": "message",
-            "channel": "C123",
-            "user": "U123",
-            "ts": "1.1",
-            "bot_profile": {"id": "B123"},
-        },
-        {"type": "message", "channel": "C123", "user": "U123"},
+        (
+            {
+                "type": "message",
+                "subtype": "message_changed",
+                "channel": "C123",
+                "message": {
+                    "type": "message",
+                    "user": "U123",
+                    "text": "updated message",
+                    "ts": "1.1",
+                },
+            },
+            "message_changed",
+            False,
+        ),
+        (
+            {
+                "type": "message",
+                "channel": "C123",
+                "text": "bot message",
+                "ts": "1.1",
+                "bot_id": "B123",
+            },
+            None,
+            True,
+        ),
+        (
+            {
+                "type": "message",
+                "subtype": "bot_message",
+                "channel": "C123",
+                "text": "bot message",
+                "ts": "1.1",
+                "bot_profile": {"id": "B123"},
+            },
+            "bot_message",
+            True,
+        ),
     ],
-    ids=["subtype", "bot-id", "bot-profile", "missing-timestamp"],
+    ids=["message-changed", "bot-id", "bot-message-subtype"],
 )
-def test_slack_ignores_non_automation_message_variants(
+def test_slack_message_subtypes_require_explicit_filtering(
     payload: dict[str, object],
+    expected_subtype: str | None,
+    expected_bot_authored: bool,
 ) -> None:
-    """Bot, system, mutation, and malformed messages launch no trigger."""
+    """Subtype and bot messages are normalized but excluded by default."""
+    event = _slack_webhook_event(event_type="message", event_payload=payload)
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert isinstance(semantic, SlackMessageEvent)
+    assert semantic.subtype == expected_subtype
+    assert semantic.bot_authored is expected_bot_authored
+    assert not semantic.matches(MessageEventFilter())
+    assert semantic.matches(MessageEventFilter(include_subtypes=True))
+    if expected_subtype is not None:
+        assert semantic.matches(MessageEventFilter(subtype=expected_subtype))
+
+
+def test_slack_matches_multiple_message_subtypes() -> None:
+    """Message subtype lists use the shared OR string-filter behavior."""
+    event = _slack_webhook_event(
+        event_type="message",
+        event_payload={
+            "type": "message",
+            "subtype": "message_deleted",
+            "channel": "C123",
+            "deleted_ts": "1.1",
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackMessageEvent(
+        event_id="Ev123",
+        team_id="T123",
+        event_time=SLACK_EVENT_TIME,
+        event_ts=SLACK_EVENT_TS,
+        channel_id="C123",
+        subtype="message_deleted",
+        bot_authored=False,
+        message_ts="1.1",
+    )
+    assert semantic.matches(
+        MessageEventFilter(subtype=["message_changed", "message_deleted"])
+    )
+    assert semantic.matches(
+        MessageEventFilter(
+            subtype='oneof:["message_changed","message_deleted"]'
+        )
+    )
+    assert not semantic.matches(MessageEventFilter(subtype="message_changed"))
+
+
+@pytest.mark.parametrize("missing_field", ["channel", "user", "ts"])
+def test_slack_ignores_malformed_regular_messages(
+    missing_field: str,
+) -> None:
+    """Regular messages require stable channel, user, and timestamp fields.
+
+    Args:
+        missing_field: The required regular-message field to omit.
+    """
+    payload = {
+        "type": "message",
+        "channel": "C123",
+        "user": "U123",
+        "text": "deploy production",
+        "ts": "1.1",
+    }
+    payload.pop(missing_field)
     event = _slack_webhook_event(event_type="message", event_payload=payload)
 
     assert SlackWebhookProvider().parse_semantic_event(event) is None
@@ -767,7 +891,7 @@ def test_slack_parses_all_documented_reaction_items(
             item_id=expected_item.id,
         )
     )
-    assert semantic.type == SlackWebhookEvent.REACTION_ADDED
+    assert semantic.type == SlackWebhookEventType.REACTION_ADDED
 
 
 def test_slack_parses_and_matches_removed_reactions() -> None:
@@ -789,7 +913,7 @@ def test_slack_parses_and_matches_removed_reactions() -> None:
     semantic = SlackWebhookProvider().parse_semantic_event(event)
 
     assert isinstance(semantic, SlackReactionRemovedEvent)
-    assert semantic.type == SlackWebhookEvent.REACTION_REMOVED
+    assert semantic.type == SlackWebhookEventType.REACTION_REMOVED
     assert semantic.matches(
         ReactionRemovedEventFilter(
             channel_id="C123", reaction="white_check_mark"
@@ -868,7 +992,7 @@ def test_slack_parses_and_matches_posted_message_metadata() -> None:
             metadata_event_type="startswith:zenml.",
         )
     )
-    assert semantic.type == SlackWebhookEvent.MESSAGE_METADATA_POSTED
+    assert semantic.type == SlackWebhookEventType.MESSAGE_METADATA_POSTED
 
 
 def test_slack_parses_and_matches_updated_message_metadata() -> None:
@@ -917,7 +1041,7 @@ def test_slack_parses_and_matches_updated_message_metadata() -> None:
             channel_id="C123", metadata_event_type="zenml.approval"
         )
     )
-    assert semantic.type == SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+    assert semantic.type == SlackWebhookEventType.MESSAGE_METADATA_UPDATED
 
 
 @pytest.mark.parametrize(
@@ -986,7 +1110,7 @@ def test_slack_parses_and_matches_shared_files() -> None:
             team_id="T123", channel_id="C123", file_id="F123"
         )
     )
-    assert semantic.type == SlackWebhookEvent.FILE_SHARED
+    assert semantic.type == SlackWebhookEventType.FILE_SHARED
     assert not semantic.matches(FileSharedEventFilter(file_id="F999"))
 
 

--- a/tests/integration/functional/webhooks/test_slack.py
+++ b/tests/integration/functional/webhooks/test_slack.py
@@ -358,9 +358,9 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
             "target_events": [
                 {
                     "type": "app_mention",
-                    "channel_id": ["C123", "C456"],
+                    "channel_id": "startswith:C",
                     "user_id": 'oneof:["U123","U456"]',
-                    "text": "startswith:<@APP123> deploy ",
+                    "text": "contains:deploy",
                     "threaded": True,
                 },
                 {
@@ -369,7 +369,10 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                     "channel_type": "channel",
                     "subtype": ["message_changed", "message_deleted"],
                 },
-                {"type": "reaction_added", "reaction": "rocket"},
+                {
+                    "type": "reaction_added",
+                    "reaction": "notequals:thumbsdown",
+                },
                 {"type": "reaction_removed", "item_type": "message"},
                 {
                     "type": "message_metadata_posted",
@@ -379,7 +382,7 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                     "type": "message_metadata_updated",
                     "app_id": "A123",
                 },
-                {"type": "file_shared", "file_id": "F123"},
+                {"type": "file_shared", "file_id": "endswith:123"},
             ],
             "removed_provider_option": True,
         }
@@ -388,9 +391,9 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
     assert configuration == SlackWebhookConfiguration(
         target_events=[
             AppMentionEventFilter(
-                channel_id=["C123", "C456"],
+                channel_id="startswith:C",
                 user_id='oneof:["U123","U456"]',
-                text="startswith:<@APP123> deploy ",
+                text="contains:deploy",
                 threaded=True,
             ),
             MessageEventFilter(
@@ -398,13 +401,13 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                 channel_type="channel",
                 subtype=["message_changed", "message_deleted"],
             ),
-            ReactionAddedEventFilter(reaction="rocket"),
+            ReactionAddedEventFilter(reaction="notequals:thumbsdown"),
             ReactionRemovedEventFilter(item_type="message"),
             MessageMetadataPostedEventFilter(
                 metadata_event_type="startswith:zenml."
             ),
             MessageMetadataUpdatedEventFilter(app_id="A123"),
-            FileSharedEventFilter(file_id="F123"),
+            FileSharedEventFilter(file_id="endswith:123"),
         ]
     )
 
@@ -416,23 +419,8 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
         {"target_events": []},
         {"target_events": [{}]},
         {"target_events": [{"type": "unknown"}]},
-        {
-            "target_events": [
-                {"type": "app_mention", "channel_id": "startswith:C"}
-            ]
-        },
-        {
-            "target_events": [
-                {"type": "app_mention", "text": "contains:deploy"}
-            ]
-        },
         {"target_events": [{"type": "app_mention", "user_id": "oneof:[]"}]},
         {"target_events": [{"type": "app_mention", "workspace_id": "T123"}]},
-        {
-            "target_events": [
-                {"type": "message", "subtype": "startswith:message_"}
-            ]
-        },
         {
             "target_events": [
                 {
@@ -444,12 +432,7 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
         },
         {
             "target_events": [
-                {"type": "reaction_added", "reaction": "startswith:approve"}
-            ]
-        },
-        {
-            "target_events": [
-                {"type": "file_shared", "file_id": "contains:F123"}
+                {"type": "file_shared", "file_id": "matches:F123"}
             ]
         },
     ],
@@ -567,7 +550,7 @@ def test_slack_matches_app_mention_targets() -> None:
                     "type": "app_mention",
                     "channel_id": ["C999", "C123"],
                     "user_id": 'oneof:["U123","U456"]',
-                    "text": "startswith:<@APP123> investigate",
+                    "text": "contains:investigate",
                 }
             ]
         },
@@ -603,7 +586,7 @@ def test_slack_matches_app_mention_targets() -> None:
         id=uuid4(),
         configuration={
             "target_events": [
-                {"type": "app_mention", "text": "startswith:deploy "}
+                {"type": "app_mention", "text": "notcontains:investigate"}
             ]
         },
     )

--- a/tests/integration/functional/webhooks/test_slack.py
+++ b/tests/integration/functional/webhooks/test_slack.py
@@ -1,0 +1,1109 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Slack webhook provider and intake endpoint tests."""
+
+import asyncio
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import SecretStr
+
+from zenml.webhooks import (
+    ParsedWebhookDelivery,
+    WebhookAuthenticationError,
+    WebhookEvent,
+    WebhookIntakeResponse,
+    WebhookPayloadError,
+    WebhookPreValidationResult,
+)
+from zenml.webhooks.providers import (
+    BuiltinWebhookType,
+    get_webhook_provider,
+)
+from zenml.webhooks.providers.slack import (
+    SLACK_REQUEST_TIMESTAMP_HEADER,
+    SLACK_SIGNATURE_HEADER,
+    AppMentionEventFilter,
+    FileSharedEventFilter,
+    MessageMetadataPostedEventFilter,
+    MessageMetadataUpdatedEventFilter,
+    MessagePostedEventFilter,
+    ReactionAddedEventFilter,
+    ReactionRemovedEventFilter,
+    SlackAppMentionEvent,
+    SlackFileSharedEvent,
+    SlackMessageMetadata,
+    SlackMessageMetadataPostedEvent,
+    SlackMessageMetadataUpdatedEvent,
+    SlackMessagePostedEvent,
+    SlackReactionAddedEvent,
+    SlackReactionItem,
+    SlackReactionRemovedEvent,
+    SlackWebhookConfiguration,
+    SlackWebhookEvent,
+    SlackWebhookProvider,
+)
+from zenml.zen_server.routers import webhook_endpoints as endpoints
+
+
+def _slack_signature(secret: str, timestamp: str, body: bytes) -> str:
+    signature_base = f"v0:{timestamp}:".encode() + body
+    return (
+        "v0="
+        + hmac.new(secret.encode(), signature_base, hashlib.sha256).hexdigest()
+    )
+
+
+def _slack_headers(
+    *,
+    body: bytes,
+    secret: str = "webhook-secret",
+    timestamp: str = "1788300000",
+) -> dict[str, str]:
+    return {
+        SLACK_REQUEST_TIMESTAMP_HEADER: timestamp,
+        SLACK_SIGNATURE_HEADER: _slack_signature(secret, timestamp, body),
+    }
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.records = []
+        self.project_id = uuid4()
+
+    def get_webhook_intake_config(self, webhook_id, expected_webhook_type):
+        assert expected_webhook_type == "slack"
+        return SimpleNamespace(
+            webhook_type="slack",
+            active=True,
+            project_id=self.project_id,
+            secret=SecretStr("webhook-secret"),
+        )
+
+    def record_webhook_event(self, webhook_id, update):
+        self.records.append((webhook_id, update))
+
+
+def _install_endpoint_dependencies(monkeypatch, store: _Store) -> None:
+    monkeypatch.setattr(endpoints, "zen_store", lambda: store)
+    monkeypatch.setattr(
+        endpoints, "get_webhook_provider", lambda _: SlackWebhookProvider()
+    )
+    monkeypatch.setattr(
+        "zenml.webhooks.providers.slack.time.time", lambda: 1788300000.0
+    )
+
+
+def test_slack_provider_is_registered() -> None:
+    """The registry exposes Slack as a built-in provider."""
+    provider = get_webhook_provider(BuiltinWebhookType.SLACK)
+
+    assert isinstance(provider, SlackWebhookProvider)
+    assert provider.webhook_type == BuiltinWebhookType.SLACK
+
+
+def test_slack_pre_validation_always_processes() -> None:
+    """Slack leaves authentication metadata checks to authentication."""
+    result = asyncio.run(SlackWebhookProvider().pre_validate(headers={}))
+
+    assert result == WebhookPreValidationResult.PROCESS
+
+
+def test_slack_authenticates_exact_raw_body(monkeypatch) -> None:
+    """Slack authentication signs the timestamp and exact raw body."""
+    provider = SlackWebhookProvider()
+    secret = "slack-signing-secret"
+    timestamp = "1788300000"
+    signed_body = b'{"type":"event_callback"}'
+    headers = _slack_headers(
+        body=signed_body, secret=secret, timestamp=timestamp
+    )
+    monkeypatch.setattr(
+        "zenml.webhooks.providers.slack.time.time",
+        lambda: float(timestamp),
+    )
+
+    provider.authenticate(signed_body, headers, secret)
+
+    with pytest.raises(WebhookAuthenticationError):
+        provider.authenticate(b'{"type": "event_callback"}', headers, secret)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {},
+        {SLACK_REQUEST_TIMESTAMP_HEADER: "1788300000"},
+        {
+            SLACK_REQUEST_TIMESTAMP_HEADER: "1788300000",
+            SLACK_SIGNATURE_HEADER: "sha256=wrong-version",
+        },
+        {SLACK_SIGNATURE_HEADER: "v0=invalid"},
+        {
+            SLACK_REQUEST_TIMESTAMP_HEADER: "not-a-timestamp",
+            SLACK_SIGNATURE_HEADER: "v0=invalid",
+        },
+        {
+            SLACK_REQUEST_TIMESTAMP_HEADER: "1" * 4301,
+            SLACK_SIGNATURE_HEADER: "v0=invalid",
+        },
+        {
+            SLACK_REQUEST_TIMESTAMP_HEADER: "1788300000",
+            SLACK_SIGNATURE_HEADER: "v0=invalid",
+        },
+    ],
+)
+def test_slack_rejects_invalid_authentication_metadata(
+    monkeypatch, headers: Mapping[str, str]
+) -> None:
+    """Slack authentication rejects missing or malformed metadata."""
+    monkeypatch.setattr(
+        "zenml.webhooks.providers.slack.time.time", lambda: 1788300000.0
+    )
+
+    with pytest.raises(WebhookAuthenticationError):
+        SlackWebhookProvider().authenticate(
+            b'{"type":"event_callback"}', headers, "secret"
+        )
+
+
+@pytest.mark.parametrize("timestamp", ["1788299699", "1788300301"])
+def test_slack_rejects_stale_and_future_timestamps(
+    monkeypatch, timestamp: str
+) -> None:
+    """Slack rejects timestamps outside the five-minute tolerance."""
+    body = b'{"type":"event_callback"}'
+    secret = "secret"
+    monkeypatch.setattr(
+        "zenml.webhooks.providers.slack.time.time", lambda: 1788300000.0
+    )
+
+    with pytest.raises(WebhookAuthenticationError, match="tolerance"):
+        SlackWebhookProvider().authenticate(
+            body,
+            _slack_headers(body=body, secret=secret, timestamp=timestamp),
+            secret,
+        )
+
+
+def test_slack_parses_event_callback() -> None:
+    """Slack callbacks preserve the envelope and event identity."""
+    payload = {
+        "type": "event_callback",
+        "team_id": "T123",
+        "event_id": "Ev123",
+        "event": {"type": "app_mention", "text": "Investigate this"},
+    }
+
+    delivery = SlackWebhookProvider().parse_delivery(
+        json.dumps(payload).encode(), {}
+    )
+
+    assert delivery.event is not None
+    assert delivery.event.event_type == "app_mention"
+    assert delivery.event.delivery_id == "Ev123"
+    assert delivery.event.payload == payload
+    assert delivery.response == WebhookIntakeResponse(status_code=200)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "event_callback"},
+        {"type": "event_callback", "event": []},
+        {"type": "event_callback", "event": {}},
+        {"type": "event_callback", "event": {"type": ""}},
+        {"type": "event_callback", "event": {"type": "message"}},
+        {
+            "type": "event_callback",
+            "event": {"type": "message"},
+            "event_id": "",
+        },
+    ],
+)
+def test_slack_rejects_malformed_event_callback(
+    payload: dict[str, object],
+) -> None:
+    """Slack callbacks require an inner type and delivery ID."""
+    with pytest.raises(WebhookPayloadError):
+        SlackWebhookProvider().parse_delivery(json.dumps(payload).encode(), {})
+
+
+@pytest.mark.parametrize("body", [b"not-json", b"[]", b'"scalar"'])
+def test_slack_rejects_invalid_json_envelopes(body: bytes) -> None:
+    """Slack requires a top-level JSON object."""
+    with pytest.raises(WebhookPayloadError):
+        SlackWebhookProvider().parse_delivery(body, {})
+
+
+def test_slack_url_verification_returns_challenge_without_event() -> None:
+    """URL verification returns the exact plaintext challenge."""
+    delivery = SlackWebhookProvider().parse_delivery(
+        b'{"type":"url_verification","challenge":"challenge-value"}', {}
+    )
+
+    assert delivery == ParsedWebhookDelivery(
+        event=None,
+        response=WebhookIntakeResponse(
+            status_code=200,
+            body="challenge-value",
+            media_type="text/plain",
+        ),
+    )
+
+
+@pytest.mark.parametrize("challenge", [None, "", 123])
+def test_slack_url_verification_rejects_invalid_challenge(
+    challenge: object,
+) -> None:
+    """URL verification requires a non-empty string challenge."""
+    body = json.dumps(
+        {"type": "url_verification", "challenge": challenge}
+    ).encode()
+
+    with pytest.raises(WebhookPayloadError, match="challenge"):
+        SlackWebhookProvider().parse_delivery(body, {})
+
+
+def test_slack_accepts_app_rate_limited_without_event() -> None:
+    """Rate-limit notifications are successful control deliveries."""
+    delivery = SlackWebhookProvider().parse_delivery(
+        json.dumps(
+            {
+                "type": "app_rate_limited",
+                "team_id": "T123",
+                "api_app_id": "A123",
+                "minute_rate_limited": 1788300000,
+            }
+        ).encode(),
+        {},
+    )
+
+    assert delivery == ParsedWebhookDelivery(
+        event=None,
+        response=WebhookIntakeResponse(status_code=200),
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "type": "app_rate_limited",
+            "api_app_id": "A123",
+            "minute_rate_limited": 1788300000,
+        },
+        {
+            "type": "app_rate_limited",
+            "team_id": "T123",
+            "minute_rate_limited": 1788300000,
+        },
+        {
+            "type": "app_rate_limited",
+            "team_id": "T123",
+            "api_app_id": "A123",
+            "minute_rate_limited": True,
+        },
+    ],
+)
+def test_slack_rejects_malformed_rate_limit_deliveries(
+    payload: dict[str, object],
+) -> None:
+    """Rate-limit notifications require their documented identity fields."""
+    with pytest.raises(WebhookPayloadError, match="rate-limit"):
+        SlackWebhookProvider().parse_delivery(json.dumps(payload).encode(), {})
+
+
+@pytest.mark.parametrize("delivery_type", [None, "", "future_control"])
+def test_slack_rejects_unsupported_delivery_types(
+    delivery_type: str | None,
+) -> None:
+    """Slack accepts only its supported delivery-envelope catalog."""
+    with pytest.raises(WebhookPayloadError):
+        SlackWebhookProvider().parse_delivery(
+            json.dumps({"type": delivery_type}).encode(), {}
+        )
+
+
+def test_slack_configuration_accepts_all_typed_targets() -> None:
+    """Slack configuration accepts all targets and ignores removed fields."""
+    provider = SlackWebhookProvider()
+    configuration = provider.validate_configuration(
+        {
+            "target_events": [
+                {
+                    "type": "app_mention",
+                    "channel_id": ["C123", "C456"],
+                    "user_id": 'oneof:["U123","U456"]',
+                    "threaded": True,
+                },
+                {
+                    "type": "message_posted",
+                    "text": "startswith:deploy ",
+                    "channel_type": "channel",
+                },
+                {"type": "reaction_added", "reaction": "rocket"},
+                {"type": "reaction_removed", "item_type": "message"},
+                {
+                    "type": "message_metadata_posted",
+                    "metadata_event_type": "startswith:zenml.",
+                },
+                {
+                    "type": "message_metadata_updated",
+                    "app_id": "A123",
+                },
+                {"type": "file_shared", "file_id": "F123"},
+            ],
+            "removed_provider_option": True,
+        }
+    )
+
+    assert configuration == SlackWebhookConfiguration(
+        target_events=[
+            AppMentionEventFilter(
+                channel_id=["C123", "C456"],
+                user_id='oneof:["U123","U456"]',
+                threaded=True,
+            ),
+            MessagePostedEventFilter(
+                text="startswith:deploy ", channel_type="channel"
+            ),
+            ReactionAddedEventFilter(reaction="rocket"),
+            ReactionRemovedEventFilter(item_type="message"),
+            MessageMetadataPostedEventFilter(
+                metadata_event_type="startswith:zenml."
+            ),
+            MessageMetadataUpdatedEventFilter(app_id="A123"),
+            FileSharedEventFilter(file_id="F123"),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "configuration",
+    [
+        {},
+        {"target_events": []},
+        {"target_events": [{}]},
+        {"target_events": [{"type": "unknown"}]},
+        {
+            "target_events": [
+                {"type": "app_mention", "channel_id": "startswith:C"}
+            ]
+        },
+        {"target_events": [{"type": "app_mention", "user_id": "oneof:[]"}]},
+        {"target_events": [{"type": "app_mention", "workspace_id": "T123"}]},
+        {
+            "target_events": [
+                {"type": "reaction_added", "reaction": "startswith:approve"}
+            ]
+        },
+        {
+            "target_events": [
+                {"type": "file_shared", "file_id": "contains:F123"}
+            ]
+        },
+    ],
+)
+def test_slack_configuration_rejects_invalid_targets(
+    configuration: dict[str, object],
+) -> None:
+    """Slack target configuration is explicit, non-empty, and strict."""
+    with pytest.raises(ValueError):
+        SlackWebhookProvider().validate_configuration(configuration)
+
+
+def _slack_webhook_event(
+    *,
+    event_type: str = "app_mention",
+    event_payload: dict[str, object] | None = None,
+) -> WebhookEvent:
+    inner_event: dict[str, object] = {
+        "type": event_type,
+        "channel": "C123",
+        "user": "U123",
+        "text": "<@APP123> investigate this",
+    }
+    if event_payload is not None:
+        inner_event = event_payload
+    return WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="slack",
+        event_type=event_type,
+        delivery_id="Ev123",
+        payload={
+            "type": "event_callback",
+            "team_id": "T123",
+            "event_id": "Ev123",
+            "event": inner_event,
+        },
+    )
+
+
+def test_slack_parses_semantic_app_mention() -> None:
+    """Semantic parsing extracts stable mention identity fields."""
+    event = _slack_webhook_event(
+        event_payload={
+            "type": "app_mention",
+            "channel": "C123",
+            "user": "U123",
+            "ts": "1788300000.000002",
+            "thread_ts": "1788300000.000001",
+        }
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackAppMentionEvent(
+        event_id="Ev123",
+        team_id="T123",
+        channel_id="C123",
+        user_id="U123",
+        message_ts="1788300000.000002",
+        thread_ts="1788300000.000001",
+    )
+    assert semantic.event_filter_type is AppMentionEventFilter
+    assert semantic.type == SlackWebhookEvent.APP_MENTION
+
+
+def test_slack_matches_app_mention_targets() -> None:
+    """Targets use OR across entries and AND across populated filters."""
+    event = _slack_webhook_event()
+    match_all = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "app_mention"}]},
+    )
+    matching_filters = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "app_mention",
+                    "channel_id": ["C999", "C123"],
+                    "user_id": 'oneof:["U123","U456"]',
+                }
+            ]
+        },
+    )
+    matching_alternative = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {"type": "app_mention", "channel_id": "C999"},
+                {"type": "app_mention", "user_id": "U123"},
+            ]
+        },
+    )
+    wrong_channel = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [{"type": "app_mention", "channel_id": "C999"}]
+        },
+    )
+    wrong_user = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "app_mention",
+                    "channel_id": "C123",
+                    "user_id": "U999",
+                }
+            ]
+        },
+    )
+    empty_channel_list = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [{"type": "app_mention", "channel_id": []}]
+        },
+    )
+
+    matches = SlackWebhookProvider().match_triggers(
+        event=event,
+        candidates=[
+            match_all,
+            matching_filters,
+            matching_alternative,
+            wrong_channel,
+            wrong_user,
+            empty_channel_list,
+        ],
+    )
+
+    assert matches.triggers == [
+        match_all,
+        matching_filters,
+        matching_alternative,
+    ]
+    assert matches.event is not None
+    assert matches.event["type"] == SlackWebhookEvent.APP_MENTION
+
+
+def test_slack_parses_and_matches_human_message_posts() -> None:
+    """Ordinary root messages and replies support semantic filtering."""
+    event = _slack_webhook_event(
+        event_type="message",
+        event_payload={
+            "type": "message",
+            "channel": "C123",
+            "channel_type": "channel",
+            "user": "U123",
+            "text": "deploy production",
+            "ts": "1788300000.000002",
+            "thread_ts": "1788300000.000001",
+            "event_ts": "1788300000.000003",
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackMessagePostedEvent(
+        event_id="Ev123",
+        team_id="T123",
+        event_ts="1788300000.000003",
+        channel_id="C123",
+        channel_type="channel",
+        user_id="U123",
+        text="deploy production",
+        message_ts="1788300000.000002",
+        thread_ts="1788300000.000001",
+    )
+    assert semantic.matches(
+        MessagePostedEventFilter(
+            team_id="T123",
+            channel_id="C123",
+            channel_type="channel",
+            user_id="U123",
+            text="startswith:deploy ",
+            threaded=True,
+        )
+    )
+    assert semantic.type == SlackWebhookEvent.MESSAGE_POSTED
+    assert not semantic.matches(MessagePostedEventFilter(threaded=False))
+
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {"type": "message_posted", "text": "deploy production"}
+            ]
+        },
+    )
+    wrong_event = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "app_mention"}]},
+    )
+    match = SlackWebhookProvider().match_triggers(
+        event=event, candidates=[matching, wrong_event]
+    )
+    assert match.triggers == [matching]
+    assert match.event is not None
+    assert match.event["type"] == SlackWebhookEvent.MESSAGE_POSTED
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "type": "message",
+            "channel": "C123",
+            "user": "U123",
+            "ts": "1.1",
+            "subtype": "message_changed",
+        },
+        {
+            "type": "message",
+            "channel": "C123",
+            "user": "U123",
+            "ts": "1.1",
+            "bot_id": "B123",
+        },
+        {
+            "type": "message",
+            "channel": "C123",
+            "user": "U123",
+            "ts": "1.1",
+            "bot_profile": {"id": "B123"},
+        },
+        {"type": "message", "channel": "C123", "user": "U123"},
+    ],
+    ids=["subtype", "bot-id", "bot-profile", "missing-timestamp"],
+)
+def test_slack_ignores_non_automation_message_variants(
+    payload: dict[str, object],
+) -> None:
+    """Bot, system, mutation, and malformed messages launch no trigger."""
+    event = _slack_webhook_event(event_type="message", event_payload=payload)
+
+    assert SlackWebhookProvider().parse_semantic_event(event) is None
+
+
+@pytest.mark.parametrize(
+    "item_payload, expected_item",
+    [
+        (
+            {
+                "type": "message",
+                "channel": "C123",
+                "ts": "1788300000.000001",
+            },
+            SlackReactionItem(
+                type="message",
+                id="1788300000.000001",
+                channel_id="C123",
+            ),
+        ),
+        (
+            {"type": "file", "file": "F123"},
+            SlackReactionItem(type="file", id="F123", file_id="F123"),
+        ),
+        (
+            {
+                "type": "file_comment",
+                "file": "F123",
+                "file_comment": "Fc123",
+            },
+            SlackReactionItem(
+                type="file_comment",
+                id="Fc123",
+                file_id="F123",
+            ),
+        ),
+    ],
+    ids=["message", "file", "file-comment"],
+)
+def test_slack_parses_all_documented_reaction_items(
+    item_payload: dict[str, object], expected_item: SlackReactionItem
+) -> None:
+    """Reaction events normalize message, file, and file-comment items."""
+    event = _slack_webhook_event(
+        event_type="reaction_added",
+        event_payload={
+            "type": "reaction_added",
+            "user": "U123",
+            "reaction": "rocket",
+            "item_user": "U456",
+            "item": item_payload,
+            "event_ts": "1788300000.000002",
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackReactionAddedEvent(
+        event_id="Ev123",
+        team_id="T123",
+        channel_id=expected_item.channel_id,
+        event_ts="1788300000.000002",
+        reaction="rocket",
+        user_id="U123",
+        item_user_id="U456",
+        item=expected_item,
+    )
+    assert semantic.matches(
+        ReactionAddedEventFilter(
+            reaction="rocket",
+            user_id="U123",
+            item_user_id="U456",
+            item_type=expected_item.type,
+            item_id=expected_item.id,
+        )
+    )
+    assert semantic.type == SlackWebhookEvent.REACTION_ADDED
+
+
+def test_slack_parses_and_matches_removed_reactions() -> None:
+    """Removed reactions match only removed-reaction targets."""
+    event = _slack_webhook_event(
+        event_type="reaction_removed",
+        event_payload={
+            "type": "reaction_removed",
+            "user": "U123",
+            "reaction": "white_check_mark",
+            "item": {
+                "type": "message",
+                "channel": "C123",
+                "ts": "1788300000.000001",
+            },
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert isinstance(semantic, SlackReactionRemovedEvent)
+    assert semantic.type == SlackWebhookEvent.REACTION_REMOVED
+    assert semantic.matches(
+        ReactionRemovedEventFilter(
+            channel_id="C123", reaction="white_check_mark"
+        )
+    )
+    assert not semantic.matches(
+        ReactionAddedEventFilter(reaction="white_check_mark")
+    )
+
+
+@pytest.mark.parametrize(
+    "item_payload",
+    [
+        {},
+        {"type": "unknown", "id": "X123"},
+        {"type": "message", "channel": "C123"},
+        {"type": "file"},
+        {"type": "file_comment", "file": "F123"},
+    ],
+)
+def test_slack_ignores_malformed_reaction_items(
+    item_payload: dict[str, object],
+) -> None:
+    """Unknown or incomplete reaction item shapes launch no trigger."""
+    event = _slack_webhook_event(
+        event_type="reaction_added",
+        event_payload={
+            "type": "reaction_added",
+            "user": "U123",
+            "reaction": "rocket",
+            "item": item_payload,
+        },
+    )
+
+    assert SlackWebhookProvider().parse_semantic_event(event) is None
+
+
+def test_slack_parses_and_matches_posted_message_metadata() -> None:
+    """Posted structured metadata supports namespaced event filtering."""
+    event = _slack_webhook_event(
+        event_type="message_metadata_posted",
+        event_payload={
+            "type": "message_metadata_posted",
+            "app_id": "A123",
+            "bot_id": "B123",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "message_ts": "1788300000.000001",
+            "metadata": {
+                "event_type": "zenml.deployment_requested",
+                "event_payload": {"snapshot_id": "snapshot-123"},
+            },
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackMessageMetadataPostedEvent(
+        event_id="Ev123",
+        team_id="T123",
+        channel_id="C123",
+        app_id="A123",
+        bot_id="B123",
+        user_id="U123",
+        message_ts="1788300000.000001",
+        metadata=SlackMessageMetadata(
+            event_type="zenml.deployment_requested",
+            event_payload={"snapshot_id": "snapshot-123"},
+        ),
+    )
+    assert semantic.matches(
+        MessageMetadataPostedEventFilter(
+            app_id="A123",
+            metadata_event_type="startswith:zenml.",
+        )
+    )
+    assert semantic.type == SlackWebhookEvent.MESSAGE_METADATA_POSTED
+
+
+def test_slack_parses_and_matches_updated_message_metadata() -> None:
+    """Metadata updates retain their previous structured value."""
+    event = _slack_webhook_event(
+        event_type="message_metadata_updated",
+        event_payload={
+            "type": "message_metadata_updated",
+            "app_id": "A123",
+            "user_id": "U123",
+            "channel_id": "C123",
+            "message_ts": "1788300000.000001",
+            "previous_metadata": {
+                "event_type": "zenml.approval",
+                "event_payload": {"status": "pending"},
+            },
+            "metadata": {
+                "event_type": "zenml.approval",
+                "event_payload": {"status": "approved"},
+            },
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackMessageMetadataUpdatedEvent(
+        event_id="Ev123",
+        team_id="T123",
+        channel_id="C123",
+        app_id="A123",
+        user_id="U123",
+        message_ts="1788300000.000001",
+        metadata=SlackMessageMetadata(
+            event_type="zenml.approval",
+            event_payload={"status": "approved"},
+        ),
+        previous_metadata=SlackMessageMetadata(
+            event_type="zenml.approval",
+            event_payload={"status": "pending"},
+        ),
+    )
+    assert semantic.matches(
+        MessageMetadataUpdatedEventFilter(
+            channel_id="C123", metadata_event_type="zenml.approval"
+        )
+    )
+    assert semantic.type == SlackWebhookEvent.MESSAGE_METADATA_UPDATED
+
+
+@pytest.mark.parametrize(
+    "event_type, payload",
+    [
+        (
+            "message_metadata_posted",
+            {
+                "type": "message_metadata_posted",
+                "app_id": "A123",
+                "channel_id": "C123",
+                "message_ts": "1.1",
+                "metadata": {"event_type": "zenml.request"},
+            },
+        ),
+        (
+            "message_metadata_updated",
+            {
+                "type": "message_metadata_updated",
+                "app_id": "A123",
+                "channel_id": "C123",
+                "message_ts": "1.1",
+                "metadata": {
+                    "event_type": "zenml.request",
+                    "event_payload": {},
+                },
+            },
+        ),
+    ],
+)
+def test_slack_ignores_malformed_message_metadata(
+    event_type: str, payload: dict[str, object]
+) -> None:
+    """Metadata callbacks require current and applicable previous values."""
+    event = _slack_webhook_event(event_type=event_type, event_payload=payload)
+
+    assert SlackWebhookProvider().parse_semantic_event(event) is None
+
+
+def test_slack_parses_and_matches_shared_files() -> None:
+    """Shared files expose stable Slack identifiers for filtering."""
+    event = _slack_webhook_event(
+        event_type="file_shared",
+        event_payload={
+            "type": "file_shared",
+            "channel_id": "C123",
+            "user_id": "U123",
+            "file_id": "F123",
+            "event_ts": "1788300000.000001",
+        },
+    )
+
+    semantic = SlackWebhookProvider().parse_semantic_event(event)
+
+    assert semantic == SlackFileSharedEvent(
+        event_id="Ev123",
+        team_id="T123",
+        event_ts="1788300000.000001",
+        channel_id="C123",
+        user_id="U123",
+        file_id="F123",
+    )
+    assert semantic.matches(
+        FileSharedEventFilter(
+            team_id="T123", channel_id="C123", file_id="F123"
+        )
+    )
+    assert semantic.type == SlackWebhookEvent.FILE_SHARED
+    assert not semantic.matches(FileSharedEventFilter(file_id="F999"))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"type": "file_shared", "user_id": "U123", "file_id": "F123"},
+        {"type": "file_shared", "channel_id": "C123", "file_id": "F123"},
+        {"type": "file_shared", "channel_id": "C123", "user_id": "U123"},
+    ],
+    ids=["missing-channel", "missing-user", "missing-file"],
+)
+def test_slack_ignores_malformed_shared_files(
+    payload: dict[str, object],
+) -> None:
+    """File-share callbacks require channel, user, and file identifiers."""
+    event = _slack_webhook_event(
+        event_type="file_shared", event_payload=payload
+    )
+
+    assert SlackWebhookProvider().parse_semantic_event(event) is None
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        _slack_webhook_event(
+            event_type="channel_created",
+            event_payload={"type": "channel_created"},
+        ),
+        _slack_webhook_event(
+            event_payload={
+                "type": "app_mention",
+                "user": "U123",
+            }
+        ),
+        _slack_webhook_event(
+            event_payload={
+                "type": "app_mention",
+                "channel": "C123",
+            }
+        ),
+        _slack_webhook_event(
+            event_payload={
+                "type": "app_mention",
+                "channel": "C123",
+                "user": "U123",
+                "bot_id": "B123",
+            }
+        ),
+        _slack_webhook_event(
+            event_payload={
+                "type": "app_mention",
+                "channel": "C123",
+                "user": "U123",
+                "subtype": "bot_message",
+            }
+        ),
+    ],
+    ids=[
+        "unsupported-event",
+        "missing-channel",
+        "missing-user",
+        "bot-id",
+        "bot-message-subtype",
+    ],
+)
+def test_slack_ignores_non_matchable_semantic_events(
+    event: WebhookEvent,
+) -> None:
+    """Unsupported, malformed, and bot-authored events launch no trigger."""
+    provider = SlackWebhookProvider()
+    candidate = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "app_mention"}]},
+    )
+
+    assert provider.parse_semantic_event(event) is None
+    match = provider.match_triggers(event=event, candidates=[candidate])
+    assert match.triggers == []
+    assert match.event is None
+
+
+def test_slack_runtime_matching_skips_stale_configuration() -> None:
+    """Defective stored Slack configuration does not break event handling."""
+    provider = SlackWebhookProvider()
+    event = _slack_webhook_event()
+    stale = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "removed_event"}]},
+    )
+
+    assert (
+        provider.match_triggers(event=event, candidates=[stale]).triggers == []
+    )
+
+
+def test_signed_slack_url_verification_is_accepted_without_dispatch(
+    monkeypatch,
+) -> None:
+    """The endpoint authenticates and answers Slack URL verification."""
+    webhook_id = uuid4()
+    body = b'{"type":"url_verification","challenge":"challenge-value"}'
+    store = _Store()
+    _install_endpoint_dependencies(monkeypatch, store)
+
+    response = endpoints._receive_webhook_event(
+        webhook_type="slack",
+        webhook_id=webhook_id,
+        body=body,
+        headers=_slack_headers(body=body),
+    )
+
+    assert response.status_code == 200
+    assert response.body == b"challenge-value"
+    assert response.media_type == "text/plain"
+    assert response.background is None
+    assert len(store.records) == 1
+    assert store.records[0][1].accepted is True
+
+
+@pytest.mark.parametrize(
+    "body, headers, expected_status, expected_outcome",
+    [
+        (
+            b'{"type":"url_verification","challenge":"value"}',
+            {
+                SLACK_REQUEST_TIMESTAMP_HEADER: "1788300000",
+                SLACK_SIGNATURE_HEADER: "v0=invalid",
+            },
+            401,
+            "auth_failed",
+        ),
+        (
+            b'{"type":"future_control"}',
+            _slack_headers(body=b'{"type":"future_control"}'),
+            400,
+            "invalid_payload",
+        ),
+    ],
+)
+def test_slack_endpoint_rejects_untrusted_or_invalid_deliveries(
+    monkeypatch,
+    body: bytes,
+    headers: dict[str, str],
+    expected_status: int,
+    expected_outcome: str,
+) -> None:
+    """Slack failures are classified before event dispatch."""
+    webhook_id = uuid4()
+    store = _Store()
+    _install_endpoint_dependencies(monkeypatch, store)
+
+    with pytest.raises(HTTPException) as error:
+        endpoints._receive_webhook_event(
+            webhook_type="slack",
+            webhook_id=webhook_id,
+            body=body,
+            headers=headers,
+        )
+
+    assert error.value.status_code == expected_status
+    assert len(store.records) == 1
+    assert getattr(store.records[0][1], expected_outcome) is True

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -217,16 +217,14 @@ def test_github_webhook_configuration_rejects_empty_event_list() -> None:
 @pytest.mark.parametrize(
     "field, value",
     [
-        ("repo", "startswith:zenml-io/"),
-        ("author", "contains:george"),
         ("source_branch", "oneof:not-json"),
         ("target_branch", 'oneof:["develop", 42]'),
     ],
 )
-def test_pull_request_merged_rejects_unsupported_filters(
+def test_pull_request_merged_rejects_invalid_filters(
     field: str, value: str
 ) -> None:
-    """Semantic event fields enforce their operator allowlists."""
+    """Semantic event fields reject malformed filter expressions."""
     with pytest.raises(ValidationError):
         MergedPullRequest(**{field: value})
 
@@ -242,10 +240,11 @@ def test_pull_request_merged_rejects_unsupported_filters(
         "milestone",
     ],
 )
-def test_issue_opened_rejects_prefix_filters(field: str) -> None:
-    """Opened-issue filters support exact values and alternatives only."""
-    with pytest.raises(ValidationError):
-        IssueOpened(**{field: "startswith:prefix"})
+def test_issue_opened_accepts_prefix_filters(field: str) -> None:
+    """All opened-issue string filter fields support prefix matching."""
+    event = IssueOpened(**{field: "startswith:prefix"})
+
+    assert getattr(event, field) == "startswith:prefix"
 
 
 def test_schedule_trigger_valid_and_inheritance():

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -28,12 +28,15 @@ from zenml.webhooks.providers import (
     BuiltinWebhookType,
     WebhookAuthenticationError,
     WebhookConfiguration,
-    WebhookIntakeResponse,
     WebhookPayloadError,
     WebhookPreValidationResult,
     WebhookProviderRegistry,
     WebhookTriggerMatch,
     get_webhook_provider,
+)
+from zenml.webhooks.providers.base import (
+    matches_string_collection_filter,
+    matches_string_filter,
 )
 from zenml.webhooks.providers.clickup import (
     CLICKUP_SIGNATURE_HEADER,
@@ -68,6 +71,108 @@ from zenml.webhooks.providers.github import (
 )
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.mark.parametrize(
+    ("configured", "matching", "non_matching"),
+    [
+        ("main", "main", "develop"),
+        ("equals:main", "main", "develop"),
+        ("notequals:develop", "main", "develop"),
+        ("contains:deploy", "please deploy production", "run training"),
+        ("notcontains:draft", "deploy production", "draft deployment"),
+        ("startswith:release/", "release/v1", "feature/release/v1"),
+        ("endswith:-prod", "model-prod", "model-stage"),
+        ('oneof:["main","develop"]', "main", "release"),
+        ('notoneof:["draft","closed"]', "open", "closed"),
+        (["main", "startswith:release/"], "release/v1", "develop"),
+    ],
+)
+def test_generic_webhook_string_filter_operators(
+    configured: str | list[str], matching: str, non_matching: str
+) -> None:
+    """Every generic webhook string operator has consistent semantics.
+
+    Args:
+        configured: The filter expression under test.
+        matching: A value that should match.
+        non_matching: A value that should not match.
+    """
+    assert matches_string_filter(actual=matching, configured=configured)
+    assert not matches_string_filter(
+        actual=non_matching, configured=configured
+    )
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "equals:main",
+        "notequals:develop",
+        "contains:zenml",
+        "notcontains:legacy",
+        "startswith:zenml-io/",
+        "endswith:/zenml",
+        'oneof:["zenml-io/zenml","zenml-io/cloud"]',
+        'notoneof:["other/repo","other/cloud"]',
+    ],
+)
+def test_filtered_providers_accept_all_generic_string_operators(
+    configured: str,
+) -> None:
+    """GitHub and ClickUp target fields accept the generic operators.
+
+    Args:
+        configured: The filter expression under test.
+    """
+    assert PushEvent(repo=configured).repo == configured
+    assert TaskCreated(task_id=configured).task_id == configured
+
+
+@pytest.mark.parametrize(
+    "configured",
+    ["matches:main", "equals:", "oneof:not-json", "notoneof:[]"],
+)
+def test_generic_webhook_string_filters_reject_invalid_expressions(
+    configured: str,
+) -> None:
+    """Unknown, empty, and malformed expressions fail validation.
+
+    Args:
+        configured: The invalid filter expression under test.
+    """
+    with pytest.raises(ValidationError):
+        PushEvent(branch=configured)
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("contains:priority", True),
+        ("contains:documentation", False),
+        ("notcontains:documentation", True),
+        ("notcontains:priority", False),
+        ("notequals:documentation", True),
+        ("notequals:bug", False),
+        ('notoneof:["documentation","chore"]', True),
+        ('notoneof:["bug","documentation"]', False),
+    ],
+)
+def test_generic_webhook_collection_string_filter_operators(
+    configured: str, expected: bool
+) -> None:
+    """Negative collection filters require every value to satisfy them.
+
+    Args:
+        configured: The filter expression under test.
+        expected: Whether the collection should match.
+    """
+    assert (
+        matches_string_collection_filter(
+            actual=["bug", "priority-high"], configured=configured
+        )
+        is expected
+    )
 
 
 class _BodyMetadataBearerConfiguration(WebhookConfiguration):
@@ -594,7 +699,7 @@ def test_github_configuration_reports_all_invalid_target_events() -> None:
                     {"type": "unknown"},
                     {
                         "type": "merged_pull_request",
-                        "repo": "startswith:zenml-io/",
+                        "repo": "oneof:[]",
                     },
                 ]
             }

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -28,6 +28,7 @@ from zenml.webhooks.providers import (
     BuiltinWebhookType,
     WebhookAuthenticationError,
     WebhookConfiguration,
+    WebhookIntakeResponse,
     WebhookPayloadError,
     WebhookPreValidationResult,
     WebhookProviderRegistry,

--- a/tests/unit/zen_server/endpoints/test_webhook_endpoints.py
+++ b/tests/unit/zen_server/endpoints/test_webhook_endpoints.py
@@ -24,9 +24,12 @@ from pydantic import SecretStr
 from zenml.constants import API, VERSION_1, WEBHOOKS
 from zenml.dispatcher import EventDispatcher
 from zenml.webhooks import (
+    ParsedWebhookDelivery,
+    ParsedWebhookEvent,
     WebhookAuthenticationError,
     WebhookEvent,
     WebhookEventHandler,
+    WebhookIntakeResponse,
     WebhookPayloadError,
 )
 from zenml.webhooks.providers.github import GitHubWebhookProvider
@@ -153,9 +156,13 @@ class _Provider:
         self,
         auth_error: Exception | None = None,
         payload_error: Exception | None = None,
+        parsed_event: bool = True,
+        response: WebhookIntakeResponse | None = None,
     ) -> None:
         self.auth_error = auth_error
         self.payload_error = payload_error
+        self.parsed_event = parsed_event
+        self.response = response or WebhookIntakeResponse()
         self.authenticate_calls = 0
         self.parse_calls = 0
 
@@ -164,15 +171,21 @@ class _Provider:
         if self.auth_error:
             raise self.auth_error
 
-    def parse(self, body, headers):
+    def parse_delivery(self, body, headers):
         self.parse_calls += 1
         if self.payload_error:
             raise self.payload_error
-        return SimpleNamespace(
-            webhook_type="custom",
-            event_type="pipeline.ready",
-            delivery_id="delivery-id",
-            payload={"event": "ready"},
+        return ParsedWebhookDelivery(
+            event=(
+                ParsedWebhookEvent(
+                    event_type="pipeline.ready",
+                    delivery_id="delivery-id",
+                    payload={"event": "ready"},
+                )
+                if self.parsed_event
+                else None
+            ),
+            response=self.response,
         )
 
 
@@ -276,44 +289,83 @@ def test_receive_webhook_event_decision_table(
     dispatcher = EventDispatcher()
     dispatcher.register_event_handler(handler)
 
+    response = None
     try:
         if expected_status == status.HTTP_202_ACCEPTED:
-            assert _receive(webhook_id).status_code == expected_status
+            response = _receive(webhook_id)
+            assert response.status_code == expected_status
         else:
             with pytest.raises(HTTPException) as error:
                 _receive(webhook_id)
             assert error.value.status_code == expected_status
             if auth_error is not None:
                 assert error.value.detail == "Invalid webhook authentication."
+
+        resolved = stored_type == "custom"
+        parsed = expected_status in {
+            status.HTTP_202_ACCEPTED,
+            status.HTTP_400_BAD_REQUEST,
+        }
+        assert store.secret_requests == int(resolved)
+        assert provider.authenticate_calls == int(resolved)
+        assert provider.parse_calls == int(parsed)
+
+        if expected_outcome is None:
+            assert store.records == []
+        else:
+            assert len(store.records) == 1
+            recorded_id, update = store.records[0]
+            assert recorded_id == webhook_id
+            assert getattr(update, expected_outcome) is True
+            assert update.error_summary == expected_error
+
+        if expected_status == status.HTTP_202_ACCEPTED:
+            assert response is not None
+            assert handler.events == []
+            assert response.background is not None
+            asyncio.run(response.background())
+            assert len(handler.events) == 1
+            event = handler.events[0]
+            assert event.project_id == store.project_id
+            assert event.webhook_id == webhook_id
+            assert event.webhook_type == "custom"
+            assert event.event_type == "pipeline.ready"
+            assert event.delivery_id == "delivery-id"
+            assert event.payload == {"event": "ready"}
+        else:
+            assert handler.events == []
     finally:
         dispatcher.unregister_event_handler(handler)
 
-    resolved = stored_type == "custom"
-    parsed = expected_status in {
-        status.HTTP_202_ACCEPTED,
-        status.HTTP_400_BAD_REQUEST,
-    }
-    assert store.secret_requests == int(resolved)
-    assert provider.authenticate_calls == int(resolved)
-    assert provider.parse_calls == int(parsed)
 
-    if expected_outcome is None:
-        assert store.records == []
-    else:
-        assert len(store.records) == 1
-        recorded_id, update = store.records[0]
-        assert recorded_id == webhook_id
-        assert getattr(update, expected_outcome) is True
-        assert update.error_summary == expected_error
+def test_control_delivery_returns_provider_response_without_dispatch(
+    monkeypatch,
+) -> None:
+    """Accepted control deliveries can return a body without an event."""
+    webhook_id = uuid4()
+    store = _Store(
+        webhook=SimpleNamespace(webhook_type="control", active=True)
+    )
+    provider = _Provider(
+        parsed_event=False,
+        response=WebhookIntakeResponse(
+            status_code=200,
+            body="challenge-value",
+            media_type="text/plain",
+        ),
+    )
+    _install_dependencies(monkeypatch, store, provider)
 
-    if expected_status == status.HTTP_202_ACCEPTED:
-        assert len(handler.events) == 1
-        event = handler.events[0]
-        assert event.project_id == store.project_id
-        assert event.webhook_id == webhook_id
-        assert event.webhook_type == "custom"
-        assert event.event_type == "pipeline.ready"
-        assert event.delivery_id == "delivery-id"
-        assert event.payload == {"event": "ready"}
-    else:
-        assert handler.events == []
+    response = endpoints._receive_webhook_event(
+        webhook_type="control",
+        webhook_id=webhook_id,
+        body=b'{"type":"url_verification"}',
+        headers={},
+    )
+
+    assert response.status_code == 200
+    assert response.body == b"challenge-value"
+    assert response.media_type == "text/plain"
+    assert response.background is None
+    assert len(store.records) == 1
+    assert store.records[0][1].accepted is True


### PR DESCRIPTION
## Describe changes

This PR introduces a first-class Slack webhook provider for ZenML Pro. Slack apps can now send authenticated Events API callbacks to ZenML and use selected Slack activity to trigger pipeline snapshots and other automation workflows.

This is an inbound integration and is separate from the Slack alerter, which sends pipeline notifications to Slack.

### Supported Slack events

The provider exposes seven automation-focused semantic event types:

- `app_mention`
- `message_posted`
- `reaction_added`
- `reaction_removed`
- `message_metadata_posted`
- `message_metadata_updated`
- `file_shared`

Message events represent ordinary, human-authored messages. Bot messages, message subtypes, and malformed events are ignored to help prevent unwanted automation loops.

### Event filtering

Webhook triggers can filter events using shared Slack identifiers such as workspace, channel, and user IDs, plus event-specific fields:

- Messages can be filtered by channel type, text, and whether they are thread replies.
- App mentions can be filtered by whether they occur in a thread.
- Reactions can be filtered by emoji name, affected user, item type, and message or file ID.
- Message metadata can be filtered by app, bot, user, and metadata event type.
- Shared files can be filtered by file ID.

String filters support exact matches, YAML lists, and `oneof:` expressions. Message text and metadata event types also support `startswith:` matching.

For example, this trigger matches either a production deployment request or a 🚀 reaction in a particular channel:

```yaml
target_events:
  - type: message_posted
    channel_id: C0123456789
    text: "startswith:deploy production"

  - type: reaction_added
    channel_id: C0123456789
    reaction: rocket
    item_type: message
```

### Getting started

First, create a Slack app and copy its signing secret from **Basic Information** → **App Credentials**. Use that secret when creating the ZenML webhook:

```bash
export SLACK_SIGNING_SECRET="<signing-secret-from-slack>"

zenml webhook create slack-events \
  --type slack \
  --secret "$SLACK_SIGNING_SECRET"
```

Copy the endpoint URL shown by:

```bash
zenml webhook describe slack-events
```

In the Slack app:

1. Disable Socket Mode so Slack uses HTTP delivery.
2. Enable **Event Subscriptions**.
3. Set the ZenML endpoint as the app’s **Request URL**.
4. Subscribe to the required bot events.
5. Add the corresponding OAuth scopes.
6. Install or reinstall the app and invite it to the relevant channels.

ZenML handles Slack’s signed URL-verification request automatically and returns the challenge expected by Slack.

Then create a webhook trigger using the YAML configuration:

```bash
zenml trigger webhook create on-slack-automation \
  --webhook slack-events \
  --config slack-automation.yaml
```

Finally, attach the trigger to a pipeline snapshot:

```bash
zenml trigger webhook attach \
  on-slack-automation \
  <SNAPSHOT_NAME_OR_ID>
```

### Source and destination filtering

Slack controls which events reach ZenML through event subscriptions, OAuth scopes, and channel visibility. ZenML then applies the configured webhook trigger filters to determine which accepted events should start an automation.

For example, Slack can be configured to send public-channel messages, while ZenML only matches messages posted in a particular channel whose text begins with `deploy production`.

### Authentication and Slack control events

Slack requests are authenticated using the app signing secret, the exact request body, and the standard Slack timestamped `v0` HMAC-SHA256 signature. Requests with invalid signatures or timestamps outside Slack’s five-minute tolerance are rejected.

The provider also handles Slack-specific control deliveries:

- URL verification requests return the requested challenge.
- Rate-limit notifications are acknowledged without creating automation events.
- Regular event callbacks return `200 OK` before matching and pipeline execution continue in the background.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

