### PR TITLE
Return Kubernetes release quickstart to GitHub-hosted runners

### DIFF
--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -198,6 +198,7 @@ jobs:
           - cloud: aws
           - cloud: azure
           - cloud: gcp
+          - cloud: kubernetes_aws
     steps:
       - name: Free disk space
         run: |
@@ -226,32 +227,6 @@ jobs:
         run: |
           scripts/qs_run_release_flow.sh \
             --cloud "${{ matrix.cloud }}" \
-            --new-version "${NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION}"
-        env:
-          NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION: ${{ needs.fetch-versions.outputs.new_version }}
-  run_kubernetes_aws_quickstart:
-    needs: [fetch-versions, setup-prep-release-tenant]
-    runs-on: codebuild-release-qs-${{ github.run_id }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-    env:
-      ZENML_STORE_URL: ${{ secrets.RELEASE_TENANT_URL }}
-      ZENML_STORE_API_KEY: ${{ secrets.RELEASE_TENANT_SERVICE_ACCOUNT_KEY }}
-      ZENML_ACTIVE_PROJECT_ID: ${{ secrets.RELEASE_TENANT_PROJECT_ID }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: '3.12'
-      - name: Install ZenML
-        run: scripts/install-zenml-dev.sh --system --integrations "no"
-      - name: Run Quickstart release flow on kubernetes_aws
-        run: |
-          scripts/qs_run_release_flow.sh \
-            --cloud kubernetes_aws \
             --new-version "${NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION}"
         env:
           NEEDS_FETCH_VERSIONS_OUTPUTS_NEW_VERSION: ${{ needs.fetch-versions.outputs.new_version }}


### PR DESCRIPTION
## Summary

- Revert #5189 and return the `kubernetes_aws` release quickstart to the existing `ubuntu-latest` matrix job.
- Remove the dedicated `codebuild-release-qs-*` workflow job.
- Keep the AWS, Azure, GCP, and Kubernetes quickstarts on the same release-validation path again.

## Why

PR #5189 introduced a private CodeBuild-hosted runner because GitHub-hosted runners could not reach the staging EKS API. That network constraint is removed by [zenml-cloud-infra #253](https://github.com/zenml-io/zenml-cloud-infra/pull/253), which makes the staging EKS API publicly reachable while keeping AWS IAM and EKS access policies as the authorization boundary.

The dedicated runner is therefore no longer needed for the Kubernetes release quickstart.

## Rollout dependency

Infrastructure PR #253 is merged. Before this PR is marked ready or merged, verify its Terraform change has also been applied and that an authorized client can reach the staging EKS API without VPN.

## Reviewer focus

- `kubernetes_aws` is restored only to the existing `run_quickstart_pipelines` matrix.
- The shared job preserves the same release tenant secrets, ZenML installation, version input, and quickstart script invocation.
- The only removed behavior is routing this lane through the `release-qs` CodeBuild runner.

## Validation

- `yamlfix --check .github/workflows/release_prepare.yml`
- `zizmor .github/workflows/release_prepare.yml` reports no findings beyond 8 existing suppressions.
- Ruby YAML parsing.
- `bash -n scripts/qs_run_release_flow.sh`
- `git diff --check origin/develop...HEAD`

No live release-preparation workflow was run. The required acceptance test is a successful `kubernetes_aws` lane on a GitHub-hosted runner after #253 is applied.
