### PR TITLE
Fix edge cases in the software factory fix loop

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -232,7 +232,7 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. `max_fix_iterations` must be `>= 1`; smaller values raise a `ValueError` before any workspace is created. If the loop exhausts its iterations without an approved review, the last action taken was an untested `fix`, so tests are re-run once more (`id="run_tests_final"`) so the `deploy_approval` metadata reflects the branch's final state rather than a pre-fix report:
 
 ```python
 for attempt in range(max_fix_iterations):
@@ -243,6 +243,8 @@ for attempt in range(max_fix_iterations):
         if verdict.load().approved:
             break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    tests = run_tests(..., id="run_tests_final")
 ```
 
 ### The agent result-file contract

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -386,6 +386,12 @@ def software_factory(
     if not plan_review.approved:
         return
 
+    if max_fix_iterations < 1:
+        raise ValueError(
+            "`max_fix_iterations` must be at least 1, got "
+            f"{max_fix_iterations}."
+        )
+
     workspace, base_branch = open_workspace(
         repo=repo, branch=target_branch, plan=plan, base_branch=base_branch
     )
@@ -398,6 +404,7 @@ def software_factory(
         base_branch=base_branch,
     )
     verdict = None
+    tests = None
     for attempt in range(max_fix_iterations):
         tests = run_tests(
             workspace=workspace,
@@ -429,6 +436,18 @@ def software_factory(
             base_branch=base_branch,
             verdict=verdict,
             id=f"fix_{attempt}",
+        )
+    else:
+        # The loop only reaches here without a `break`, i.e. the last action
+        # taken on the branch was an untested `fix`. Re-run tests so
+        # `deploy_approval` reflects the branch's actual final state instead
+        # of the pre-fix report.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
         )
     close_workspace(workspace=workspace)
 

--- a/spec/plans/factory-polish-validation.md
+++ b/spec/plans/factory-polish-validation.md
@@ -1,0 +1,217 @@
+# Fix edge cases in the software factory fix loop
+
+## Root cause
+
+`software_factory` (`examples/software_factory/pipeline.py:355-448`) drives the
+test/review/fix loop with:
+
+```python
+verdict = None
+for attempt in range(max_fix_iterations):
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+close_workspace(workspace=workspace)
+
+pr_result = pr.load()
+metadata = {"pr_url": pr_result.url, "tests": tests.load().model_dump()}
+```
+
+Two bugs fall out of this:
+
+1. **`max_fix_iterations=0` → `NameError`.** `tests` is only ever bound
+   inside the loop body. If the loop runs zero times, `tests` is never
+   assigned, and `tests.load()` when building `metadata` raises
+   `NameError: name 'tests' is not defined`. `verdict` doesn't have this
+   problem because it's pre-initialized to `None` before the loop, but
+   `tests` is not.
+
+2. **Stale test report when the loop is exhausted on a `fix`.** The loop's
+   only exit conditions are (a) `break` right after an *approved* review, or
+   (b) the `for` running out of iterations. Every iteration that doesn't
+   `break` ends by calling `fix(...)`. So whenever the loop is exhausted
+   without a `break`, the last thing that happened on the branch was a
+   `fix` call whose output was never re-tested. The `tests` variable used in
+   `deploy_approval`'s metadata still holds the *pre-fix* report, which
+   misrepresents the state of the branch being proposed for deploy.
+
+## Fix
+
+Both issues share one root cause: the loop has no step for "the loop ended
+right after a fix, with no subsequent test run." Python's `for...else`
+clause is a natural fit — `else` runs exactly when the loop finishes
+*without* hitting `break`, which is precisely the set of cases where the
+last action taken was a `fix` (including the zero-iteration case, where "the
+last action" is vacuously true and no fix even ran).
+
+Change the loop in `software_factory` (`examples/software_factory/pipeline.py`)
+from:
+
+```python
+    verdict = None
+    for attempt in range(max_fix_iterations):
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id=f"run_tests_{attempt}",
+        )
+        verdict = None
+        if tests.load().passed:
+            verdict = review(
+                workspace=workspace,
+                repo=repo,
+                branch=target_branch,
+                issue=issue,
+                plan=plan,
+                tests=tests,
+                base_branch=base_branch,
+                id=f"review_{attempt}",
+            )
+            if verdict.load().approved:
+                break
+        pr = fix(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            issue=issue,
+            tests=tests,
+            base_branch=base_branch,
+            verdict=verdict,
+            id=f"fix_{attempt}",
+        )
+    close_workspace(workspace=workspace)
+```
+
+to:
+
+```python
+    if max_fix_iterations < 1:
+        raise ValueError(
+            "`max_fix_iterations` must be at least 1, got "
+            f"{max_fix_iterations}."
+        )
+
+    verdict = None
+    tests = None
+    for attempt in range(max_fix_iterations):
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id=f"run_tests_{attempt}",
+        )
+        verdict = None
+        if tests.load().passed:
+            verdict = review(
+                workspace=workspace,
+                repo=repo,
+                branch=target_branch,
+                issue=issue,
+                plan=plan,
+                tests=tests,
+                base_branch=base_branch,
+                id=f"review_{attempt}",
+            )
+            if verdict.load().approved:
+                break
+        pr = fix(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            issue=issue,
+            tests=tests,
+            base_branch=base_branch,
+            verdict=verdict,
+            id=f"fix_{attempt}",
+        )
+    else:
+        # Reached only when the loop exhausted `max_fix_iterations` without
+        # an approved review, i.e. the branch's last change was an
+        # untested `fix`. Re-run tests so `deploy_approval` reflects the
+        # branch's actual final state instead of a pre-fix report.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
+        )
+    close_workspace(workspace=workspace)
+```
+
+Notes on why this is minimal and correct:
+
+- The explicit `max_fix_iterations < 1` guard gives a clear error message
+  (per the issue's first acceptable option) instead of silently relying on
+  the `for...else` fallback to paper over a nonsensical configuration where
+  no fix loop can ever run at all. It also keeps `implement()`'s PR from
+  being deployed without ever having been tested once.
+- With the guard in place, `range(max_fix_iterations)` always has at least
+  one iteration, so the `else` clause only fires in the "exhausted after a
+  fix" case described in bug 2 — not in the zero-iteration case, which is
+  now rejected earlier with a clear error.
+- `tests = None` before the loop is defensive/documents intent; it is
+  always overwritten before use once the `ValueError` guard is in place,
+  but keeps the variable's existence obvious to a reader and avoids relying
+  on the loop running at all.
+- No new dependencies; the change is confined to `software_factory` in
+  `examples/software_factory/pipeline.py`.
+
+## Tests to add
+
+`examples/software_factory` pipelines aren't unit-tested directly today (no
+existing `tests/` coverage for this example — it's an integration-style
+example driven by sandboxes/agents per the project's testing guidelines for
+integration-heavy code). Given that, validate the two edge cases with a
+small, focused unit test around the pure control-flow logic rather than
+running the full pipeline:
+
+1. Add `tests/unit/examples/test_software_factory_pipeline.py` (or the
+   nearest existing convention for example pipelines, if one exists —
+   check `tests/unit/` for a precedent first) that:
+   - Calls `software_factory.entrypoint` (the undecorated function) — or
+     extracts the loop into a tiny helper if the pipeline function can't be
+     called directly outside a pipeline context — with
+     `max_fix_iterations=0` and asserts it raises `ValueError` with a
+     message mentioning `max_fix_iterations`, instead of `NameError`.
+   - Simulates the "exhausted on a fix" path (`max_fix_iterations=1`,
+     tests fail or review isn't approved) with mocked `run_tests`/`review`/
+     `fix` steps and asserts `run_tests` is invoked a second time with
+     `id="run_tests_final"` after the loop, so `deploy_approval`'s metadata
+     is built from the post-fix report.
+   - Simulates the "approved on first try" path and asserts the `else`
+     branch's extra `run_tests_final` call does **not** happen (no
+     redundant test run when the loop broke out normally).
+2. If direct unit testing of the `dynamic=True` pipeline entrypoint proves
+   impractical (e.g. it requires a live orchestration context), fall back
+   to documenting manual verification steps in the PR description instead
+   of forcing artificial coverage, consistent with the codebase guidance
+   that integration-heavy code may rely on local/CI runs rather than unit
+   tests. In that case, at minimum manually exercise:
+   - `max_fix_iterations=0` → pipeline raises `ValueError` before creating
+     any workspace/sandbox resources.
+   - A run where the last loop iteration ends in `fix` (e.g.
+     `max_fix_iterations=1` with a failing test command) → confirm a
+     `run_tests_final` step appears in the run and `deploy_approval`'s
+     metadata contains the post-fix test report.
+
+## Documentation
+
+Update the "Bounded fix loop with deterministic step ids" section in
+`examples/software_factory/README.md` (around line 233) since the loop
+shape changes:
+
+- Extend the code snippet to include the `else` clause and the
+  `run_tests_final` re-test call.
+- Add a sentence noting that `max_fix_iterations` must be `>= 1` (invalid
+  values raise `ValueError`), and that if the loop exhausts its iterations
+  on a `fix`, tests are re-run once more (`id="run_tests_final"`) so the
+  `deploy_approval` metadata reflects the branch's final state rather than
+  a pre-fix report.

--- a/tests/unit/examples/__init__.py
+++ b/tests/unit/examples/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the pipelines under `examples/`."""

--- a/tests/unit/examples/test_software_factory_pipeline.py
+++ b/tests/unit/examples/test_software_factory_pipeline.py
@@ -1,0 +1,213 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the fix loop control flow in the software factory example.
+
+The pipeline module lives outside the `zenml` package (`examples/`) and is
+only importable once its directory is on `sys.path`, mirroring how
+`run.py` imports it. The pipeline's own steps talk to sandboxes and GitHub,
+so these tests replace them with plain mocks and call the undecorated
+`software_factory.entrypoint` directly to exercise the fix loop's control
+flow in isolation.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+EXAMPLE_DIR = (
+    Path(__file__).resolve().parents[3] / "examples" / "software_factory"
+)
+
+
+@pytest.fixture
+def software_factory_module() -> Iterator[SimpleNamespace]:
+    """Import the example's `pipeline` module with its directory on path.
+
+    Yields:
+        The imported `pipeline` module.
+    """
+    sys.path.insert(0, str(EXAMPLE_DIR))
+    for name in ("pipeline", "factory_utils", "models"):
+        sys.modules.pop(name, None)
+    try:
+        import pipeline as pipeline_module
+
+        yield pipeline_module
+    finally:
+        sys.path.remove(str(EXAMPLE_DIR))
+        for name in ("pipeline", "factory_utils", "models"):
+            sys.modules.pop(name, None)
+
+
+def _dumpable(**fields: object) -> MagicMock:
+    """Build a mock model-like object exposing `model_dump()` and `fields`.
+
+    Args:
+        fields: Attribute names and values to set on the mock, and to
+            include in `model_dump()`'s return value.
+
+    Returns:
+        A mock object mimicking a Pydantic model.
+    """
+    obj = MagicMock()
+    obj.model_dump.return_value = fields
+    for name, value in fields.items():
+        setattr(obj, name, value)
+    return obj
+
+
+def _artifact(value: object) -> MagicMock:
+    """Build a mock step output whose `.load()` returns `value`.
+
+    Args:
+        value: The value `.load()` should return.
+
+    Returns:
+        A mock artifact.
+    """
+    artifact = MagicMock()
+    artifact.load.return_value = value
+    return artifact
+
+
+def _patch_common_steps(monkeypatch: pytest.MonkeyPatch, module) -> MagicMock:  # type: ignore[no-untyped-def]
+    """Patch the steps outside the fix loop with no-op mocks.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        module: The imported `pipeline` module.
+
+    Returns:
+        The mock used for `wait`, so tests can inspect its calls.
+    """
+    monkeypatch.setattr(
+        module,
+        "write_plan",
+        MagicMock(return_value=_artifact("plan")),
+    )
+
+    def _wait_side_effect(**kwargs: object) -> object:
+        if kwargs.get("name") == "deploy_approval":
+            # Decline the deploy so the real `deploy` step is never invoked.
+            return False
+        return SimpleNamespace(approved=True)
+
+    wait_mock = MagicMock(side_effect=_wait_side_effect)
+    monkeypatch.setattr(module, "wait", wait_mock)
+    monkeypatch.setattr(
+        module,
+        "open_workspace",
+        MagicMock(return_value=("workspace", "main")),
+    )
+    monkeypatch.setattr(
+        module,
+        "implement",
+        MagicMock(return_value=_artifact(_dumpable(url="pr-url"))),
+    )
+    monkeypatch.setattr(module, "close_workspace", MagicMock())
+    monkeypatch.setattr(module, "deploy", MagicMock())
+    return wait_mock
+
+
+def test_zero_max_fix_iterations_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch, software_factory_module
+) -> None:
+    """`max_fix_iterations=0` raises a clear error instead of `NameError`."""
+    module = software_factory_module
+    _patch_common_steps(monkeypatch, module)
+    run_tests_mock = MagicMock()
+    monkeypatch.setattr(module, "run_tests", run_tests_mock)
+
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        module.software_factory.entrypoint(
+            repo="owner/repo",
+            issue="issue",
+            target_branch="fix-branch",
+            max_fix_iterations=0,
+        )
+
+    run_tests_mock.assert_not_called()
+
+
+def test_exhausted_loop_reruns_tests_after_final_fix(
+    monkeypatch: pytest.MonkeyPatch, software_factory_module
+) -> None:
+    """If the loop ends on a `fix`, tests are re-run for `deploy_approval`."""
+    module = software_factory_module
+    wait_mock = _patch_common_steps(monkeypatch, module)
+
+    failing_report = _artifact(_dumpable(passed=False))
+    final_report = _artifact(_dumpable(passed=True))
+    run_tests_mock = MagicMock(side_effect=[failing_report, final_report])
+    monkeypatch.setattr(module, "run_tests", run_tests_mock)
+    monkeypatch.setattr(module, "review", MagicMock())
+    monkeypatch.setattr(
+        module,
+        "fix",
+        MagicMock(return_value=_artifact(_dumpable(url="pr-url"))),
+    )
+
+    module.software_factory.entrypoint(
+        repo="owner/repo",
+        issue="issue",
+        target_branch="fix-branch",
+        max_fix_iterations=1,
+    )
+
+    assert run_tests_mock.call_count == 2
+    final_call_kwargs = run_tests_mock.call_args_list[-1].kwargs
+    assert final_call_kwargs["id"] == "run_tests_final"
+
+    deploy_approval_call = next(
+        call
+        for call in wait_mock.call_args_list
+        if call.kwargs.get("name") == "deploy_approval"
+    )
+    assert (
+        deploy_approval_call.kwargs["metadata"]["tests"]
+        == final_report.load().model_dump()
+    )
+
+
+def test_approved_review_skips_final_rerun(
+    monkeypatch: pytest.MonkeyPatch, software_factory_module
+) -> None:
+    """An approved review breaks the loop without an extra test run."""
+    module = software_factory_module
+    _patch_common_steps(monkeypatch, module)
+
+    passing_report = _artifact(_dumpable(passed=True))
+    run_tests_mock = MagicMock(return_value=passing_report)
+    monkeypatch.setattr(module, "run_tests", run_tests_mock)
+    monkeypatch.setattr(
+        module,
+        "review",
+        MagicMock(return_value=_artifact(_dumpable(approved=True))),
+    )
+    fix_mock = MagicMock()
+    monkeypatch.setattr(module, "fix", fix_mock)
+
+    module.software_factory.entrypoint(
+        repo="owner/repo",
+        issue="issue",
+        target_branch="fix-branch",
+        max_fix_iterations=3,
+    )
+
+    assert run_tests_mock.call_count == 1
+    fix_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- Added a `max_fix_iterations < 1` guard in `software_factory` (`examples/software_factory/pipeline.py`) that raises a clear `ValueError` instead of letting the loop skip entirely and later crash on `tests.load()` with a `NameError`.
- Added a `for...else` clause to the fix loop: it fires exactly when the loop exhausts `max_fix_iterations` without an approved review (i.e. the last action was an untested `fix`), and re-runs tests once more with `id="run_tests_final"` so `deploy_approval`'s metadata reflects the branch's actual final state instead of a pre-fix report.
- Updated the "Bounded fix loop with deterministic step ids" section of `examples/software_factory/README.md` to show the `else` clause and describe both edge-case behaviors.
- Added `tests/unit/examples/test_software_factory_pipeline.py` (plus package `__init__.py`), which imports the example's `pipeline` module by adding its directory to `sys.path` and calls the undecorated `software_factory.entrypoint` with the pipeline's own steps mocked out. Covers: `max_fix_iterations=0` raises `ValueError` before running any tests; the loop re-runs tests via `run_tests_final` when exhausted on a `fix`; an approved review breaks the loop without a redundant final test run.

Plan: `spec/plans/factory-polish-validation.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/f79cb8fb-4fc2-440a-94b9-51be793d9c18
