### PR TITLE
Add a one-line curl | bash installer for ZenML

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -124,7 +124,7 @@ jobs:
           cd "$(mktemp -d)"
           uv init --quiet -p 3.12 --name demo-pipelines .
           bash "$GITHUB_WORKSPACE/install.sh" --no-skills
-          grep -q 'zenml\[local\]' pyproject.toml
+          grep -q 'zenml\[server\]' pyproject.toml
           uv run zenml --version
       - name: A failed install must exit nonzero (quiet path)
         shell: bash

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,138 @@
+---
+name: Installer smoke
+# Runs install.sh on real GitHub-hosted runners the way a user would
+# (`curl ... | bash`), then checks the CLI, skills, and PATH.
+# Triggers: PRs that touch the script (path-filtered, so this does not run on
+# ordinary PRs), manual dispatch, and workflow_call so the release workflow can
+# prove the one-liner installs a freshly published version. `source: file`
+# runs the checked-out script (PRs); `source: url` fetches the script from
+# the main branch on GitHub, the bytes users run (release).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: ZenML version the installer must produce (empty = latest)
+        required: false
+        type: string
+      source:
+        description: 'Where to get install.sh from: "file" (checkout) or "url" (main
+          branch on GitHub)'
+        required: false
+        type: string
+        default: file
+  workflow_call:
+    inputs:
+      version:
+        description: ZenML version the installer must produce (empty = latest)
+        required: false
+        type: string
+      source:
+        description: 'Where to get install.sh from: "file" (checkout) or "url" (main
+          branch on GitHub)'
+        required: false
+        type: string
+        default: file
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths: [install.sh, .github/workflows/installer.yml]
+permissions: {}
+concurrency:
+  group: installer-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+env:
+  # Until zenml.io/install serves the script, the raw file on main is the URL
+  # form of "the bytes users run".
+  INSTALL_URL: https://raw.githubusercontent.com/zenml-io/zenml/main/install.sh
+  SKILLS_TARBALL: https://github.com/zenml-io/skills/archive/refs/heads/main.tar.gz
+  ZENML_ANALYTICS_OPT_IN: false
+jobs:
+  install:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - macos-15-intel
+          - windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          # Only the script is needed, not the whole tree.
+          sparse-checkout: install.sh
+          sparse-checkout-cone-mode: false
+      - name: Run the installer as a user would
+        shell: bash
+        env:
+          ZENML_VERSION: ${{ inputs.version }}
+          SOURCE: ${{ inputs.source || 'file' }}
+        # The default (non-verbose) path is the one users run, so that is the
+        # path that has to pass. On failure, rerun once with --verbose purely to
+        # print diagnostics; the step still fails. Retries only make sense when
+        # a version is pinned: that is the release case where PyPI can lag the
+        # publish by a few seconds.
+        run: |
+          get_script() {
+            if [ "$SOURCE" = "url" ]; then curl -fsSL "$INSTALL_URL"; else cat "$GITHUB_WORKSPACE/install.sh"; fi
+          }
+          attempts=1; [ -n "$ZENML_VERSION" ] && attempts=5
+          # Run from an empty directory: the checkout is itself a Python project,
+          # which would put the installer into project mode.
+          cd "$(mktemp -d)"
+          for attempt in $(seq "$attempts"); do
+            get_script | bash -s -- && { echo "$HOME/.local/bin" >> "$GITHUB_PATH"; exit 0; }
+            echo "installer attempt $attempt of $attempts failed; retrying in 30s" >&2
+            sleep 30
+          done
+          echo "::group::verbose rerun for diagnostics"
+          get_script | bash -s -- --verbose || true
+          echo "::endgroup::"
+          exit 1
+      - name: Verify
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euxo pipefail
+          uname -a
+          zenml --version
+          if [ -n "$EXPECTED_VERSION" ]; then
+            uv tool list | grep -qx "zenml v$EXPECTED_VERSION"
+          fi
+          zenml status
+          # Every SKILL.md in the skills repo must have landed, whatever they are called.
+          expected="$(curl -fsSL "$SKILLS_TARBALL" | tar -tzf - | grep -c '/SKILL.md$')"
+          installed="$(find "$HOME/.agents/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l)"
+          test "$expected" -gt 0 && test "$installed" -eq "$expected"
+          # `set -o pipefail` above would fail the pipe on a missing rc file, so
+          # swallow cat's status and let grep decide.
+          { cat "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile" "$HOME/.bash_profile" 2>/dev/null || true; } \
+            | grep -q ".local/bin" || { echo "PATH not persisted"; exit 1; }
+      - name: Re-run is an upgrade, not an error
+        shell: bash
+        run: cd "$(mktemp -d)" && bash "$GITHUB_WORKSPACE/install.sh" --no-skills
+          --quiet
+      - name: Inside a project, install into that project's environment
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd "$(mktemp -d)"
+          uv init --quiet -p 3.12 --name demo-pipelines .
+          bash "$GITHUB_WORKSPACE/install.sh" --no-skills
+          grep -q 'zenml\[local\]' pyproject.toml
+          uv run zenml --version
+      - name: A failed install must exit nonzero (quiet path)
+        shell: bash
+        # Regression for the status-swallowing bug in `quiet`: an impossible
+        # version pin makes `uv tool install` fail, and that must surface.
+        run: |-
+          cd "$(mktemp -d)"
+          if bash "$GITHUB_WORKSPACE/install.sh" --no-skills --version=99.99.99; then
+            echo "installer exited 0 on a failed install" >&2; exit 1
+          fi
+          echo "failed install correctly exited nonzero"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ZenML is used by thousands of companies to run their AI workflows. Here are some
 ## 🚀 Get Started (5 minutes)
 
 ```bash
-# Install ZenML (macOS/Linux one-liner; add `-s -- --server` for the local dashboard)
+# Install ZenML with one command (macOS, Linux, WSL). Add `-s -- --server` for the local dashboard.
 curl -fsSL https://zenml.io/install | bash
 
 # Or with pip, including server capabilities

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ ZenML is used by thousands of companies to run their AI workflows. Here are some
 ## 🚀 Get Started (5 minutes)
 
 ```bash
-# Install ZenML with server capabilities
+# Install ZenML (macOS/Linux one-liner; add `-s -- --server` for the local dashboard)
+curl -fsSL https://zenml.io/install | bash
+
+# Or with pip, including server capabilities
 pip install "zenml[server]"  # pip install zenml will install a slimmer client
 
 # Initialize your ZenML repository

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ZenML is used by thousands of companies to run their AI workflows. Here are some
 ## 🚀 Get Started (5 minutes)
 
 ```bash
-# Install ZenML with one command (macOS, Linux, WSL). Add `-s -- --server` for the local dashboard.
+# Install ZenML with one command (macOS, Linux, WSL). Includes the local server and dashboard.
 curl -fsSL https://zenml.io/install | bash
 
 # Or with pip, including server capabilities

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -20,7 +20,7 @@ curl -fsSL https://zenml.io/install | bash
 That one command:
 
 1. Installs [uv](https://docs.astral.sh/uv/) if you do not have it. No system Python and no `sudo` are needed.
-2. Installs `zenml[local]`. Run inside a Python project (a `pyproject.toml` or `uv.lock` in the current directory) it adds ZenML to that project's environment with `uv add`, so your pipelines and ZenML share one set of dependencies. Run anywhere else it installs an isolated `zenml` CLI on your PATH.
+2. Installs `zenml[server]`, the client plus everything `zenml login --local` needs to run the server and dashboard on your machine. Run inside a Python project (a `pyproject.toml` or `uv.lock` in the current directory) it adds ZenML to that project's environment with `uv add`, so your pipelines and ZenML share one set of dependencies. Run anywhere else it installs an isolated `zenml` CLI on your PATH.
 3. Installs the [ZenML coding-agent skills](https://github.com/zenml-io/skills) into `~/.agents/skills`, plus `~/.claude/skills` and `~/.codex/skills` when Claude Code or Codex is installed.
 4. Prints what to do next and stops:
 
@@ -35,12 +35,12 @@ zenml login            managed cloud. 14-day free trial
 Works on macOS, Linux, WSL, and Git Bash on Windows. Running it again upgrades.
 
 {% hint style="info" %}
-**Want the local dashboard?** `zenml login --local` needs the `server` extra. Add `--server` to the installer (`curl -fsSL https://zenml.io/install | bash -s -- --server`) and it installs `zenml[server]` instead of `zenml[local]`. On Apple Silicon also set `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` before starting the server (see the Local Dashboard tab below).
+**Only need a client?** Add `--no-server` (`curl -fsSL https://zenml.io/install | bash -s -- --no-server`) and it installs the slimmer `zenml[local]` instead, enough to connect to a deployed server or run pipelines against a local SQLite store. `zenml login --local` then needs Docker (`--docker`). On Apple Silicon set `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` before starting the local server (see the Local Dashboard tab below).
 {% endhint %}
 
 | Option | Effect |
 | --- | --- |
-| `--server` | Install `zenml[server]` so `zenml login --local` can run the server and dashboard here |
+| `--no-server` | Install the slimmer `zenml[local]` instead of `zenml[server]` (no local dashboard) |
 | `--version 0.96.3` | Pin a ZenML release (`--pre` allows pre-releases) |
 | `--with PKG` | Also install a package into the same environment (repeatable), e.g. an integration |
 | `--project` / `--global` | Force the in-project or the isolated install |
@@ -52,7 +52,7 @@ Options go after `bash -s --`, so `curl -fsSL https://zenml.io/install | bash -s
 **Prefer to do it by hand?** Inside your project, the installer is equivalent to:
 
 ```shell
-uv add "zenml[local]"                  # or "zenml[server]" for the local dashboard
+uv add "zenml[server]"                 # or "zenml[local]" for a client without the dashboard
 npx skills add zenml-io/skills         # the coding-agent skills
 uv run zenml init
 ```

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -11,6 +11,16 @@ icon: cauldron
 
 ZenML currently supports **Python 3.10, 3.11, 3.12, 3.13, and 3.14**. Please make sure that you are using a supported Python version.
 
+The quickest way to install ZenML on macOS or Linux is the one-line installer:
+
+```shell
+curl -fsSL https://zenml.io/install | bash
+```
+
+It installs [uv](https://docs.astral.sh/uv/) if you do not have it, then installs `zenml` into the Python project in your current directory (when a `pyproject.toml` or `uv.lock` is present) or into an isolated environment with the `zenml` CLI on your PATH. It also installs the [ZenML coding-agent skills](https://github.com/zenml-io/skills). Pass options after `bash -s --`: for example `curl -fsSL https://zenml.io/install | bash -s -- --server` adds the `server` extra for the local dashboard, and `--help` lists every option.
+
+If you prefer to manage the installation yourself, use `pip` or another Python package manager:
+
 {% tabs %}
 {% tab title="Base package" %}
 **ZenML** is a Python package that can be installed using `pip` or other Python package managers:

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -11,15 +11,53 @@ icon: cauldron
 
 ZenML currently supports **Python 3.10, 3.11, 3.12, 3.13, and 3.14**. Please make sure that you are using a supported Python version.
 
-The quickest way to install ZenML on macOS or Linux is the one-line installer:
+Open a terminal and run:
 
 ```shell
 curl -fsSL https://zenml.io/install | bash
 ```
 
-It installs [uv](https://docs.astral.sh/uv/) if you do not have it, then installs `zenml` into the Python project in your current directory (when a `pyproject.toml` or `uv.lock` is present) or into an isolated environment with the `zenml` CLI on your PATH. It also installs the [ZenML coding-agent skills](https://github.com/zenml-io/skills). Pass options after `bash -s --`: for example `curl -fsSL https://zenml.io/install | bash -s -- --server` adds the `server` extra for the local dashboard, and `--help` lists every option.
+That one command:
 
-If you prefer to manage the installation yourself, use `pip` or another Python package manager:
+1. Installs [uv](https://docs.astral.sh/uv/) if you do not have it. No system Python and no `sudo` are needed.
+2. Installs `zenml[local]`. Run inside a Python project (a `pyproject.toml` or `uv.lock` in the current directory) it adds ZenML to that project's environment with `uv add`, so your pipelines and ZenML share one set of dependencies. Run anywhere else it installs an isolated `zenml` CLI on your PATH.
+3. Installs the [ZenML coding-agent skills](https://github.com/zenml-io/skills) into `~/.agents/skills`, plus `~/.claude/skills` and `~/.codex/skills` when Claude Code or Codex is installed.
+4. Prints what to do next and stops:
+
+```
+zenml init             mark this directory as a ZenML repository
+zenml login --local    local server and dashboard on this machine
+zenml login            managed cloud. 14-day free trial
+```
+
+(Inside a project ZenML is not on your PATH, hence the printed commands read `uv run zenml ...`. The isolated install uses plain `zenml`.)
+
+Works on macOS, Linux, WSL, and Git Bash on Windows. Running it again upgrades.
+
+{% hint style="info" %}
+**Want the local dashboard?** `zenml login --local` needs the `server` extra. Add `--server` to the installer (`curl -fsSL https://zenml.io/install | bash -s -- --server`) and it installs `zenml[server]` instead of `zenml[local]`. On Apple Silicon also set `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` before starting the server (see the Local Dashboard tab below).
+{% endhint %}
+
+| Option | Effect |
+| --- | --- |
+| `--server` | Install `zenml[server]` so `zenml login --local` can run the server and dashboard here |
+| `--version 0.96.3` | Pin a ZenML release (`--pre` allows pre-releases) |
+| `--with PKG` | Also install a package into the same environment (repeatable), e.g. an integration |
+| `--project` / `--global` | Force the in-project or the isolated install |
+| `--no-skills` | Skip the coding-agent skills |
+| `--no-modify-path` | Leave your shell rc files alone (isolated install) |
+
+Options go after `bash -s --`, so `curl -fsSL https://zenml.io/install | bash -s -- --help` lists everything, with environment-variable equivalents.
+
+**Prefer to do it by hand?** Inside your project, the installer is equivalent to:
+
+```shell
+uv add "zenml[local]"                  # or "zenml[server]" for the local dashboard
+npx skills add zenml-io/skills         # the coding-agent skills
+uv run zenml init
+```
+
+If you prefer to manage the installation yourself with `pip` or another Python package manager:
 
 {% tabs %}
 {% tab title="Base package" %}

--- a/install.sh
+++ b/install.sh
@@ -24,10 +24,9 @@
 #
 # Nothing here needs sudo. Everything lands under $HOME. Re-running upgrades.
 #
-# Design borrowed from the Kitaru installer (zenml-io/kitaru), which in turn
-# borrows from raindrop.sh/install and astral.sh/uv/install.sh. ZenML ships as
-# a Python package, not a binary, so uv is the one dependency this script will
-# install for you.
+# Design shared with the Kitaru installer (zenml-io/kitaru) and follows
+# astral.sh/uv/install.sh. ZenML ships as a Python package, not a binary, so uv
+# is the one dependency this script will install for you.
 
 # Bash-only, but fail politely under sh/dash/zsh-as-sh. This line is POSIX so
 # it runs before the shell reaches any bash syntax below.

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # install.sh: one-line ZenML installer.
 #
 #   curl -fsSL https://zenml.io/install | bash
-#   curl -fsSL https://zenml.io/install | bash -s -- --server
+#   curl -fsSL https://zenml.io/install | bash -s -- --no-server
 #
 # What it does, in order:
 #   1. Makes sure `uv` is available (installs it from astral.sh if not).
@@ -12,10 +12,10 @@
 #          pipelines import zenml next to their own dependencies;
 #        - anywhere else: `uv tool install` into an isolated environment, with
 #          the `zenml` CLI on PATH (~/.local/bin).
-#      --project / --global force either. The `local` extra is what lets the
-#      client work against a local SQLite store with no server at all;
-#      --server swaps it for the `server` extra, which the local server and
-#      dashboard (`zenml login --local`) need.
+#      --project / --global force either. The default is the `server` extra,
+#      so `zenml login --local` can run the server and dashboard on this
+#      machine; --no-server installs the slimmer `local` extra (client plus
+#      a local SQLite store, no dashboard).
 #   3. Installs the ZenML coding-agent skills (zenml-io/skills) from the
 #      repository tarball into ~/.agents/skills, plus ~/.claude/skills and
 #      ~/.codex/skills when those CLIs are installed. No Node needed.
@@ -40,7 +40,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 ZENML_VERSION="${ZENML_VERSION:-}"            # pin, e.g. 0.96.3
 ZENML_PRE="${ZENML_PRE:-0}"                   # allow pre-releases
-ZENML_SERVER_EXTRA="${ZENML_SERVER_EXTRA:-0}" # zenml[server] instead of zenml[local]
+ZENML_SERVER_EXTRA="${ZENML_SERVER_EXTRA:-1}" # 0: zenml[local] (slimmer client) instead of zenml[server]
 ZENML_SKIP_SKILLS="${ZENML_SKIP_SKILLS:-0}"
 ZENML_QUIET="${ZENML_QUIET:-0}"
 ZENML_VERBOSE="${ZENML_VERBOSE:-0}"
@@ -58,9 +58,9 @@ Usage: install.sh [options]
 
   --version=X.Y.Z     Install a specific ZenML version (default: latest)
   --pre               Allow pre-release versions
-  --server            Install zenml[server] instead of zenml[local], so
-                      `zenml login --local` can run the server and dashboard
-                      on this machine
+  --no-server         Install the slimmer zenml[local] instead of zenml[server].
+                      `zenml login --local` then needs Docker (--docker) or a
+                      re-run of this installer without --no-server
   --with=PKG          Also install PKG into the same environment (repeatable)
   --project           Install into the Python project in the current directory
                       (uv add). Default when a pyproject.toml or uv.lock is here.
@@ -72,7 +72,7 @@ Usage: install.sh [options]
   --verbose           Print every command
   -h, --help          This text
 
-Environment equivalents: ZENML_VERSION, ZENML_PRE=1, ZENML_SERVER_EXTRA=1,
+Environment equivalents: ZENML_VERSION, ZENML_PRE=1, ZENML_SERVER_EXTRA=0,
 ZENML_SCOPE=project|global, ZENML_SKIP_SKILLS=1, ZENML_NO_MODIFY_PATH=1,
 ZENML_QUIET=1, ZENML_VERBOSE=1, ZENML_PYTHON (default 3.12), NO_COLOR.
 USAGE
@@ -84,6 +84,7 @@ while [ $# -gt 0 ]; do
     --version) shift; ZENML_VERSION="${1:-}" ;;
     --pre) ZENML_PRE=1 ;;
     --server) ZENML_SERVER_EXTRA=1 ;;
+    --no-server) ZENML_SERVER_EXTRA=0 ;;
     --with=?*) ZENML_WITH+=("${1#*=}") ;;
     --with) shift; [ -n "${1:-}" ] && ZENML_WITH+=("$1") ;;
     --project) ZENML_SCOPE=project ;;
@@ -236,9 +237,10 @@ zenml_version_of() {
 # on a fresh machine fails with an ImportError without the `local` extra
 # (SQLite store). The `server` extra is a superset that adds what `zenml login
 # --local` needs to run the server and dashboard on this machine without
-# Docker; it is opt-in because it pulls in FastAPI, uvicorn and friends.
-SPEC="zenml[local]"
-[ "$ZENML_SERVER_EXTRA" = "1" ] && SPEC="zenml[server]"
+# Docker. It is the default so the printed next step just works; --no-server
+# opts out of FastAPI, uvicorn and friends.
+SPEC="zenml[server]"
+[ "$ZENML_SERVER_EXTRA" = "0" ] && SPEC="zenml[local]"
 [ -n "$ZENML_VERSION" ] && SPEC="${SPEC}==${ZENML_VERSION}"
 
 PROJECT_DIR="$PWD"
@@ -400,7 +402,7 @@ if [ "$ZENML_SERVER_EXTRA" = "1" ]; then
   say "    ${C_BOLD}$Z login --local${C_RESET}    local server and dashboard on this machine. Free, open source."
 else
   say "    ${C_BOLD}$Z login --local${C_RESET}    local server and dashboard. Needs the server extra:"
-  say "                            re-run this installer with --server, or use --local --docker."
+  say "                            re-run this installer without --no-server, or use --local --docker."
 fi
 say "    ${C_BOLD}$Z login${C_RESET}            managed cloud. 14-day free trial."
 say ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# install.sh: one-line ZenML installer.
+#
+#   curl -fsSL https://zenml.io/install | bash
+#   curl -fsSL https://zenml.io/install | bash -s -- --server
+#
+# What it does, in order:
+#   1. Makes sure `uv` is available (installs it from astral.sh if not).
+#   2. Installs zenml[local]. Where depends on where you run it:
+#        - inside a Python project (pyproject.toml or uv.lock in the current
+#          directory): `uv add` into that project's environment, so your
+#          pipelines import zenml next to their own dependencies;
+#        - anywhere else: `uv tool install` into an isolated environment, with
+#          the `zenml` CLI on PATH (~/.local/bin).
+#      --project / --global force either. The `local` extra is what lets the
+#      client work against a local SQLite store with no server at all;
+#      --server swaps it for the `server` extra, which the local server and
+#      dashboard (`zenml login --local`) need.
+#   3. Installs the ZenML coding-agent skills (zenml-io/skills) from the
+#      repository tarball into ~/.agents/skills, plus ~/.claude/skills and
+#      ~/.codex/skills when those CLIs are installed. No Node needed.
+#   4. Stops there and prints the next commands. Logging in to a server is a
+#      decision, so the script does not make it for you.
+#
+# Nothing here needs sudo. Everything lands under $HOME. Re-running upgrades.
+#
+# Design borrowed from the Kitaru installer (zenml-io/kitaru), which in turn
+# borrows from raindrop.sh/install and astral.sh/uv/install.sh. ZenML ships as
+# a Python package, not a binary, so uv is the one dependency this script will
+# install for you.
+
+# Bash-only, but fail politely under sh/dash/zsh-as-sh. This line is POSIX so
+# it runs before the shell reaches any bash syntax below.
+if [ -z "${BASH_VERSION:-}" ]; then echo "ZenML's installer needs bash. Run: curl -fsSL https://zenml.io/install | bash" >&2; exit 1; fi
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+ZENML_VERSION="${ZENML_VERSION:-}"            # pin, e.g. 0.96.3
+ZENML_PRE="${ZENML_PRE:-0}"                   # allow pre-releases
+ZENML_SERVER_EXTRA="${ZENML_SERVER_EXTRA:-0}" # zenml[server] instead of zenml[local]
+ZENML_SKIP_SKILLS="${ZENML_SKIP_SKILLS:-0}"
+ZENML_QUIET="${ZENML_QUIET:-0}"
+ZENML_VERBOSE="${ZENML_VERBOSE:-0}"
+ZENML_WITH=()                                 # extra packages
+ZENML_PYTHON="${ZENML_PYTHON:-3.12}"          # uv-managed Python if none suitable (global mode)
+ZENML_SCOPE="${ZENML_SCOPE:-auto}"            # auto | project | global
+ZENML_SKILLS_REPO="${ZENML_SKILLS_REPO:-zenml-io/skills}"
+ZENML_NO_MODIFY_PATH="${ZENML_NO_MODIFY_PATH:-0}"    # leave rc files alone
+ZENML_MIN_UV="0.5.0"                                 # older uv lacks the tool flags we use
+ZENML_FIRST_SKILL="zenml-pipeline-authoring"         # the skill the closing hint points at
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh [options]
+
+  --version=X.Y.Z     Install a specific ZenML version (default: latest)
+  --pre               Allow pre-release versions
+  --server            Install zenml[server] instead of zenml[local], so
+                      `zenml login --local` can run the server and dashboard
+                      on this machine
+  --with=PKG          Also install PKG into the same environment (repeatable)
+  --project           Install into the Python project in the current directory
+                      (uv add). Default when a pyproject.toml or uv.lock is here.
+  --global            Install into an isolated uv tool environment on PATH.
+                      Default anywhere else.
+  --no-skills         Skip installing the coding-agent skills
+  --no-modify-path    Do not edit shell rc files; you add ~/.local/bin yourself
+  --quiet             Only print errors
+  --verbose           Print every command
+  -h, --help          This text
+
+Environment equivalents: ZENML_VERSION, ZENML_PRE=1, ZENML_SERVER_EXTRA=1,
+ZENML_SCOPE=project|global, ZENML_SKIP_SKILLS=1, ZENML_NO_MODIFY_PATH=1,
+ZENML_QUIET=1, ZENML_VERBOSE=1, ZENML_PYTHON (default 3.12), NO_COLOR.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version=*) ZENML_VERSION="${1#*=}" ;;
+    --version) shift; ZENML_VERSION="${1:-}" ;;
+    --pre) ZENML_PRE=1 ;;
+    --server) ZENML_SERVER_EXTRA=1 ;;
+    --with=?*) ZENML_WITH+=("${1#*=}") ;;
+    --with) shift; [ -n "${1:-}" ] && ZENML_WITH+=("$1") ;;
+    --project) ZENML_SCOPE=project ;;
+    --global) ZENML_SCOPE=global ;;
+    --no-skills) ZENML_SKIP_SKILLS=1 ;;
+    --no-modify-path) ZENML_NO_MODIFY_PATH=1 ;;
+    --quiet) ZENML_QUIET=1 ;;
+    --verbose) ZENML_VERBOSE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+C_ACCENT=""; C_GREEN=""; C_RED=""; C_DIM=""; C_BOLD=""; C_RESET=""
+if [ -z "${NO_COLOR:-}" ] && [ -t 1 ]; then
+  C_ACCENT=$'\033[35m'; C_GREEN=$'\033[32m'; C_RED=$'\033[31m'
+  C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_RESET=$'\033[0m'
+fi
+
+say()  { [ "$ZENML_QUIET" = "1" ] || printf '%s\n' "$*"; }
+step() { [ "$ZENML_QUIET" = "1" ] || printf '%s◇%s %s\n' "$C_ACCENT" "$C_RESET" "$*"; }
+ok()   { [ "$ZENML_QUIET" = "1" ] || printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+note() { [ "$ZENML_QUIET" = "1" ] || printf '  %s%s%s\n' "$C_DIM" "$*" "$C_RESET"; }
+warn() { printf '%s!%s %s\n' "$C_ACCENT" "$C_RESET" "$*" >&2; }
+die()  { printf '%s✕%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; exit 1; }
+run()  { [ "$ZENML_VERBOSE" = "1" ] && printf '  %s$ %s%s\n' "$C_DIM" "$*" "$C_RESET" >&2; "$@"; }
+quiet() {
+  # Run a command, showing its output only on failure or --verbose.
+  # stdin is /dev/null so a child can never swallow the rest of this script
+  # when it is being piped in from curl.
+  if [ "$ZENML_VERBOSE" = "1" ]; then run "$@" </dev/null; return $?; fi
+  local out status=0; out="$(mktemp)"
+  "$@" >"$out" 2>&1 </dev/null || status=$?
+  [ "$status" -eq 0 ] || cat "$out" >&2
+  rm -f "$out"; return "$status"
+}
+have() { command -v "$1" >/dev/null 2>&1; }
+
+main() {
+# PATH as the user had it, before this script adds anything to it.
+ORIG_PATH="$PATH"
+# Scratch space for downloads; every early exit below can just return.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+  die "Do not run this installer with sudo. It installs into your home directory and needs no root access."
+fi
+
+# Windows (Git Bash / MSYS) differs in the venv layout and executable suffix.
+IS_WINDOWS=0; EXE=""
+case "$(uname -s)" in
+  Darwin|Linux) ;;
+  MINGW*|MSYS*|CYGWIN*)
+    IS_WINDOWS=1; EXE=".exe"
+    warn "Windows (Git Bash) detected. Installing; WSL is recommended." ;;
+  *) die "Unsupported OS: $(uname -s)" ;;
+esac
+
+if ! have curl && ! have wget; then die "Need curl or wget."; fi
+
+fetch_to_stdout() {
+  if have curl; then curl -fsSL --proto '=https' --tlsv1.2 "$1"
+  else wget -q --https-only -O- "$1"; fi
+}
+
+say ""
+say "${C_ACCENT}◆${C_RESET} ${C_BOLD}Installing ZenML${C_RESET}"
+say ""
+
+# ---------------------------------------------------------------------------
+# 1. uv
+# ---------------------------------------------------------------------------
+ensure_path() {
+  case ":$PATH:" in *":$1:"*) ;; *) export PATH="$1:$PATH" ;; esac
+}
+ensure_path "$HOME/.local/bin"
+ensure_path "$HOME/.cargo/bin"
+
+version_ge() {
+  # version_ge A B is true if A >= B (dotted numerics only)
+  [ "$(printf '%s\n%s\n' "$2" "$1" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)" = "$2" ]
+}
+
+uv_version_of() { "$1" --version 2>/dev/null | awk '{print $2}'; }
+
+install_uv() {
+  local installer="$TMP/uv-install.sh" ver
+  step "Installing uv (Python package manager, from astral.sh)"
+  # Download to a file first: `quiet` closes stdin, so piping into `sh -s`
+  # would hand the installer an empty script.
+  fetch_to_stdout https://astral.sh/uv/install.sh >"$installer" \
+    || die "Could not download the uv installer from https://astral.sh/uv/install.sh"
+  quiet sh "$installer" --quiet \
+    || die "uv install failed. Install it from https://docs.astral.sh/uv/ and re-run."
+  # Use the binary we just installed by absolute path, and put its directory
+  # in front so an older uv earlier on PATH (or bash's hashed path) can't win.
+  UV="$HOME/.local/bin/uv"
+  export PATH="$HOME/.local/bin:$PATH"; hash -r
+  [ -x "$UV" ] || die "uv installed but $UV is missing. Install it from https://docs.astral.sh/uv/ and re-run."
+  ver="$(uv_version_of "$UV")"
+  version_ge "$ver" "$ZENML_MIN_UV" \
+    || die "uv at $UV is $ver, older than $ZENML_MIN_UV. Install a current uv and re-run."
+  ok "uv $ver installed"
+}
+
+# $UV is the uv binary used for everything below (absolute path).
+UV=""
+if have uv; then
+  UV="$(command -v uv)"
+  UV_VER="$(uv_version_of "$UV")"
+  if version_ge "$UV_VER" "$ZENML_MIN_UV"; then
+    ok "uv $UV_VER found"
+  else
+    note "uv $UV_VER is older than $ZENML_MIN_UV; installing a current one alongside it."
+    install_uv
+  fi
+else
+  install_uv
+fi
+
+persist_path() {
+  # `uv tool update-shell` handles bash/zsh/fish when it recognizes the login
+  # shell. Cover the rest (Alpine sh, containers, CI images) by appending to
+  # ~/.profile when no rc file mentions the directory yet.
+  local dir="$1" f
+  for f in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.config/fish/config.fish"; do
+    [ -f "$f" ] && grep -qs "$dir\|\.local/bin" "$f" && return 0
+  done
+  # shellcheck disable=SC2016  # $PATH is meant to expand in the user's shell, not here
+  printf '\n# Added by the ZenML installer\nexport PATH="%s:$PATH"\n' "$dir" >> "$HOME/.profile"
+}
+
+zenml_version_of() {
+  # `zenml --version` prints "zenml, version X.Y.Z", on stderr: the CLI
+  # reroutes stdout there so that piped command output stays clean.
+  "$1" --version 2>&1 </dev/null | awk '/version/ {print $NF; exit}'
+}
+
+# ---------------------------------------------------------------------------
+# 2. zenml: into this project, or an isolated tool env
+# ---------------------------------------------------------------------------
+# The bare package is a client that needs a server to talk to; `zenml status`
+# on a fresh machine fails with an ImportError without the `local` extra
+# (SQLite store). The `server` extra is a superset that adds what `zenml login
+# --local` needs to run the server and dashboard on this machine without
+# Docker; it is opt-in because it pulls in FastAPI, uvicorn and friends.
+SPEC="zenml[local]"
+[ "$ZENML_SERVER_EXTRA" = "1" ] && SPEC="zenml[server]"
+[ -n "$ZENML_VERSION" ] && SPEC="${SPEC}==${ZENML_VERSION}"
+
+PROJECT_DIR="$PWD"
+if [ "$ZENML_SCOPE" = "auto" ]; then
+  if [ -f "$PROJECT_DIR/pyproject.toml" ] || [ -f "$PROJECT_DIR/uv.lock" ]; then
+    ZENML_SCOPE=project
+  else
+    ZENML_SCOPE=global
+  fi
+fi
+
+# What `zenml` resolved to on the PATH the user started with, if anything.
+# Global mode uses it for the shadowing warning and the new-terminal hint.
+RESOLVED_ZENML=""
+if [ "$ZENML_SCOPE" = "project" ]; then
+  # ---- into the project in the current directory ---------------------------
+  # Pipelines import zenml, so it has to live where the pipeline code's
+  # dependencies live. `uv add` puts zenml into this project's environment
+  # (creating .venv if needed) and records it in pyproject.toml.
+  [ -f "$PROJECT_DIR/pyproject.toml" ] || die "--project needs a pyproject.toml in $PROJECT_DIR (run \`uv init\` first, or use --global)."
+  step "Installing $SPEC into this project ($PROJECT_DIR)"
+  UV_ADD=(add --quiet)
+  [ "$ZENML_PRE" = "1" ] && UV_ADD+=(--prerelease allow)
+  quiet "$UV" "${UV_ADD[@]}" "$SPEC" "${ZENML_WITH[@]:+${ZENML_WITH[@]}}" \
+    || die "uv add failed (uv's message is above; ZenML needs Python >= 3.10). To install outside this project instead: --global"
+  VENV_DIR="${UV_PROJECT_ENVIRONMENT:-$PROJECT_DIR/.venv}"
+  if [ "$IS_WINDOWS" = "1" ]; then TOOL_BIN="$VENV_DIR/Scripts"; else TOOL_BIN="$VENV_DIR/bin"; fi
+  ZENML_BIN="$TOOL_BIN/zenml$EXE"
+  [ -x "$ZENML_BIN" ] || die "uv reported success but $ZENML_BIN is missing. Re-run with --verbose."
+  ok "zenml $(zenml_version_of "$ZENML_BIN") installed into this project's environment"
+  note "environment: $VENV_DIR (recorded in pyproject.toml)"
+  note "run it as: uv run zenml ...   (or activate the environment)"
+else
+  # ---- isolated tool environment on PATH -----------------------------------
+  UV_ARGS=(tool install --upgrade --quiet --python "$ZENML_PYTHON")
+  [ "$ZENML_PRE" = "1" ] && UV_ARGS+=(--prerelease allow)
+  for pkg in "${ZENML_WITH[@]:+${ZENML_WITH[@]}}"; do UV_ARGS+=(--with "$pkg"); done
+
+  step "Installing $SPEC (isolated, on PATH)"
+  quiet "$UV" "${UV_ARGS[@]}" "$SPEC" || die "uv tool install failed. Re-run with --verbose for details."
+
+  # uv puts tool executables in its tool bin dir; make sure future shells see it.
+  TOOL_BIN="$("$UV" tool dir --bin 2>/dev/null || echo "$HOME/.local/bin")"
+  TOOL_ENV="$("$UV" tool dir 2>/dev/null || echo "$HOME/.local/share/uv/tools")/zenml"
+  [ "$IS_WINDOWS" = "1" ] && TOOL_BIN="$(cygpath -u "$TOOL_BIN" 2>/dev/null || echo "$TOOL_BIN")"
+  ensure_path "$TOOL_BIN"
+  if [ "$ZENML_NO_MODIFY_PATH" = "1" ]; then
+    note "Not editing shell rc files (--no-modify-path). Make sure $TOOL_BIN is on your PATH."
+  else
+    quiet "$UV" tool update-shell || true
+    persist_path "$TOOL_BIN"
+  fi
+
+  ZENML_BIN="$TOOL_BIN/zenml$EXE"
+  [ -x "$ZENML_BIN" ] || die "uv reported success but $ZENML_BIN is missing. Re-run with --verbose."
+  ok "zenml $(zenml_version_of "$ZENML_BIN") installed"
+  note "isolated environment: $TOOL_ENV   (uv tool; no other Python touched)"
+  note "command: $ZENML_BIN"
+  # Warn if a different zenml was already reachable on the PATH the user
+  # started with (a pip or pipx install, say): depending on their rc order it
+  # may keep winning in new terminals.
+  hash -r
+  RESOLVED_ZENML="$(PATH="$ORIG_PATH" command -v zenml 2>/dev/null || true)"
+  if [ -n "$RESOLVED_ZENML" ] && [ "$RESOLVED_ZENML" != "$ZENML_BIN" ]; then
+    warn "Another zenml at $RESOLVED_ZENML ($(zenml_version_of "$RESOLVED_ZENML" || echo unknown)) shadows the one just installed. Remove it or put $TOOL_BIN first on PATH."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Coding-agent skills
+# ---------------------------------------------------------------------------
+# Destinations: ~/.agents/skills is the cross-agent location; ~/.claude and
+# ~/.codex get their own copy when that CLI is installed or the dir exists.
+SKILL_DESTS=("$HOME/.agents/skills")
+if have claude || [ -d "$HOME/.claude" ]; then SKILL_DESTS+=("$HOME/.claude/skills"); fi
+if have codex || [ -d "$HOME/.codex" ]; then SKILL_DESTS+=("$HOME/.codex/skills"); fi
+SKILL_NAMES=()
+
+skill_name_of() {
+  # The `name:` line of a SKILL.md front matter, or the empty string.
+  sed -n '/^---$/,/^---$/{s/^name:[[:space:]]*//p;}' "$1" | head -1 | tr -d '"'"'"' '
+}
+
+install_skills() {
+  # Fetch the repository tarball (no git, no Node, no auth, nothing executed
+  # from the current directory) and copy every skill into each destination.
+  # A skill is any directory holding a SKILL.md, wherever the repo keeps it
+  # (zenml-io/skills is a plugin marketplace, so they sit two levels down).
+  # Agents key on a flat <name>/SKILL.md, so each one is copied under the
+  # name its own front matter declares. Every mutation is checked; a partial
+  # copy is a failure.
+  local src="$TMP/skills" url skill name dest
+  mkdir -p "$src" || return 1
+  url="https://github.com/${ZENML_SKILLS_REPO}/archive/refs/heads/main.tar.gz"
+  fetch_to_stdout "$url" | tar -xzf - -C "$src" 2>/dev/null || return 1
+  for dest in "${SKILL_DESTS[@]}"; do mkdir -p "$dest" || return 1; done
+  while IFS= read -r skill; do
+    skill="$(dirname "$skill")"
+    name="$(skill_name_of "$skill/SKILL.md")"
+    [ -n "$name" ] || name="$(basename "$skill")"
+    for dest in "${SKILL_DESTS[@]}"; do
+      rm -rf "${dest:?}/${name:?}" || return 1
+      cp -R "$skill" "$dest/$name" || return 1
+    done
+    SKILL_NAMES+=("$name")
+  done < <(find "$src" -name SKILL.md -not -path '*/node_modules/*' | sort)
+  [ "${#SKILL_NAMES[@]}" -gt 0 ] || return 1
+  skills_complete
+}
+
+# Postcondition: every skill from the tarball is present in every destination.
+skills_complete() {
+  local dest name
+  for dest in "${SKILL_DESTS[@]}"; do
+    for name in "${SKILL_NAMES[@]}"; do
+      [ -f "$dest/$name/SKILL.md" ] || return 1
+    done
+  done
+  return 0
+}
+
+if [ "$ZENML_SKIP_SKILLS" = "1" ]; then
+  note "Skipping skills (--no-skills)"
+else
+  step "Installing ZenML agent skills ($ZENML_SKILLS_REPO)"
+  if install_skills; then
+    ok "${#SKILL_NAMES[@]} skills installed into ${SKILL_DESTS[*]}"
+  else
+    warn "Could not install skills. Later: https://github.com/$ZENML_SKILLS_REPO"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+say ""
+say "${C_GREEN}◆${C_RESET} ${C_BOLD}ZenML is installed.${C_RESET}"
+say ""
+if [ "$ZENML_SCOPE" = "project" ]; then
+  # zenml is not on PATH in project mode; every command goes through uv run.
+  Z="uv run zenml"
+  say "  Installed into this project's environment, so run it as ${C_BOLD}uv run zenml ...${C_RESET}"
+  say "  (or activate $VENV_DIR)."
+  say ""
+else
+  Z="zenml"
+  if [ "$RESOLVED_ZENML" != "$ZENML_BIN" ]; then
+    say "  Open a new terminal so 'zenml' is on your PATH."
+    say ""
+  fi
+fi
+say "  Next, in your project directory:"
+say ""
+say "    ${C_BOLD}$Z init${C_RESET}             mark it as a ZenML repository"
+say ""
+say "  Then pick where your ZenML server lives:"
+say ""
+if [ "$ZENML_SERVER_EXTRA" = "1" ]; then
+  say "    ${C_BOLD}$Z login --local${C_RESET}    local server and dashboard on this machine. Free, open source."
+else
+  say "    ${C_BOLD}$Z login --local${C_RESET}    local server and dashboard. Needs the server extra:"
+  say "                            re-run this installer with --server, or use --local --docker."
+fi
+say "    ${C_BOLD}$Z login${C_RESET}            managed cloud. 14-day free trial."
+say ""
+for name in "${SKILL_NAMES[@]:+${SKILL_NAMES[@]}}"; do
+  if [ "$name" = "$ZENML_FIRST_SKILL" ]; then
+    say "  In your ML project, tell your coding agent:"
+    say "    ${C_BOLD}Use $ZENML_FIRST_SKILL to write my first pipeline.${C_RESET}"
+    say ""
+    break
+  fi
+done
+say "  Check setup:   $Z status"
+say "  Docs:          https://docs.zenml.io"
+say ""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a one-line installer for ZenML, mirroring the Kitaru installer that shipped this week:

```bash
curl -fsSL https://zenml.io/install | bash
```

Until the website serves `zenml.io/install` (separate PR in the website repo), the same bytes are at `https://raw.githubusercontent.com/zenml-io/zenml/main/install.sh` once this lands on `main`.

The script makes sure `uv` is present (installs it from astral.sh if not), installs `zenml[local]` either into the Python project in the current directory or into an isolated `uv tool` environment on PATH, installs the coding-agent skills from `zenml-io/skills`, and prints the next commands. It does not log in anywhere.

## What changed

- **`install.sh`** (new, repo root). Bash 3.2 compatible. POSIX guard line so `sh`/`dash` fail politely. Whole body in `main()` so a truncated download never executes. `quiet()` helper runs children with `</dev/null` and captures the exit status, so a failed `uv` call cannot swallow the rest of the piped script or hide its failure. Project mode (`pyproject.toml` or `uv.lock` in cwd, or `--project`) does `uv add`; global mode (`--global`, the default elsewhere) does `uv tool install --upgrade --python 3.12`, persists PATH via `uv tool update-shell` plus a `~/.profile` fallback, and warns if a pre-existing `zenml` on the original PATH shadows the new one. Options: `--version --pre --server --with --project --global --no-skills --no-modify-path --quiet --verbose`, each with an env equivalent.
- **`.github/workflows/installer.yml`** (new). Smoke matrix on `ubuntu-latest`, `ubuntu-24.04-arm`, `macos-latest`, `macos-15-intel`, `windows-latest` (Git Bash). Every step runs from `mktemp -d` because the checkout itself is a Python project. Steps: user-style `cat | bash -s --` run, verify (CLI, `zenml status`, skill count vs the tarball, PATH persisted), re-run is an upgrade, project-mode run after `uv init`, and a must-fail run with `--version=99.99.99`. Triggers: PRs touching the script or workflow, `workflow_dispatch`, and `workflow_call` with `version` and `source` (`file` = checkout, `url` = raw file on `main`) inputs. Retries only when a version is pinned (release case). Sparse checkout of just the script.
- **`docs/book/getting-started/installation.md`**: the one-liner leads the install step; pip and extras tabs stay as they were.
- **`README.md`**: one-liner added above the pip line in Get Started.

## Decisions (please push back)

- **Default extra is `zenml[local]`, not bare `zenml`.** I first shipped bare `zenml` and the Debian test showed `zenml status` on a fresh machine dies with an ImportError asking for the `local` extra. A client that cannot talk to a local SQLite store is not a useful default. `--server` swaps in `zenml[server]` (a superset) for the local dashboard. Flipping the default to `server` is a one-line change if we would rather people get the dashboard out of the box at the cost of FastAPI/uvicorn.
- **Skills are installed.** `zenml-io/skills` is a Claude Code plugin marketplace laid out as `skills/<plugin>/skills/<skill>/SKILL.md`. The installer discovers every `SKILL.md` in the tarball and copies its directory to `~/.agents/skills/<name>` (plus `~/.claude/skills` and `~/.codex/skills` when those CLIs or dirs exist), using the front-matter `name:` as the directory name so `/zenml-quick-wins` etc. resolve. The plugins' `agents/` subagent files are not installed (the skills do not require them). Users who already installed via the marketplace get a duplicate copy under `~/.claude/skills`; same trade-off Kitaru made. Postcondition check: every skill in every destination, else a warning and the install continues.
- **No MCP registration** in this version. `zenml-io/mcp-zenml` exists but wiring it needs a server URL decision; follow-up.
- **Closing message** (global mode, default extra; verbatim from a Debian run):

```
◆ ZenML is installed.

  Open a new terminal so 'zenml' is on your PATH.

  Next, in your project directory:

    zenml init             mark it as a ZenML repository

  Then pick where your ZenML server lives:

    zenml login --local    local server and dashboard. Needs the server extra:
                            re-run this installer with --server, or use --local --docker.
    zenml login            managed cloud. 14-day free trial.

  In your ML project, tell your coding agent:
    Use zenml-pipeline-authoring to write my first pipeline.

  Check setup:   zenml status
  Docs:          https://docs.zenml.io
```

  With `--server` the `login --local` line reads "local server and dashboard on this machine. Free, open source." In project mode every command is prefixed `uv run`. "14-day free trial" is what `hello-world.md` says; I did not add "no credit card" because the docs do not state it.

## What reviewers should focus on

- **Bash hazards**: `quiet()` status capture (`|| status=$?`), the `</dev/null` on every child, `set -u` with possibly-empty arrays (`"${arr[@]:+${arr[@]}}"` idiom), the `${dest:?}/${name:?}` guard before `rm -rf`, and the single `TMP` dir with an EXIT trap.
- **PATH handling**: `ORIG_PATH` is captured before the script touches PATH and drives both the shadow warning and the "open a new terminal" hint; `persist_path` appends to `~/.profile` only if no rc file already mentions the bin dir.
- **`zenml --version` prints on stderr** because `zenml_cli` reroutes stdout to stderr. The script parses `2>&1`; the workflow asserts a pinned version via `uv tool list` instead of parsing CLI output.
- **Skills layout discovery** (`find -name SKILL.md`) and the CI assertion that the installed count equals the tarball count.
- **Docs**: `https://zenml.io/install` 404s until the website PR ships. It only appears inside code spans and fences, which lychee does not check by default, but shout if the docs link checker complains.

## Validation

Local, from the checked-out file:

```bash
# shellcheck (koalaman/shellcheck:stable, -S style): clean
docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable -S style /mnt/install.sh

# Ubuntu 24.04, project mode: uv init, run script, check .venv/bin/zenml, uv run zenml --version, 14 skills in ~/.agents/skills  -> PASS
docker run --rm -v "$PWD:/mnt:ro" -v "$PWD/test-project.sh:/t.sh:ro" ubuntu:24.04 bash /t.sh

# Debian bookworm-slim, global mode: fresh uv install, zenml --version, zenml status, skills, ~/.profile PATH, quiet re-run, --version=99.99.99 exits nonzero, --server then import fastapi+sqlalchemy  -> PASS
docker run --rm -v "$PWD:/mnt:ro" -v "$PWD/test-global.sh:/t.sh:ro" debian:bookworm-slim bash /t.sh

# Alpine 3.20 (musl, bash from apk), global mode --no-skills: zenml --version, zenml status, ~/.profile PATH  -> PASS
docker run --rm -v "$PWD:/mnt:ro" -v "$PWD/test-alpine.sh:/t.sh:ro" alpine:3.20 sh /t.sh

sh install.sh            # -> "ZenML's installer needs bash", exit 1
bash install.sh --help   # -> usage, exit 0

yamlfix .github/workflows/installer.yml                                   # applied
docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest          # clean
GH_TOKEN=$(gh auth token) uvx --constraints .github/zizmor/requirements.txt zizmor --config=.github/zizmor.yml .github/workflows/   # no findings
uvx typos install.sh .github/workflows/installer.yml README.md docs/book/getting-started/installation.md --config .typos.toml       # clean
```

The `Installer smoke` workflow runs on this PR (it is path-filtered to the script and workflow). Not verified locally: macOS and Windows Git Bash; the matrix covers them.

## Follow-ups

- Website PR to serve `https://zenml.io/install` (proxy or copy of the file on `main`), then switch `INSTALL_URL` in the workflow to it.
- Register the `mcp-zenml` server with Claude Code / Codex from the installer once we decide which server URL it should point at.
- Call this workflow from `release.yml` after `wait-for-package-release` with `version: <new>` and `source: url`, so every release proves the one-liner installs it.
- Decide whether the docs `hello-world.md` and quickstart should also lead with the one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrD7eCgTu11F6qsYMS5JMP
