### PR TITLE
Fix edge cases in the software factory fix loop

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -232,7 +232,7 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. `max_fix_iterations` must be at least 1; the pipeline raises `ValueError` immediately (before any sandbox work) otherwise. The loop's `else` clause runs whenever the loop is exhausted without an approved review — every non-`break` path ends with `fix`, which does not re-run tests, so the `else` branch re-tests the branch once more (`run_tests_final`) to make sure `deploy_approval`'s metadata reflects the final state rather than a stale pre-fix report:
 
 ```python
 for attempt in range(max_fix_iterations):
@@ -243,6 +243,10 @@ for attempt in range(max_fix_iterations):
         if verdict.load().approved:
             break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    # Loop exhausted without an approved review: the last action was
+    # always `fix`, so re-run tests to reflect the branch's final state.
+    tests = run_tests(..., id="run_tests_final")
 ```
 
 ### The agent result-file contract

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -374,7 +374,15 @@ def software_factory(
             Tests are skipped if unset.
         max_fix_iterations: The maximum number of test and review fix
             iterations.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
     """
+    if max_fix_iterations < 1:
+        raise ValueError(
+            f"max_fix_iterations must be at least 1, got {max_fix_iterations}."
+        )
+
     plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
     plan_review = wait(
         schema=Review,
@@ -429,6 +437,18 @@ def software_factory(
             base_branch=base_branch,
             verdict=verdict,
             id=f"fix_{attempt}",
+        )
+    else:
+        # Every non-`break` path above ends with `fix`, which does not
+        # re-run tests. Re-run tests here so `deploy_approval` reflects
+        # the branch's actual final state rather than a stale report from
+        # before the last fix.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
         )
     close_workspace(workspace=workspace)
 

--- a/spec/plans/factory-polish-validation-2.md
+++ b/spec/plans/factory-polish-validation-2.md
@@ -1,0 +1,256 @@
+# Fix edge cases in the software factory fix loop
+
+## Root cause
+
+In `examples/software_factory/pipeline.py`, the `software_factory` pipeline
+runs a `for attempt in range(max_fix_iterations):` loop that assigns the
+local variable `tests` on every iteration and conditionally calls `fix`.
+After the loop, the pipeline unconditionally does `tests.load()` to build
+the `deploy_approval` metadata. Two edge cases break this:
+
+1. **`max_fix_iterations == 0`** — `range(0)` never executes the loop body,
+   so `tests` is never bound. `tests.load()` below the loop then raises
+   `NameError: name 'tests' is not defined`.
+
+2. **Loop exhausted on a `fix` iteration** — every non-`break` path through
+   the loop body ends with a call to `fix(...)`. `fix` does not re-run
+   tests, it just pushes a new commit. So when the loop runs out of
+   `max_fix_iterations` without an approved review, the `tests` object used
+   in the `deploy_approval` metadata is a stale report from *before* the
+   final `fix`, not a report of the state actually being proposed for
+   deployment. This is misleading for whoever approves the deploy.
+
+Both edge cases stem from the same structural issue: the loop is the only
+place that produces a `TestReport`, but the loop can end (or never start)
+without the current branch state having been tested.
+
+## Fix
+
+Both edge cases can be handled with one structural change: use the `for
+...  else:` construct. The `else` clause of a `for` loop runs whenever the
+loop finishes **without** hitting `break` — which is exactly "loop
+exhausted" (edge case 2) and also covers "loop never ran because
+`max_fix_iterations == 0`" (edge case 1), since a zero-iteration loop also
+never breaks.
+
+Combine this with an explicit minimum check on `max_fix_iterations`, since
+a fix loop that cannot run at all (0 iterations) is nonsensical for this
+pipeline (there would never be an implement→test→review cycle) and silently
+"handling" it by only running the final tests would hide a likely
+misconfiguration. Fail fast, before any sandbox/agent work happens.
+
+### Concrete steps
+
+1. **Validate `max_fix_iterations` early.**
+   At the very top of `software_factory`, before `write_plan` is called,
+   add:
+
+   ```python
+   if max_fix_iterations < 1:
+       raise ValueError(
+           "max_fix_iterations must be at least 1, got "
+           f"{max_fix_iterations}."
+       )
+   ```
+
+   This gives a clear, immediate error instead of a `NameError` deep in
+   the pipeline, and avoids wasting a `write_plan` sandbox run on a
+   misconfigured pipeline.
+
+2. **Add a final test run via `for...else` after the fix loop.**
+   Change:
+
+   ```python
+   verdict = None
+   for attempt in range(max_fix_iterations):
+       tests = run_tests(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           test_command=test_command,
+           id=f"run_tests_{attempt}",
+       )
+       verdict = None
+       if tests.load().passed:
+           verdict = review(
+               workspace=workspace,
+               repo=repo,
+               branch=target_branch,
+               issue=issue,
+               plan=plan,
+               tests=tests,
+               base_branch=base_branch,
+               id=f"review_{attempt}",
+           )
+           if verdict.load().approved:
+               break
+       pr = fix(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           issue=issue,
+           tests=tests,
+           base_branch=base_branch,
+           verdict=verdict,
+           id=f"fix_{attempt}",
+       )
+   close_workspace(workspace=workspace)
+   ```
+
+   to:
+
+   ```python
+   verdict = None
+   for attempt in range(max_fix_iterations):
+       tests = run_tests(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           test_command=test_command,
+           id=f"run_tests_{attempt}",
+       )
+       verdict = None
+       if tests.load().passed:
+           verdict = review(
+               workspace=workspace,
+               repo=repo,
+               branch=target_branch,
+               issue=issue,
+               plan=plan,
+               tests=tests,
+               base_branch=base_branch,
+               id=f"review_{attempt}",
+           )
+           if verdict.load().approved:
+               break
+       pr = fix(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           issue=issue,
+           tests=tests,
+           base_branch=base_branch,
+           verdict=verdict,
+           id=f"fix_{attempt}",
+       )
+   else:
+       # Every non-`break` path above ends with `fix`, which does not
+       # re-run tests. Re-run tests here so `deploy_approval` reflects
+       # the branch's actual final state rather than a stale report from
+       # before the last fix (or, if max_fix_iterations was exhausted
+       # with zero iterations, the only test run at all).
+       tests = run_tests(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           test_command=test_command,
+           id="run_tests_final",
+       )
+   close_workspace(workspace=workspace)
+   ```
+
+   Notes:
+   - `tests` is now guaranteed to be assigned by the time
+     `close_workspace`/`deploy_approval` metadata construction run, for
+     every value of `max_fix_iterations >= 1` (guaranteed by step 1).
+   - No other control flow changes: `break` still only happens on an
+     approved review, so the `else` only fires when the loop is exhausted
+     or never entered — precisely the cases described in the issue.
+   - `verdict` semantics are unchanged: it stays `None` unless the last
+     *loop* iteration produced a review; the final `else`-branch test run
+     does not set `verdict`, so `deploy_approval` metadata correctly omits
+     `verdict` when the branch was never approved.
+
+3. **No other files need to change.** The fix is entirely within
+   `examples/software_factory/pipeline.py`; `models.py`, `factory_utils.py`,
+   and the `deploy_approval`/`metadata` construction below the loop need no
+   changes since `tests` is now always defined.
+
+## README update
+
+Update `examples/software_factory/README.md`, section
+"### Bounded fix loop with deterministic step ids" (around line 233-246), to
+show the new loop shape (the `else` clause and `run_tests_final` id) and to
+mention the `max_fix_iterations >= 1` requirement. Replace the existing code
+block:
+
+```python
+for attempt in range(max_fix_iterations):
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+```
+
+with:
+
+```python
+for attempt in range(max_fix_iterations):
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    # Loop exhausted without an approved review: the last action was
+    # always `fix`, so re-run tests to reflect the branch's final state.
+    tests = run_tests(..., id="run_tests_final")
+```
+
+and add a sentence noting that `max_fix_iterations` must be at least 1
+(the pipeline raises `ValueError` otherwise), and that the `else` branch
+re-tests the branch after the loop's last `fix` so `deploy_approval`'s
+metadata is never stale.
+
+## Tests to add
+
+Add tests near wherever existing `software_factory` pipeline-level tests
+live (check `tests/unit/` — if a pipeline construction/dry-run smoke test
+exists for `examples/software_factory`, extend it; otherwise these can be
+plain unit tests that import the module and exercise the pipeline function
+in dynamic/compile mode, mocking the underlying steps).
+
+1. **`max_fix_iterations == 0` raises `ValueError`.**
+   Call `software_factory(..., max_fix_iterations=0)` (or however the
+   dynamic pipeline is invoked/compiled in the existing test harness for
+   this example) and assert a `ValueError` is raised with a message
+   mentioning `max_fix_iterations`, before any step (e.g. `write_plan`) is
+   invoked — assert the mocked `write_plan`/steps were never called.
+
+2. **Negative `max_fix_iterations` also raises `ValueError`.**
+   Same as above with e.g. `max_fix_iterations=-1`, to confirm the check is
+   `< 1` and not just `== 0`.
+
+3. **Loop exhausted on a `fix` iteration triggers `run_tests_final`.**
+   Mock `run_tests`, `review`, and `fix` so that every `review` call
+   returns `approved=False` (or every `run_tests` call returns
+   `passed=False`) for `max_fix_iterations=2`. Assert:
+   - `run_tests` is called 3 times total: `run_tests_0`, `run_tests_1`,
+     and `run_tests_final` (by inspecting the `id=` kwarg each call was
+     made with).
+   - The metadata passed to the `deploy_approval` `wait(...)` call reflects
+     the `TestReport` returned by the `run_tests_final` invocation, not the
+     one from `run_tests_1`.
+
+4. **Loop exits via `break` does not trigger a final test run.**
+   Mock `run_tests` (passed=True) and `review` (approved=True) on the
+   first iteration with `max_fix_iterations=3`. Assert `run_tests` is
+   called exactly once (`run_tests_0`) and no `run_tests_final` /
+   `fix` call happens, i.e. behavior for the already-working happy path is
+   unchanged.
+
+If no existing test infrastructure invokes this dynamic pipeline function
+directly (dynamic pipelines commonly need a `SANDBOX`/mocked orchestration
+context), scope the new tests to whatever mocking pattern
+`tests/unit/examples/` (or similar) already uses for this example; if none
+exists yet, a minimal test can monkeypatch `factory_utils`/step functions
+referenced via `zenml.step`-decorated functions' `.entrypoint` or invoke the
+pipeline in a `with pipeline.testing_context(...)`-style harness consistent
+with how other dynamic ZenML pipelines in this repo are unit-tested — grep
+`tests/unit` for other `dynamic=True` pipeline tests before inventing a new
+pattern.

--- a/tests/unit/examples/software_factory/test_pipeline.py
+++ b/tests/unit/examples/software_factory/test_pipeline.py
@@ -1,0 +1,230 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the fix loop edge cases in the software factory example pipeline.
+
+These tests call the pipeline's raw `.entrypoint` function directly (the
+undecorated Python function stored by `@pipeline`) instead of running it
+through the real dynamic pipeline orchestration machinery. All steps used
+by `software_factory` are monkeypatched with plain Python callables, so
+these tests exercise only the loop control flow in
+`examples/software_factory/pipeline.py`, not real sandbox/agent/server
+interactions.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+_EXAMPLE_DIR = (
+    Path(__file__).resolve().parents[4] / "examples" / "software_factory"
+)
+if str(_EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import pipeline as sf_pipeline  # noqa: E402
+from models import PRRef, Review, ReviewVerdict, TestReport  # noqa: E402
+
+
+class _Loaded:
+    """Stand-in for a dynamic pipeline output future with a `.load()`."""
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def load(self) -> Any:
+        return self._value
+
+
+@pytest.fixture
+def recorder() -> Dict[str, List[Optional[str]]]:
+    return {
+        "write_plan": [],
+        "open_workspace": [],
+        "implement": [],
+        "run_tests": [],
+        "review": [],
+        "fix": [],
+        "close_workspace": [],
+        "deploy": [],
+        "wait": [],
+    }
+
+
+@pytest.fixture
+def patch_steps(monkeypatch, recorder):
+    """Replace every step/`wait` call used by `software_factory` with a stub.
+
+    Returns a dict of dicts the test can populate to control the
+    `TestReport`/`ReviewVerdict` returned for a given step `id`.
+    """
+    test_reports: Dict[str, TestReport] = {}
+    review_verdicts: Dict[str, ReviewVerdict] = {}
+    wait_metadata: Dict[str, Any] = {}
+
+    def _fake_write_plan(*, repo, issue, base_branch=None):
+        recorder["write_plan"].append(None)
+        return _Loaded("plan text")
+
+    def _fake_open_workspace(*, repo, branch, plan, base_branch=None):
+        recorder["open_workspace"].append(None)
+        return "workspace-id", base_branch or "main"
+
+    def _fake_implement(*, workspace, repo, branch, issue, plan, base_branch):
+        recorder["implement"].append(None)
+        return _Loaded(PRRef(url="https://example.com/pr/1", number=1))
+
+    def _fake_run_tests(
+        *, workspace, repo, branch, test_command=None, id=None
+    ):
+        recorder["run_tests"].append(id)
+        report = test_reports.get(
+            id, TestReport(passed=True, summary=f"summary-{id}")
+        )
+        return _Loaded(report)
+
+    def _fake_review(
+        *,
+        workspace,
+        repo,
+        branch,
+        issue,
+        plan,
+        tests,
+        base_branch,
+        id=None,
+    ):
+        recorder["review"].append(id)
+        verdict = review_verdicts.get(
+            id, ReviewVerdict(approved=False, comments=[])
+        )
+        return _Loaded(verdict)
+
+    def _fake_fix(
+        *,
+        workspace,
+        repo,
+        branch,
+        issue,
+        tests,
+        base_branch,
+        verdict=None,
+        id=None,
+    ):
+        recorder["fix"].append(id)
+        return _Loaded(PRRef(url="https://example.com/pr/1", number=1))
+
+    def _fake_close_workspace(*, workspace):
+        recorder["close_workspace"].append(None)
+
+    def _fake_deploy(*, pr, repo):
+        recorder["deploy"].append(None)
+
+    def _fake_wait(
+        *,
+        schema=None,
+        type=None,
+        timeout=None,
+        poll_interval=None,
+        question=None,
+        metadata=None,
+        after=None,
+        name=None,
+    ):
+        recorder["wait"].append(name)
+        if name == "plan_review":
+            return Review(approved=True, feedback="")
+        if name == "deploy_approval":
+            wait_metadata["deploy_approval"] = metadata
+            return False
+        raise AssertionError(f"Unexpected wait() call: name={name!r}")
+
+    monkeypatch.setattr(sf_pipeline, "write_plan", _fake_write_plan)
+    monkeypatch.setattr(sf_pipeline, "open_workspace", _fake_open_workspace)
+    monkeypatch.setattr(sf_pipeline, "implement", _fake_implement)
+    monkeypatch.setattr(sf_pipeline, "run_tests", _fake_run_tests)
+    monkeypatch.setattr(sf_pipeline, "review", _fake_review)
+    monkeypatch.setattr(sf_pipeline, "fix", _fake_fix)
+    monkeypatch.setattr(sf_pipeline, "close_workspace", _fake_close_workspace)
+    monkeypatch.setattr(sf_pipeline, "deploy", _fake_deploy)
+    monkeypatch.setattr(sf_pipeline, "wait", _fake_wait)
+
+    return {
+        "test_reports": test_reports,
+        "review_verdicts": review_verdicts,
+        "wait_metadata": wait_metadata,
+    }
+
+
+def _run(max_fix_iterations: int) -> None:
+    sf_pipeline.software_factory.entrypoint(
+        repo="zenml-io/zenml",
+        issue="Some bug",
+        target_branch="fix/some-bug",
+        base_branch="develop",
+        test_command="pytest",
+        max_fix_iterations=max_fix_iterations,
+    )
+
+
+def test_zero_max_fix_iterations_raises(recorder, patch_steps) -> None:
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        _run(max_fix_iterations=0)
+
+    assert recorder["write_plan"] == []
+
+
+def test_negative_max_fix_iterations_raises(recorder, patch_steps) -> None:
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        _run(max_fix_iterations=-1)
+
+    assert recorder["write_plan"] == []
+
+
+def test_loop_exhausted_runs_final_tests(recorder, patch_steps) -> None:
+    patch_steps["test_reports"]["run_tests_final"] = TestReport(
+        passed=True, summary="final-report"
+    )
+
+    _run(max_fix_iterations=2)
+
+    assert recorder["run_tests"] == [
+        "run_tests_0",
+        "run_tests_1",
+        "run_tests_final",
+    ]
+    assert recorder["review"] == ["review_0", "review_1"]
+    assert recorder["fix"] == ["fix_0", "fix_1"]
+    assert recorder["wait"] == ["plan_review", "deploy_approval"]
+
+    metadata = patch_steps["wait_metadata"]["deploy_approval"]
+    assert metadata["tests"]["summary"] == "final-report"
+
+
+def test_loop_breaks_on_first_approval(recorder, patch_steps) -> None:
+    patch_steps["review_verdicts"]["review_0"] = ReviewVerdict(
+        approved=True, comments=[]
+    )
+
+    _run(max_fix_iterations=3)
+
+    assert recorder["run_tests"] == ["run_tests_0"]
+    assert recorder["review"] == ["review_0"]
+    assert recorder["fix"] == []
+    assert recorder["wait"] == ["plan_review", "deploy_approval"]
+
+    metadata = patch_steps["wait_metadata"]["deploy_approval"]
+    assert metadata["tests"]["summary"] == "summary-run_tests_0"
+    assert metadata["verdict"]["approved"] is True


### PR DESCRIPTION
## Summary

- Added an early `max_fix_iterations < 1` check in `software_factory` (examples/software_factory/pipeline.py) that raises a clear `ValueError` before any sandbox work starts, instead of letting `tests.load()` fail with a `NameError` later.
- Added a `for...else` clause to the fix loop: whenever the loop is exhausted without an approved review (every non-`break` path ends in `fix`, which doesn't re-run tests), the branch is tested once more with `id="run_tests_final"` so `tests` is always defined and `deploy_approval`'s metadata reflects the branch's actual final state rather than a stale pre-fix report.
- Updated the "Bounded fix loop with deterministic step ids" section of examples/software_factory/README.md to show the new `else` clause and note the `max_fix_iterations >= 1` requirement.
- Added tests/unit/examples/software_factory/test_pipeline.py, which calls `software_factory.entrypoint(...)` directly (bypassing real ZenML orchestration) with every step and `wait()` call monkeypatched, covering: `max_fix_iterations=0` and `-1` raise `ValueError` before `write_plan` runs; loop exhaustion triggers `run_tests_final` and its report (not the stale one from before the last fix) flows into `deploy_approval` metadata; and the existing break-on-approval happy path is unaffected (single `run_tests_0`/`review_0`, no `fix`/`run_tests_final`).

Plan: `spec/plans/factory-polish-validation-2.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/8a5bad7e-d7bc-4f53-a51e-a98958292704
