### PR TITLE
Fix edge cases in the software factory fix loop

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -232,7 +232,7 @@ Every mutating step commits and pushes before returning, so the branch on GitHub
 
 ### Bounded fix loop with deterministic step ids
 
-Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs:
+Each invocation inside the loop carries an explicit `id=`, so a resumed run matches the same step runs. `max_fix_iterations` must be at least 1, which the pipeline validates up front so `deploy_approval`'s metadata always has a test report to show. If the loop exhausts its iterations without a `break` (its last action was a `fix`), the `else` branch re-runs tests once more with the distinct id `run_tests_final`, so the deploy approval reflects the final state of the branch rather than a stale pre-fix report:
 
 ```python
 for attempt in range(max_fix_iterations):
@@ -243,6 +243,8 @@ for attempt in range(max_fix_iterations):
         if verdict.load().approved:
             break
     pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    tests = run_tests(..., id="run_tests_final")
 ```
 
 ### The agent result-file contract

--- a/examples/software_factory/pipeline.py
+++ b/examples/software_factory/pipeline.py
@@ -373,8 +373,14 @@ def software_factory(
         test_command: Shell command that runs the tests in the checkout.
             Tests are skipped if unset.
         max_fix_iterations: The maximum number of test and review fix
-            iterations.
+            iterations. Must be at least 1.
+
+    Raises:
+        ValueError: If `max_fix_iterations` is less than 1.
     """
+    if max_fix_iterations < 1:
+        raise ValueError("max_fix_iterations must be at least 1.")
+
     plan = write_plan(repo=repo, issue=issue, base_branch=base_branch)
     plan_review = wait(
         schema=Review,
@@ -429,6 +435,14 @@ def software_factory(
             base_branch=base_branch,
             verdict=verdict,
             id=f"fix_{attempt}",
+        )
+    else:
+        tests = run_tests(
+            workspace=workspace,
+            repo=repo,
+            branch=target_branch,
+            test_command=test_command,
+            id="run_tests_final",
         )
     close_workspace(workspace=workspace)
 

--- a/spec/plans/factory-polish-validation-4.md
+++ b/spec/plans/factory-polish-validation-4.md
@@ -1,0 +1,194 @@
+# Plan: Fix edge cases in the software factory fix loop
+
+## Root cause
+
+`software_factory` (`examples/software_factory/pipeline.py:355-448`) drives a
+test/review/fix loop:
+
+```python
+verdict = None
+for attempt in range(max_fix_iterations):
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+close_workspace(workspace=workspace)
+
+pr_result = pr.load()
+metadata = {"pr_url": pr_result.url, "tests": tests.load().model_dump()}
+```
+
+Two bugs fall out of this shape:
+
+1. **`max_fix_iterations=0` → `NameError`.** If the loop body never executes
+   (`range(0)` is empty), `tests` is never bound, but it's referenced
+   unconditionally afterwards in `tests.load().model_dump()`. This raises
+   `NameError: name 'tests' is not defined` when building the
+   `deploy_approval` metadata.
+
+2. **Stale test report after the last fix.** If the loop runs out of
+   iterations while the last action taken was `fix` (i.e. it never hit the
+   `break`), no `run_tests` call happens after that final `fix`. The `tests`
+   variable used in the `deploy_approval` metadata still reflects the state
+   of the branch *before* the last fix was applied, which misrepresents the
+   branch that's actually being proposed for deploy.
+
+Note that a `for...else` block in Python runs the `else` clause exactly when
+the loop completes without hitting `break` — which is precisely the "last
+action was a fix" condition. That's the natural, minimal way to express fix
+#2 without extra flags.
+
+## Code changes (all within `examples/software_factory/pipeline.py`)
+
+1. **Validate `max_fix_iterations` up front.** At the very start of
+   `software_factory`, before any step is invoked, add:
+
+   ```python
+   if max_fix_iterations < 1:
+       raise ValueError("max_fix_iterations must be at least 1.")
+   ```
+
+   This fails fast with a clear error instead of letting the pipeline run
+   partway and then hit a `NameError` deep in metadata construction. Update
+   the `max_fix_iterations` docstring entry to note the `>= 1` constraint,
+   e.g. "The maximum number of test and review fix iterations. Must be at
+   least 1."
+
+2. **Run tests once more if the loop ended on a `fix`.** Convert the `for`
+   loop to use a `for...else`, and in the `else` branch call `run_tests`
+   again with a distinct step id, reassigning `tests`:
+
+   ```python
+   for attempt in range(max_fix_iterations):
+       tests = run_tests(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           test_command=test_command,
+           id=f"run_tests_{attempt}",
+       )
+       verdict = None
+       if tests.load().passed:
+           verdict = review(
+               workspace=workspace,
+               repo=repo,
+               branch=target_branch,
+               issue=issue,
+               plan=plan,
+               tests=tests,
+               base_branch=base_branch,
+               id=f"review_{attempt}",
+           )
+           if verdict.load().approved:
+               break
+       pr = fix(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           issue=issue,
+           tests=tests,
+           base_branch=base_branch,
+           verdict=verdict,
+           id=f"fix_{attempt}",
+       )
+   else:
+       tests = run_tests(
+           workspace=workspace,
+           repo=repo,
+           branch=target_branch,
+           test_command=test_command,
+           id="run_tests_final",
+       )
+   ```
+
+   Since `max_fix_iterations >= 1` is now guaranteed, `tests` is always bound
+   by the time the loop finishes (either from the last loop iteration or from
+   the `else` branch), so the `NameError` from bug #1 can't occur even as a
+   secondary effect of this change.
+
+   Scope note: only `tests` is refreshed here, matching what the issue asks
+   for. `verdict` is intentionally left as whatever it was set to inside the
+   loop (i.e. `None`, or the last rejected review) — that's pre-existing
+   behavior for the "ran out of iterations" case and isn't part of what's
+   reported as misleading; re-reviewing after the final fix is out of scope
+   for a minimal change.
+
+3. No changes needed to `deploy_approval` metadata construction itself —
+   once `tests` is always bound, `tests.load().model_dump()` is safe.
+
+## README update
+
+`examples/software_factory/README.md`, section "Bounded fix loop with
+deterministic step ids" (around line 233), shows the loop as sample code.
+Since the loop shape changes (added `else` clause), update the snippet to
+match:
+
+```python
+for attempt in range(max_fix_iterations):
+    tests = run_tests(..., id=f"run_tests_{attempt}")
+    verdict = None
+    if tests.load().passed:
+        verdict = review(..., tests=tests, id=f"review_{attempt}")
+        if verdict.load().approved:
+            break
+    pr = fix(..., tests=tests, verdict=verdict, id=f"fix_{attempt}")
+else:
+    tests = run_tests(..., id="run_tests_final")
+```
+
+Add a short sentence noting that `max_fix_iterations` must be at least 1, and
+that the `else` branch re-runs tests once more with a distinct id when the
+loop's last action was a fix, so `deploy_approval` always reflects the final
+state of the branch.
+
+## Tests to add
+
+Look for existing tests for this example (check
+`tests/` for `software_factory` or example-level pipeline tests; if none
+exist yet, add a new test module, e.g.
+`tests/unit/examples/software_factory/test_pipeline.py`, mirroring how other
+dynamic-pipeline examples are tested — likely by invoking `software_factory`
+against a fake/mocked step layer, since the real steps hit sandboxes,
+GitHub, and Claude). Concretely add tests that:
+
+1. **`max_fix_iterations=0` raises a clear error.** Call `software_factory`
+   (or invoke the pipeline function directly if it can be unit-tested
+   without a full run) with `max_fix_iterations=0` and assert a `ValueError`
+   is raised with a message mentioning `max_fix_iterations`, and that no
+   steps are executed beforehand (or at least that no `NameError` occurs).
+
+2. **Negative `max_fix_iterations` also raises.** Same as above with `-1`,
+   to confirm the `< 1` check (not just `== 0`).
+
+3. **Final test re-run happens when the loop exhausts on a `fix`.** Mock/fake
+   `run_tests`, `review`, and `fix` such that every review is rejected (or
+   every test run fails) across all `max_fix_iterations` attempts, run the
+   pipeline with e.g. `max_fix_iterations=2`, and assert:
+   - `run_tests` is called `max_fix_iterations + 1` times total.
+   - The last `run_tests` call uses `id="run_tests_final"`.
+   - The `deploy_approval` wait step's metadata `tests` reflects the result
+     of that final call (not the one from the last loop iteration).
+
+4. **No extra test run when the loop breaks early.** Mock the loop so that
+   the review is approved on, say, the first attempt (`break` hits), run the
+   pipeline with `max_fix_iterations > 1`, and assert `run_tests` is called
+   exactly once (i.e. the `else` branch of the `for` loop does *not* run),
+   confirming the `for...else` behaves as expected and doesn't add a
+   redundant test run on the success path.
+
+5. **Regression check for `max_fix_iterations=1` exhausting via fix.** A
+   dedicated minimal case: one iteration, tests fail (or review rejects),
+   `fix` runs, loop exhausts without `break`, and the final `run_tests_final`
+   call still occurs and its result is what's used downstream — this is the
+   simplest reproduction of the original bug report's second issue.
+
+If the test harness for this example only supports invoking the annotated
+pipeline through ZenML's dynamic-pipeline test utilities (rather than calling
+the plain function), structure the fakes/mocks around whatever pattern
+existing example pipeline tests already use in this repo — check
+`tests/unit/` for other `examples/*/pipeline.py` coverage before deciding
+between "call the undecorated function directly" vs. "run the pipeline
+end-to-end with stubbed steps."

--- a/tests/unit/examples/__init__.py
+++ b/tests/unit/examples/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/examples/software_factory/__init__.py
+++ b/tests/unit/examples/software_factory/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.

--- a/tests/unit/examples/software_factory/test_pipeline.py
+++ b/tests/unit/examples/software_factory/test_pipeline.py
@@ -1,0 +1,338 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the fix loop edge cases in the software factory example pipeline.
+
+The real steps of `examples/software_factory/pipeline.py` drive Claude Code
+sandboxes and GitHub, so they aren't exercised here. Instead, the pipeline's
+own step functions are monkeypatched with lightweight stand-ins and the
+dynamic pipeline itself is run for real (against the local test stack) so
+that the actual control flow of `software_factory` -- the bounded fix loop
+and its edge cases -- is what's under test.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+import zenml
+from zenml import step
+
+EXAMPLE_DIR = Path(zenml.__file__).resolve().parents[2] / "examples" / "software_factory"
+
+
+def _load_example_module(name: str, filename: str) -> Any:
+    """Load a module from the software factory example by file path.
+
+    The example's modules use plain top-level imports (e.g. `from models
+    import ...`), so the example directory needs to be on `sys.path` for
+    them to resolve, independent of the name used to load this module.
+    """
+    if str(EXAMPLE_DIR) not in sys.path:
+        sys.path.insert(0, str(EXAMPLE_DIR))
+    spec = importlib.util.spec_from_file_location(
+        name, EXAMPLE_DIR / filename
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+models = _load_example_module("_software_factory_models", "models.py")
+sf_pipeline = _load_example_module("_software_factory_pipeline", "pipeline.py")
+
+PRRef = models.PRRef
+TestReport = models.TestReport
+ReviewVerdict = models.ReviewVerdict
+
+
+class _RecordingWait:
+    """Stand-in for `zenml.wait()` that resolves immediately.
+
+    Records every call so tests can assert on the metadata passed to the
+    `deploy_approval` wait condition, and returns canned results keyed by
+    the wait condition's `name` so the pipeline doesn't actually block.
+    """
+
+    def __init__(
+        self,
+        plan_review_approved: bool = True,
+        deploy_approval_result: bool = False,
+    ) -> None:
+        self.plan_review_approved = plan_review_approved
+        self.deploy_approval_result = deploy_approval_result
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(
+        self,
+        schema: Any = None,
+        type: Any = None,
+        timeout: int = 600,
+        poll_interval: int = 5,
+        question: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        after: Any = None,
+        name: Optional[str] = None,
+    ) -> Any:
+        self.calls.append({"name": name, "metadata": metadata})
+        if name == "plan_review":
+            return SimpleNamespace(approved=self.plan_review_approved)
+        if name == "deploy_approval":
+            return self.deploy_approval_result
+        raise AssertionError(f"Unexpected wait() call with name={name!r}")
+
+
+class _StepCallRecorder:
+    """Tracks how many times each fake step was invoked in a test."""
+
+    def __init__(self) -> None:
+        self.run_tests_reports: List[TestReport] = []
+        self.review_approved: bool = False
+        self.run_tests_calls = 0
+        self.review_calls = 0
+        self.fix_calls = 0
+
+    def next_test_report(self) -> TestReport:
+        index = min(self.run_tests_calls, len(self.run_tests_reports) - 1)
+        return self.run_tests_reports[index]
+
+
+@pytest.fixture
+def recorder() -> _StepCallRecorder:
+    return _StepCallRecorder()
+
+
+@pytest.fixture(autouse=True)
+def patch_steps(
+    monkeypatch: pytest.MonkeyPatch, recorder: _StepCallRecorder
+) -> None:
+    """Replace every real step with a lightweight fake.
+
+    None of the fakes talk to sandboxes, GitHub or Claude -- they just
+    exercise the dynamic pipeline's step-invocation and artifact-loading
+    machinery so the loop logic in `software_factory` runs for real.
+    """
+
+    @step
+    def fake_write_plan(
+        repo: str, issue: str, base_branch: Optional[str] = None
+    ) -> str:
+        return "PLAN"
+
+    @step
+    def fake_open_workspace(
+        repo: str,
+        branch: str,
+        plan: str,
+        base_branch: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        return "workspace-1", base_branch or "main"
+
+    @step
+    def fake_implement(
+        workspace: str,
+        repo: str,
+        branch: str,
+        issue: str,
+        plan: str,
+        base_branch: str,
+    ) -> PRRef:
+        return PRRef(url="https://example.com/pulls/1", number=1)
+
+    @step
+    def fake_run_tests(
+        workspace: str,
+        repo: str,
+        branch: str,
+        test_command: Optional[str] = None,
+    ) -> TestReport:
+        report = recorder.next_test_report()
+        recorder.run_tests_calls += 1
+        return report
+
+    @step
+    def fake_review(
+        workspace: str,
+        repo: str,
+        branch: str,
+        issue: str,
+        plan: str,
+        tests: TestReport,
+        base_branch: str,
+    ) -> ReviewVerdict:
+        recorder.review_calls += 1
+        return ReviewVerdict(approved=recorder.review_approved, comments=[])
+
+    @step
+    def fake_fix(
+        workspace: str,
+        repo: str,
+        branch: str,
+        issue: str,
+        tests: TestReport,
+        base_branch: str,
+        verdict: Optional[ReviewVerdict] = None,
+    ) -> PRRef:
+        recorder.fix_calls += 1
+        return PRRef(url="https://example.com/pulls/1", number=1)
+
+    @step
+    def fake_close_workspace(workspace: str) -> None:
+        return None
+
+    @step
+    def fake_deploy(pr: PRRef, repo: str) -> None:
+        return None
+
+    monkeypatch.setattr(sf_pipeline, "write_plan", fake_write_plan)
+    monkeypatch.setattr(sf_pipeline, "open_workspace", fake_open_workspace)
+    monkeypatch.setattr(sf_pipeline, "implement", fake_implement)
+    monkeypatch.setattr(sf_pipeline, "run_tests", fake_run_tests)
+    monkeypatch.setattr(sf_pipeline, "review", fake_review)
+    monkeypatch.setattr(sf_pipeline, "fix", fake_fix)
+    monkeypatch.setattr(sf_pipeline, "close_workspace", fake_close_workspace)
+    monkeypatch.setattr(sf_pipeline, "deploy", fake_deploy)
+
+
+def test_zero_max_fix_iterations_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`max_fix_iterations=0` must fail fast instead of hitting a NameError."""
+    fake_wait = _RecordingWait()
+    monkeypatch.setattr(sf_pipeline, "wait", fake_wait)
+
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        sf_pipeline.software_factory(
+            repo="owner/repo",
+            issue="issue",
+            target_branch="fix-branch",
+            max_fix_iterations=0,
+        )
+    assert fake_wait.calls == []
+
+
+def test_negative_max_fix_iterations_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative `max_fix_iterations` values are rejected too, not just 0."""
+    fake_wait = _RecordingWait()
+    monkeypatch.setattr(sf_pipeline, "wait", fake_wait)
+
+    with pytest.raises(ValueError, match="max_fix_iterations"):
+        sf_pipeline.software_factory(
+            repo="owner/repo",
+            issue="issue",
+            target_branch="fix-branch",
+            max_fix_iterations=-1,
+        )
+    assert fake_wait.calls == []
+
+
+def test_loop_exhausted_after_fix_reruns_tests(
+    monkeypatch: pytest.MonkeyPatch, recorder: _StepCallRecorder
+) -> None:
+    """If the loop runs out of attempts on a `fix`, tests run once more.
+
+    Every review is rejected across all attempts, so the loop never
+    breaks. The `else` branch of the `for` loop must run one final
+    `run_tests` (with id `run_tests_final`) so the `deploy_approval`
+    metadata reflects the branch state after the last fix.
+    """
+    recorder.run_tests_reports = [
+        TestReport(passed=True, summary="ok"),
+    ]
+    recorder.review_approved = False
+    fake_wait = _RecordingWait()
+    monkeypatch.setattr(sf_pipeline, "wait", fake_wait)
+
+    sf_pipeline.software_factory(
+        repo="owner/repo",
+        issue="issue",
+        target_branch="fix-branch",
+        max_fix_iterations=2,
+    )
+
+    assert recorder.run_tests_calls == 3
+    assert recorder.review_calls == 2
+    assert recorder.fix_calls == 2
+
+    deploy_call = next(
+        c for c in fake_wait.calls if c["name"] == "deploy_approval"
+    )
+    assert deploy_call["metadata"]["tests"] == TestReport(
+        passed=True, summary="ok"
+    ).model_dump()
+    assert "verdict" in deploy_call["metadata"]
+
+
+def test_loop_breaks_early_skips_final_rerun(
+    monkeypatch: pytest.MonkeyPatch, recorder: _StepCallRecorder
+) -> None:
+    """When the review approves on the first attempt, no extra rerun happens."""
+    recorder.run_tests_reports = [TestReport(passed=True, summary="ok")]
+    recorder.review_approved = True
+    fake_wait = _RecordingWait()
+    monkeypatch.setattr(sf_pipeline, "wait", fake_wait)
+
+    sf_pipeline.software_factory(
+        repo="owner/repo",
+        issue="issue",
+        target_branch="fix-branch",
+        max_fix_iterations=3,
+    )
+
+    assert recorder.run_tests_calls == 1
+    assert recorder.review_calls == 1
+    assert recorder.fix_calls == 0
+
+
+def test_single_iteration_exhausted_via_fix_reruns_tests(
+    monkeypatch: pytest.MonkeyPatch, recorder: _StepCallRecorder
+) -> None:
+    """Minimal regression case: one iteration, failing tests, then a fix.
+
+    The single attempt's tests fail, so `fix` runs without ever reviewing.
+    The loop then exhausts without a `break`, so tests must run again and
+    the `deploy_approval` metadata must reflect that final, passing report
+    instead of the stale failing one from the only loop iteration.
+    """
+    recorder.run_tests_reports = [
+        TestReport(passed=False, summary="failing"),
+        TestReport(passed=True, summary="fixed"),
+    ]
+    fake_wait = _RecordingWait()
+    monkeypatch.setattr(sf_pipeline, "wait", fake_wait)
+
+    sf_pipeline.software_factory(
+        repo="owner/repo",
+        issue="issue",
+        target_branch="fix-branch",
+        max_fix_iterations=1,
+    )
+
+    assert recorder.run_tests_calls == 2
+    assert recorder.review_calls == 0
+    assert recorder.fix_calls == 1
+
+    deploy_call = next(
+        c for c in fake_wait.calls if c["name"] == "deploy_approval"
+    )
+    assert deploy_call["metadata"]["tests"] == TestReport(
+        passed=True, summary="fixed"
+    ).model_dump()


### PR DESCRIPTION
## Summary

- `examples/software_factory/pipeline.py`: `software_factory` now raises `ValueError` up front if `max_fix_iterations < 1`, preventing the `NameError` that previously hit `tests.load()` when the loop body never ran.
- `examples/software_factory/pipeline.py`: converted the fix loop's `for` to `for...else`; if the loop exhausts its attempts without hitting `break` (i.e. the last action was a `fix`), the `else` branch reruns `run_tests` once more with id `run_tests_final` and reassigns `tests`, so `deploy_approval`'s metadata reflects the branch's actual final state instead of a stale pre-fix report.
- Updated the docstring for `max_fix_iterations` and added a `Raises` section.
- `examples/software_factory/README.md`: updated the "Bounded fix loop with deterministic step ids" section's code sample and prose to show the new `for...else` shape and explain both edge-case fixes.
- Added `tests/unit/examples/software_factory/test_pipeline.py` (plus package `__init__.py` files) covering: `max_fix_iterations=0` and `-1` raising `ValueError`, the loop rerunning tests after exhausting via a `fix` (both a multi-iteration and the minimal single-iteration case), and the early-break path not triggering an extra rerun. Tests monkeypatch the pipeline's step functions and `wait()` with lightweight fakes and run the real dynamic pipeline against the local test stack, following the pattern used in `tests/unit/execution/pipeline/dynamic/`.

Plan: `spec/plans/factory-polish-validation-4.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/6a528afb-30d1-4fa0-a557-d4a7a17bd0a3
