### PR TITLE
Raw event storage and downstream access

### DIFF
--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -946,8 +946,8 @@ custom webhooks that do not produce a semantic event, `event` is `null`.
 ### Access the raw webhook body
 
 When at least one trigger matches an accepted delivery, ZenML retains its
-original JSON body for 30 days. Use `get_raw_webhook_event` inside a downstream
-step to retrieve it:
+original JSON body. Use `get_raw_webhook_event` inside a downstream step to
+retrieve it:
 
 ```python
 from zenml import step
@@ -980,8 +980,8 @@ The returned envelope has the following extensible shape:
 You can pass an existing pipeline run response with
 `get_raw_webhook_event(pipeline_run=run)`. The helper returns `None` when the
 run was not started directly by a webhook trigger or when the retained body is
-missing or expired. Reading the body requires read access to its webhook.
-Request headers are not retained in this version.
+missing. Reading the body requires read access to its webhook. Request headers
+are not retained in this version.
 
 ### Custom webhook triggers
 

--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -890,7 +890,8 @@ use trigger dispatch state and pipeline runs to verify downstream execution.
 ### Access the upstream webhook event
 
 A pipeline run started directly by a webhook trigger stores the provider's
-parsed semantic event in its trigger execution information. Use
+delivery locator and, when available, its parsed semantic event in the run's
+trigger execution information. Use
 `get_webhook_upstream_event` inside a step to retrieve it as a plain dictionary:
 
 ```python
@@ -917,6 +918,7 @@ For example, a GitHub push event has this shape:
 ```json
 {
   "github": {
+    "webhook_id": "7f9f38a7-8dd6-4ced-91c8-bf05857838d5",
     "delivery_id": "delivery-001",
     "event": {
       "type": "push",
@@ -937,9 +939,49 @@ necessarily the provider's raw event family. Optional semantic fields are
 included with `null` values when unavailable. You can also pass an existing
 pipeline run response to `get_webhook_upstream_event(pipeline_run=run)`.
 
-Only runs started directly by a provider with semantic event support contain
-this metadata. It is not propagated through later platform event triggers, and
-custom webhook triggers do not currently persist their arbitrary payloads.
+Only runs started directly by a webhook trigger contain this metadata. It is
+not propagated through later platform event triggers. For providers such as
+custom webhooks that do not produce a semantic event, `event` is `null`.
+
+### Access the raw webhook body
+
+When at least one trigger matches an accepted delivery, ZenML retains its
+original JSON body for 30 days. Use `get_raw_webhook_event` inside a downstream
+step to retrieve it:
+
+```python
+from zenml import step
+from zenml.utils.trigger_utils import get_raw_webhook_event
+
+
+@step
+def inspect_raw_webhook_event() -> None:
+    raw_event = get_raw_webhook_event()
+    if raw_event is None:
+        print("No retained webhook body is available.")
+        return
+
+    print(raw_event["body"])
+```
+
+The returned envelope has the following extensible shape:
+
+```json
+{
+  "body": {
+    "action": "closed",
+    "pull_request": {
+      "body": "Description from the original pull request"
+    }
+  }
+}
+```
+
+You can pass an existing pipeline run response with
+`get_raw_webhook_event(pipeline_run=run)`. The helper returns `None` when the
+run was not started directly by a webhook trigger or when the retained body is
+missing or expired. Reading the body requires read access to its webhook.
+Request headers are not retained in this version.
 
 ### Custom webhook triggers
 

--- a/docs/book/getting-started/zenml-pro/webhooks.md
+++ b/docs/book/getting-started/zenml-pro/webhooks.md
@@ -29,6 +29,11 @@ events and execute attached pipeline snapshots when a pull request is merged
 or a task status changes, a deployment message is posted, or an approval reaction
 is added.
 
+When at least one webhook trigger matches, ZenML retains the original JSON
+request body so directly triggered pipeline steps can retrieve
+fields omitted from the normalized semantic event. Request headers are not
+retained. See [Access the raw webhook body](triggers.md#access-the-raw-webhook-body).
+
 The endpoint returns an HTTP response selected by the provider. GitHub and
 custom deliveries normally return `202 Accepted`; Slack returns `200 OK`. An
 invalid signature, invalid payload, missing webhook, or inactive webhook returns

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -7284,6 +7284,26 @@ class Client(metaclass=ClientMetaClass):
             request=WebhookRotateSecretRequest(secret=secret),
         )
 
+    @_fail_for_sql_zen_store
+    def get_raw_webhook_event(
+        self,
+        webhook_id: UUID,
+        delivery_id: str,
+    ) -> Dict[str, Any]:
+        """Get a retained raw webhook event payload.
+
+        Args:
+            webhook_id: The exact webhook ID.
+            delivery_id: The provider or ZenML delivery ID.
+
+        Returns:
+            The extensible raw webhook event payload.
+        """
+        return self.zen_store.get_raw_webhook_event(
+            webhook_id=webhook_id,
+            delivery_id=delivery_id,
+        )
+
     # --------------------------- Service Connectors ---------------------------
 
     def create_service_connector(

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -1239,8 +1239,9 @@ class WebhookTriggerResponse(TriggerResponse[WebhookTriggerResponseBody,]):
 class WebhookTriggerExecutionInfo(BaseModel):
     """Information about the webhook event that triggered a pipeline run."""
 
-    delivery_id: str | None = None
-    event: dict[str, Any]
+    webhook_id: UUID
+    delivery_id: str
+    event: dict[str, Any] | None = None
 
 
 class TriggerExecutionInfo(BaseModel):

--- a/src/zenml/utils/trigger_utils.py
+++ b/src/zenml/utils/trigger_utils.py
@@ -407,3 +407,42 @@ def get_webhook_upstream_event(
         provider: provider_info.model_dump(mode="json")
         for provider, provider_info in info.webhook_upstream_event.items()
     }
+
+
+def get_raw_webhook_event(
+    pipeline_run: PipelineRunResponse | None = None,
+) -> dict[str, Any] | None:
+    """Get the retained raw webhook event for a pipeline run.
+
+    When no run is provided, the current step's pipeline run is used. Only
+    runs started directly by a webhook trigger carry the lookup information.
+
+    Args:
+        pipeline_run: Pipeline run to inspect. If omitted, the current run is
+            resolved from the active step context.
+
+    Returns:
+        The extensible raw event envelope, or `None` if it is unavailable.
+    """
+    if pipeline_run is None:
+        from zenml.steps.step_context import get_step_context
+
+        pipeline_run = get_step_context().pipeline_run
+
+    info = pipeline_run.trigger_execution_info
+    if info is None or not info.webhook_upstream_event:
+        return None
+    if len(info.webhook_upstream_event) != 1:
+        logger.error(
+            "Expected one webhook provider in trigger execution information."
+        )
+        return None
+
+    _, event = next(iter(info.webhook_upstream_event.items()))
+    try:
+        return Client().get_raw_webhook_event(
+            webhook_id=event.webhook_id,
+            delivery_id=event.delivery_id,
+        )
+    except KeyError:
+        return None

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -564,7 +564,8 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
             headers: The request headers.
 
         Returns:
-            The delivery ID, if the payload contains a webhook ID.
+            The documented history-based delivery ID, if available. Intake
+            generates a unique ID for history-less events.
 
         Raises:
             WebhookPayloadError: If webhook_id is missing.
@@ -577,17 +578,7 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
         history_ids = _history_item_ids(payload)
         if history_ids:
             return f"{webhook_id}:{','.join(history_ids)}"
-        resource_id = next(
-            (
-                value
-                for key in _RESOURCE_KEYS
-                if (value := _id_string(payload, key)) is not None
-            ),
-            "unknown",
-        )
-        event_type = payload.get("event")
-        event_name = event_type if isinstance(event_type, str) else "unknown"
-        return f"{webhook_id}:{event_name}:{resource_id}"
+        return None
 
     def _cast_runtime_targets(
         self, trigger: "WebhookTriggerResponse"

--- a/src/zenml/zen_server/routers/webhook_endpoints.py
+++ b/src/zenml/zen_server/routers/webhook_endpoints.py
@@ -13,7 +13,8 @@
 #  permissions and limitations under the License.
 """Management and public intake endpoints for webhooks."""
 
-from uuid import UUID
+from typing import Any
+from uuid import UUID, uuid4
 
 from fastapi import (
     APIRouter,
@@ -180,6 +181,34 @@ def get_webhook(
     )
     _set_webhook_endpoint_url(webhook)
     return webhook
+
+
+@management_router.get("/{webhook_id}/events/raw")
+@async_fastapi_endpoint_wrapper
+def get_raw_webhook_event(
+    webhook_id: UUID,
+    delivery_id: str,
+    _: AuthContext = Security(authorize),
+) -> dict[str, Any]:
+    """Get the retained raw body for a consumed webhook event.
+
+    The delivery ID is a query parameter because provider-defined IDs may not
+    be safe path segments. The response is an extensible envelope so headers
+    can be added in a future API version without changing its shape.
+
+    Args:
+        webhook_id: The webhook ID.
+        delivery_id: The provider or ZenML delivery ID.
+
+    Returns:
+        The raw event envelope in the form ``{"body": {...}}``.
+    """
+    webhook = zen_store().get_webhook(webhook_id, hydrate=False)
+    verify_permission_for_model(model=webhook, action=Action.READ)
+    return zen_store().get_raw_webhook_event(
+        webhook_id=webhook_id,
+        delivery_id=delivery_id,
+    )
 
 
 @management_router.put("/{webhook_id}")
@@ -378,7 +407,7 @@ def _receive_webhook_event(
             webhook_id=webhook_id,
             webhook_type=webhook_type,
             event_type=parsed_event.event_type,
-            delivery_id=parsed_event.delivery_id,
+            delivery_id=parsed_event.delivery_id or str(uuid4()),
             payload=parsed_event.payload,
         )
         background_task = BackgroundTask(

--- a/src/zenml/zen_stores/migrations/versions/d91e2f4a6b3c_add_webhook_event_payloads.py
+++ b/src/zenml/zen_stores/migrations/versions/d91e2f4a6b3c_add_webhook_event_payloads.py
@@ -1,0 +1,69 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Add retained webhook event payloads [d91e2f4a6b3c].
+
+Revision ID: d91e2f4a6b3c
+Revises: 7c0d9e4a1b2f
+Create Date: 2026-09-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import LONGBLOB
+
+revision = "d91e2f4a6b3c"
+down_revision = "7c0d9e4a1b2f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the retained webhook event payload table."""
+    op.create_table(
+        "webhook_event_payload",
+        sa.Column("webhook_id", sa.Uuid(), nullable=False),
+        sa.Column("delivery_id", sa.String(length=255), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "payload",
+            LONGBLOB
+            if op.get_bind().dialect.name == "mysql"
+            else sa.LargeBinary(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["webhook_id"],
+            ["webhook.id"],
+            name="fk_webhook_event_payload_webhook_id_webhook",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("webhook_id", "delivery_id"),
+    )
+    op.create_index(
+        "ix_webhook_event_payload_expires_at",
+        "webhook_event_payload",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove the retained webhook event payload table."""
+    op.drop_index(
+        "ix_webhook_event_payload_expires_at",
+        table_name="webhook_event_payload",
+    )
+    op.drop_table("webhook_event_payload")

--- a/src/zenml/zen_stores/migrations/versions/d91e2f4a6b3c_add_webhook_event_payloads.py
+++ b/src/zenml/zen_stores/migrations/versions/d91e2f4a6b3c_add_webhook_event_payloads.py
@@ -36,7 +36,6 @@ def upgrade() -> None:
         sa.Column("webhook_id", sa.Uuid(), nullable=False),
         sa.Column("delivery_id", sa.String(length=255), nullable=False),
         sa.Column("created", sa.DateTime(), nullable=False),
-        sa.Column("expires_at", sa.DateTime(), nullable=False),
         sa.Column(
             "payload",
             LONGBLOB
@@ -52,18 +51,8 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("webhook_id", "delivery_id"),
     )
-    op.create_index(
-        "ix_webhook_event_payload_expires_at",
-        "webhook_event_payload",
-        ["expires_at"],
-        unique=False,
-    )
 
 
 def downgrade() -> None:
     """Remove the retained webhook event payload table."""
-    op.drop_index(
-        "ix_webhook_event_payload_expires_at",
-        table_name="webhook_event_payload",
-    )
     op.drop_table("webhook_event_payload")

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -2682,6 +2682,31 @@ class RestZenStore(BaseZenStore):
         response = self.put(f"{WEBHOOKS}/{webhook_id}/secret", body=request)
         return WebhookSecretResponse.model_validate(response)
 
+    def get_raw_webhook_event(
+        self,
+        webhook_id: UUID,
+        delivery_id: str,
+    ) -> Dict[str, Any]:
+        """Get a retained raw webhook event payload.
+
+        Args:
+            webhook_id: The webhook ID.
+            delivery_id: The provider or ZenML delivery ID.
+
+        Returns:
+            The extensible raw webhook event payload.
+
+        Raises:
+            ValueError: If the server returns an invalid payload shape.
+        """
+        response = self.get(
+            f"{WEBHOOKS}/{webhook_id}/events/raw",
+            params={"delivery_id": delivery_id},
+        )
+        if not isinstance(response, dict):
+            raise ValueError("Invalid raw webhook event response.")
+        return response
+
     # ----------------------------- Triggers ------------------------------
 
     def create_trigger(

--- a/src/zenml/zen_stores/schemas/__init__.py
+++ b/src/zenml/zen_stores/schemas/__init__.py
@@ -111,6 +111,7 @@ from zenml.zen_stores.schemas.trigger_assoc import (
 from zenml.zen_stores.schemas.trigger_schemas import TriggerSchema
 from zenml.zen_stores.schemas.user_schemas import UserSchema
 from zenml.zen_stores.schemas.webhook_schemas import (
+    WebhookEventPayloadSchema,
     WebhookSchema,
     WebhookStatsSchema,
 )
@@ -176,6 +177,7 @@ __all__ = [
     "TriggerSchema",
     "TriggerSnapshotSchema",
     "TriggerExecutionSchema",
+    "WebhookEventPayloadSchema",
     "WebhookSchema",
     "WebhookStatsSchema",
 ]

--- a/src/zenml/zen_stores/schemas/webhook_schemas.py
+++ b/src/zenml/zen_stores/schemas/webhook_schemas.py
@@ -17,7 +17,8 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Sequence
 from uuid import UUID
 
-from sqlalchemy import TEXT, Column, UniqueConstraint
+from sqlalchemy import TEXT, Column, LargeBinary, String, UniqueConstraint
+from sqlalchemy.dialects.mysql import LONGBLOB
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.sql.base import ExecutableOption
 from sqlmodel import Field, Relationship, SQLModel
@@ -238,3 +239,36 @@ class WebhookStatsSchema(SQLModel, table=True):
             The webhook intake statistics.
         """
         return WebhookStats.model_validate(self, from_attributes=True)
+
+
+class WebhookEventPayloadSchema(SQLModel, table=True):
+    """Compressed raw body retained for a consumed webhook event."""
+
+    __tablename__ = "webhook_event_payload"
+    __table_args__ = (
+        build_index(
+            table_name=__tablename__,
+            column_names=["expires_at"],
+        ),
+    )
+
+    webhook_id: UUID = build_foreign_key_field(
+        source=__tablename__,
+        target=WebhookSchema.__tablename__,
+        source_column="webhook_id",
+        target_column="id",
+        ondelete="CASCADE",
+        nullable=False,
+        primary_key=True,
+    )
+    delivery_id: str = Field(
+        sa_column=Column(String(255), primary_key=True, nullable=False),
+    )
+    created: datetime = Field(default_factory=utc_now, nullable=False)
+    expires_at: datetime = Field(nullable=False)
+    payload: bytes = Field(
+        sa_column=Column(
+            LargeBinary().with_variant(LONGBLOB, "mysql"),
+            nullable=False,
+        ),
+    )

--- a/src/zenml/zen_stores/schemas/webhook_schemas.py
+++ b/src/zenml/zen_stores/schemas/webhook_schemas.py
@@ -245,12 +245,6 @@ class WebhookEventPayloadSchema(SQLModel, table=True):
     """Compressed raw body retained for a consumed webhook event."""
 
     __tablename__ = "webhook_event_payload"
-    __table_args__ = (
-        build_index(
-            table_name=__tablename__,
-            column_names=["expires_at"],
-        ),
-    )
 
     webhook_id: UUID = build_foreign_key_field(
         source=__tablename__,
@@ -265,7 +259,6 @@ class WebhookEventPayloadSchema(SQLModel, table=True):
         sa_column=Column(String(255), primary_key=True, nullable=False),
     )
     created: datetime = Field(default_factory=utc_now, nullable=False)
-    expires_at: datetime = Field(nullable=False)
     payload: bytes = Field(
         sa_column=Column(
             LargeBinary().with_variant(LONGBLOB, "mysql"),

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -8581,12 +8581,9 @@ class SqlZenStore(BaseZenStore):
         payload = gzip.compress(
             json.dumps({"body": body}, separators=(",", ":")).encode("utf-8")
         )
-        created = utc_now()
         schema = WebhookEventPayloadSchema(
             webhook_id=webhook_id,
             delivery_id=delivery_id,
-            created=created,
-            expires_at=created + timedelta(days=30),
             payload=payload,
         )
         with Session(self.engine) as session:
@@ -8611,7 +8608,7 @@ class SqlZenStore(BaseZenStore):
         webhook_id: UUID,
         delivery_id: str,
     ) -> Dict[str, Any]:
-        """Get an unexpired retained raw webhook event payload.
+        """Get a retained raw webhook event payload.
 
         Args:
             webhook_id: The webhook ID.
@@ -8621,7 +8618,7 @@ class SqlZenStore(BaseZenStore):
             The extensible raw webhook event payload.
 
         Raises:
-            KeyError: If no unexpired payload exists.
+            KeyError: If no payload exists.
             ValueError: If the stored payload is invalid.
         """
         with Session(self.engine) as session:
@@ -8629,7 +8626,6 @@ class SqlZenStore(BaseZenStore):
                 select(WebhookEventPayloadSchema).where(
                     col(WebhookEventPayloadSchema.webhook_id) == webhook_id,
                     col(WebhookEventPayloadSchema.delivery_id) == delivery_id,
-                    col(WebhookEventPayloadSchema.expires_at) > utc_now(),
                 )
             ).first()
         if schema is None:

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -468,6 +468,7 @@ from zenml.zen_stores.schemas import (
     TriggerSchema,
     TriggerSnapshotSchema,
     UserSchema,
+    WebhookEventPayloadSchema,
     WebhookSchema,
     WebhookStatsSchema,
 )
@@ -8556,6 +8557,91 @@ class SqlZenStore(BaseZenStore):
             if result.rowcount == 0:
                 raise KeyError(f"Webhook {webhook_id} not found.")
             session.commit()
+
+    def store_raw_webhook_event(
+        self,
+        webhook_id: UUID,
+        delivery_id: str,
+        body: Dict[str, Any],
+    ) -> None:
+        """Idempotently retain the raw body for a consumed webhook event.
+
+        The first writer wins when concurrent consumers try to retain the same
+        delivery.
+
+        Args:
+            webhook_id: The webhook ID.
+            delivery_id: The provider or ZenML delivery ID.
+            body: The parsed top-level JSON request body.
+
+        Raises:
+            IntegrityError: If persistence fails for a reason other than an
+                existing delivery.
+        """
+        payload = gzip.compress(
+            json.dumps({"body": body}, separators=(",", ":")).encode("utf-8")
+        )
+        created = utc_now()
+        schema = WebhookEventPayloadSchema(
+            webhook_id=webhook_id,
+            delivery_id=delivery_id,
+            created=created,
+            expires_at=created + timedelta(days=30),
+            payload=payload,
+        )
+        with Session(self.engine) as session:
+            session.add(schema)
+            try:
+                session.commit()
+            except IntegrityError as error:
+                session.rollback()
+                existing = session.exec(
+                    select(WebhookEventPayloadSchema).where(
+                        col(WebhookEventPayloadSchema.webhook_id)
+                        == webhook_id,
+                        col(WebhookEventPayloadSchema.delivery_id)
+                        == delivery_id,
+                    )
+                ).first()
+                if existing is None:
+                    raise error
+
+    def get_raw_webhook_event(
+        self,
+        webhook_id: UUID,
+        delivery_id: str,
+    ) -> Dict[str, Any]:
+        """Get an unexpired retained raw webhook event payload.
+
+        Args:
+            webhook_id: The webhook ID.
+            delivery_id: The provider or ZenML delivery ID.
+
+        Returns:
+            The extensible raw webhook event payload.
+
+        Raises:
+            KeyError: If no unexpired payload exists.
+            ValueError: If the stored payload is invalid.
+        """
+        with Session(self.engine) as session:
+            schema = session.exec(
+                select(WebhookEventPayloadSchema).where(
+                    col(WebhookEventPayloadSchema.webhook_id) == webhook_id,
+                    col(WebhookEventPayloadSchema.delivery_id) == delivery_id,
+                    col(WebhookEventPayloadSchema.expires_at) > utc_now(),
+                )
+            ).first()
+        if schema is None:
+            raise KeyError(
+                f"Raw webhook event {webhook_id}/{delivery_id} not found."
+            )
+        payload = json.loads(gzip.decompress(schema.payload).decode("utf-8"))
+        if not isinstance(payload, dict) or not isinstance(
+            payload.get("body"), dict
+        ):
+            raise ValueError("Invalid stored raw webhook event payload.")
+        return payload
 
     # -------------------- Triggers ---------------------
 

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -15,7 +15,7 @@
 
 import datetime
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 from uuid import UUID
 
 from zenml.config.pipeline_run_configuration import (
@@ -1912,6 +1912,25 @@ class ZenStoreInterface(ResourcePoolsStoreInterface, ABC):
 
         Returns:
             The newly active signing secret.
+        """
+
+    @abstractmethod
+    def get_raw_webhook_event(
+        self,
+        webhook_id: UUID,
+        delivery_id: str,
+    ) -> dict[str, Any]:
+        """Get a retained raw webhook event payload.
+
+        Args:
+            webhook_id: The webhook ID.
+            delivery_id: The provider or ZenML delivery ID.
+
+        Returns:
+            The extensible raw webhook event payload.
+
+        Raises:
+            KeyError: If no unexpired payload exists.
         """
 
     # -------------------- Triggers ---------------------

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -1930,7 +1930,7 @@ class ZenStoreInterface(ResourcePoolsStoreInterface, ABC):
             The extensible raw webhook event payload.
 
         Raises:
-            KeyError: If no unexpired payload exists.
+            KeyError: If no payload exists.
         """
 
     # -------------------- Triggers ---------------------

--- a/tests/integration/functional/webhooks/test_zen_store.py
+++ b/tests/integration/functional/webhooks/test_zen_store.py
@@ -11,6 +11,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
+import gzip
+from datetime import timedelta
+from uuid import uuid4
+
 import pytest
 from sqlalchemy import event
 from sqlmodel import Session, select
@@ -23,8 +27,10 @@ from zenml.models import (
     WebhookRotateSecretRequest,
     WebhookUpdate,
 )
+from zenml.utils.time_utils import utc_now
 from zenml.zen_stores.schemas.secret_schemas import SecretSchema
 from zenml.zen_stores.schemas.webhook_schemas import (
+    WebhookEventPayloadSchema,
     WebhookSchema,
 )
 from zenml.zen_stores.sql_zen_store import SqlZenStore
@@ -53,6 +59,8 @@ def test_client_webhook_methods_require_rest_store(
         clean_client.delete_webhook("webhook")
     with pytest.raises(TypeError, match=error):
         clean_client.rotate_webhook_secret("webhook")
+    with pytest.raises(TypeError, match=error):
+        clean_client.get_raw_webhook_event(uuid4(), "delivery-001")
 
 
 def test_zen_store_webhook_lifecycle(clean_client):
@@ -168,6 +176,66 @@ def test_zen_store_webhook_lifecycle(clean_client):
 
     with pytest.raises(KeyError):
         store.get_webhook(webhook.id)
+
+
+def test_raw_webhook_event_storage_is_idempotent_and_expires(clean_client):
+    """Raw event bodies are compressed, immutable, and hidden after expiry."""
+    store = clean_client.zen_store
+    if not isinstance(store, SqlZenStore):
+        pytest.skip("Local SQL store behavior is required for this test.")
+
+    webhook = store.create_webhook(
+        WebhookRequest(
+            project=clean_client.active_project.id,
+            name=sample_name("webhook-raw-event"),
+            webhook_type="custom",
+        )
+    )
+    delivery_id = "delivery-001"
+
+    try:
+        store.store_raw_webhook_event(
+            webhook_id=webhook.id,
+            delivery_id=delivery_id,
+            body={"message": "first"},
+        )
+        store.store_raw_webhook_event(
+            webhook_id=webhook.id,
+            delivery_id=delivery_id,
+            body={"message": "second"},
+        )
+
+        assert store.get_raw_webhook_event(
+            webhook_id=webhook.id,
+            delivery_id=delivery_id,
+        ) == {"body": {"message": "first"}}
+
+        with Session(store.engine) as session:
+            schema = session.exec(
+                select(WebhookEventPayloadSchema).where(
+                    WebhookEventPayloadSchema.webhook_id == webhook.id,
+                    WebhookEventPayloadSchema.delivery_id == delivery_id,
+                )
+            ).one()
+            assert gzip.decompress(schema.payload)
+            assert schema.expires_at - schema.created == timedelta(days=30)
+            schema.expires_at = utc_now() - timedelta(seconds=1)
+            session.add(schema)
+            session.commit()
+
+        with pytest.raises(KeyError):
+            store.get_raw_webhook_event(
+                webhook_id=webhook.id,
+                delivery_id=delivery_id,
+            )
+    finally:
+        store.delete_webhook(webhook.id)
+
+    with Session(store.engine) as session:
+        assert (
+            session.get(WebhookEventPayloadSchema, (webhook.id, delivery_id))
+            is None
+        )
 
 
 def test_sql_store_webhook_intake_config_contains_masked_secret(

--- a/tests/integration/functional/webhooks/test_zen_store.py
+++ b/tests/integration/functional/webhooks/test_zen_store.py
@@ -12,7 +12,6 @@
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 import gzip
-from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -27,7 +26,6 @@ from zenml.models import (
     WebhookRotateSecretRequest,
     WebhookUpdate,
 )
-from zenml.utils.time_utils import utc_now
 from zenml.zen_stores.schemas.secret_schemas import SecretSchema
 from zenml.zen_stores.schemas.webhook_schemas import (
     WebhookEventPayloadSchema,
@@ -178,8 +176,8 @@ def test_zen_store_webhook_lifecycle(clean_client):
         store.get_webhook(webhook.id)
 
 
-def test_raw_webhook_event_storage_is_idempotent_and_expires(clean_client):
-    """Raw event bodies are compressed, immutable, and hidden after expiry."""
+def test_raw_webhook_event_storage_is_idempotent(clean_client):
+    """Raw event bodies are compressed and immutable."""
     store = clean_client.zen_store
     if not isinstance(store, SqlZenStore):
         pytest.skip("Local SQL store behavior is required for this test.")
@@ -218,16 +216,6 @@ def test_raw_webhook_event_storage_is_idempotent_and_expires(clean_client):
                 )
             ).one()
             assert gzip.decompress(schema.payload)
-            assert schema.expires_at - schema.created == timedelta(days=30)
-            schema.expires_at = utc_now() - timedelta(seconds=1)
-            session.add(schema)
-            session.commit()
-
-        with pytest.raises(KeyError):
-            store.get_raw_webhook_event(
-                webhook_id=webhook.id,
-                delivery_id=delivery_id,
-            )
     finally:
         store.delete_webhook(webhook.id)
 

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -54,10 +54,12 @@ def test_trigger_execution_info_defaults_pipeline_lineage() -> None:
 
 def test_trigger_execution_info_parses_webhook_upstream_event() -> None:
     """Webhook trigger execution metadata keeps a dynamic provider event."""
+    webhook_id = uuid4()
     info = TriggerExecutionInfo.model_validate(
         {
             "webhook_upstream_event": {
                 "github": {
+                    "webhook_id": str(webhook_id),
                     "delivery_id": "delivery-001",
                     "event": {
                         "type": "push",
@@ -71,12 +73,37 @@ def test_trigger_execution_info_parses_webhook_upstream_event() -> None:
 
     assert info.webhook_upstream_event == {
         "github": WebhookTriggerExecutionInfo(
+            webhook_id=webhook_id,
             delivery_id="delivery-001",
             event={
                 "type": "push",
                 "repo": "zenml-io/zenml",
                 "commit": None,
             },
+        )
+    }
+
+
+def test_trigger_execution_info_allows_missing_semantic_event() -> None:
+    """Custom webhook runs still carry a complete raw payload locator."""
+    webhook_id = uuid4()
+
+    info = TriggerExecutionInfo.model_validate(
+        {
+            "webhook_upstream_event": {
+                "custom": {
+                    "webhook_id": str(webhook_id),
+                    "delivery_id": "delivery-001",
+                }
+            }
+        }
+    )
+
+    assert info.webhook_upstream_event == {
+        "custom": WebhookTriggerExecutionInfo(
+            webhook_id=webhook_id,
+            delivery_id="delivery-001",
+            event=None,
         )
     }
 

--- a/tests/unit/utils/test_trigger_utils.py
+++ b/tests/unit/utils/test_trigger_utils.py
@@ -43,10 +43,12 @@ def test_list_supported_events():
 
 def test_get_webhook_upstream_event_returns_plain_dict() -> None:
     """Webhook event helper hides the typed trigger execution structure."""
+    webhook_id = uuid4()
     run = Mock()
     run.trigger_execution_info = TriggerExecutionInfo(
         webhook_upstream_event={
             "github": WebhookTriggerExecutionInfo(
+                webhook_id=webhook_id,
                 delivery_id="delivery-001",
                 event={"type": "push", "commit": None},
             )
@@ -57,10 +59,55 @@ def test_get_webhook_upstream_event_returns_plain_dict() -> None:
 
     assert result == {
         "github": {
+            "webhook_id": str(webhook_id),
             "delivery_id": "delivery-001",
             "event": {"type": "push", "commit": None},
         }
     }
+
+
+def test_get_raw_webhook_event_resolves_locator() -> None:
+    """Raw event helper resolves the webhook and delivery IDs from the run."""
+    webhook_id = uuid4()
+    run = Mock()
+    run.trigger_execution_info = TriggerExecutionInfo(
+        webhook_upstream_event={
+            "custom": WebhookTriggerExecutionInfo(
+                webhook_id=webhook_id,
+                delivery_id="delivery-001",
+            )
+        }
+    )
+    client = Mock()
+    client.get_raw_webhook_event.return_value = {"body": {"message": "hello"}}
+
+    with patch.object(trigger_utils, "Client", return_value=client):
+        result = trigger_utils.get_raw_webhook_event(pipeline_run=run)
+
+    assert result == {"body": {"message": "hello"}}
+    client.get_raw_webhook_event.assert_called_once_with(
+        webhook_id=webhook_id,
+        delivery_id="delivery-001",
+    )
+
+
+def test_get_raw_webhook_event_returns_none_when_payload_is_missing() -> None:
+    """An absent or expired raw event is exposed as no payload."""
+    run = Mock()
+    run.trigger_execution_info = TriggerExecutionInfo(
+        webhook_upstream_event={
+            "github": WebhookTriggerExecutionInfo(
+                webhook_id=uuid4(),
+                delivery_id="delivery-001",
+                event={"type": "push"},
+            )
+        }
+    )
+    client = Mock()
+    client.get_raw_webhook_event.side_effect = KeyError("missing")
+
+    with patch.object(trigger_utils, "Client", return_value=client):
+        assert trigger_utils.get_raw_webhook_event(pipeline_run=run) is None
 
 
 def test_get_webhook_upstream_event_uses_current_run() -> None:

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -851,6 +851,18 @@ def test_clickup_parse_extracts_event_and_history_delivery_id() -> None:
     assert parsed.payload["task_id"] == "abc"
 
 
+def test_clickup_parse_defers_ambiguous_delivery_id_to_intake() -> None:
+    """History-less ClickUp events receive a unique ID at intake."""
+    provider = ClickUpWebhookProvider()
+
+    parsed = provider.parse(
+        body=(b'{"event":"taskDeleted","webhook_id":"wh-1","task_id":"abc"}'),
+        headers={},
+    )
+
+    assert parsed.delivery_id is None
+
+
 def test_clickup_parse_rejects_missing_event_or_webhook_id() -> None:
     """ClickUp parsing requires event and webhook_id in the JSON body."""
     provider = ClickUpWebhookProvider()

--- a/tests/unit/zen_server/endpoints/test_webhook_endpoints.py
+++ b/tests/unit/zen_server/endpoints/test_webhook_endpoints.py
@@ -15,6 +15,7 @@
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -33,6 +34,7 @@ from zenml.webhooks import (
     WebhookPayloadError,
 )
 from zenml.webhooks.providers.github import GitHubWebhookProvider
+from zenml.zen_server.rbac.models import Action
 from zenml.zen_server.routers import webhook_endpoints as endpoints
 
 
@@ -42,6 +44,34 @@ def test_webhook_routers_use_public_webhook_prefix() -> None:
 
     assert endpoints.management_router.prefix == expected_prefix
     assert endpoints.intake_router.prefix == expected_prefix
+
+
+def test_get_raw_webhook_event_inherits_webhook_read_permission(
+    monkeypatch,
+) -> None:
+    """Raw payload reads authorize against their owning webhook."""
+    webhook_id = uuid4()
+    webhook = SimpleNamespace(id=webhook_id)
+    store = Mock()
+    store.get_webhook.return_value = webhook
+    store.get_raw_webhook_event.return_value = {"body": {"action": "push"}}
+    verify = Mock()
+    monkeypatch.setattr(endpoints, "zen_store", lambda: store)
+    monkeypatch.setattr(endpoints, "verify_permission_for_model", verify)
+
+    result = endpoints.get_raw_webhook_event.__wrapped__(
+        webhook_id=webhook_id,
+        delivery_id="delivery/with/provider/characters",
+        _=Mock(),
+    )
+
+    assert result == {"body": {"action": "push"}}
+    store.get_webhook.assert_called_once_with(webhook_id, hydrate=False)
+    verify.assert_called_once_with(model=webhook, action=Action.READ)
+    store.get_raw_webhook_event.assert_called_once_with(
+        webhook_id=webhook_id,
+        delivery_id="delivery/with/provider/characters",
+    )
 
 
 def test_unknown_webhook_provider_is_hidden_before_body_read() -> None:
@@ -369,3 +399,35 @@ def test_control_delivery_returns_provider_response_without_dispatch(
     assert response.background is None
     assert len(store.records) == 1
     assert store.records[0][1].accepted is True
+
+
+def test_receive_webhook_event_generates_missing_delivery_id(
+    monkeypatch,
+) -> None:
+    """Accepted events always receive a stable lookup ID before dispatch."""
+    webhook_id = uuid4()
+    store = _Store(webhook=SimpleNamespace(webhook_type="custom", active=True))
+    provider = _Provider()
+    original_parse = provider.parse_delivery
+
+    def parse_without_delivery_id(body, headers):
+        parsed = original_parse(body, headers)
+        if parsed.event is not None:
+            parsed.event.delivery_id = None
+        return parsed
+
+    provider.parse_delivery = parse_without_delivery_id
+    _install_dependencies(monkeypatch, store, provider)
+    handler = _Handler()
+    dispatcher = EventDispatcher()
+    dispatcher.register_event_handler(handler)
+
+    try:
+        response = _receive(webhook_id)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.background is not None
+        asyncio.run(response.background())
+        assert len(handler.events) == 1
+        assert handler.events[0].delivery_id is not None
+    finally:
+        dispatcher.unregister_event_handler(handler)

--- a/tests/unit/zen_stores/test_rest_zen_store.py
+++ b/tests/unit/zen_stores/test_rest_zen_store.py
@@ -23,6 +23,7 @@ from zenml.models import WebhookTriggerUpdate
 from zenml.zen_stores.rest_zen_store import (
     ARTIFACT_VERSIONS,
     TRIGGERS,
+    WEBHOOKS,
     RestZenStore,
     RestZenStoreConfiguration,
 )
@@ -125,4 +126,25 @@ def test_webhook_trigger_updates_use_full_serialization(
         body=trigger_update,
         params=None,
         exclude_unset=False,
+    )
+
+
+def test_get_raw_webhook_event_uses_delivery_query_parameter(
+    mocker: MockerFixture,
+) -> None:
+    """Provider delivery IDs are not interpolated into URL path segments."""
+    store = mocker.Mock()
+    webhook_id = uuid4()
+    store.get.return_value = {"body": {"message": "hello"}}
+
+    result = RestZenStore.get_raw_webhook_event(
+        store,
+        webhook_id=webhook_id,
+        delivery_id="provider/id:with,characters",
+    )
+
+    assert result == {"body": {"message": "hello"}}
+    store.get.assert_called_once_with(
+        f"{WEBHOOKS}/{webhook_id}/events/raw",
+        params={"delivery_id": "provider/id:with,characters"},
     )


### PR DESCRIPTION
## Describe changes

Webhook-triggered pipeline runs can now access the original JSON request body through the new get_raw_webhook_event() utility. Payloads are stored only when a webhook trigger matches and protected by the same read permissions as the associated webhook. This allows downstream steps to use provider data omitted from the normalized event, such as pull-request descriptions or message contents.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

