### PR TITLE
Bump click to 8.3.3+ (CVE-2026-7246)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires-python = ">=3.10,<3.15"
 
 dependencies = [
     "asgiref~=3.10.0",
-    "click>=8.0.1,<=8.2.1",
+    "click>=8.3.3,<9",
     "cloudpickle>=2.0.0",
     "distro>=1.6.0,<2.0.0",
     "docker~=7.1.0",

--- a/src/zenml/cli/formatter.py
+++ b/src/zenml/cli/formatter.py
@@ -13,7 +13,7 @@
 #  permissions and limitations under the License.
 """Helper functions to format output for CLI."""
 
-from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple
+from typing import Dict, Iterable, Iterator, Optional, Tuple
 
 from click import formatting
 from click._compat import term_len
@@ -75,7 +75,7 @@ class ZenFormatter(formatting.HelpFormatter):
 
     def write_dl(
         self,
-        rows: Sequence[Tuple[str, ...]],
+        rows: Iterable[Tuple[str, ...]],
         col_max: int = 30,
         col_spacing: int = 2,
     ) -> None:

--- a/src/zenml/cli/stack_components.py
+++ b/src/zenml/cli/stack_components.py
@@ -15,7 +15,7 @@
 
 import time
 from importlib import import_module
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 from uuid import UUID
 
 import click
@@ -1224,13 +1224,14 @@ def prompt_select_resource_id(
                 f"argument to select a {resource_name} resource from the "
                 "list."
             )
-        resource_id = click.prompt(
+        # click >= 8.4 types `prompt(type=Choice(...))` as returning `str`.
+        resource_id: str = click.prompt(
             f"{msg}Please select the {resource_name} that you want to use",
             type=click.Choice(resource_ids),
             show_choices=False,
         )
 
-        return cast(str, resource_id)
+        return resource_id
 
     # We should never get here, but just in case...
     cli_utils.error(

--- a/src/zenml/cli/utils.py
+++ b/src/zenml/cli/utils.py
@@ -205,9 +205,12 @@ def error(text: str) -> NoReturn:
 
     class StyledClickException(click.ClickException):
         def show(self, file: Optional[IO[Any]] = None) -> None:
+            # `click.get_text_stream` is deprecated since click 8.5 (removed
+            # in 9.0); `echo(err=True)` resolves the same stderr wrapper.
             if file is None:
-                file = click.get_text_stream("stderr")
-            click.echo(self.message, file=file)
+                click.echo(self.message, err=True)
+            else:
+                click.echo(self.message, file=file)
 
     raise StyledClickException(message=error_prefix + error_message)
 
@@ -974,6 +977,9 @@ def prompt_configuration(
             else:
                 title = "Please enter a new value or press Enter to skip it"
 
+        # click >= 8.4 types `prompt(type=str)` as returning `str`, so the
+        # variable needs an explicit `Optional` for the "skip" branch below.
+        value: Optional[str]
         while True:
             # Ask the user to enter a value for the attribute
             value = click.prompt(


### PR DESCRIPTION
## Summary

The `Python Dependency Audit` workflow has been red on `develop` since late August. `pyproject.toml` capped click at `<=8.2.1`, and every click release up to and including 8.3.2 is flagged by PYSEC-2026-2132 / GHSA-47fr-3ffg-hgmw / CVE-2026-7246 (command injection in `click.edit()` and the pager, which built the editor command with `shell=True`). The fix landed in click 8.3.3, which switched to `shlex.split()` and dropped `shell=True`.

ZenML never calls `click.edit()` (checked `src/` and `tests/`), so the vulnerable code path is not reachable from our CLI, but pip-audit blocks on the installed version regardless.

The `<=8.2.1` cap was introduced in #3905 purely to widen the *lower* end of what could be co-installed (Google ADK needed a newer click than the previous cap allowed); it was not protecting against any known click 8.3 breakage. This PR lifts it to `click>=8.3.3,<9`. With that range, `uv pip install` currently resolves to click 8.5.0.

## What changed

- `pyproject.toml`: `click>=8.0.1,<=8.2.1` -> `click>=8.3.3,<9`. No lockfile is tracked in this repo, so nothing else to regenerate.
- `src/zenml/cli/utils.py`: `StyledClickException.show()` used `click.get_text_stream("stderr")`, which click 8.5 deprecated for removal in 9.0 (and whose deprecation wrapper mypy now rejects as `"object" not callable`). It now calls `click.echo(..., err=True)`, which resolves the same stderr wrapper internally. Also added an explicit `Optional[str]` annotation on the `value` variable in `prompt_configuration()`, because click 8.4's `prompt()` overloads now return `str` for `type=str` and the function later assigns `None` on the "skip" branch.
- `src/zenml/cli/stack_components.py`: `prompt(type=click.Choice(...))` is now typed as returning `str`, so the `cast(str, ...)` became a mypy `redundant-cast` error. Dropped the cast and the now-unused import.
- `src/zenml/cli/formatter.py`: click 8.4 changed the `HelpFormatter.write_dl` supertype signature to accept `Iterable[tuple[str, str]]`. Our `ZenFormatter.write_dl` override declared `Sequence[Tuple[str, ...]]`, which mypy now flags as an incompatible override. Widened to `Iterable[Tuple[str, ...]]` (the body already does `list(rows)` first, so no behaviour change).

## What reviewers should focus on

- **Behaviour changes in click 8.3 to 8.5 that I checked and found harmless for us:**
  - 8.3.0 preserves option `default` values as-is instead of coercing them. We have three `is_flag=True` options with `default=None` (`zenml user update --admin/--user`, plus `webhook`). I ran the same option definitions under click 8.2.1 and 8.5.0 with `CliRunner`: identical results (`None` when omitted, `True` when passed). The `user update` code already branches on `is True` / `is not None`.
  - 8.3.x introduced `Sentinel.UNSET` internally but hides it as `None` in callbacks and `Context.invoke()`; no ZenML code inspects parameter sources or `default_map`.
  - 8.5.0 stores the help flag under `_click_default_help` instead of `help`; nothing in `src/zenml` reads `ctx.params["help"]`.
  - 8.5.0 dropped the Colorama dependency on Windows and enables ANSI by default. We do not import colorama ourselves.
  - No `flag_value`, `click.edit`, `isolated_filesystem`, or `get_binary_stream` usages in the codebase.
- All four code edits are typing-only adjustments; runtime output of `--help`, `stack list`, `integration list`, `stack register --help`, `pipeline run --help` and error rendering were compared between 8.2.1 and 8.5.0 and are byte-identical on stdout/stderr.
- `mypy src/zenml/cli` is clean on `develop` with click 8.2.1 and clean on this branch with click 8.5.0. The only lint output I could not fully clear locally is the pre-existing `import-not-found` noise for integration packages (`nltk`, `databricks.sdk`, etc.) that were not installed in my environment; CI installs those.

## Validation

Run from a fresh `uv venv --python 3.11` with `.[server,dev,local,templates]` plus the optional test packages the unit suite imports (`kubernetes`, `paramiko`, `mock`, `boto3`, `numpy`, `mlflow`, `s3fs`, `ipython`, google-cloud storage/container/artifact-registry). Resolved `click==8.5.0`.

- `uv pip check`: all installed packages compatible
- `pytest tests/unit/cli -q`: 28 passed
- `pytest tests/unit -q`: 1837 passed, 3 failed, 1 skipped (53 min on WSL2). The 3 failures are environment-only and unrelated to click: `test_setting_a_custom_source_root` trips on the in-repo `.venv` path, and two `test_child_pipelines` cases hit the "Pipeline thread did not finish in time" timeout on this slow machine (one of them passes when rerun alone). CI `ubuntu-setup-and-unit-test (3.11)`, `ubuntu-unit-test (3.10)` and `macos-unit-test (3.10, 3.11, 3.13)` all pass on this PR
- `pytest tests/integration/functional/cli -q`: not completed locally (the run was killed by the session harness before finishing); covered by the CI `integration-tests-fast` default shards 1-6, which all pass on this PR
- `ruff check src/zenml/cli`, `ruff format --check src/zenml/cli`, `pydoclint` on the three touched files: clean
- `mypy src/zenml/cli tests/harness`: no issues found (61 files)
- Manual: `zenml --help`, `zenml --version`, `zenml stack list`, `zenml stack describe`, `zenml pipeline list`, `zenml integration list`, `zenml stack register --help`, `zenml artifact-store register --help`, `zenml orchestrator register foo` (missing-option error path), `zenml login --help`, `zenml pipeline run --help`
- Cross-check on develop with click 8.2.1 in a second venv: `mypy src/zenml/cli` clean there too, which confirms the four typing errors are introduced by the click upgrade and not pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrD7eCgTu11F6qsYMS5JMP
