### PR TITLE
Fix edge cases in the software factory fix loop

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -232,10 +232,16 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. `max_fix_iterations` must be at least 1, since the deploy approval below needs a test report to show. If the loop runs out of attempts and the last one ended with a `fix`, tests are run one more time under a distinct `run_tests_final` id, so the deploy approval always reflects the latest state of the branch instead of a stale pre-fix report:
 
 ```python
+if max_fix_iterations < 1:
+    raise ValueError("max_fix_iterations must be at least 1")
+
+verdict = None
+fixed_last = False
 for attempt in range(max_fix_iterations):
+    fixed_last = False
     tests = run_tests(..., id=f"run_tests_{attempt}")
     verdict = None
     if tests.load().passed:
@@ -243,6 +249,10 @@ for attempt in range(max_fix_iterations):
         if verdict.load().approved:
             break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+    fixed_last = True
+
+if fixed_last:
+    tests = run_tests(..., id="run_tests_final")
 ```
 
 ### The agent result-file contract

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -341,6 +341,22 @@ def deploy(pr: PRRef, repo: str) -> None:
         )
 
 
+def _validate_max_fix_iterations(max_fix_iterations: int) -> None:
+    """Validate the `max_fix_iterations` argument of `software_factory`.
+
+    Args:
+        max_fix_iterations: The maximum number of test and review fix
+            iterations.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
+    """
+    if max_fix_iterations < 1:
+        raise ValueError(
+            f"max_fix_iterations must be at least 1, got {max_fix_iterations}."
+        )
+
+
 @pipeline(
     dynamic=True,
     enable_cache=False,
@@ -374,7 +390,12 @@ def software_factory(
             Tests are skipped if unset.
         max_fix_iterations: The maximum number of test and review fix
             iterations.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
     """
+    _validate_max_fix_iterations(max_fix_iterations)
+
     plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
     plan_review = wait(
         schema=Review,
@@ -398,7 +419,9 @@ def software_factory(
         base_branch=base_branch,
     )
     verdict = None
+    fixed_last = False
     for attempt in range(max_fix_iterations):
+        fixed_last = False
         tests = run_tests(
             workspace=workspace,
             repo=repo,
@@ -429,6 +452,19 @@ def software_factory(
             base_branch=base_branch,
             verdict=verdict,
             id=f"fix_{attempt}",
+        )
+        fixed_last = True
+
+    if fixed_last:
+        # The last loop iteration ended with an untested fix. Re-run tests
+        # so the deploy approval below reflects the branch's final state
+        # instead of a stale pre-fix report.
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
         )
     close_workspace(workspace=workspace)
 

--- a/examples/software_factory/tests/test_pipeline.py
+++ b/examples/software_factory/tests/test_pipeline.py
@@ -1,0 +1,42 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the software factory pipeline's fix loop guard."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pipeline import _validate_max_fix_iterations  # noqa: E402
+
+
+@pytest.mark.parametrize("max_fix_iterations", [0, -1, -10])
+def test_validate_max_fix_iterations_rejects_non_positive(
+    max_fix_iterations: int,
+) -> None:
+    """`max_fix_iterations` below 1 must raise a clear `ValueError`."""
+    with pytest.raises(
+        ValueError, match="max_fix_iterations must be at least 1"
+    ):
+        _validate_max_fix_iterations(max_fix_iterations)
+
+
+@pytest.mark.parametrize("max_fix_iterations", [1, 2, 10])
+def test_validate_max_fix_iterations_accepts_positive(
+    max_fix_iterations: int,
+) -> None:
+    """`max_fix_iterations` of 1 or more must be accepted without error."""
+    _validate_max_fix_iterations(max_fix_iterations)

--- a/spec/plans/factory-polish-validation-3.md
+++ b/spec/plans/factory-polish-validation-3.md
@@ -1,0 +1,227 @@
+# Plan: Fix edge cases in the software factory fix loop
+
+## Root cause
+
+In `examples/software_factory/pipeline.py`, the `software_factory` dynamic
+pipeline function (lines ~400-433) has a `for attempt in
+range(max_fix_iterations):` loop that assigns the local variables `tests` and
+`verdict`, both of which are read after the loop when building the
+`deploy_approval` metadata (line 436-438: `tests.load()...`,
+`verdict.load()...`).
+
+1. **`max_fix_iterations == 0`**: `range(0)` never executes the loop body, so
+   `tests` is never bound. `tests.load()` at line 436 then raises
+   `NameError: name 'tests' is not defined`. `verdict` is pre-initialized to
+   `None` (line 400) so it doesn't have the same problem, but `tests` does
+   not have a fallback.
+
+2. **Loop exhausted, last action was a fix**: When the loop runs out of
+   attempts (`attempt == max_fix_iterations - 1`) and that final iteration
+   ends by calling `fix(...)` (i.e., tests failed, or tests passed but the
+   review was not approved), the branch now has uncommitted-to-history state
+   from that fix that has never been tested. The `tests` variable used in the
+   `deploy_approval` metadata still holds the *pre-fix* test report from
+   `run_tests_{attempt}`, which is stale/misleading — a human approving the
+   deploy sees a test report that doesn't reflect the code they're about to
+   ship.
+
+## Fix approach
+
+Keep the change minimal and contained to
+`examples/software_factory/pipeline.py`.
+
+### 1. Guard `max_fix_iterations`
+
+Validate that `max_fix_iterations >= 1` at the top of `software_factory`
+(after the docstring, before any steps run) and raise a clear `ValueError` if
+not. This is preferable to making the metadata construction tolerate a
+missing `tests`/`verdict` because:
+- A `TestReport`-less deploy approval would be a materially different
+  (weaker) contract for anyone reviewing/approving the wait step.
+- Zero fix iterations means "never test or review the implementation before
+  asking to deploy," which is very likely a misconfiguration worth failing
+  fast on, rather than silently proceeding with no test data.
+
+```python
+if max_fix_iterations < 1:
+    raise ValueError(
+        "max_fix_iterations must be at least 1, got "
+        f"{max_fix_iterations}."
+    )
+```
+
+Place this check near the top of the function body, before `write_plan(...)`
+is invoked, so it fails immediately without wasting a sandbox session or
+agent call.
+
+### 2. Re-run tests after a trailing fix
+
+Track whether the *last action taken inside the loop* was a `fix(...)` call.
+Reset the flag at the top of each iteration and set it right after the `fix`
+call, so it reflects only the final iteration's outcome (it must not leak
+`True` from an earlier iteration into a later one that ends via `break`):
+
+```python
+verdict = None
+fixed_last = False
+for attempt in range(max_fix_iterations):
+    fixed_last = False
+    tests = run_tests(
+        workspace=workspace,
+        repo=repo,
+        branch=target_branch,
+        test_command=test_command,
+        id=f"run_tests_{attempt}",
+    )
+    verdict = None
+    if tests.load().passed:
+        verdict = review(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            issue=issue,
+            plan=plan,
+            tests=tests,
+            base_branch=base_branch,
+            id=f"review_{attempt}",
+        )
+        if verdict.load().approved:
+            break
+    pr = fix(
+        workspace=workspace,
+        repo=repo,
+        branch=target_branch,
+        issue=issue,
+        tests=tests,
+        base_branch=base_branch,
+        verdict=verdict,
+        id=f"fix_{attempt}",
+    )
+    fixed_last = True
+
+if fixed_last:
+    tests = run_tests(
+        workspace=workspace,
+        repo=repo,
+        branch=target_branch,
+        test_command=test_command,
+        id="run_tests_final",
+    )
+
+close_workspace(workspace=workspace)
+```
+
+Notes:
+- `run_tests_final` is a distinct, deterministic step id as required, so
+  resumed runs still match the same step runs (consistent with the "Bounded
+  fix loop with deterministic step ids" convention already documented in the
+  README).
+- `verdict` is intentionally left as whatever it was when the loop exited
+  (`None` if the trailing fix followed a test failure, or the unapproved
+  `ReviewVerdict` if it followed a rejected review) — the fix step already
+  received it as input, and the deploy-approval metadata block below still
+  only includes `verdict` when it is not `None`, so no change needed there.
+- This extra `run_tests` call only happens when the loop actually ends on a
+  fix; the normal case (breaking out after an approved review) is unaffected
+  and does not gain an extra test run.
+
+### 3. No changes needed to the `deploy_approval` metadata block
+
+Once `max_fix_iterations >= 1` is enforced and the trailing re-test is added,
+`tests` is always bound by the time the metadata dict is built, and it always
+reflects the latest state of the branch. The existing code:
+
+```python
+pr_result = pr.load()
+metadata = {"pr_url": pr_result.url, "tests": tests.load().model_dump()}
+if verdict is not None:
+    metadata["verdict"] = verdict.load().model_dump()
+```
+
+remains correct as-is.
+
+## Tests to add
+
+There isn't an existing unit test file for this example pipeline (it's an
+`examples/` sandbox-driven pipeline, not covered by `/tests/unit`), so add
+lightweight tests that exercise the pipeline's loop *logic* in isolation
+without needing a real sandbox — following the "generally test integrations
+extensively locally" guidance, but since this is plain Python control flow
+(not an external-service integration), it should get direct coverage:
+
+1. Check whether `examples/software_factory/` already has any test files
+   (`tests/` folder in the example dir) before deciding where new tests go.
+   If none exist, create `examples/software_factory/tests/test_pipeline.py`
+   (or similar) that:
+   - Imports `software_factory` and calls it (or refactors the validation
+     into a small importable helper if the pipeline function itself is hard
+     to invoke without ZenML runtime) to assert `ValueError` is raised when
+     `max_fix_iterations=0`.
+   - If the pipeline body can't be unit-tested directly without a ZenML run
+     (likely, since steps are decorated with `@step`/`@pipeline`), consider
+     extracting the `max_fix_iterations` validation into a small pure
+     function (e.g. `_validate_max_fix_iterations(max_fix_iterations: int) ->
+     None`) that can be unit-tested directly, and call it from
+     `software_factory`. This keeps the change minimal while still giving
+     the guard clause direct test coverage.
+2. For the "final re-test after trailing fix" behavior, since it depends on
+   ZenML's dynamic-pipeline step execution, prefer a targeted manual/local
+   verification (e.g., running the example pipeline against a local sandbox
+   with `max_fix_iterations=1` and a failing `test_command` that always
+   fails, then confirming two `run_tests_*` step runs appear:
+   `run_tests_0` and `run_tests_final`) over trying to unit test dynamic
+   pipeline orchestration. Document this manual check in the PR description
+   if no automated test is feasible for the orchestration path itself.
+
+## Documentation update
+
+Update `examples/software_factory/README.md`, section "Bounded fix loop with
+deterministic step ids" (around line 233), to reflect the new loop shape:
+add the `max_fix_iterations >= 1` validation and the trailing
+`run_tests_final` call to the code sample, e.g.:
+
+```python
+if max_fix_iterations < 1:
+    raise ValueError("max_fix_iterations must be at least 1")
+
+verdict = None
+fixed_last = False
+for attempt in range(max_fix_iterations):
+    fixed_last = False
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+    fixed_last = True
+
+if fixed_last:
+    tests = run_tests(..., id="run_tests_final")
+```
+
+and add a sentence explaining why the extra re-test exists (so the
+`deploy_approval` wait always reflects the latest test run, not a stale one
+from before the last fix).
+
+## Summary of concrete steps
+
+1. In `examples/software_factory/pipeline.py`, add a `max_fix_iterations < 1`
+   validation with a clear `ValueError` near the top of `software_factory`.
+2. Add a `fixed_last` boolean flag inside the fix loop: reset to `False` at
+   the top of each iteration, set to `True` immediately after the `fix(...)`
+   call.
+3. After the loop and before `close_workspace(...)`, if `fixed_last` is
+   `True`, call `run_tests(..., id="run_tests_final")` again and reassign
+   `tests` to its result.
+4. Leave the `deploy_approval` metadata construction unchanged — it already
+   handles `verdict is None` and will now always have a valid `tests` value.
+5. Update `examples/software_factory/README.md`'s "Bounded fix loop with
+   deterministic step ids" section to show the updated loop shape and to
+   note the new `run_tests_final` step id.
+6. Add/extend tests: unit-test the `max_fix_iterations` validation (extracting
+   it to a small pure helper if needed for testability); manually verify the
+   `run_tests_final` behavior against a local sandbox run since it depends on
+   dynamic pipeline orchestration.
+7. Run `bash scripts/format.sh` and targeted tests before committing.


### PR DESCRIPTION
## Summary

- Added `_validate_max_fix_iterations` helper and call it at the top of `software_factory` to raise a clear `ValueError` when `max_fix_iterations < 1`, preventing the `NameError` from an unbound `tests` variable.
- Tracked whether the last fix-loop iteration ended with a `fix(...)` call via a `fixed_last` flag (reset each iteration, set after `fix`), and re-run `run_tests(..., id="run_tests_final")` after the loop when it did, so `deploy_approval` metadata always reflects the branch's latest tested state.
- Updated `examples/software_factory/README.md`'s "Bounded fix loop with deterministic step ids" section to show the validation guard and the trailing `run_tests_final` call.
- Added `examples/software_factory/tests/test_pipeline.py` with unit tests for `_validate_max_fix_iterations` covering both rejected (<=0) and accepted (>=1) values.
- Ran `ruff format`/`ruff check` on the changed files and the new test suite (`python3.12 -m pytest examples/software_factory/tests/test_pipeline.py`, 6 passed).

Plan: `spec/plans/factory-polish-validation-3.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/37f7a4df-3eea-4c37-b347-985f008ea05a
