### PR TITLE
Fix edge cases in the software factory fix loop

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -35,7 +35,7 @@ issue ──▶ write_plan ──▶ [plan_review] ──▶ open_workspace ─�
 | `close_workspace` | attach | Destroys the shared session | |
 | `deploy` | own session | Marks the pull request ready for review, a stand-in for a real deployment | |
 
-The loop over `run_tests`, `review` and `fix` runs at most `max_fix_iterations` times and stops early on an approved review.
+The loop over `run_tests`, `review` and `fix` runs at most `max_fix_iterations` times (must be at least 1) and stops early on an approved review. If the loop runs out of attempts and the last thing that happened was a `fix`, the tests are run one more time as `run_tests_final` so the deploy approval reflects the branch as it stands after that last fix.
 
 ## 📋 Prerequisites
 
@@ -127,7 +127,7 @@ python run.py \
 The run prints a dashboard URL. It stops twice for you:
 
 1. `plan_review` after the plan is written. The plan is attached to the wait condition. Answer with `{"approved": true, "feedback": ""}` to continue, `approved: false` ends the run.
-2. `deploy_approval` after the loop settles. The wait condition carries the pull request URL, the last test report and the last review verdict. Answer `true` to mark the pull request ready for review.
+2. `deploy_approval` after the loop settles. The wait condition carries the pull request URL, the last test report and the last review verdict. If the loop was exhausted on a `fix`, "last test report" is the `run_tests_final` report from after that fix, not the report from before it. Answer `true` to mark the pull request ready for review.
 
 Resolve them in the dashboard or from the CLI:
 
@@ -232,9 +232,10 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+`max_fix_iterations` must be at least 1 — the loop has to run at least once to produce a test report for the deploy approval, so the pipeline validates this and raises before doing any work otherwise. Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. The loop's `else` clause only runs when every attempt was used up without an `approved` review ever `break`-ing out of it, i.e. when the last thing that happened was a `fix`. It re-runs the tests as `run_tests_final` so `tests` reflects the branch after that fix instead of the stale pre-fix report:
 
 ```python
+verdict = None
 for attempt in range(max_fix_iterations):
     tests = run_tests(..., id=f"run_tests_{attempt}")
     verdict = None
@@ -243,6 +244,8 @@ for attempt in range(max_fix_iterations):
         if verdict.load().approved:
             break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    tests = run_tests(..., id="run_tests_final")
 ```
 
 ### The agent result-file contract

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -374,7 +374,17 @@ def software_factory(
             Tests are skipped if unset.
         max_fix_iterations: The maximum number of test and review fix
             iterations.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
     """
+    if max_fix_iterations < 1:
+        raise ValueError(
+            "`max_fix_iterations` must be at least 1; the test, review and "
+            "fix loop needs to run at least once to produce a test report "
+            "for the deploy approval."
+        )
+
     plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
     plan_review = wait(
         schema=Review,
@@ -429,6 +439,19 @@ def software_factory(
             base_branch=base_branch,
             verdict=verdict,
             id=f"fix_{attempt}",
+        )
+    else:
+        # Every attempt was used up without hitting the `break` above, so
+        # the last thing that happened on the branch was a `fix()` call.
+        # Re-run the tests so the deploy_approval metadata reflects the
+        # branch as it stands after that last fix, not the report from
+        # before it.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
         )
     close_workspace(workspace=workspace)
 

--- a/spec/plans/factory-fix-loop-edge-cases.md
+++ b/spec/plans/factory-fix-loop-edge-cases.md
@@ -1,0 +1,241 @@
+# Fix edge cases in the software factory fix loop
+
+## Root cause
+
+Both bugs live in the `software_factory` dynamic pipeline function in
+`examples/software_factory/pipeline.py` (lines ~400-445), specifically in the
+`for attempt in range(max_fix_iterations): ...` loop and the metadata built
+for the `deploy_approval` wait condition right after it.
+
+1. **`NameError` when `max_fix_iterations=0`.** `tests` is only ever assigned
+   inside the loop body (`tests = run_tests(...)`, line 402). `verdict` is
+   pre-initialized to `None` before the loop (line 400), but `tests` is not.
+   When `max_fix_iterations` is `0`, `range(0)` is empty, the loop body never
+   runs, and `tests` stays unbound. Execution reaches
+   `metadata = {"pr_url": pr_result.url, "tests": tests.load().model_dump()}`
+   (line 436) and raises `NameError: name 'tests' is not defined`.
+
+2. **Stale test report when the loop exhausts on a `fix`.** Inside each
+   iteration, `fix(...)` runs whenever the iteration does *not* `break` (i.e.
+   whenever tests failed, or tests passed but the review wasn't approved).
+   `break` is the only way to skip `fix` in a given iteration. So if the loop
+   runs out of attempts without ever hitting `break`, the very last thing
+   that happened on the branch is a `fix()` call — but the `tests` variable
+   still holds the report from *before* that fix (either a failing run, or a
+   passing run whose review was rejected). The `deploy_approval` wait
+   condition (line 439) then shows a test report that doesn't reflect what's
+   actually on the branch, which is misleading for whoever has to decide
+   whether to deploy.
+
+The issue text allows either fixing the metadata construction to tolerate a
+missing `tests`/`verdict`, or requiring `max_fix_iterations >= 1`. This plan
+picks explicit validation: `max_fix_iterations=0` disables the entire
+test/review/fix loop, which silently changes the meaning of the pipeline
+(nothing gets tested or reviewed before the deploy prompt) rather than being
+a meaningful "run with zero iterations" configuration. A clear, fail-fast
+error is more honest than quietly tolerating `None` tests/verdict in the
+metadata. This also composes cleanly with the fix for bug 2 below (see the
+`for...else` construct), which relies on the loop having run at least once.
+
+## Code changes (`examples/software_factory/pipeline.py`)
+
+### 1. Validate `max_fix_iterations` up front
+
+Add a guard as the first statement in `software_factory`, before
+`write_plan` is called, so a misconfigured run fails immediately instead of
+after burning a plan-writing agent call and a human plan approval:
+
+```python
+def software_factory(
+    repo: str,
+    issue: str,
+    target_branch: str,
+    base_branch: Optional[str] = None,
+    test_command: Optional[str] = None,
+    max_fix_iterations: int = 3,
+) -> None:
+    """Drive a GitHub issue through plan, implement, test and review.
+
+    Args:
+        repo: The repository to work in, `owner/name`.
+        issue: The issue description.
+        target_branch: The branch to work on. Created from the base branch
+            if it does not exist, checked out if it does.
+        base_branch: The branch to create `target_branch` from and to open
+            the pull request against. The repository's default branch if
+            unset.
+        test_command: Shell command that runs the tests in the checkout.
+            Tests are skipped if unset.
+        max_fix_iterations: The maximum number of test and review fix
+            iterations.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
+    """
+    if max_fix_iterations < 1:
+        raise ValueError(
+            "`max_fix_iterations` must be at least 1; the test, review and "
+            "fix loop needs to run at least once to produce a test report "
+            "for the deploy approval."
+        )
+
+    plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
+    ...
+```
+
+(Only the `Raises` section is added to the docstring; `Args` is unchanged.)
+
+### 2. Refresh the test report when the loop exhausts on a `fix`
+
+Replace the `for` loop with a `for...else` (Python runs the `else` block only
+when the loop completes without `break` — which, now that
+`max_fix_iterations >= 1` is guaranteed, means the last thing that happened
+was an unconditional `fix()` call):
+
+```python
+    verdict = None
+    for attempt in range(max_fix_iterations):
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id=f"run_tests_{attempt}",
+        )
+        verdict = None
+        if tests.load().passed:
+            verdict = review(
+                workspace=workspace,
+                repo=repo,
+                branch=target_branch,
+                issue=issue,
+                plan=plan,
+                tests=tests,
+                base_branch=base_branch,
+                id=f"review_{attempt}",
+            )
+            if verdict.load().approved:
+                break
+        pr = fix(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            issue=issue,
+            tests=tests,
+            base_branch=base_branch,
+            verdict=verdict,
+            id=f"fix_{attempt}",
+        )
+    else:
+        # Every attempt was used up and the last one ended with `fix`
+        # (the only way to leave the loop without hitting `break` above).
+        # Re-run the tests so the deploy_approval metadata reflects the
+        # branch as it stands after that last fix, not the report from
+        # before it.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
+        )
+    close_workspace(workspace=workspace)
+```
+
+Notes:
+- `verdict` is intentionally left as-is in the `else` branch (whatever the
+  last iteration set it to, possibly `None`). The issue only asks to refresh
+  the test report, not to force another review — re-reviewing would add a
+  new agent call and iteration semantics that aren't part of this fix.
+- The rest of the function (`close_workspace` onward, metadata construction,
+  `deploy_approval` wait) needs no changes: `tests` is now always bound by
+  the time it's read.
+- No new imports or dependencies are needed.
+
+## README changes (`examples/software_factory/README.md`)
+
+1. In the "🔁 The Flow" intro paragraph (around line 38: *"The loop over
+   `run_tests`, `review` and `fix` runs at most `max_fix_iterations` times
+   and stops early on an approved review."*), add a sentence noting that
+   `max_fix_iterations` must be at least 1, and that if the loop runs out of
+   attempts on a `fix`, the tests are re-run once more (`run_tests_final`)
+   before the deploy approval.
+2. Update the "Bounded fix loop with deterministic step ids" section
+   (currently lines 233-246) to show the `for...else` shape with
+   `run_tests_final`, matching the new code in `pipeline.py`.
+3. In the `deploy_approval` bullet under "🏃 Run It" (line 130: *"The wait
+   condition carries the pull request URL, the last test report and the last
+   review verdict."*), clarify that "last test report" means the report from
+   `run_tests_final` when the loop was exhausted on a fix.
+
+## Tests to add
+
+`examples/software_factory/pipeline.py` has no existing automated test
+coverage — end-to-end execution needs a live sandbox, the `claude` CLI and a
+real GitHub repo/token, which is why the codebase's testing guidance
+(exception for code integrating with external services) applies here. But
+both bugs are pure Python control flow in the pipeline body, independent of
+what the individual steps do internally, so they can be covered with a
+hermetic unit test that swaps in fake step implementations:
+
+1. Add `tests/unit/examples/software_factory/test_pipeline.py` (with the
+   necessary `__init__.py` files, or a local `conftest.py`, mirroring the
+   structure ZenML already uses for dynamic-pipeline tests in
+   `tests/unit/execution/pipeline/dynamic/`).
+2. Because `pipeline.py` uses bare imports (`from factory_utils import ...`,
+   `from models import ...`) that only resolve when
+   `examples/software_factory` is on `sys.path`, load it in the test via
+   `importlib.util.spec_from_file_location` under a private module name
+   (e.g. `_software_factory_pipeline_under_test`) with
+   `monkeypatch.syspath_prepend("examples/software_factory")` scoped to the
+   import, and restore `sys.path`/`sys.modules` afterwards. This avoids
+   polluting the shared pytest process with generically-named modules like
+   `models` or `factory_utils` that could collide with other examples.
+3. After loading the module, monkeypatch every sandbox/GitHub/agent helper
+   it imported (`active_sandbox`, `attach_sandbox`, `attach_or_recreate`,
+   `branch_exists`, `clone_repo`, `commit_all`, `destroy_workspace_hook`,
+   `github_token`, `open_pr`, `plan_path`, `pr_body`, `push_branch`,
+   `read_repo_file`, `resolve_base_branch`, `run_agent`, `run_command`,
+   `run_url`, `write_repo_file`) plus `wait` (from `zenml`) with lightweight
+   fakes: `write_plan`/`open_workspace`/`implement` just need to return
+   trivial values so the pipeline reaches the loop, and `wait` should
+   auto-approve the `plan_review` schema so the run doesn't block.
+4. Test cases:
+   - `test_zero_max_fix_iterations_raises`: call the loaded
+     `software_factory(..., max_fix_iterations=0)` and assert it raises
+     `ValueError` before any step runs (no sandbox/agent fakes are even
+     invoked — this is a good smoke test that the guard fires first).
+   - `test_loop_exhausted_on_fix_reruns_tests`: monkeypatch the module's
+     `run_tests`/`fix`/`review` step-equivalents (or drive `test_command`
+     handling through a fake `run_command` that always returns a failing
+     exit code) so every iteration fails tests and never gets an approved
+     review; run with e.g. `max_fix_iterations=2`; assert the resulting
+     `PipelineRunResponse.steps` contains a `run_tests_final` step whose
+     recorded output matches the fake "final" test result, and that its
+     upstream is `fix_1` (the last iteration's fix).
+   - `test_loop_breaks_early_on_approval`: make the first iteration's tests
+     pass and review get approved; assert the loop exits via `break`, that
+     `run_tests_final` is *not* present in `run.steps`, and that the
+     `deploy_approval` wait's metadata carries the `tests`/`verdict` from
+     `attempt=0`.
+5. Follow the existing pattern in
+   `tests/unit/execution/pipeline/dynamic/test_sync_step_chaining.py` for
+   asserting on `run.steps[...].spec.upstream_steps` and step presence.
+
+## Manual verification (since full end-to-end coverage needs live infra)
+
+Per the project's testing guidance for code that integrates with external
+services, verify locally against a scratch repo before merging:
+
+1. `python run.py --max-fix-iterations 0 ...` — should fail immediately with
+   the new `ValueError` message, before any sandbox session is created (the
+   guard runs before `write_plan`).
+2. `python run.py --max-fix-iterations 1 --test-command "exit 1" ...` (a
+   test command that always fails) — the loop should exhaust after one
+   attempt ending in `fix`, and the run should show a `run_tests_final` step
+   after the last `fix_0` step; the `deploy_approval` wait's metadata `tests`
+   field should match that final run's report, not the pre-fix one.
+3. `python run.py --max-fix-iterations 2 --test-command "true" ...` with a
+   review that approves on the first attempt — confirm the loop still stops
+   early via `break` and no `run_tests_final` step is created (unchanged
+   behavior).

--- a/tests/unit/examples/__init__.py
+++ b/tests/unit/examples/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/examples/software_factory/__init__.py
+++ b/tests/unit/examples/software_factory/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/examples/software_factory/test_pipeline.py
+++ b/tests/unit/examples/software_factory/test_pipeline.py
@@ -1,0 +1,291 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the test/review/fix loop edge cases in the software factory
+example pipeline (examples/software_factory/pipeline.py).
+
+The pipeline needs a live sandbox, the `claude` CLI and a real GitHub
+repo/token to run end to end, so these tests load the module directly from
+the example directory and replace every sandbox/GitHub/agent helper it uses
+with lightweight fakes, exercising only the pure Python control flow of the
+`software_factory` dynamic pipeline body.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Optional
+
+import pytest
+
+from zenml.client import Client
+
+EXAMPLE_DIR = (
+    Path(__file__).resolve().parents[4] / "examples" / "software_factory"
+)
+MODULE_NAME = "_software_factory_pipeline_under_test"
+
+
+@pytest.fixture
+def pipeline_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[Any]:
+    """Load `examples/software_factory/pipeline.py` as an isolated module."""
+    # The `github`/`claude` secrets referenced by `secrets=[...]` on the
+    # steps only need to exist for step compilation to succeed; their
+    # values are never read because every helper that would use them is
+    # replaced with a fake.
+    client = Client()
+    for secret_name in ("github", "claude"):
+        try:
+            client.get_secret(secret_name)
+        except KeyError:
+            client.create_secret(name=secret_name, values={"token": "fake"})
+
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    spec = importlib.util.spec_from_file_location(
+        MODULE_NAME, EXAMPLE_DIR / "pipeline.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(MODULE_NAME, None)
+        sys.modules.pop("factory_utils", None)
+        sys.modules.pop("models", None)
+
+
+class FakeSession:
+    """Stand-in for `zenml.sandboxes.SandboxSession`."""
+
+    def __init__(self, id: str = "session") -> None:
+        self.id = id
+
+    def close(self) -> None:
+        pass
+
+    def destroy(self) -> None:
+        pass
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        pass
+
+
+class FakeSandbox:
+    """Stand-in for `zenml.sandboxes.BaseSandbox`."""
+
+    def create_session(self, destroy_on_exit: bool = False) -> FakeSession:
+        return FakeSession()
+
+
+class FakeOutput:
+    """Stand-in for `zenml.sandboxes.SandboxOutput`."""
+
+    def __init__(
+        self, stdout: str = "", stderr: str = "", exit_code: int = 0
+    ) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+
+
+def _make_fake_run_command(test_exit_code: int) -> Callable[..., FakeOutput]:
+    """Fake `run_command` that only cares about the `run_tests` test command."""
+
+    def fake_run_command(
+        session: FakeSession,
+        command: Any,
+        cwd: Optional[str] = "repo",
+        env: Optional[Dict[str, str]] = None,
+        check: bool = True,
+    ) -> FakeOutput:
+        if command[:2] == ["bash", "-lc"]:
+            return FakeOutput(stdout="test output", exit_code=test_exit_code)
+        return FakeOutput(exit_code=0)
+
+    return fake_run_command
+
+
+def _make_fake_read_repo_file(review_approved: bool) -> Callable[..., str]:
+    def fake_read_repo_file(session: FakeSession, path: str) -> str:
+        if path.endswith("plan.md"):
+            return "plan body"
+        if path.endswith("summary.md"):
+            return "summary body"
+        if path.endswith("review.json"):
+            return json.dumps({"approved": review_approved, "comments": []})
+        raise AssertionError(f"unexpected read_repo_file path: {path}")
+
+    return fake_read_repo_file
+
+
+def _make_fake_wait(
+    module: Any, captured_metadata: Dict[str, Any]
+) -> Callable[..., Any]:
+    def fake_wait(
+        schema: Any = None,
+        question: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if name == "plan_review":
+            return module.Review(approved=True, feedback="")
+        if name == "deploy_approval":
+            captured_metadata.update(metadata or {})
+            return False
+        raise AssertionError(f"unexpected wait condition: {name}")
+
+    return fake_wait
+
+
+def _install_fakes(
+    module: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    test_exit_code: int,
+    review_approved: bool,
+    captured_metadata: Dict[str, Any],
+) -> None:
+    monkeypatch.setattr(module, "active_sandbox", lambda: FakeSandbox())
+    monkeypatch.setattr(
+        module, "attach_sandbox", lambda workspace: FakeSession(workspace)
+    )
+    monkeypatch.setattr(
+        module,
+        "attach_or_recreate",
+        lambda workspace, repo, branch: FakeSession(workspace),
+    )
+    monkeypatch.setattr(module, "branch_exists", lambda session, branch: False)
+    monkeypatch.setattr(
+        module, "clone_repo", lambda session, repo, ref=None: None
+    )
+    monkeypatch.setattr(module, "commit_all", lambda session, message: True)
+    monkeypatch.setattr(module, "github_token", lambda: "fake-token")
+    monkeypatch.setattr(
+        module,
+        "open_pr",
+        lambda session, repo, branch, base, title, body: module.PRRef(
+            url="https://github.com/example/repo/pull/1", number=1
+        ),
+    )
+    monkeypatch.setattr(
+        module, "plan_path", lambda branch: f"spec/plans/{branch}.md"
+    )
+    monkeypatch.setattr(module, "pr_body", lambda summary, branch, run: "body")
+    monkeypatch.setattr(module, "push_branch", lambda session, branch: None)
+    monkeypatch.setattr(
+        module, "read_repo_file", _make_fake_read_repo_file(review_approved)
+    )
+    monkeypatch.setattr(
+        module,
+        "resolve_base_branch",
+        lambda session, repo, base_branch: base_branch or "main",
+    )
+    monkeypatch.setattr(
+        module, "run_agent", lambda session, prompt, cwd="repo": "ok"
+    )
+    monkeypatch.setattr(
+        module, "run_command", _make_fake_run_command(test_exit_code)
+    )
+    monkeypatch.setattr(module, "run_url", lambda: None)
+    monkeypatch.setattr(
+        module, "write_repo_file", lambda session, path, content: None
+    )
+    monkeypatch.setattr(
+        module, "wait", _make_fake_wait(module, captured_metadata)
+    )
+
+
+def test_zero_max_fix_iterations_raises(pipeline_module: Any) -> None:
+    """`max_fix_iterations=0` must fail fast, before any step runs."""
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        pipeline_module.software_factory(
+            repo="example/repo",
+            issue="Some issue",
+            target_branch="fix-branch",
+            max_fix_iterations=0,
+        )
+
+
+def test_loop_exhausted_on_fix_reruns_tests(
+    pipeline_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If every attempt ends in `fix`, the tests are re-run once more."""
+    captured_metadata: Dict[str, Any] = {}
+    _install_fakes(
+        pipeline_module,
+        monkeypatch,
+        test_exit_code=1,
+        review_approved=False,
+        captured_metadata=captured_metadata,
+    )
+
+    run = pipeline_module.software_factory(
+        repo="example/repo",
+        issue="Some issue",
+        target_branch="fix-branch",
+        test_command="pytest",
+        max_fix_iterations=2,
+    )
+
+    assert "run_tests_final" in run.steps
+    # `open_workspace` is an explicit data dependency (the `workspace` param);
+    # `fix_1` is the implicit dependency on the last synchronous step call.
+    assert sorted(run.steps["run_tests_final"].spec.upstream_steps) == [
+        "fix_1",
+        "open_workspace",
+    ]
+    assert "fix_0" in run.steps
+    assert "fix_1" in run.steps
+    assert "review_0" not in run.steps
+    assert "review_1" not in run.steps
+
+    assert captured_metadata["tests"]["passed"] is False
+    assert "verdict" not in captured_metadata
+
+
+def test_loop_breaks_early_on_approval(
+    pipeline_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An approved review on the first attempt stops the loop via `break`."""
+    captured_metadata: Dict[str, Any] = {}
+    _install_fakes(
+        pipeline_module,
+        monkeypatch,
+        test_exit_code=0,
+        review_approved=True,
+        captured_metadata=captured_metadata,
+    )
+
+    run = pipeline_module.software_factory(
+        repo="example/repo",
+        issue="Some issue",
+        target_branch="fix-branch",
+        test_command="pytest",
+        max_fix_iterations=2,
+    )
+
+    assert "run_tests_0" in run.steps
+    assert "review_0" in run.steps
+    assert "fix_0" not in run.steps
+    assert "run_tests_1" not in run.steps
+    assert "run_tests_final" not in run.steps
+
+    assert captured_metadata["tests"]["passed"] is True
+    assert captured_metadata["verdict"]["approved"] is True


### PR DESCRIPTION
## Summary

- Added a guard at the top of `software_factory` (`examples/software_factory/pipeline.py`) that raises `ValueError` when `max_fix_iterations < 1`, before `write_plan` runs, so the loop-required `tests`/`verdict` metadata is never built from an unbound `tests` variable.
- Turned the `for attempt in range(max_fix_iterations): ...` loop into a `for...else`: the `else` clause (which only runs when the loop exhausts without a `break`, i.e. the last thing that happened was a `fix()` call) re-runs `run_tests` with `id="run_tests_final"` so the `deploy_approval` metadata reflects the branch as it stands after the last fix instead of a stale pre-fix report.
- Updated `examples/software_factory/README.md`: the flow intro paragraph, the `deploy_approval` bullet under "Run It", and the "Bounded fix loop with deterministic step ids" section now describe the `max_fix_iterations >= 1` requirement and the `run_tests_final` re-run.
- Added `tests/unit/examples/software_factory/test_pipeline.py`, a hermetic unit test that loads `pipeline.py` via `importlib` (with `examples/software_factory` prepended to `sys.path`) and monkeypatches every sandbox/GitHub/agent helper plus `zenml.wait` with lightweight fakes, covering: `max_fix_iterations=0` raising `ValueError` before any step runs, the loop exhausting on repeated `fix`es and producing a `run_tests_final` step (upstream of `fix_1` and `open_workspace`) with tests metadata reflecting the post-fix state and no `verdict` key, and an early `break` on an approved first-attempt review leaving no `run_tests_final` step.

Plan: `spec/plans/factory-fix-loop-edge-cases.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/06a5f509-cbc9-4d0c-993d-fd091b163572
