### PR TITLE
Software factory example: agent usage metadata, webhook-driven runs and a demo-ready setup

### DIFF
--- a/examples/software_factory/AGENTS.md
+++ b/examples/software_factory/AGENTS.md
@@ -1,0 +1,59 @@
+# Software Factory Agent Guidelines
+
+This file applies when a coding agent works in `examples/software_factory/`.
+`README.md` explains what the pipeline does, how to run it and the design
+behind it ("How It Works"). Read it first, this file only adds the rules
+for changing the code.
+
+## Layout
+
+- `pipeline.py` - step definitions and the dynamic `software_factory` pipeline.
+- `factory_utils.py` - sandbox, git, `gh` and agent CLI helpers. Steps call
+  these, they never call `session.exec` or `subprocess` directly.
+- `models.py` - Pydantic models exchanged between steps and gates.
+- `run.py` - CLI entrypoint. Every pipeline parameter has a flag here.
+- `snapshot.yaml` - placeholder parameters and settings for snapshots.
+- `Dockerfile` - the sandbox image, not the orchestrator image.
+
+## Rules
+
+- Secrets reach the sandbox only per command, through `git_auth_env()`,
+  `GH_TOKEN` and the agent auth variables. Never write credentials into
+  files, git config or the image.
+- Steps that change the checkout commit and push before they return.
+  `attach_or_recreate` resets the session to `origin/<branch>`, so
+  uncommitted work is lost by design.
+- Agent results go through files in `.factory/`, read with
+  `read_repo_file`. Do not parse the agent's free-text answer.
+- A step invoked more than once in the pipeline function needs a
+  deterministic `id=`.
+- A step that creates its own session destroys it. The shared workspace is
+  destroyed by `close_workspace` and by the `on_end` hook.
+
+## Changing the pipeline
+
+- Adding a parameter: add it to `software_factory`, the steps that need it,
+  `run.py`, `snapshot.yaml` and the flag table in `README.md`.
+- Adding a step that runs the agent: declare
+  `secrets=["github", "claude"]`, call `run_agent(session, prompt,
+  model=agent_model)` and read the result file. `run_agent` already logs
+  model, tokens and cost as step metadata.
+- Adding a step that touches the checkout: take `workspace`, `repo` and
+  `branch`, and open the session with `attach_or_recreate`.
+- Changing the loop shape: update "Bounded fix loop" in `README.md`.
+
+## Verifying changes
+
+There are no unit tests for this example, the sandbox and agent cannot run
+in CI. Verify with:
+
+```bash
+cd examples/software_factory
+ruff format . && ruff check .
+MYPYPATH=. mypy --explicit-package-bases factory_utils.py pipeline.py run.py models.py
+```
+
+Then do a real run against a scratch branch, see "Run It" in `README.md`.
+Use the local sandbox flavor for a quick check, a containerized flavor to
+exercise `attach(...)`. Answer both gates within their timeout when running
+with the local orchestrator.

--- a/examples/software_factory/CLAUDE.md
+++ b/examples/software_factory/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -227,7 +227,7 @@ Or whenever someone reacts with 🏭 to a message in a channel, with that messag
    zenml webhook create slack-events --type slack --secret "<signing secret>"
    zenml webhook describe slack-events
    ```
-3. In the app, open Event Subscriptions, enable events, paste the endpoint URL as Request URL and wait for **Verified**. Socket Mode must be off.
+3. In the app, turn **Socket Mode off** first. New Slack apps have it on by default, and with it on Slack sends events over a WebSocket instead of to the Request URL, so nothing reaches ZenML. Then open Event Subscriptions, enable events, paste the endpoint URL as Request URL and wait for **Verified**.
 4. Under Subscribe to bot events add `reaction_added`. Under OAuth & Permissions add the scopes `reactions:read` and `channels:history` (`groups:history` for private channels).
 5. Install the app, invite it to the channel, and store its bot token for the step:
    ```bash
@@ -245,6 +245,8 @@ Or whenever someone reacts with 🏭 to a message in a channel, with that messag
    zenml trigger webhook create on-slack-reaction --webhook slack-events --config on-reaction.yaml
    zenml trigger webhook attach on-slack-reaction software-factory-on-issue
    ```
+
+If a reaction starts no run, check the app settings in this order, which is the order they usually fail in: `reaction_added` is listed under Subscribe to bot events, since enabling events and verifying the URL alone subscribes to nothing. Changes on that page are saved, the Save Changes button sits at the bottom. The app was reinstalled after the scopes were added, Slack shows a yellow banner while that is pending. The app is a member of the channel, invite it with `/invite @<app name>`, since Slack only delivers reactions for conversations the bot is in. Socket Mode is off. The webhook's `received_count` in `zenml webhook describe slack-events` tells you whether deliveries arrive at all.
 
 An `app_mention` target works the same way without the extra scope, since the mention carries its text. ClickUp task events only carry ids, extend `issue_from_webhook_body` in `factory_utils.py` with a ClickUp API call in the same way as the Slack reaction. The [webhook trigger docs](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) describe the filters of each provider. On an OSS server, use the REST API or the Python client shown above from your own webhook handler.
 

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -1,16 +1,17 @@
 # Software Factory Pipeline
 
-Turn a GitHub issue into a reviewed pull request. A dynamic ZenML pipeline drives a coding agent (the `claude` CLI) through plan, implementation, tests, review and a fix loop, running every command inside a ZenML [Sandbox](../../docs/book/component-guide/sandboxes/README.md) and pausing for a human at two points with `zenml.wait(...)`.
+Turn a GitHub issue into a reviewed pull request. A dynamic ZenML pipeline drives a coding agent (the `claude` CLI) through plan, implementation, tests, review and a bounded fix loop. Every command runs inside a ZenML [Sandbox](../../docs/book/component-guide/sandboxes/README.md), and the run pauses for a human at two points with `zenml.wait(...)`.
 
 **ZenML version**: 0.96+ (Python 3.10+)
 
 ## 🎯 What You'll Learn
 
-- Build a `@pipeline(dynamic=True)` that drives an agent CLI through a multi-stage workflow with plain Python control flow
-- Run commands in a `Sandbox` stack component, stream the agent's output into the step logs, and reconnect to one live session across steps with `attach(...)`
+- Drive an agent CLI through a multi-stage workflow with plain Python control flow in a `@pipeline(dynamic=True)`
+- Run commands in a `Sandbox` stack component, stream the agent's output into the step logs, and share one live session across steps with `attach(...)`
 - Pause a run with `zenml.wait(...)` for a plan approval and a deploy approval
-- Pass secrets into the sandbox for single commands without leaving them in the checkout or the logs
+- Pass secrets into the sandbox per command, so they never land in the checkout or the logs
 - Bound a test, review and fix loop with `id=` on repeated step invocations
+- Record which model the agent used, how many tokens it consumed and what it cost, per step
 - Publish the pipeline as a snapshot that anyone can trigger from the ZenML server
 
 ## 🔁 The Flow
@@ -26,7 +27,7 @@ issue ──▶ write_plan ──▶ [plan_review] ──▶ open_workspace ─�
 
 | Step | Sandbox | What it does | Output |
 |---|---|---|---|
-| `write_plan` | own session | Clones the base branch, asks the agent for a plan | `plan` (Markdown) |
+| `write_plan` | own session | Clones the base branch, asks the agent for a plan | `plan` (Markdown), `plan_preview` (HTML) |
 | `open_workspace` | creates the shared session | Checks out or creates the target branch, commits the plan as `spec/plans/<branch>.md`, pushes | `workspace`, `base_branch` |
 | `implement` | attach | Agent makes the changes, step commits, pushes and opens a draft pull request | `pr` |
 | `run_tests` | attach | Runs `test_command` in the checkout, skipped when unset | `tests` |
@@ -35,15 +36,19 @@ issue ──▶ write_plan ──▶ [plan_review] ──▶ open_workspace ─�
 | `close_workspace` | attach | Destroys the shared session | |
 | `deploy` | own session | Marks the pull request ready for review, a stand-in for a real deployment | |
 
-The loop over `run_tests`, `review` and `fix` runs at most `max_fix_iterations` times and stops early on an approved review.
+The loop stops on an approved review or after `max_fix_iterations` fixes. Tests and review run once more than fixes, so the last fix is always tested before the deploy gate.
 
-## 📋 Prerequisites
+## 📋 Setup
 
-### ZenML server and stack
+### 1. ZenML server
 
-A ZenML server (`zenml login --local` or `zenml login <workspace>` for ZenML Pro) and a stack with a sandbox component. The agent and every git command run inside the sandbox.
+Log in to a ZenML server: `zenml login --local` for a local one, or `zenml login <workspace>` for ZenML Pro. Then pick or create a project:
 
-### Sandbox image
+```bash
+zenml project set default
+```
+
+### 2. Sandbox image
 
 The sandbox needs `git`, `gh`, the `claude` CLI, Python, `pytest` and `uv`. The `Dockerfile` in this directory builds such an image. It runs as a non-root user because the `claude` CLI refuses `--dangerously-skip-permissions` as root. Build it for the platform of your cluster nodes and push it to a registry the sandbox can pull from:
 
@@ -52,51 +57,52 @@ cd examples/software_factory
 docker buildx build --platform linux/amd64 -t <registry>/software-factory-sandbox:latest --push .
 ```
 
-Register the sandbox component without an image. The image is passed per run through step settings, so one component serves any pipeline:
+### 3. Sandbox component and stack
+
+Register a sandbox component without an image and add it to your stack. The image is passed per run, so one component serves any pipeline:
 
 ```bash
 zenml sandbox register agent-sandbox --flavor=docker
 zenml stack update --sandbox agent-sandbox
 ```
 
-Use `--flavor=kubernetes` (with `--kubernetes_namespace=...` and a service connector) or `--flavor=modal` in the same way. See the [sandbox flavors](https://docs.zenml.io/component-guide/sandboxes) for their options.
+Use `--flavor=kubernetes` (with `--kubernetes_namespace=...` and a service connector) or `--flavor=modal` in the same way. See the [sandbox flavors](https://docs.zenml.io/component-guide/sandboxes) for their options. The containerized flavors (Docker, Kubernetes, Modal) support `attach(...)`, so one sandbox session is shared across the steps of a run.
 
-`run.py --sandbox-image <image>` sets `settings={"sandbox:<component name>": ContainerizedSandboxSettings(image=<image>)}` on the pipeline, and `snapshot.yaml` carries the same setting for snapshots:
+`run.py --sandbox-image <image>` puts the image into the pipeline settings under the key `sandbox:<component name>`, and `snapshot.yaml` carries the same setting for snapshots. Replace `agent-sandbox` in `snapshot.yaml` with the name of your sandbox component.
 
-```yaml
-settings:
-  sandbox:agent-sandbox:
-    image: <registry>/software-factory-sandbox:latest
-```
-
-Replace `agent-sandbox` with the name of your sandbox component.
-
-The containerized flavors (Docker, Kubernetes, Modal) support `attach(...)`, so one sandbox session is shared across the steps of a run.
-
-**Local flavor**, for trying the example out without a container. It has no isolation and no `attach(...)`, so every step re-clones the branch, and it ignores the image. The `claude` CLI reads its login from the user keychain and needs the `USER` variable in the session, which the default forwarded set does not include:
+**Local flavor**, for trying the example out on your machine without a container. It has no isolation and no `attach(...)`, so every step re-clones the branch, and it ignores the image. The `claude` CLI, `git` and `gh` must be installed locally. The CLI needs the `USER` variable, which the default forwarded set does not include:
 
 ```bash
 zenml sandbox register agent-sandbox --flavor=local --forward_env=true
-zenml stack update --sandbox agent-sandbox
+zenml stack register software-factory -o default -a default --sandbox agent-sandbox --set
 ```
 
-### Secrets
+### 4. Secrets
 
-The pipeline reads two ZenML secrets. Their key names matter, the steps look them up as environment variables.
+The steps declare `@step(secrets=["github", "claude"])`. ZenML turns the keys of those two secrets into environment variables of the step process, so the secret names and key names must match exactly.
 
-| Secret | Key | Value | Used for |
-|---|---|---|---|
-| `github` | `GITHUB_TOKEN` | A GitHub token that can clone, push and open pull requests on the target repository. A fine-grained token with `Contents: read and write` and `Pull requests: read and write` on that repository is enough. | `git clone`, `fetch`, `push`, `ls-remote` and the `gh pr` calls |
-| `claude` | `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` | Either a long-lived login token from `claude setup-token` (Claude subscription) or an Anthropic API key | Every agent invocation |
+**GitHub.** Create a token that can clone, push and open pull requests on the target repository. A [fine-grained token](https://github.com/settings/personal-access-tokens/new) with `Contents: read and write` and `Pull requests: read and write` on that repository is enough. If you use the `gh` CLI, the token from `gh auth token` works as well, as long as it has the `repo` scope.
 
 ```bash
-zenml secret create github --GITHUB_TOKEN=<token>
-zenml secret create claude --CLAUDE_CODE_OAUTH_TOKEN=<token>
+zenml secret create github --private --GITHUB_TOKEN=<token>
 ```
 
-Add `--private` to keep a secret visible to your user only. On ZenML Pro that is the right default for personal tokens.
+**Claude.** Either a long-lived login token for a Claude subscription, or an Anthropic API key. For the login token, run this on your own machine, complete the browser flow and copy the token it prints:
 
-The steps declare the secrets with `@step(secrets=["github", "claude"])`, which turns the keys into environment variables of the step process. From there the token reaches the sandbox only for the duration of single commands: the GitHub token as git config environment variables on each git call and as `GH_TOKEN` on each `gh` call, the Claude variables on each agent call. The checkout never contains a credential, so the agent cannot push, and the sandbox log shows commands without secrets. On the local flavor the `claude` secret can be skipped because the CLI uses the keychain login.
+```bash
+claude setup-token
+zenml secret create claude --private --CLAUDE_CODE_OAUTH_TOKEN=<token>
+```
+
+For an API key instead:
+
+```bash
+zenml secret create claude --private --ANTHROPIC_API_KEY=<key>
+```
+
+`--private` keeps a secret visible to your user only. On ZenML Pro that is the right default for personal tokens.
+
+The steps pass the tokens into the sandbox only for the duration of single commands: the GitHub token as git config environment variables on each git call and as `GH_TOKEN` on each `gh` call, the Claude variables on each agent call. The checkout never contains a credential, so the agent cannot push, and the sandbox log shows commands without secrets.
 
 ## 🏃 Run It
 
@@ -111,22 +117,24 @@ python run.py \
   --base-branch develop \
   --test-command "uv run pytest tests/unit -q" \
   --max-fix-iterations 2 \
+  --agent-model sonnet \
   --sandbox-image <registry>/software-factory-sandbox:latest
 ```
 
 | Flag | Meaning |
 |---|---|
 | `--repo` | Repository as `owner/name` |
-| `--issue`, `--issue-file` | The issue description, inline or from a file |
+| `--issue`, `--issue-file` | The issue description, inline or from a file. The first line becomes the pull request title |
 | `--target-branch` | Branch to work on. Created from the base branch if it does not exist, checked out if it does |
 | `--base-branch` | Branch the work starts from and the pull request targets. The repository's default branch if omitted |
 | `--test-command` | Shell command run in the checkout after each implementation. Tests are skipped if omitted |
-| `--max-fix-iterations` | Upper bound for the test, review and fix loop |
-| `--sandbox-image` | Container image for the sandbox sessions of this run |
+| `--max-fix-iterations` | Upper bound for fix rounds. Zero means test and review only |
+| `--agent-model` | Model alias or id for the agent, `sonnet` by default. Try `opus` or a full model id |
+| `--sandbox-image` | Container image for the sandbox sessions of this run. Ignored by the local flavor |
 
 The run prints a dashboard URL. It stops twice for you:
 
-1. `plan_review` after the plan is written. The plan is attached to the wait condition. Answer with `{"approved": true, "feedback": ""}` to continue, `approved: false` ends the run.
+1. `plan_review` after the plan is written. The plan is attached to the wait condition, and the `plan_preview` artifact of `write_plan` shows it rendered. Answer with `{"approved": true, "feedback": ""}` to continue, `approved: false` ends the run.
 2. `deploy_approval` after the loop settles. The wait condition carries the pull request URL, the last test report and the last review verdict. Answer `true` to mark the pull request ready for review.
 
 Resolve them in the dashboard or from the CLI:
@@ -135,11 +143,11 @@ Resolve them in the dashboard or from the CLI:
 zenml pipeline runs wait-conditions resolve --run <RUN_ID_OR_NAME> --interactive
 ```
 
-Each gate polls for 60 seconds and then pauses the run. ZenML Pro resumes a paused run when the condition is resolved, on an OSS server run `zenml pipeline runs resume <RUN_ID_OR_NAME>` afterwards.
+Each gate polls for 60 seconds and then pauses the run. ZenML Pro resumes a paused run when the condition is resolved, on an OSS server run `zenml pipeline runs resume <RUN_ID_OR_NAME>` afterwards. With the local orchestrator there is no process left to resume, so answer the gates within the 60 seconds or raise `timeout` in `pipeline.py`.
 
 ## 📸 Trigger It From the Server
 
-A snapshot packages the pipeline, its code and the stack so runs can be started from the dashboard, the CLI or the REST API without a local checkout. `snapshot.yaml` holds placeholder parameters and the sandbox image setting described above. Put your image and sandbox component name in it, then:
+A snapshot packages the pipeline, its code and the stack so runs can be started from the dashboard, the CLI or the REST API without a local checkout. `snapshot.yaml` holds placeholder parameters and the sandbox image setting. Put your image and sandbox component name in it, then:
 
 ```bash
 cd examples/software_factory
@@ -204,11 +212,12 @@ The dashboard's snapshot page offers the same run dialog with editable parameter
 ├── run.py             - CLI entrypoint
 ├── snapshot.yaml      - Parameters and settings for creating a snapshot
 ├── Dockerfile         - Sandbox image
+├── AGENTS.md          - Conventions for coding agents that change this example
 ├── requirements.txt
 └── README.md
 ```
 
-## 🔑 Key Concepts
+## 🔑 How It Works
 
 ### One shared sandbox session per run
 
@@ -232,16 +241,18 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. The loop runs one test and review round more than fixes, so it never ends on an untested fix:
 
 ```python
-for attempt in range(max_fix_iterations):
+for attempt in range(max_fix_iterations + 1):
     tests = run_tests(..., id=f"run_tests_{attempt}")
     verdict = None
     if tests.load().passed:
         verdict = review(..., tests=tests, id=f"review_{attempt}")
         if verdict.load().approved:
             break
+    if attempt == max_fix_iterations:
+        break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
 ```
 
@@ -251,22 +262,30 @@ Prompts that expect a structured result end with the same instruction, and the s
 
 ```python
 prompt = f"...\nWrite your result to the file .factory/plan.md relative to the repository root."
-run_agent(session, prompt)
+run_agent(session, prompt, model=agent_model)
 plan = read_repo_file(session, ".factory/plan.md")
 ```
 
 `.factory/` is excluded from git through `.git/info/exclude`, so review verdicts and summaries never end up in a commit. The plan is the exception: `open_workspace` commits it as `spec/plans/<branch>.md`, with slashes in the branch name replaced by dashes, so the pull request carries it as a file. The pull request body is the agent's own summary of the changes plus links to the plan and the ZenML run.
 
-### Streaming agent output
+### Streaming agent output and usage metadata
 
-The agent runs with `--output-format stream-json`, and `run_agent` renders each event into the step log as it happens:
+The agent runs with `--output-format stream-json`, and `run_agent` renders each event into the step log as it happens. The final `result` event carries the model, turn count, token counts, cost and duration, which `run_agent` logs as step metadata under `agent`, visible on the step's Metadata tab in the dashboard:
 
 ```
-[tool] Read plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py
-[tool] Bash uv run pytest -q plugins/tests/evaluators/test_deterministic.py
-[assistant] Removed both provenance results from every bundle, updating the tests next.
-[result] success after 14 turns
+[tool] Read examples/software_factory/pipeline.py
+[tool] Bash python -m py_compile examples/software_factory/*.py
+[assistant] Both edge cases are fixed, updating the README next.
+[result] success after 12 turns
+Agent used claude-sonnet-5 for 12 turns, 41 input / 3120 output tokens, $0.42, 98.3s.
 ```
+
+## 🔧 Troubleshooting
+
+- **`No active project is configured` or the wrong stack is used when running `run.py`.** A `.zen/` directory in a parent folder holds a repository-level ZenML config that overrides your global one, and this repository's `examples/` folder may have one from earlier experiments. Run `zenml project set ...` and `zenml stack set ...` from inside `examples/software_factory`, or delete the stale `examples/.zen` directory.
+- **`claude` exits immediately in the sandbox.** The CLI refuses `--dangerously-skip-permissions` as root, so the image must run as a non-root user. On the local flavor make sure `--forward_env=true` is set so the CLI sees `USER` and finds its login.
+- **The first attach after a long step fails with a 401 on EKS.** The cached Kubernetes client carries a short-lived token. `attach_sandbox` drops the cached client before every attach as a workaround.
+- **`No Sandbox component in the active stack`.** Add one with `zenml stack update --sandbox <name>`, see [Setup](#3-sandbox-component-and-stack).
 
 ## 📚 Learn More
 
@@ -275,3 +294,4 @@ The agent runs with `--output-format stream-json`, and `run_agent` renders each 
 - [Snapshots](https://docs.zenml.io/how-to/snapshots/snapshots)
 - [Hooks](https://docs.zenml.io/how-to/steps-pipelines/hooks)
 - [Dynamic pipelines](https://docs.zenml.io/how-to/steps-pipelines/dynamic_pipelines)
+- [Metadata](https://docs.zenml.io/how-to/metadata/metadata)

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -219,19 +219,32 @@ zenml trigger webhook create on-agent-issue --webhook github-issues --config on-
 zenml trigger webhook attach on-agent-issue software-factory
 ```
 
-Or whenever someone reacts with 🏭 to a message in a channel, with that message as the issue. Follow the [Slack webhook setup](https://docs.zenml.io/getting-started/zenml-pro/webhooks/slack) with the `reaction_added` bot event, and give the app the `channels:history` scope as well, because a reaction delivery only carries the message's channel and timestamp and the step fetches the text through the Slack API with a bot token:
+Or whenever someone reacts with 🏭 to a message in a channel, with that message as the issue. A reaction delivery only carries the message's channel and timestamp, so the step fetches the text through the Slack API with a bot token. Setup, in this order, since Slack signs the URL verification with the signing secret:
 
-```bash
-zenml secret create slack --private --SLACK_BOT_TOKEN=xoxb-...
-```
-
-```yaml
-target_events:
-  - type: reaction_added
-    channel_id: C0123456789
-    reaction: factory
-    item_type: message
-```
+1. Create a [Slack app](https://api.slack.com/apps) in your workspace. Copy the **Signing Secret** from Basic Information, App Credentials.
+2. Create the ZenML webhook with that secret and copy its endpoint URL:
+   ```bash
+   zenml webhook create slack-events --type slack --secret "<signing secret>"
+   zenml webhook describe slack-events
+   ```
+3. In the app, open Event Subscriptions, enable events, paste the endpoint URL as Request URL and wait for **Verified**. Socket Mode must be off.
+4. Under Subscribe to bot events add `reaction_added`. Under OAuth & Permissions add the scopes `reactions:read` and `channels:history` (`groups:history` for private channels).
+5. Install the app, invite it to the channel, and store its bot token for the step:
+   ```bash
+   zenml secret create slack --private --SLACK_BOT_TOKEN=xoxb-...
+   ```
+6. Create the trigger with the channel id and the emoji name, and attach it to the snapshot with the empty `issue`:
+   ```yaml
+   target_events:
+     - type: reaction_added
+       channel_id: C0123456789
+       reaction: factory
+       item_type: message
+   ```
+   ```bash
+   zenml trigger webhook create on-slack-reaction --webhook slack-events --config on-reaction.yaml
+   zenml trigger webhook attach on-slack-reaction software-factory-on-issue
+   ```
 
 An `app_mention` target works the same way without the extra scope, since the mention carries its text. ClickUp task events only carry ids, extend `issue_from_webhook_body` in `factory_utils.py` with a ClickUp API call in the same way as the Slack reaction. The [webhook trigger docs](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) describe the filters of each provider. On an OSS server, use the REST API or the Python client shown above from your own webhook handler.
 

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -27,7 +27,7 @@ issue ──▶ write_plan ──▶ [plan_review] ──▶ open_workspace ─�
 
 | Step | Sandbox | What it does | Output |
 |---|---|---|---|
-| `issue_from_event` | none | Reads the issue from the webhook delivery that started the run, only when no `issue` parameter is given | `repo`, `issue` |
+| `issue_from_event` | none | Reads the issue from the webhook delivery that started the run, only when the `issue` parameter is empty | `repo`, `issue` |
 | `write_plan` | own session | Clones the base branch, asks the agent for a plan | `plan` (Markdown), `plan_preview` (HTML) |
 | `open_workspace` | creates the shared session | Checks out or creates the target branch, commits the plan as `spec/plans/<branch>.md`, pushes | `workspace`, `base_branch` |
 | `implement` | attach | Agent makes the changes, step commits, pushes and opens a draft pull request | `pr` |
@@ -201,7 +201,7 @@ The dashboard's snapshot page offers the same run dialog with editable parameter
 
 ### Start runs from GitHub issues or Slack
 
-On ZenML Pro, [webhooks](https://docs.zenml.io/getting-started/zenml-pro/webhooks) receive signed deliveries from GitHub, Slack, ClickUp or any custom system, and [webhook triggers](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) start the attached snapshot when a delivery matches. A trigger starts the snapshot with the parameters stored in it, so create the snapshot with `issue` left empty. The `issue_from_event` step then reads the issue from the delivery: title and body of a GitHub issue, or the text of a Slack message or app mention.
+On ZenML Pro, [webhooks](https://docs.zenml.io/getting-started/zenml-pro/webhooks) receive signed deliveries from GitHub, Slack, ClickUp or any custom system, and [webhook triggers](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) start the attached snapshot when a delivery matches. A trigger starts the snapshot with the parameters stored in it, so create a second snapshot with `issue: ""` for the trigger and keep the one with the example issue for the run dialog. The `issue_from_event` step then reads the issue from the delivery: title and body of a GitHub issue, the text of a Slack message or app mention, or the text of the message an emoji reaction was added to.
 
 Run the pipeline whenever an issue labeled `agent` is opened:
 
@@ -219,15 +219,21 @@ zenml trigger webhook create on-agent-issue --webhook github-issues --config on-
 zenml trigger webhook attach on-agent-issue software-factory
 ```
 
-Or whenever someone mentions your Slack app in a channel, with the message as the issue:
+Or whenever someone reacts with 🏭 to a message in a channel, with that message as the issue. Follow the [Slack webhook setup](https://docs.zenml.io/getting-started/zenml-pro/webhooks/slack) with the `reaction_added` bot event, and give the app the `channels:history` scope as well, because a reaction delivery only carries the message's channel and timestamp and the step fetches the text through the Slack API with a bot token:
+
+```bash
+zenml secret create slack --private --SLACK_BOT_TOKEN=xoxb-...
+```
 
 ```yaml
 target_events:
-  - type: app_mention
+  - type: reaction_added
     channel_id: C0123456789
+    reaction: factory
+    item_type: message
 ```
 
-Slack reactions and ClickUp task events only carry ids, so starting a run from an emoji reaction means fetching the message through the Slack API first. `issue_from_webhook_body` in `factory_utils.py` is the place to add that. The [webhook trigger docs](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) describe the filters of each provider. On an OSS server, use the REST API or the Python client shown above from your own webhook handler.
+An `app_mention` target works the same way without the extra scope, since the mention carries its text. ClickUp task events only carry ids, extend `issue_from_webhook_body` in `factory_utils.py` with a ClickUp API call in the same way as the Slack reaction. The [webhook trigger docs](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) describe the filters of each provider. On an OSS server, use the REST API or the Python client shown above from your own webhook handler.
 
 ## 🏗️ What's Inside
 

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -113,22 +113,20 @@ pip install -r requirements.txt
 python run.py \
   --repo owner/name \
   --issue "Add a health check endpoint." \
-  --target-branch feature/health-check \
-  --base-branch develop \
   --test-command "uv run pytest tests/unit -q" \
-  --max-fix-iterations 2 \
-  --agent-model sonnet \
   --sandbox-image <registry>/software-factory-sandbox:latest
 ```
+
+Only the repository, the issue and the sandbox image are required. Everything else has a default:
 
 | Flag | Meaning |
 |---|---|
 | `--repo` | Repository as `owner/name` |
 | `--issue`, `--issue-file` | The issue description, inline or from a file. The first line becomes the pull request title |
-| `--target-branch` | Branch to work on. Created from the base branch if it does not exist, checked out if it does |
+| `--target-branch` | Branch to work on. Created from the base branch if it does not exist, checked out if it does. Derived from the issue title if omitted, for example `factory/add-health-check-endpoint` |
 | `--base-branch` | Branch the work starts from and the pull request targets. The repository's default branch if omitted |
 | `--test-command` | Shell command run in the checkout after each implementation. Tests are skipped if omitted |
-| `--max-fix-iterations` | Upper bound for fix rounds. Zero means test and review only |
+| `--max-fix-iterations` | Upper bound for fix rounds, 2 by default. Zero means test and review only |
 | `--agent-model` | Model alias or id for the agent, `sonnet` by default. Try `opus` or a full model id |
 | `--sandbox-image` | Container image for the sandbox sessions of this run. Ignored by the local flavor |
 
@@ -147,7 +145,7 @@ Each gate polls for 60 seconds and then pauses the run. ZenML Pro resumes a paus
 
 ## 📸 Trigger It From the Server
 
-A snapshot packages the pipeline, its code and the stack so runs can be started from the dashboard, the CLI or the REST API without a local checkout. `snapshot.yaml` holds placeholder parameters and the sandbox image setting. Put your image and sandbox component name in it, then:
+A snapshot packages the pipeline, its code and the stack so runs can be started from the dashboard, the CLI or the REST API without a local checkout. `snapshot.yaml` holds the parameters shown in the run dialog and the sandbox image setting. Only `repo` and `issue` need a real value per run. Put your image and sandbox component name in it, then:
 
 ```bash
 cd examples/software_factory
@@ -165,8 +163,6 @@ cat > run.yaml <<'EOF'
 parameters:
   repo: owner/name
   issue: Add a health check endpoint.
-  target_branch: feature/health-check
-  base_branch: develop
   test_command: uv run pytest tests/unit -q
 EOF
 
@@ -185,7 +181,6 @@ Client().trigger_pipeline(
             "repo": "owner/name",
             "issue": issue_body,
             "target_branch": f"issue/{issue_number}",
-            "base_branch": "develop",
         }
     },
 )
@@ -197,7 +192,7 @@ Or from any system with a ZenML API token:
 curl -X POST "<ZENML_SERVER_URL>/api/v1/pipeline_snapshots/<SNAPSHOT_ID>/runs" \
   -H "Authorization: Bearer <TOKEN>" \
   -H "Content-Type: application/json" \
-  -d '{"run_configuration": {"parameters": {"repo": "owner/name", "issue": "...", "target_branch": "issue/42"}}}'
+  -d '{"run_configuration": {"parameters": {"repo": "owner/name", "issue": "..."}}}'
 ```
 
 The dashboard's snapshot page offers the same run dialog with editable parameters.

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -128,12 +128,13 @@ Only the repository, the issue and the sandbox image are required. Everything el
 | `--test-command` | Shell command run in the checkout after each implementation. Tests are skipped if omitted |
 | `--max-fix-iterations` | Upper bound for fix rounds, 2 by default. Zero means test and review only |
 | `--agent-model` | Model alias or id for the agent, `sonnet` by default. Try `opus` or a full model id |
+| `--gate-timeout` | Seconds each approval gate waits for an answer before the run is paused, 10 minutes by default |
 | `--sandbox-image` | Container image for the sandbox sessions of this run. Ignored by the local flavor |
 
 The run prints a dashboard URL. It stops twice for you:
 
 1. `plan_review` after the plan is written. The plan is attached to the wait condition, and the `plan_preview` artifact of `write_plan` shows it rendered. Answer with `{"approved": true, "feedback": ""}` to continue, `approved: false` ends the run.
-2. `deploy_approval` after the loop settles. The wait condition carries the pull request URL, the last test report and the last review verdict. Answer `true` to mark the pull request ready for review.
+2. `deploy_approval` after the loop settles. The question states what the agent cost across the run, and the wait condition carries the pull request URL, the last test report, the last review verdict and the summed agent usage. Answer `true` to mark the pull request ready for review.
 
 Resolve them in the dashboard or from the CLI:
 
@@ -141,7 +142,7 @@ Resolve them in the dashboard or from the CLI:
 zenml pipeline runs wait-conditions resolve --run <RUN_ID_OR_NAME> --interactive
 ```
 
-Each gate polls for 60 seconds and then pauses the run. ZenML Pro resumes a paused run when the condition is resolved, on an OSS server run `zenml pipeline runs resume <RUN_ID_OR_NAME>` afterwards. With the local orchestrator there is no process left to resume, so answer the gates within the 60 seconds or raise `timeout` in `pipeline.py`.
+Each gate polls for `gate_timeout` seconds and then pauses the run. ZenML Pro resumes a paused run when the condition is resolved, on an OSS server run `zenml pipeline runs resume <RUN_ID_OR_NAME>` afterwards. With the local orchestrator there is no process left to resume, so answer the gates within the 60 seconds or raise `timeout` in `pipeline.py`.
 
 ## 📸 Trigger It From the Server
 
@@ -265,7 +266,7 @@ plan = read_repo_file(session, ".factory/plan.md")
 
 ### Streaming agent output and usage metadata
 
-The agent runs with `--output-format stream-json`, and `run_agent` renders each event into the step log as it happens. The final `result` event carries the model, turn count, token counts, cost and duration, which `run_agent` logs as step metadata under `agent`, visible on the step's Metadata tab in the dashboard:
+The agent runs with `--output-format stream-json`, and `run_agent` renders each event into the step log as it happens. The final `result` event carries the model, turn count, token counts, cost and duration, which `run_agent` logs as step metadata under `agent`, visible on the step's Metadata tab in the dashboard. Before the deploy gate, the pipeline sums these across all steps and logs the result on the run under `agent_total`:
 
 ```
 [tool] Read examples/software_factory/pipeline.py

--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -11,8 +11,8 @@ Turn a GitHub issue into a reviewed pull request. A dynamic ZenML pipeline drive
 - Pause a run with `zenml.wait(...)` for a plan approval and a deploy approval
 - Pass secrets into the sandbox per command, so they never land in the checkout or the logs
 - Bound a test, review and fix loop with `id=` on repeated step invocations
-- Record which model the agent used, how many tokens it consumed and what it cost, per step
-- Publish the pipeline as a snapshot that anyone can trigger from the ZenML server
+- Record which model the agent used, how many tokens it consumed and what it cost, per step and per run
+- Publish the pipeline as a snapshot that anyone can trigger from the ZenML server, and start runs from GitHub issues or Slack messages through webhook triggers
 
 ## 🔁 The Flow
 
@@ -27,6 +27,7 @@ issue ──▶ write_plan ──▶ [plan_review] ──▶ open_workspace ─�
 
 | Step | Sandbox | What it does | Output |
 |---|---|---|---|
+| `issue_from_event` | none | Reads the issue from the webhook delivery that started the run, only when no `issue` parameter is given | `repo`, `issue` |
 | `write_plan` | own session | Clones the base branch, asks the agent for a plan | `plan` (Markdown), `plan_preview` (HTML) |
 | `open_workspace` | creates the shared session | Checks out or creates the target branch, commits the plan as `spec/plans/<branch>.md`, pushes | `workspace`, `base_branch` |
 | `implement` | attach | Agent makes the changes, step commits, pushes and opens a draft pull request | `pr` |
@@ -198,6 +199,36 @@ curl -X POST "<ZENML_SERVER_URL>/api/v1/pipeline_snapshots/<SNAPSHOT_ID>/runs" \
 
 The dashboard's snapshot page offers the same run dialog with editable parameters.
 
+### Start runs from GitHub issues or Slack
+
+On ZenML Pro, [webhooks](https://docs.zenml.io/getting-started/zenml-pro/webhooks) receive signed deliveries from GitHub, Slack, ClickUp or any custom system, and [webhook triggers](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) start the attached snapshot when a delivery matches. A trigger starts the snapshot with the parameters stored in it, so create the snapshot with `issue` left empty. The `issue_from_event` step then reads the issue from the delivery: title and body of a GitHub issue, or the text of a Slack message or app mention.
+
+Run the pipeline whenever an issue labeled `agent` is opened:
+
+```bash
+zenml webhook create github-issues --type github
+zenml webhook describe github-issues   # endpoint URL and signing secret for the GitHub webhook settings
+
+cat > on-issue.yaml <<'EOF'
+target_events:
+  - type: issue_opened
+    repo: owner/name
+    labels: agent
+EOF
+zenml trigger webhook create on-agent-issue --webhook github-issues --config on-issue.yaml
+zenml trigger webhook attach on-agent-issue software-factory
+```
+
+Or whenever someone mentions your Slack app in a channel, with the message as the issue:
+
+```yaml
+target_events:
+  - type: app_mention
+    channel_id: C0123456789
+```
+
+Slack reactions and ClickUp task events only carry ids, so starting a run from an emoji reaction means fetching the message through the Slack API first. `issue_from_webhook_body` in `factory_utils.py` is the place to add that. The [webhook trigger docs](https://docs.zenml.io/getting-started/zenml-pro/triggers#webhook-triggers) describe the filters of each provider. On an OSS server, use the REST API or the Python client shown above from your own webhook handler.
+
 ## 🏗️ What's Inside
 
 ```
@@ -263,6 +294,10 @@ plan = read_repo_file(session, ".factory/plan.md")
 ```
 
 `.factory/` is excluded from git through `.git/info/exclude`, so review verdicts and summaries never end up in a commit. The plan is the exception: `open_workspace` commits it as `spec/plans/<branch>.md`, with slashes in the branch name replaced by dashes, so the pull request carries it as a file. The pull request body is the agent's own summary of the changes plus links to the plan and the ZenML run.
+
+### Readable artifacts and tagged runs
+
+`TestReport` and `ReviewVerdict` are Pydantic models. Their materializer in `models.py` adds a Markdown visualization next to the JSON, so test output and review comments are readable on the artifact page. Every run is tagged with the repository and the work branch, so the runs list filters by either.
 
 ### Streaming agent output and usage metadata
 

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -612,21 +612,23 @@ def slack_message_text(channel: str, ts: str) -> str:
     token = (
         Client().get_secret(SLACK_SECRET_NAME).secret_values[SLACK_TOKEN_KEY]
     )
-    query = urllib.parse.urlencode(
-        {"channel": channel, "latest": ts, "inclusive": "true", "limit": 1}
-    )
+    # `conversations.replies` resolves both top-level messages and thread
+    # replies by their timestamp, `conversations.history` only the former.
+    query = urllib.parse.urlencode({"channel": channel, "ts": ts})
     request = urllib.request.Request(
-        f"https://slack.com/api/conversations.history?{query}",
+        f"https://slack.com/api/conversations.replies?{query}",
         headers={"Authorization": f"Bearer {token}"},
     )
     with urllib.request.urlopen(request, timeout=30) as response:
         payload = json.load(response)
-    if not payload.get("ok") or not payload.get("messages"):
+    messages = payload.get("messages") or []
+    match = next((m for m in messages if m.get("ts") == ts), None)
+    if not payload.get("ok") or match is None:
         raise RuntimeError(
             f"Slack did not return message {ts} in {channel}: "
-            f"{payload.get('error', 'no messages')}"
+            f"{payload.get('error', 'no matching message')}"
         )
-    return str(payload["messages"][0].get("text", ""))
+    return str(match.get("text", ""))
 
 
 def issue_from_webhook_body(

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -16,6 +16,7 @@
 import base64
 import json
 import os
+import re
 import tempfile
 import threading
 from typing import Any, Dict, List, Optional
@@ -534,6 +535,20 @@ def push_branch(session: SandboxSession, branch: str) -> None:
     run_command(
         session, ["git", "push", "-u", "origin", branch], env=git_auth_env()
     )
+
+
+def branch_for_issue(issue: str) -> str:
+    """Derive a work branch name from the first line of an issue.
+
+    Args:
+        issue: The issue description.
+
+    Returns:
+        A branch name like `factory/add-health-check-endpoint`.
+    """
+    title = issue.strip().splitlines()[0].lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", title).strip("-")[:50].rstrip("-")
+    return f"factory/{slug or 'issue'}"
 
 
 def plan_path(branch: str) -> str:

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -19,7 +19,7 @@ import os
 import re
 import tempfile
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 import markdown
@@ -586,6 +586,45 @@ def branch_for_issue(issue: str) -> str:
     title = issue.strip().splitlines()[0].lower()
     slug = re.sub(r"[^a-z0-9]+", "-", title).strip("-")[:50].rstrip("-")
     return f"factory/{slug or 'issue'}"
+
+
+def issue_from_webhook_body(
+    body: Dict[str, Any], default_repo: str
+) -> Tuple[str, str]:
+    """Turn the raw payload of a webhook delivery into repository and issue.
+
+    Supports GitHub `issues` deliveries and Slack `message` and
+    `app_mention` events. Other payloads, such as Slack reactions or
+    ClickUp tasks, only carry ids and need an API call to fetch the text.
+    Extend this function for those.
+
+    Args:
+        body: The JSON body of the delivery.
+        default_repo: The repository to use when the payload names none.
+
+    Raises:
+        ValueError: If the payload is not supported.
+
+    Returns:
+        The repository, `owner/name`, and the issue text.
+    """
+    if "issue" in body:
+        issue = body["issue"]
+        text = issue["title"].strip()
+        if issue.get("body"):
+            text += "\n\n" + issue["body"].strip()
+        return body["repository"]["full_name"], text
+
+    event = body.get("event") or {}
+    if event.get("text"):
+        # Slack keeps app mentions in the text as `<@U0123456789>`.
+        text = re.sub(r"<@[A-Z0-9]+>", "", event["text"]).strip()
+        return default_repo, text
+
+    raise ValueError(
+        "The webhook payload carries no issue text. Supported are GitHub "
+        "issue deliveries and Slack messages or app mentions."
+    )
 
 
 def plan_path(branch: str) -> str:

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -20,15 +20,17 @@ import tempfile
 import threading
 from typing import Any, Dict, List, Optional
 
+import markdown
 from models import PRRef
 
-from zenml import get_step_context
+from zenml import get_step_context, log_metadata
 from zenml.client import Client
 from zenml.execution.pipeline.dynamic.run_context import (
     DynamicPipelineRunContext,
 )
 from zenml.logger import get_logger
 from zenml.sandboxes import BaseSandbox, SandboxOutput, SandboxSession
+from zenml.types import HTMLString
 from zenml.utils.dashboard_utils import get_run_url
 
 logger = get_logger(__name__)
@@ -38,16 +40,6 @@ RESULT_DIR = ".factory"
 PLAN_DIR = "spec/plans"
 GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 AGENT_AUTH_ENV_VARS = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
-AGENT_COMMAND = [
-    "claude",
-    "-p",
-    "--model",
-    "sonnet",
-    "--dangerously-skip-permissions",
-    "--output-format",
-    "stream-json",
-    "--verbose",
-]
 
 
 def active_sandbox() -> BaseSandbox:
@@ -288,20 +280,15 @@ def attach_or_recreate(
     return session
 
 
-def render_agent_event(line: str) -> List[str]:
-    """Render one stream-json line of the agent CLI as log lines.
+def render_agent_event(event: Dict[str, Any]) -> List[str]:
+    """Render one stream-json event of the agent CLI as log lines.
 
     Args:
-        line: The raw stdout line.
+        event: The decoded event.
 
     Returns:
         Log lines for the event.
     """
-    try:
-        event = json.loads(line)
-    except ValueError:
-        return [line.rstrip("\n")]
-
     event_type = event.get("type")
     if event_type == "assistant":
         rendered = []
@@ -340,26 +327,63 @@ def _summarize_tool_input(tool_input: Dict[str, Any]) -> str:
     return json.dumps(tool_input)[:200]
 
 
+def agent_metadata(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract model, token and cost figures from the agent's result event.
+
+    Args:
+        result: The `result` event emitted by the agent CLI.
+
+    Returns:
+        Metadata describing the agent invocation.
+    """
+    usage = result.get("usage", {})
+    # The CLI also bills small helper calls to a cheaper model. Report the
+    # model that did the actual work.
+    model_usage: Dict[str, Dict[str, Any]] = result.get("modelUsage", {})
+    model = max(
+        model_usage, key=lambda m: model_usage[m]["costUSD"], default="unknown"
+    )
+    return {
+        "model": model,
+        "turns": result.get("num_turns", 0),
+        "duration_s": round(result.get("duration_ms", 0) / 1000, 1),
+        "cost_usd": round(result.get("total_cost_usd", 0.0), 4),
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+        "cache_read_tokens": usage.get("cache_read_input_tokens", 0),
+        "cache_write_tokens": usage.get("cache_creation_input_tokens", 0),
+    }
+
+
 def run_agent(
-    session: SandboxSession, prompt: str, cwd: str = REPO_DIR
-) -> str:
-    """Run the agent CLI non-interactively and stream its output.
+    session: SandboxSession, prompt: str, model: str, cwd: str = REPO_DIR
+) -> None:
+    """Run the agent CLI non-interactively, stream its output, log its usage.
+
+    Model, turn count, token counts, cost and duration are attached to the
+    calling step run as metadata under the `agent` key. Results are read
+    from files the agent writes, see the prompts in `pipeline.py`.
 
     Args:
         session: The sandbox session to run the agent in.
         prompt: The prompt to pass to the agent.
+        model: The model alias or id the agent should use.
         cwd: Working directory for the agent, relative to the session.
 
     Raises:
         RuntimeError: If the agent exits with a non-zero code.
-
-    Returns:
-        The final answer of the agent.
     """
-    insert_index = AGENT_COMMAND.index("-p") + 1
-    command = (
-        AGENT_COMMAND[:insert_index] + [prompt] + AGENT_COMMAND[insert_index:]
-    )
+    command = [
+        "claude",
+        "-p",
+        prompt,
+        "--model",
+        model,
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    ]
     env = {
         name: os.environ[name]
         for name in AGENT_AUTH_ENV_VARS
@@ -373,22 +397,69 @@ def run_agent(
         target=lambda: stderr_lines.extend(process.stderr()), daemon=True
     )
     stderr_thread.start()
-    result = ""
+    result: Dict[str, Any] = {}
     for line in process.stdout():
-        for rendered in render_agent_event(line):
-            logger.info(rendered)
         try:
             event = json.loads(line)
         except ValueError:
+            logger.info(line.rstrip("\n"))
             continue
+        for rendered in render_agent_event(event):
+            logger.info(rendered)
         if event.get("type") == "result":
-            result = event.get("result") or ""
+            result = event
     stderr_thread.join()
     exit_code = process.wait()
     if exit_code != 0:
         stderr = "".join(stderr_lines)
         raise RuntimeError(f"Agent failed (exit {exit_code}): {stderr}")
-    return result
+
+    if result:
+        metadata = agent_metadata(result)
+        logger.info(
+            "Agent used %s for %s turns, %s input / %s output tokens, "
+            "$%s, %ss.",
+            metadata["model"],
+            metadata["turns"],
+            metadata["input_tokens"],
+            metadata["output_tokens"],
+            metadata["cost_usd"],
+            metadata["duration_s"],
+        )
+        log_metadata(metadata={"agent": metadata})
+
+
+def markdown_to_html(text: str, title: str) -> HTMLString:
+    """Render Markdown as a self-contained HTML page for the dashboard.
+
+    The dashboard's own Markdown view styles fenced code blocks poorly, so
+    plan-like artifacts are also stored as HTML with explicit code styling.
+
+    Args:
+        text: The Markdown source.
+        title: The page title.
+
+    Returns:
+        The rendered page.
+    """
+    body = markdown.markdown(text, extensions=["fenced_code", "tables"])
+    style = (
+        "body{font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;"
+        "max-width:900px;margin:2rem auto;padding:0 1rem;line-height:1.5;"
+        "color:#1f2933}"
+        "pre{background:#f4f6f8;border:1px solid #d9dee3;border-radius:6px;"
+        "padding:12px;overflow-x:auto}"
+        "code{font-family:SFMono-Regular,Consolas,Menlo,monospace;"
+        "font-size:0.9em}"
+        ":not(pre)>code{background:#f4f6f8;padding:1px 4px;border-radius:4px}"
+        "table{border-collapse:collapse}td,th{border:1px solid #d9dee3;"
+        "padding:4px 8px}"
+    )
+    return HTMLString(
+        f"<!doctype html><html><head><meta charset='utf-8'>"
+        f"<title>{title}</title><style>{style}</style></head>"
+        f"<body>{body}</body></html>"
+    )
 
 
 def read_repo_file(session: SandboxSession, path: str) -> str:
@@ -596,11 +667,11 @@ def destroy_workspace_hook(exception: Optional[BaseException] = None) -> None:
         if step_run is None:
             return
 
-        outputs = step_run.regular_outputs
-        if not outputs:
+        output = step_run.regular_outputs.get("workspace")
+        if output is None:
             return
 
-        workspace = next(iter(outputs.values())).load()
+        workspace = output.load()
         try:
             session = attach_sandbox(workspace)
         except (KeyError, RuntimeError):

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -20,6 +20,7 @@ import re
 import tempfile
 import threading
 from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 import markdown
 from models import PRRef
@@ -428,6 +429,42 @@ def run_agent(
             metadata["duration_s"],
         )
         log_metadata(metadata={"agent": metadata})
+
+
+def log_agent_totals(run_id: UUID) -> Dict[str, Any]:
+    """Sum the agent usage of all steps of a run and log it on the run.
+
+    Args:
+        run_id: The pipeline run.
+
+    Returns:
+        The summed cost, tokens, turns and duration under the `agent_total`
+        key, plus the number of agent invocations.
+    """
+    totals = {
+        "cost_usd": 0.0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "turns": 0,
+        "duration_s": 0.0,
+        "invocations": 0,
+    }
+    for step in Client().get_pipeline_run(run_id).steps.values():
+        usage = step.run_metadata.get("agent")
+        if not isinstance(usage, dict):
+            continue
+        totals["invocations"] += 1
+        for key in totals:
+            if key in usage:
+                totals[key] += usage[key]
+    totals["cost_usd"] = round(totals["cost_usd"], 4)
+    totals["duration_s"] = round(totals["duration_s"], 1)
+    log_metadata(
+        metadata={"agent_total": totals}, run_id_name_or_prefix=run_id
+    )
+    return totals
 
 
 def markdown_to_html(text: str, title: str) -> HTMLString:

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -19,6 +19,8 @@ import os
 import re
 import tempfile
 import threading
+import urllib.parse
+import urllib.request
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -42,6 +44,8 @@ RESULT_DIR = ".factory"
 PLAN_DIR = "spec/plans"
 GITHUB_TOKEN_ENV = "GITHUB_TOKEN"
 AGENT_AUTH_ENV_VARS = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
+SLACK_SECRET_NAME = "slack"
+SLACK_TOKEN_KEY = "SLACK_BOT_TOKEN"
 
 
 def active_sandbox() -> BaseSandbox:
@@ -588,15 +592,52 @@ def branch_for_issue(issue: str) -> str:
     return f"factory/{slug or 'issue'}"
 
 
+def slack_message_text(channel: str, ts: str) -> str:
+    """Fetch the text of one Slack message through the Web API.
+
+    Needs a ZenML secret named `slack` with the key `SLACK_BOT_TOKEN`, a bot
+    token whose app has the `channels:history` scope (and `groups:history`
+    for private channels) and is a member of the channel.
+
+    Args:
+        channel: The channel id.
+        ts: The message timestamp, which is the message id in Slack.
+
+    Raises:
+        RuntimeError: If Slack does not return the message.
+
+    Returns:
+        The message text.
+    """
+    token = (
+        Client().get_secret(SLACK_SECRET_NAME).secret_values[SLACK_TOKEN_KEY]
+    )
+    query = urllib.parse.urlencode(
+        {"channel": channel, "latest": ts, "inclusive": "true", "limit": 1}
+    )
+    request = urllib.request.Request(
+        f"https://slack.com/api/conversations.history?{query}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    if not payload.get("ok") or not payload.get("messages"):
+        raise RuntimeError(
+            f"Slack did not return message {ts} in {channel}: "
+            f"{payload.get('error', 'no messages')}"
+        )
+    return str(payload["messages"][0].get("text", ""))
+
+
 def issue_from_webhook_body(
     body: Dict[str, Any], default_repo: str
 ) -> Tuple[str, str]:
     """Turn the raw payload of a webhook delivery into repository and issue.
 
-    Supports GitHub `issues` deliveries and Slack `message` and
-    `app_mention` events. Other payloads, such as Slack reactions or
-    ClickUp tasks, only carry ids and need an API call to fetch the text.
-    Extend this function for those.
+    Supports GitHub `issues` deliveries and the Slack events `message`,
+    `app_mention` and `reaction_added` on a message. ClickUp task events
+    only carry ids and would need a ClickUp API call in the same way as the
+    Slack reaction.
 
     Args:
         body: The JSON body of the delivery.
@@ -616,14 +657,19 @@ def issue_from_webhook_body(
         return body["repository"]["full_name"], text
 
     event = body.get("event") or {}
-    if event.get("text"):
+    text = event.get("text")
+    if event.get("type") == "reaction_added":
+        item = event.get("item") or {}
+        if item.get("type") != "message":
+            raise ValueError("Only reactions on messages are supported.")
+        text = slack_message_text(item["channel"], item["ts"])
+    if text:
         # Slack keeps app mentions in the text as `<@U0123456789>`.
-        text = re.sub(r"<@[A-Z0-9]+>", "", event["text"]).strip()
-        return default_repo, text
+        return default_repo, re.sub(r"<@[A-Z0-9]+>", "", text).strip()
 
     raise ValueError(
         "The webhook payload carries no issue text. Supported are GitHub "
-        "issue deliveries and Slack messages or app mentions."
+        "issue deliveries and Slack messages, app mentions and reactions."
     )
 
 

--- a/examples/software_factory/models.py
+++ b/examples/software_factory/models.py
@@ -13,9 +13,13 @@
 #  permissions and limitations under the License.
 """Structured data models for the software factory pipeline."""
 
-from typing import List
+import os
+from typing import Any, Dict, List
 
 from pydantic import BaseModel
+
+from zenml.enums import VisualizationType
+from zenml.materializers.pydantic_materializer import PydanticMaterializer
 
 
 class PRRef(BaseModel):
@@ -31,12 +35,55 @@ class TestReport(BaseModel):
     passed: bool
     summary: str
 
+    def to_markdown(self) -> str:
+        """Render the report for the dashboard.
+
+        Returns:
+            The report as Markdown.
+        """
+        status = "passed" if self.passed else "failed"
+        return f"## Tests {status}\n\n```\n{self.summary.strip()}\n```\n"
+
 
 class ReviewVerdict(BaseModel):
     """Review verdict."""
 
     approved: bool
     comments: List[str]
+
+    def to_markdown(self) -> str:
+        """Render the verdict for the dashboard.
+
+        Returns:
+            The verdict as Markdown.
+        """
+        status = "approved" if self.approved else "changes requested"
+        comments = "\n".join(f"- {c}" for c in self.comments) or "No comments."
+        return f"## Review {status}\n\n{comments}\n"
+
+
+class ReportMaterializer(PydanticMaterializer):
+    """Stores test reports and review verdicts with a Markdown visualization.
+
+    The dashboard shows the JSON of a Pydantic artifact by default. The
+    visualization makes test output and review comments readable at a glance.
+    """
+
+    ASSOCIATED_TYPES = (TestReport, ReviewVerdict)
+
+    def save_visualizations(self, data: Any) -> Dict[str, VisualizationType]:
+        """Write the Markdown rendering next to the artifact.
+
+        Args:
+            data: The test report or review verdict.
+
+        Returns:
+            The visualization path and its type.
+        """
+        path = os.path.join(self.uri, "report.md").replace("\\", "/")
+        with self.artifact_store.open(path, "w") as f:
+            f.write(data.to_markdown())
+        return {path: VisualizationType.MARKDOWN}
 
 
 class Review(BaseModel):

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -60,8 +60,9 @@ def issue_from_event(
     """Read the issue from the webhook delivery that started this run.
 
     Used when the run was started by a webhook trigger instead of with an
-    explicit `issue` parameter, for example from a GitHub issue or a Slack
-    message. Needs a ZenML Pro server with webhooks.
+    explicit `issue` parameter, for example from a GitHub issue, a Slack
+    message or an emoji reaction on one. Needs a ZenML Pro server with
+    webhooks.
 
     Args:
         repo: The repository configured on the snapshot, used when the

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -25,6 +25,7 @@ from factory_utils import (
     commit_all,
     destroy_workspace_hook,
     github_token,
+    log_agent_totals,
     markdown_to_html,
     open_pr,
     plan_path,
@@ -42,6 +43,9 @@ from models import PRRef, Review, ReviewVerdict, TestReport
 from zenml import pipeline, step, wait
 from zenml.config import DockerSettings
 from zenml.config.retry_config import StepRetryConfig
+from zenml.execution.pipeline.dynamic.run_context import (
+    DynamicPipelineRunContext,
+)
 from zenml.logger import get_logger
 from zenml.types import HTMLString, MarkdownString
 
@@ -376,6 +380,7 @@ def software_factory(
     test_command: Optional[str] = None,
     max_fix_iterations: int = 2,
     agent_model: str = "sonnet",
+    gate_timeout: int = 600,
 ) -> None:
     """Drive a GitHub issue through plan, implement, test and review.
 
@@ -396,6 +401,8 @@ def software_factory(
             tested. Zero means test and review only.
         agent_model: The model alias or id the agent uses, for example
             `sonnet`, `opus` or a full model id.
+        gate_timeout: Seconds each approval gate polls for an answer before
+            the run is paused.
     """
     target_branch = target_branch or branch_for_issue(issue)
     plan, _ = write_plan(
@@ -409,7 +416,7 @@ def software_factory(
         question="Approve plan?",
         metadata={"plan": plan.load()},
         name="plan_review",
-        timeout=60,
+        timeout=gate_timeout,
     )
     if not plan_review.approved:
         return
@@ -467,15 +474,25 @@ def software_factory(
     close_workspace(workspace=workspace)
 
     pr_result = pr.load()
-    metadata = {"pr_url": pr_result.url, "tests": tests.load().model_dump()}
+    context = DynamicPipelineRunContext.get()
+    assert context is not None
+    totals = log_agent_totals(context.run.id)
+    metadata = {
+        "pr_url": pr_result.url,
+        "tests": tests.load().model_dump(),
+        "agent_total": totals,
+    }
     if verdict is not None:
         metadata["verdict"] = verdict.load().model_dump()
     deploy_approval = wait(
         schema=bool,
-        question=f"Deploy {pr_result.url}?",
+        question=(
+            f"Deploy {pr_result.url}? The agent used {totals['turns']} turns "
+            f"and ${totals['cost_usd']} across {totals['invocations']} calls."
+        ),
         metadata=metadata,
         name="deploy_approval",
-        timeout=60,
+        timeout=gate_timeout,
     )
     if deploy_approval:
         deploy(pr=pr, repo=repo)

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -20,6 +20,7 @@ from factory_utils import (
     attach_or_recreate,
     attach_sandbox,
     branch_exists,
+    branch_for_issue,
     clone_repo,
     commit_all,
     destroy_workspace_hook,
@@ -370,19 +371,21 @@ def deploy(pr: PRRef, repo: str) -> None:
 def software_factory(
     repo: str,
     issue: str,
-    target_branch: str,
+    target_branch: Optional[str] = None,
     base_branch: Optional[str] = None,
     test_command: Optional[str] = None,
-    max_fix_iterations: int = 3,
+    max_fix_iterations: int = 2,
     agent_model: str = "sonnet",
 ) -> None:
     """Drive a GitHub issue through plan, implement, test and review.
 
     Args:
         repo: The repository to work in, `owner/name`.
-        issue: The issue description.
+        issue: The issue description. The first line is the title.
         target_branch: The branch to work on. Created from the base branch
-            if it does not exist, checked out if it does.
+            if it does not exist, checked out if it does. Derived from the
+            issue title if unset, for example
+            `factory/add-health-check-endpoint`.
         base_branch: The branch to create `target_branch` from and to open
             the pull request against. The repository's default branch if
             unset.
@@ -394,6 +397,7 @@ def software_factory(
         agent_model: The model alias or id the agent uses, for example
             `sonnet`, `opus` or a full model id.
     """
+    target_branch = target_branch or branch_for_issue(issue)
     plan, _ = write_plan(
         repo=repo,
         issue=issue,

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -24,6 +24,7 @@ from factory_utils import (
     commit_all,
     destroy_workspace_hook,
     github_token,
+    markdown_to_html,
     open_pr,
     plan_path,
     pr_body,
@@ -41,7 +42,7 @@ from zenml import pipeline, step, wait
 from zenml.config import DockerSettings
 from zenml.config.retry_config import StepRetryConfig
 from zenml.logger import get_logger
-from zenml.types import MarkdownString
+from zenml.types import HTMLString, MarkdownString
 
 logger = get_logger(__name__)
 
@@ -51,17 +52,24 @@ logger = get_logger(__name__)
     retry=StepRetryConfig(max_retries=2, delay=5),
 )
 def write_plan(
-    repo: str, issue: str, base_branch: Optional[str] = None
-) -> Annotated[MarkdownString, "plan"]:
+    repo: str,
+    issue: str,
+    agent_model: str,
+    base_branch: Optional[str] = None,
+) -> Tuple[
+    Annotated[MarkdownString, "plan"],
+    Annotated[HTMLString, "plan_preview"],
+]:
     """Draft a fix plan for a GitHub issue in a fresh sandbox session.
 
     Args:
         repo: The repository to work in, `owner/name`.
         issue: The issue description.
+        agent_model: The model the agent uses.
         base_branch: The branch to plan against, the default branch if unset.
 
     Returns:
-        The plan written by the agent.
+        The plan written by the agent and an HTML rendering of it.
     """
     session = active_sandbox().create_session()
     try:
@@ -75,8 +83,9 @@ def write_plan(
             "Write your result to the file .factory/plan.md relative to the "
             "repository root."
         )
-        run_agent(session, prompt)
-        return MarkdownString(read_repo_file(session, ".factory/plan.md"))
+        run_agent(session, prompt, model=agent_model)
+        plan = read_repo_file(session, ".factory/plan.md")
+        return MarkdownString(plan), markdown_to_html(plan, title="Plan")
     finally:
         session.destroy()
 
@@ -126,6 +135,7 @@ def implement(
     issue: str,
     plan: MarkdownString,
     base_branch: str,
+    agent_model: str,
 ) -> Annotated[PRRef, "pr"]:
     """Implement the plan and open a draft pull request.
 
@@ -136,6 +146,7 @@ def implement(
         issue: The issue description.
         plan: The plan for the issue.
         base_branch: The pull request base.
+        agent_model: The model the agent uses.
 
     Returns:
         A reference to the opened pull request.
@@ -152,7 +163,7 @@ def implement(
             "made, as bullet points without headings, to the file "
             ".factory/summary.md relative to the repository root."
         )
-        run_agent(session, prompt)
+        run_agent(session, prompt, model=agent_model)
         summary = read_repo_file(session, ".factory/summary.md")
         commit_all(session, f"Implement: {issue.splitlines()[0]}")
         push_branch(session, branch)
@@ -208,6 +219,7 @@ def review(
     plan: MarkdownString,
     tests: TestReport,
     base_branch: str,
+    agent_model: str,
 ) -> Annotated[ReviewVerdict, "verdict"]:
     """Review the diff on the branch against the issue, plan and test report.
 
@@ -219,6 +231,7 @@ def review(
         plan: The plan for the issue.
         tests: The result of the latest test run.
         base_branch: The branch to diff against.
+        agent_model: The model the agent uses.
 
     Returns:
         The verdict of the review.
@@ -240,7 +253,7 @@ def review(
             "Write your result to the file .factory/review.json relative "
             "to the repository root."
         )
-        run_agent(session, prompt)
+        run_agent(session, prompt, model=agent_model)
         result = read_repo_file(session, ".factory/review.json")
         return ReviewVerdict.model_validate_json(result)
 
@@ -256,6 +269,7 @@ def fix(
     issue: str,
     tests: TestReport,
     base_branch: str,
+    agent_model: str,
     verdict: Optional[ReviewVerdict] = None,
 ) -> Annotated[PRRef, "pr"]:
     """Address review and test feedback and update the pull request.
@@ -267,6 +281,7 @@ def fix(
         issue: The issue description.
         tests: The result of the latest test run.
         base_branch: The pull request base.
+        agent_model: The model the agent uses.
         verdict: The verdict of the latest review, unset if the tests failed.
 
     Returns:
@@ -290,7 +305,7 @@ def fix(
             "this branch, as bullet points without headings, to the file "
             ".factory/summary.md relative to the repository root."
         )
-        run_agent(session, prompt)
+        run_agent(session, prompt, model=agent_model)
         summary = read_repo_file(session, ".factory/summary.md")
         commit_all(session, "Fix: address review and test feedback")
         push_branch(session, branch)
@@ -359,6 +374,7 @@ def software_factory(
     base_branch: Optional[str] = None,
     test_command: Optional[str] = None,
     max_fix_iterations: int = 3,
+    agent_model: str = "sonnet",
 ) -> None:
     """Drive a GitHub issue through plan, implement, test and review.
 
@@ -372,10 +388,18 @@ def software_factory(
             unset.
         test_command: Shell command that runs the tests in the checkout.
             Tests are skipped if unset.
-        max_fix_iterations: The maximum number of test and review fix
-            iterations.
+        max_fix_iterations: The maximum number of fix rounds. Tests and
+            review run once more than this, so the last fix is always
+            tested. Zero means test and review only.
+        agent_model: The model alias or id the agent uses, for example
+            `sonnet`, `opus` or a full model id.
     """
-    plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
+    plan, _ = write_plan(
+        repo=repo,
+        issue=issue,
+        agent_model=agent_model,
+        base_branch=base_branch,
+    )
     plan_review = wait(
         schema=Review,
         question="Approve plan?",
@@ -396,9 +420,11 @@ def software_factory(
         issue=issue,
         plan=plan,
         base_branch=base_branch,
+        agent_model=agent_model,
     )
-    verdict = None
-    for attempt in range(max_fix_iterations):
+    # One more test and review round than fixes, so the loop never ends
+    # on an untested fix.
+    for attempt in range(max_fix_iterations + 1):
         tests = run_tests(
             workspace=workspace,
             repo=repo,
@@ -416,10 +442,13 @@ def software_factory(
                 plan=plan,
                 tests=tests,
                 base_branch=base_branch,
+                agent_model=agent_model,
                 id=f"review_{attempt}",
             )
             if verdict.load().approved:
                 break
+        if attempt == max_fix_iterations:
+            break
         pr = fix(
             workspace=workspace,
             repo=repo,
@@ -427,6 +456,7 @@ def software_factory(
             issue=issue,
             tests=tests,
             base_branch=base_branch,
+            agent_model=agent_model,
             verdict=verdict,
             id=f"fix_{attempt}",
         )

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -25,6 +25,7 @@ from factory_utils import (
     commit_all,
     destroy_workspace_hook,
     github_token,
+    issue_from_webhook_body,
     log_agent_totals,
     markdown_to_html,
     open_pr,
@@ -40,7 +41,7 @@ from factory_utils import (
 )
 from models import PRRef, Review, ReviewVerdict, TestReport
 
-from zenml import pipeline, step, wait
+from zenml import add_tags, pipeline, step, wait
 from zenml.config import DockerSettings
 from zenml.config.retry_config import StepRetryConfig
 from zenml.execution.pipeline.dynamic.run_context import (
@@ -50,6 +51,38 @@ from zenml.logger import get_logger
 from zenml.types import HTMLString, MarkdownString
 
 logger = get_logger(__name__)
+
+
+@step
+def issue_from_event(
+    repo: str,
+) -> Tuple[Annotated[str, "repo"], Annotated[str, "issue"]]:
+    """Read the issue from the webhook delivery that started this run.
+
+    Used when the run was started by a webhook trigger instead of with an
+    explicit `issue` parameter, for example from a GitHub issue or a Slack
+    message. Needs a ZenML Pro server with webhooks.
+
+    Args:
+        repo: The repository configured on the snapshot, used when the
+            delivery names none.
+
+    Raises:
+        RuntimeError: If the run was not started by a webhook trigger.
+
+    Returns:
+        The repository and the issue text.
+    """
+    # Imported here so the example also imports on servers without webhooks.
+    from zenml.utils.trigger_utils import get_raw_webhook_event
+
+    delivery = get_raw_webhook_event()
+    if delivery is None:
+        raise RuntimeError(
+            "No issue was given and this run was not started by a webhook "
+            "trigger. Pass the `issue` parameter."
+        )
+    return issue_from_webhook_body(delivery["body"], default_repo=repo)
 
 
 @step(
@@ -374,7 +407,7 @@ def deploy(pr: PRRef, repo: str) -> None:
 )
 def software_factory(
     repo: str,
-    issue: str,
+    issue: Optional[str] = None,
     target_branch: Optional[str] = None,
     base_branch: Optional[str] = None,
     test_command: Optional[str] = None,
@@ -385,8 +418,10 @@ def software_factory(
     """Drive a GitHub issue through plan, implement, test and review.
 
     Args:
-        repo: The repository to work in, `owner/name`.
-        issue: The issue description. The first line is the title.
+        repo: The repository to work in, `owner/name`. A GitHub issue
+            delivery overrides it with the issue's repository.
+        issue: The issue description. The first line is the title. Read
+            from the webhook delivery that started the run if unset.
         target_branch: The branch to work on. Created from the base branch
             if it does not exist, checked out if it does. Derived from the
             issue title if unset, for example
@@ -404,7 +439,14 @@ def software_factory(
         gate_timeout: Seconds each approval gate polls for an answer before
             the run is paused.
     """
+    context = DynamicPipelineRunContext.get()
+    assert context is not None
+    if not issue:
+        repo_output, issue_output = issue_from_event(repo=repo)
+        repo, issue = repo_output.load(), issue_output.load()
     target_branch = target_branch or branch_for_issue(issue)
+    add_tags(tags=[repo, target_branch], run=context.run.id)
+
     plan, _ = write_plan(
         repo=repo,
         issue=issue,
@@ -474,8 +516,6 @@ def software_factory(
     close_workspace(workspace=workspace)
 
     pr_result = pr.load()
-    context = DynamicPipelineRunContext.get()
-    assert context is not None
     totals = log_agent_totals(context.run.id)
     metadata = {
         "pr_url": pr_result.url,

--- a/examples/software_factory/requirements.txt
+++ b/examples/software_factory/requirements.txt
@@ -1,1 +1,2 @@
 zenml
+markdown

--- a/examples/software_factory/run.py
+++ b/examples/software_factory/run.py
@@ -33,7 +33,8 @@ def main() -> None:
         "--issue-file", help="Path to a file containing the issue description."
     )
     parser.add_argument(
-        "--target-branch", required=True, help="The branch to work on."
+        "--target-branch",
+        help="The branch to work on. Derived from the issue title if not set.",
     )
     parser.add_argument(
         "--base-branch",
@@ -48,7 +49,7 @@ def main() -> None:
     parser.add_argument(
         "--max-fix-iterations",
         type=int,
-        default=3,
+        default=2,
         help="The maximum number of fix rounds. Zero means test and review "
         "only.",
     )

--- a/examples/software_factory/run.py
+++ b/examples/software_factory/run.py
@@ -15,10 +15,11 @@
 
 import argparse
 
+from factory_utils import active_sandbox
 from pipeline import software_factory
 
-from zenml.client import Client
 from zenml.sandboxes import ContainerizedSandboxSettings
+from zenml.utils.settings_utils import get_stack_component_name_setting_key
 
 
 def main() -> None:
@@ -48,12 +49,18 @@ def main() -> None:
         "--max-fix-iterations",
         type=int,
         default=3,
-        help="The maximum number of test and review fix iterations.",
+        help="The maximum number of fix rounds. Zero means test and review "
+        "only.",
     )
     parser.add_argument(
         "--sandbox-image",
         required=True,
         help="Container image for the sandbox sessions of this run.",
+    )
+    parser.add_argument(
+        "--agent-model",
+        default="sonnet",
+        help="Model alias or id for the agent, for example sonnet or opus.",
     )
     args = parser.parse_args()
 
@@ -65,15 +72,12 @@ def main() -> None:
     else:
         parser.error("One of --issue or --issue-file is required.")
 
-    sandbox = Client().active_stack.sandbox
-    if sandbox is None:
-        parser.error("The active stack has no sandbox component.")
-
+    sandbox = active_sandbox()
     pipeline = software_factory.with_options(
         settings={
-            f"sandbox:{sandbox.name}": ContainerizedSandboxSettings(
-                image=args.sandbox_image
-            )
+            get_stack_component_name_setting_key(
+                sandbox
+            ): ContainerizedSandboxSettings(image=args.sandbox_image)
         }
     )
     pipeline(
@@ -83,6 +87,7 @@ def main() -> None:
         base_branch=args.base_branch,
         test_command=args.test_command,
         max_fix_iterations=args.max_fix_iterations,
+        agent_model=args.agent_model,
     )
 
 

--- a/examples/software_factory/run.py
+++ b/examples/software_factory/run.py
@@ -63,6 +63,12 @@ def main() -> None:
         default="sonnet",
         help="Model alias or id for the agent, for example sonnet or opus.",
     )
+    parser.add_argument(
+        "--gate-timeout",
+        type=int,
+        default=600,
+        help="Seconds each approval gate waits before the run is paused.",
+    )
     args = parser.parse_args()
 
     if args.issue_file:
@@ -89,6 +95,7 @@ def main() -> None:
         test_command=args.test_command,
         max_fix_iterations=args.max_fix_iterations,
         agent_model=args.agent_model,
+        gate_timeout=args.gate_timeout,
     )
 
 

--- a/examples/software_factory/snapshot.yaml
+++ b/examples/software_factory/snapshot.yaml
@@ -12,6 +12,7 @@ parameters:
   test_command: null
   max_fix_iterations: 2
   agent_model: sonnet
+  gate_timeout: 600
 # Sandbox image for the sessions of this pipeline. The key is
 # `sandbox:<name of your sandbox component>`.
 settings:

--- a/examples/software_factory/snapshot.yaml
+++ b/examples/software_factory/snapshot.yaml
@@ -6,6 +6,7 @@ parameters:
   base_branch: null
   test_command: null
   max_fix_iterations: 3
+  agent_model: sonnet
 # Sandbox image for the sessions of this pipeline. The key is
 # `sandbox:<name of your sandbox component>`.
 settings:

--- a/examples/software_factory/snapshot.yaml
+++ b/examples/software_factory/snapshot.yaml
@@ -1,11 +1,16 @@
-# Parameters are placeholders, override them when triggering the snapshot.
+# Parameters shown in the run dialog. Only `repo` and `issue` are
+# required, the rest are sensible defaults you can override per run.
 parameters:
   repo: owner/name
-  issue: Replace with the issue description when triggering.
-  target_branch: replace-me
+  issue: |
+    Add a health check endpoint.
+
+    Add a `GET /health` route that returns HTTP 200 and the JSON body
+    `{"status": "ok"}`, plus a test for it.
+  target_branch: null
   base_branch: null
   test_command: null
-  max_fix_iterations: 3
+  max_fix_iterations: 2
   agent_model: sonnet
 # Sandbox image for the sessions of this pipeline. The key is
 # `sandbox:<name of your sandbox component>`.

--- a/examples/software_factory/snapshot.yaml
+++ b/examples/software_factory/snapshot.yaml
@@ -1,5 +1,7 @@
 # Parameters shown in the run dialog. Only `repo` and `issue` are
 # required, the rest are sensible defaults you can override per run.
+# Leave `issue` empty on a snapshot attached to a webhook trigger, the run
+# then reads the issue from the GitHub or Slack delivery.
 parameters:
   repo: owner/name
   issue: |

--- a/examples/software_factory/snapshot.yaml
+++ b/examples/software_factory/snapshot.yaml
@@ -1,6 +1,6 @@
-# Parameters shown in the run dialog. Only `repo` and `issue` are
-# required, the rest are sensible defaults you can override per run.
-# Leave `issue` empty on a snapshot attached to a webhook trigger, the run
+# Only `repo` and `issue` need a real value. `target_branch`, `base_branch`
+# and `test_command` are left out so they keep their defaults. Set `issue`
+# to an empty string on a snapshot attached to a webhook trigger, the run
 # then reads the issue from the GitHub or Slack delivery.
 parameters:
   repo: owner/name
@@ -9,9 +9,6 @@ parameters:
 
     Add a `GET /health` route that returns HTTP 200 and the JSON body
     `{"status": "ok"}`, plus a test for it.
-  target_branch: null
-  base_branch: null
-  test_command: null
   max_fix_iterations: 2
   agent_model: sonnet
   gate_timeout: 600


### PR DESCRIPTION
## What this is

The software factory example turns a GitHub issue into a reviewed pull request: a dynamic pipeline drives the `claude` CLI through plan, implementation, tests, review and a bounded fix loop, every command inside a ZenML Sandbox, with two human gates via `zenml.wait(...)`. This PR carries six commits that polish the example for customer demos, on top of the branch that adds it.

## What the polish adds

- **Agent usage metadata.** Every agent step logs model, turns, cost, input, output and cache tokens, and duration under an `agent` metadata group, parsed from the CLI's `result` event. Before the deploy gate the pipeline sums them across steps, logs `agent_total` on the run, and states the total in the gate question ("Deploy PR …? The agent used 59 turns and $1.67 across 3 calls.").
- **Model as a parameter.** `agent_model` (default `sonnet`) is a pipeline parameter and `--agent-model` flag, so runs with different models are directly comparable on cost and outcome.
- **Webhook-driven runs.** `issue` is optional. When unset, the new `issue_from_event` step reads the issue from the raw webhook delivery that started the run: title and body of a GitHub issue, the text of a Slack message or app mention, or the text of the message an emoji reaction was added to, fetched through the Slack API with a bot token. This is what lets a snapshot attached to a webhook trigger work without parameter mapping. The README documents the GitHub issue and Slack setups and points at the REST API for OSS servers.
- **Fewer required inputs.** Only `repo` and `issue` are required. The target branch defaults to `factory/<issue-title-slug>`, the base branch to the repository default, fix rounds to two. `snapshot.yaml` shows a realistic example issue so the dashboard run dialog is two edits away from a run.
- **Sane loop.** Tests and review run once more than fixes, so a run never ends on an untested fix and zero fix rounds is a valid "test and review only" configuration. The previous shape raised a `NameError` for zero iterations.
- **Readable artifacts.** `write_plan` also outputs a `plan_preview` HTML artifact with proper code-block styling. `TestReport` and `ReviewVerdict` get a Markdown visualization through a materializer.
- **Tags and gate timeout.** Runs are tagged with repository and work branch. Gates poll for `gate_timeout` seconds (default 10 minutes) instead of 60, so a run does not pause while someone is still reading the plan.
- **Docs.** README restructured into numbered setup steps with explicit `zenml secret create` commands for the GitHub token and the Claude login token, a troubleshooting section, and less repetition. `AGENTS.md` and `CLAUDE.md` state the conventions for changing the example.

## Validation

Eight end-to-end runs on the staging Pro workspace, all against scratch branches of this repository with the example's own loop bug as the issue. Six on a local orchestrator with the local sandbox flavor, two on `kubernetes_aws` with the Kubernetes sandbox through a snapshot, the last one from a snapshot of the final code. All completed and opened a pull request (since closed). The metadata, HTML preview, roll-up, derived branch, zero-iteration path and tags were checked on the server through the client, not only in the logs.

Not exercised: `issue_from_event` end to end, since the GitHub webhook and Slack app were not configured yet. The payload parsing is exercised with GitHub and Slack sample payloads, the Slack API call is mocked.

## Things reviewers should know

- The PR targets `misc/software-factory-example` and only shows the polish commits. `issue_from_event` uses `get_raw_webhook_event` from #5227, which is on `develop` but not yet on that branch, so the base branch needs a rebase onto `develop` before the whole example merges. The import is local to the step so the example still imports without it.
- `examples/software_factory/requirements.txt` gains `markdown` for the HTML preview.
- `refresh_sandbox_client` in `factory_utils.py` still pokes `KubernetesSandbox._k8s_client` as a workaround for the EKS token expiry, with the existing TODO to move that into core.
- Observed while testing: a local-orchestrator run that pauses at a gate is marked failed by the Pro server when the gate is resolved from the dashboard, presumably because there is no workload to resume. The README tells local users to answer within the timeout; the server behavior may deserve its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bn9mw3cNkDabgkW8c23QD

