### PR TITLE
Support for dynamic target events

### DIFF
--- a/docs/book/getting-started/zenml-pro/triggers.md
+++ b/docs/book/getting-started/zenml-pro/triggers.md
@@ -660,6 +660,12 @@ case-sensitive operators:
 | `oneof:["a","b"]` | The field equals one of the JSON-list values |
 | `notoneof:["a","b"]` | The field equals none of the JSON-list values |
 
+The text before the first colon is treated as an operator only when it is one
+of the operators above. Other colon-containing values, such as
+`https://example.com/hook`, are matched literally. Use an explicit `equals:`
+when a literal value starts with an operator name, for example
+`equals:startswith:queued`.
+
 A YAML list combines multiple expressions for one field with OR. Use
 `notoneof:` instead of a list of `notequals:` expressions when excluding
 several exact values:
@@ -678,6 +684,77 @@ multiple target events combine with OR. An absent event field does not satisfy
 a configured filter, including a negative filter. For collection-valued event
 fields such as GitHub labels, positive operators match any item and negative
 operators require every item to satisfy the expression.
+
+### Dynamic event filters
+
+GitHub, ClickUp, Slack, and Custom triggers support a `dynamic` target for
+provider events and payload fields that are not covered by the semantic event
+catalog. For example, this target matches GitHub pull requests when they are
+opened against a release branch:
+
+```yaml
+target_events:
+  - type: dynamic
+    event_type: pull_request
+    filters:
+      action: opened
+      pull_request.base.ref: "startswith:release/"
+```
+
+`event_type` is required and supports all shared string filter operators. The
+provider determines its value: GitHub uses `X-GitHub-Event`, ClickUp uses the
+top-level `event` field, Slack uses `event.type` inside an event callback, and
+Custom uses `X-ZenML-Event`. Dynamic filters do not match Slack control
+deliveries such as URL verification or rate-limit notifications.
+
+The optional `filters` mapping is evaluated against the complete authenticated
+JSON body. All configured paths must match. A path supports object traversal,
+non-negative array indexes, one array wildcard, and JSON-quoted unusual keys:
+
+```yaml
+filters:
+  history_items[0].after.status: ready
+  labels[*].name: "contains:priority"
+  metadata["build.version"]: v2
+```
+
+Wildcard results use the same collection semantics as typed filters: positive
+operators match any resolved scalar and negative operators require all resolved
+scalars to match. Missing keys, incompatible payload types, out-of-range
+indexes, empty wildcard results, and object or array terminal values do not
+match. Strings are compared unchanged; JSON numbers, booleans, and null are
+compared as strings such as `42`, `false`, and `null`.
+
+Paths are intentionally smaller than JSONPath: recursive descent, functions,
+slices, inline predicates, negative indexes, and implicit numeric segments such
+as `items.0` are not supported. A configuration can contain at most 10 target
+events. Each dynamic target can contain at most 10 paths; paths are limited to
+512 characters, eight segments, and one wildcard. Each string filter supports
+at most 10 expressions, a 512-character expression, and 10 `oneof` or
+`notoneof` choices.
+
+Via the SDK, use the same public dynamic target model with any provider
+configuration:
+
+```python
+from zenml.webhooks import DynamicWebhookTargetEvent
+from zenml.webhooks.providers.github import GitHubWebhookConfiguration
+
+configuration = GitHubWebhookConfiguration(
+    target_events=[
+        DynamicWebhookTargetEvent(
+            event_type="pull_request",
+            filters={
+                "action": "opened",
+                "pull_request.base.ref": "startswith:release/",
+            },
+        )
+    ]
+)
+```
+
+Typed and dynamic targets can be combined in the same `target_events` list.
+They retain the usual OR behavior across target entries.
 
 ### GitHub webhook triggers
 
@@ -908,8 +985,10 @@ def inspect_webhook_event() -> None:
 
     github_event = upstream_event.get("github")
     if github_event is not None:
+        print(f"Provider event type: {github_event['event_type']}")
         event = github_event["event"]
-        print(f"Event type: {event['type']}")
+        if event is not None:
+            print(f"Semantic event type: {event['type']}")
         print(f"Delivery ID: {github_event['delivery_id']}")
 ```
 
@@ -920,6 +999,7 @@ For example, a GitHub push event has this shape:
   "github": {
     "webhook_id": "7f9f38a7-8dd6-4ced-91c8-bf05857838d5",
     "delivery_id": "delivery-001",
+    "event_type": "push",
     "event": {
       "type": "push",
       "repo": "acme/ml-pipelines",
@@ -934,10 +1014,11 @@ For example, a GitHub push event has this shape:
 }
 ```
 
-The event `type` is the semantic type used by the webhook trigger, not
-necessarily the provider's raw event family. Optional semantic fields are
-included with `null` values when unavailable. You can also pass an existing
-pipeline run response to `get_webhook_upstream_event(pipeline_run=run)`.
+`event_type` is the provider's raw event type. The nested event `type` is the
+semantic type used by typed webhook targets and can differ from the raw family.
+Optional semantic fields are included with `null` values when unavailable. You
+can also pass an existing pipeline run response to
+`get_webhook_upstream_event(pipeline_run=run)`.
 
 Only runs started directly by a webhook trigger contain this metadata. It is
 not propagated through later platform event triggers. For providers such as
@@ -985,10 +1066,12 @@ are not retained in this version.
 
 ### Custom webhook triggers
 
-Custom webhooks do not currently provide semantic event or payload filtering.
-Every accepted delivery matches every active, non-archived custom webhook
-trigger owned by that webhook. Use separate custom webhooks when you need
-distinct routes.
+Custom webhooks do not provide a semantic event catalog. An omitted, null, or
+empty `target_events` list preserves the original behavior: every accepted
+delivery matches every active, non-archived custom trigger owned by that
+webhook. Supply a non-empty list of
+[dynamic event filters](#dynamic-event-filters) to filter on `X-ZenML-Event`
+and the custom JSON body.
 
 Create `custom-webhook.yaml` with an empty provider configuration:
 
@@ -1014,8 +1097,20 @@ client = Client()
 trigger = client.create_webhook_trigger(
     name="on-custom-event",
     webhook="custom-events",
-    configuration=CustomWebhookConfiguration(),
+configuration=CustomWebhookConfiguration(),
 )
+```
+
+For example, this configuration matches only successful publication events for
+one model:
+
+```yaml
+target_events:
+  - type: dynamic
+    event_type: model.published
+    filters:
+      model: fraud-detector
+      successful: "true"
 ```
 
 Attach the trigger to a snapshot as shown above, then follow

--- a/docs/book/getting-started/zenml-pro/webhooks/custom.md
+++ b/docs/book/getting-started/zenml-pro/webhooks/custom.md
@@ -9,9 +9,11 @@ events to ZenML. Use it when a service can make HTTP requests but does not have
 a dedicated ZenML webhook provider.
 
 Custom webhooks preserve the sender's event name and JSON payload for consumers.
-They do not define a ZenML semantic event catalog or provider-level payload
-filters. A [custom webhook trigger](../triggers.md#custom-webhook-triggers)
-uses an empty configuration and matches every accepted delivery for its webhook.
+They do not define a ZenML semantic event catalog. A
+[custom webhook trigger](../triggers.md#custom-webhook-triggers) can retain the
+original match-all behavior with an empty configuration or use a
+[dynamic event filter](../triggers.md#dynamic-event-filters) to match the event
+name and fields in the authenticated JSON body.
 
 ## Create a custom webhook
 

--- a/src/zenml/models/v2/core/triggers.py
+++ b/src/zenml/models/v2/core/triggers.py
@@ -1241,6 +1241,7 @@ class WebhookTriggerExecutionInfo(BaseModel):
 
     webhook_id: UUID
     delivery_id: str
+    event_type: str | None = None
     event: dict[str, Any] | None = None
 
 

--- a/src/zenml/webhooks/__init__.py
+++ b/src/zenml/webhooks/__init__.py
@@ -18,6 +18,7 @@ from zenml.webhooks.handler import WebhookEventHandler
 from zenml.webhooks.intake import WebhookIntakeConfig
 from zenml.webhooks.providers import (
     BaseWebhookProvider,
+    DynamicWebhookTargetEvent,
     ParsedWebhookDelivery,
     ParsedWebhookEvent,
     WebhookAuthenticationError,
@@ -34,6 +35,7 @@ from zenml.webhooks.providers import (
 
 __all__ = [
     "BaseWebhookProvider",
+    "DynamicWebhookTargetEvent",
     "ParsedWebhookDelivery",
     "ParsedWebhookEvent",
     "WebhookConfiguration",

--- a/src/zenml/webhooks/providers/__init__.py
+++ b/src/zenml/webhooks/providers/__init__.py
@@ -13,6 +13,7 @@ from zenml.webhooks.providers.base import (
     WebhookTargetEvent,
     WebhookTriggerMatch,
 )
+from zenml.webhooks.providers.dynamic import DynamicWebhookTargetEvent
 from zenml.webhooks.providers.registry import (
     WebhookProviderRegistry,
     get_webhook_provider,
@@ -23,6 +24,7 @@ from zenml.webhooks.providers.types import BuiltinWebhookType
 __all__ = [
     "BaseWebhookProvider",
     "BuiltinWebhookType",
+    "DynamicWebhookTargetEvent",
     "ParsedWebhookDelivery",
     "ParsedWebhookEvent",
     "WebhookConfiguration",

--- a/src/zenml/webhooks/providers/base.py
+++ b/src/zenml/webhooks/providers/base.py
@@ -42,6 +42,11 @@ _WEBHOOK_NEGATIVE_STRING_FILTER_OPERATORS = {
     GenericFilterOps.NOT_ONEOF,
 }
 
+WEBHOOK_FILTER_MAX_EXPRESSIONS = 10
+WEBHOOK_FILTER_MAX_EXPRESSION_LENGTH = 512
+WEBHOOK_FILTER_MAX_ONEOF_CHOICES = 10
+WEBHOOK_MAX_TARGET_EVENTS = 10
+
 
 class WebhookAuthenticationError(CredentialsNotValid):
     """Raised when a webhook request cannot be authenticated."""
@@ -85,19 +90,30 @@ class WebhookTargetEvent(BaseModel):
         """
         if value is None:
             return None
-        for item in value if isinstance(value, list) else [value]:
+        items = value if isinstance(value, list) else [value]
+        if not items:
+            raise ValueError(f"Webhook event filter '{field_name}' is empty.")
+        if len(items) > WEBHOOK_FILTER_MAX_EXPRESSIONS:
+            raise ValueError(
+                f"Webhook event filter '{field_name}' supports at most "
+                f"{WEBHOOK_FILTER_MAX_EXPRESSIONS} expressions."
+            )
+        for item in items:
             if not item:
                 raise ValueError(
                     f"Webhook event filter '{field_name}' is empty."
+                )
+            if len(item) > WEBHOOK_FILTER_MAX_EXPRESSION_LENGTH:
+                raise ValueError(
+                    f"Webhook event filter '{field_name}' expressions must "
+                    f"not exceed {WEBHOOK_FILTER_MAX_EXPRESSION_LENGTH} "
+                    "characters."
                 )
             if ":" not in item:
                 continue
             operator, operand = item.split(":", 1)
             if operator not in _WEBHOOK_STRING_FILTER_OPERATORS:
-                raise ValueError(
-                    f"Webhook event filter '{field_name}' does not support "
-                    f"the '{operator}' operator."
-                )
+                continue
             if not operand:
                 raise ValueError(
                     f"Webhook event filter '{field_name}' has an empty "
@@ -117,6 +133,7 @@ class WebhookTargetEvent(BaseModel):
                 if (
                     not isinstance(choices, list)
                     or not choices
+                    or len(choices) > WEBHOOK_FILTER_MAX_ONEOF_CHOICES
                     or not all(
                         isinstance(choice, str) and choice
                         for choice in choices
@@ -124,7 +141,9 @@ class WebhookTargetEvent(BaseModel):
                 ):
                     raise ValueError(
                         f"Webhook event filter '{field_name}' requires a "
-                        f"non-empty JSON list of strings for '{operator}'."
+                        "non-empty JSON list of at most "
+                        f"{WEBHOOK_FILTER_MAX_ONEOF_CHOICES} strings for "
+                        f"'{operator}'."
                     )
         return value
 
@@ -158,6 +177,8 @@ def _matches_string_filter_value(*, actual: str, configured: str) -> bool:
     if ":" not in configured:
         return actual == configured
     operator, operand = configured.split(":", 1)
+    if operator not in _WEBHOOK_STRING_FILTER_OPERATORS:
+        return actual == configured
     if operator == GenericFilterOps.EQUALS:
         return actual == operand
     if operator == GenericFilterOps.NOT_EQUALS:

--- a/src/zenml/webhooks/providers/clickup.py
+++ b/src/zenml/webhooks/providers/clickup.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
 from zenml.webhooks.providers.base import (
+    WEBHOOK_MAX_TARGET_EVENTS,
     BaseWebhookProvider,
     WebhookConfiguration,
     WebhookPayloadError,
@@ -26,6 +27,10 @@ from zenml.webhooks.providers.base import (
     WebhookTriggerMatch,
     authenticate_hmac_sha256,
     matches_string_filter,
+)
+from zenml.webhooks.providers.dynamic import (
+    DynamicWebhookTargetEvent,
+    matches_webhook_target,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -165,7 +170,8 @@ ClickUpWebhookTargetEvent: TypeAlias = Annotated[
     | TaskCommentPosted
     | ListCreated
     | ListUpdated
-    | ListDeleted,
+    | ListDeleted
+    | DynamicWebhookTargetEvent,
     Field(discriminator="type"),
 ]
 
@@ -173,7 +179,9 @@ ClickUpWebhookTargetEvent: TypeAlias = Annotated[
 class ClickUpWebhookConfiguration(WebhookConfiguration):
     """Typed configuration for a ClickUp webhook trigger."""
 
-    target_events: list[ClickUpWebhookTargetEvent] = Field(min_length=1)
+    target_events: list[ClickUpWebhookTargetEvent] = Field(
+        min_length=1, max_length=WEBHOOK_MAX_TARGET_EVENTS
+    )
 
 
 def _matches_location_filters(
@@ -617,16 +625,23 @@ class ClickUpWebhookProvider(BaseWebhookProvider):
             Matching triggers and their shared semantic event.
         """
         semantic = self.parse_semantic_event(event)
-        if semantic is None:
-            return WebhookTriggerMatch(triggers=[])
+        semantic_matcher = semantic.matches if semantic is not None else None
         matches: list[WebhookTriggerResponse] = []
         for trigger in candidates:
             targets = self._cast_runtime_targets(trigger)
-            if any(semantic.matches(target) for target in targets):
+            if any(
+                matches_webhook_target(
+                    target=target,
+                    event_type=event.event_type,
+                    payload=event.payload,
+                    semantic_matcher=semantic_matcher,
+                )
+                for target in targets
+            ):
                 matches.append(trigger)
         return WebhookTriggerMatch(
             triggers=matches,
-            event=semantic.model_dump(mode="json"),
+            event=(semantic.model_dump(mode="json") if semantic else None),
         )
 
     def parse_semantic_event(

--- a/src/zenml/webhooks/providers/custom.py
+++ b/src/zenml/webhooks/providers/custom.py
@@ -3,14 +3,21 @@
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import Field
 
 from zenml.webhooks.providers.base import (
+    WEBHOOK_MAX_TARGET_EVENTS,
     BaseWebhookProvider,
     WebhookConfiguration,
     WebhookPayloadError,
     WebhookTriggerMatch,
     authenticate_hmac_sha256,
+)
+from zenml.webhooks.providers.dynamic import (
+    DynamicWebhookTargetEvent,
+    matches_webhook_target,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -26,7 +33,11 @@ CUSTOM_DELIVERY_HEADER = "x-zenml-delivery"
 
 
 class CustomWebhookConfiguration(WebhookConfiguration):
-    """Configuration for an unfiltered custom webhook trigger."""
+    """Optional dynamic filtering for a custom webhook trigger."""
+
+    target_events: list[DynamicWebhookTargetEvent] | None = Field(
+        default=None, max_length=WEBHOOK_MAX_TARGET_EVENTS
+    )
 
 
 class CustomWebhookProvider(BaseWebhookProvider):
@@ -94,7 +105,7 @@ class CustomWebhookProvider(BaseWebhookProvider):
         event: "WebhookEvent",
         candidates: Sequence["WebhookTriggerResponse"],
     ) -> "WebhookTriggerMatch[WebhookTriggerResponse]":
-        """Match candidates with valid unfiltered custom configuration.
+        """Match candidates using optional dynamic custom filters.
 
         Args:
             event: The trusted custom event.
@@ -106,12 +117,26 @@ class CustomWebhookProvider(BaseWebhookProvider):
         matches: list[WebhookTriggerResponse] = []
         for trigger in candidates:
             try:
-                self.validate_configuration(trigger.configuration)
+                configuration = self.validate_configuration(
+                    trigger.configuration
+                )
             except (TypeError, ValueError):
                 logger.exception(
                     "Skipping defective webhook trigger configuration %s",
                     trigger.id,
                 )
                 continue
-            matches.append(trigger)
+            targets = cast(
+                CustomWebhookConfiguration, configuration
+            ).target_events
+            if not targets or any(
+                matches_webhook_target(
+                    target=target,
+                    event_type=event.event_type,
+                    payload=event.payload,
+                    semantic_matcher=None,
+                )
+                for target in targets
+            ):
+                matches.append(trigger)
         return WebhookTriggerMatch(triggers=matches)

--- a/src/zenml/webhooks/providers/dynamic.py
+++ b/src/zenml/webhooks/providers/dynamic.py
@@ -1,0 +1,317 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Dynamic webhook target filters over authenticated JSON payloads."""
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from typing import Any, Literal
+
+from pydantic import Field, PrivateAttr, model_validator
+
+from zenml.webhooks.providers.base import (
+    WebhookTargetEvent,
+    matches_string_collection_filter,
+    matches_string_filter,
+)
+
+WEBHOOK_DYNAMIC_FILTER_MAX_PATHS = 10
+WEBHOOK_DYNAMIC_FILTER_MAX_PATH_LENGTH = 512
+WEBHOOK_DYNAMIC_FILTER_MAX_SEGMENTS = 8
+WEBHOOK_DYNAMIC_FILTER_MAX_WILDCARDS = 1
+
+_BARE_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_-]*")
+
+
+class _Wildcard:
+    """Marker for a wildcard array projection."""
+
+
+_WILDCARD = _Wildcard()
+_PathToken = str | int | _Wildcard
+
+
+def _invalid_path_message(path: str, reason: str) -> str:
+    """Create a consistent dynamic path validation error message.
+
+    Args:
+        path: The configured payload path.
+        reason: The validation failure.
+
+    Returns:
+        The path validation error message.
+    """
+    return f"Invalid dynamic webhook filter path '{path}': {reason}"
+
+
+def _parse_bracket(path: str, position: int) -> tuple[_PathToken, int]:
+    """Parse one bracket path segment.
+
+    Args:
+        path: The complete payload path.
+        position: The position of the opening bracket.
+
+    Returns:
+        The parsed token and the next unread position.
+
+    Raises:
+        ValueError: If the bracket segment is malformed.
+    """
+    value_position = position + 1
+    if value_position >= len(path):
+        raise ValueError(_invalid_path_message(path, "unclosed bracket"))
+
+    if path[value_position] == '"':
+        try:
+            key, end = json.JSONDecoder().raw_decode(path, value_position)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                _invalid_path_message(path, "invalid quoted object key")
+            ) from error
+        if not isinstance(key, str) or end >= len(path) or path[end] != "]":
+            raise ValueError(
+                _invalid_path_message(
+                    path, "quoted object keys must end with ']'"
+                )
+            )
+        return key, end + 1
+
+    end = path.find("]", value_position)
+    if end < 0:
+        raise ValueError(_invalid_path_message(path, "unclosed bracket"))
+    value = path[value_position:end]
+    if value == "*":
+        return _WILDCARD, end + 1
+    if value.isdigit():
+        return int(value), end + 1
+    raise ValueError(
+        _invalid_path_message(
+            path,
+            "brackets require a non-negative index, '*', or JSON-quoted key",
+        )
+    )
+
+
+def _parse_dynamic_path(path: str) -> tuple[_PathToken, ...]:
+    """Parse and validate a constrained dynamic webhook payload path.
+
+    Args:
+        path: The configured payload path.
+
+    Returns:
+        The compiled path tokens.
+
+    Raises:
+        ValueError: If the path does not follow the supported grammar.
+    """
+    if not path:
+        raise ValueError(_invalid_path_message(path, "path must not be empty"))
+    if len(path) > WEBHOOK_DYNAMIC_FILTER_MAX_PATH_LENGTH:
+        raise ValueError(
+            _invalid_path_message(
+                path,
+                "path must not exceed "
+                f"{WEBHOOK_DYNAMIC_FILTER_MAX_PATH_LENGTH} characters",
+            )
+        )
+
+    tokens: list[_PathToken] = []
+    position = 0
+    if path.startswith('["'):
+        token, position = _parse_bracket(path, position)
+        tokens.append(token)
+    else:
+        match = _BARE_KEY.match(path, position)
+        if match is None:
+            raise ValueError(
+                _invalid_path_message(
+                    path, "path must start with an object key"
+                )
+            )
+        tokens.append(match.group())
+        position = match.end()
+
+    while position < len(path):
+        character = path[position]
+        if character == ".":
+            position += 1
+            match = _BARE_KEY.match(path, position)
+            if match is None:
+                raise ValueError(
+                    _invalid_path_message(
+                        path, "'.' must be followed by an object key"
+                    )
+                )
+            tokens.append(match.group())
+            position = match.end()
+        elif character == "[":
+            token, position = _parse_bracket(path, position)
+            tokens.append(token)
+        else:
+            raise ValueError(
+                _invalid_path_message(
+                    path, f"unexpected character at position {position}"
+                )
+            )
+
+        if len(tokens) > WEBHOOK_DYNAMIC_FILTER_MAX_SEGMENTS:
+            raise ValueError(
+                _invalid_path_message(
+                    path,
+                    "path must not contain more than "
+                    f"{WEBHOOK_DYNAMIC_FILTER_MAX_SEGMENTS} segments",
+                )
+            )
+
+    wildcard_count = sum(token is _WILDCARD for token in tokens)
+    if wildcard_count > WEBHOOK_DYNAMIC_FILTER_MAX_WILDCARDS:
+        raise ValueError(
+            _invalid_path_message(
+                path,
+                "path must not contain more than "
+                f"{WEBHOOK_DYNAMIC_FILTER_MAX_WILDCARDS} wildcard",
+            )
+        )
+    return tuple(tokens)
+
+
+def _resolve_dynamic_path(
+    payload: Mapping[str, Any], tokens: tuple[_PathToken, ...]
+) -> list[Any]:
+    """Resolve compiled path tokens without treating failures as errors.
+
+    Args:
+        payload: The authenticated JSON payload.
+        tokens: The compiled path tokens.
+
+    Returns:
+        Every value resolved by the path.
+    """
+    values: list[Any] = [payload]
+    for token in tokens:
+        resolved: list[Any] = []
+        for value in values:
+            if token is _WILDCARD:
+                if isinstance(value, list):
+                    resolved.extend(value)
+            elif isinstance(token, int):
+                if isinstance(value, list) and token < len(value):
+                    resolved.append(value[token])
+            elif isinstance(value, Mapping) and token in value:
+                resolved.append(value[token])
+        values = resolved
+        if not values:
+            break
+    return values
+
+
+def _stringify_json_scalar(value: Any) -> str | None:
+    """Convert a JSON scalar to its stable matching representation.
+
+    Args:
+        value: A resolved JSON value.
+
+    Returns:
+        The string representation, or `None` for objects and arrays.
+    """
+    if isinstance(value, str):
+        return value
+    if value is None or isinstance(value, (bool, int, float)):
+        try:
+            return json.dumps(value, allow_nan=False, separators=(",", ":"))
+        except ValueError:
+            return None
+    return None
+
+
+class DynamicWebhookTargetEvent(WebhookTargetEvent):
+    """User-defined webhook event filter over an authenticated JSON body."""
+
+    type: Literal["dynamic"] = "dynamic"
+    event_type: str | list[str]
+    filters: dict[str, str | list[str]] = Field(
+        default_factory=dict,
+        max_length=WEBHOOK_DYNAMIC_FILTER_MAX_PATHS,
+    )
+
+    _compiled_filters: dict[str, tuple[_PathToken, ...]] = PrivateAttr(
+        default_factory=dict
+    )
+
+    @model_validator(mode="after")
+    def validate_dynamic_filters(self) -> "DynamicWebhookTargetEvent":
+        """Validate body filters and compile their paths.
+
+        Returns:
+            The validated dynamic target event.
+        """
+        self._validate_filter(self.event_type, field_name="event_type")
+
+        compiled_filters: dict[str, tuple[_PathToken, ...]] = {}
+        for path, configured in self.filters.items():
+            self._validate_filter(configured, field_name=path)
+            compiled_filters[path] = _parse_dynamic_path(path)
+        self._compiled_filters = compiled_filters
+        return self
+
+    def matches(self, *, event_type: str, payload: Mapping[str, Any]) -> bool:
+        """Match a provider event type and authenticated JSON body.
+
+        Args:
+            event_type: The provider-specific raw event type.
+            payload: The complete authenticated JSON body.
+
+        Returns:
+            Whether the event satisfies every configured filter.
+        """
+        if not matches_string_filter(
+            actual=event_type, configured=self.event_type
+        ):
+            return False
+        for path, configured in self.filters.items():
+            actual_values = [
+                string_value
+                for value in _resolve_dynamic_path(
+                    payload, self._compiled_filters[path]
+                )
+                if (string_value := _stringify_json_scalar(value)) is not None
+            ]
+            if not matches_string_collection_filter(
+                actual=actual_values, configured=configured
+            ):
+                return False
+        return True
+
+
+def matches_webhook_target(
+    *,
+    target: WebhookTargetEvent,
+    event_type: str,
+    payload: Mapping[str, Any],
+    semantic_matcher: Callable[[Any], bool] | None,
+) -> bool:
+    """Dispatch matching to a dynamic or provider-semantic target.
+
+    Args:
+        target: The configured webhook target.
+        event_type: The provider-specific raw event type.
+        payload: The complete authenticated JSON body.
+        semantic_matcher: Provider semantic matching, when parsing succeeded.
+
+    Returns:
+        Whether the provider event matches the target.
+    """
+    if isinstance(target, DynamicWebhookTargetEvent):
+        return target.matches(event_type=event_type, payload=payload)
+    return semantic_matcher is not None and semantic_matcher(target)

--- a/src/zenml/webhooks/providers/github.py
+++ b/src/zenml/webhooks/providers/github.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
 from zenml.webhooks.providers.base import (
+    WEBHOOK_MAX_TARGET_EVENTS,
     BaseWebhookProvider,
     WebhookConfiguration,
     WebhookPayloadError,
@@ -28,6 +29,10 @@ from zenml.webhooks.providers.base import (
     authenticate_hmac_sha256,
     matches_string_collection_filter,
     matches_string_filter,
+)
+from zenml.webhooks.providers.dynamic import (
+    DynamicWebhookTargetEvent,
+    matches_webhook_target,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -125,7 +130,8 @@ GitHubWebhookTargetEvent: TypeAlias = Annotated[
     | WorkflowRunCompleted
     | PushEvent
     | ReleasePublished
-    | IssueOpened,
+    | IssueOpened
+    | DynamicWebhookTargetEvent,
     Field(discriminator="type"),
 ]
 
@@ -133,7 +139,9 @@ GitHubWebhookTargetEvent: TypeAlias = Annotated[
 class GitHubWebhookConfiguration(WebhookConfiguration):
     """Typed configuration for a GitHub webhook trigger."""
 
-    target_events: list[GitHubWebhookTargetEvent] = Field(min_length=1)
+    target_events: list[GitHubWebhookTargetEvent] = Field(
+        min_length=1, max_length=WEBHOOK_MAX_TARGET_EVENTS
+    )
 
 
 def _string_at(payload: Mapping[str, Any], *path: str) -> str | None:
@@ -414,7 +422,7 @@ class GitHubWebhookProvider(BaseWebhookProvider):
     async def pre_validate(
         self, headers: Mapping[str, str]
     ) -> WebhookPreValidationResult:
-        """Reject malformed and ignore unsupported GitHub event families.
+        """Reject missing event metadata before processing a GitHub delivery.
 
         Args:
             headers: The untrusted request headers.
@@ -430,10 +438,6 @@ class GitHubWebhookProvider(BaseWebhookProvider):
             raise WebhookPayloadError(
                 f"Missing or empty {GITHUB_EVENT_HEADER} header."
             )
-        try:
-            GitHubWebhookEventType(event_type)
-        except ValueError:
-            return WebhookPreValidationResult.IGNORE
         return WebhookPreValidationResult.PROCESS
 
     def authenticate(
@@ -518,16 +522,23 @@ class GitHubWebhookProvider(BaseWebhookProvider):
             Matching triggers and their shared semantic event.
         """
         semantic = self.parse_semantic_event(event)
-        if semantic is None:
-            return WebhookTriggerMatch(triggers=[])
+        semantic_matcher = semantic.matches if semantic is not None else None
         matches: list[WebhookTriggerResponse] = []
         for trigger in candidates:
             targets = self._cast_runtime_targets(trigger)
-            if any(semantic.matches(target) for target in targets):
+            if any(
+                matches_webhook_target(
+                    target=target,
+                    event_type=event.event_type,
+                    payload=event.payload,
+                    semantic_matcher=semantic_matcher,
+                )
+                for target in targets
+            ):
                 matches.append(trigger)
         return WebhookTriggerMatch(
             triggers=matches,
-            event=semantic.model_dump(mode="json"),
+            event=(semantic.model_dump(mode="json") if semantic else None),
         )
 
     def parse_semantic_event(

--- a/src/zenml/webhooks/providers/slack.py
+++ b/src/zenml/webhooks/providers/slack.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, model_validator
 from zenml.models.v2.base.filter import StringFilterOption
 from zenml.utils.enum_utils import StrEnum
 from zenml.webhooks.providers.base import (
+    WEBHOOK_MAX_TARGET_EVENTS,
     BaseWebhookProvider,
     ParsedWebhookDelivery,
     ParsedWebhookEvent,
@@ -33,6 +34,10 @@ from zenml.webhooks.providers.base import (
     WebhookTargetEvent,
     WebhookTriggerMatch,
     matches_string_filter,
+)
+from zenml.webhooks.providers.dynamic import (
+    DynamicWebhookTargetEvent,
+    matches_webhook_target,
 )
 from zenml.webhooks.providers.types import BuiltinWebhookType
 
@@ -170,14 +175,17 @@ class FileSharedEventFilter(SlackEventFilter):
     file_id: StringFilterOption = None
 
 
-SlackWebhookEventFilter: TypeAlias = Annotated[
+SlackSemanticEventFilter: TypeAlias = (
     AppMentionEventFilter
     | MessageEventFilter
     | ReactionAddedEventFilter
     | ReactionRemovedEventFilter
     | MessageMetadataPostedEventFilter
     | MessageMetadataUpdatedEventFilter
-    | FileSharedEventFilter,
+    | FileSharedEventFilter
+)
+SlackWebhookEventFilter: TypeAlias = Annotated[
+    SlackSemanticEventFilter | DynamicWebhookTargetEvent,
     Field(discriminator="type"),
 ]
 
@@ -185,7 +193,9 @@ SlackWebhookEventFilter: TypeAlias = Annotated[
 class SlackWebhookConfiguration(WebhookConfiguration):
     """Typed configuration for a Slack webhook trigger."""
 
-    target_events: list[SlackWebhookEventFilter] = Field(min_length=1)
+    target_events: list[SlackWebhookEventFilter] = Field(
+        min_length=1, max_length=WEBHOOK_MAX_TARGET_EVENTS
+    )
 
 
 class _SlackCommonEventFields(TypedDict):
@@ -220,7 +230,7 @@ class SlackSemanticEvent(BaseModel):
     event_time: int
     event_ts: str
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Match identifiers shared by all Slack semantic events.
 
         Args:
@@ -239,7 +249,7 @@ class SlackUserEvent(SlackSemanticEvent):
 
     user_id: str
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Match the required user identifier.
 
         Args:
@@ -263,7 +273,7 @@ class SlackChannelEvent(SlackUserEvent):
 
     channel_id: str
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Match the required channel identifier.
 
         Args:
@@ -293,7 +303,7 @@ class SlackAppMentionEvent(SlackChannelEvent):
     message_ts: str | None = None
     thread_ts: str | None = None
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Return whether this mention matches an app-mention target.
 
         Args:
@@ -334,7 +344,7 @@ class SlackMessageEvent(SlackSemanticEvent):
     message_ts: str | None = None
     thread_ts: str | None = None
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Return whether this message matches a message target.
 
         Args:
@@ -394,7 +404,7 @@ class SlackReactionEvent(SlackUserEvent):
     item_user_id: str | None = None
     item: SlackReactionItem
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Return whether this reaction matches its reaction target.
 
         Args:
@@ -463,7 +473,7 @@ class SlackMessageMetadataEvent(SlackChannelEvent):
     message_ts: str
     metadata: SlackMessageMetadata
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Return whether this metadata event matches its typed target.
 
         Args:
@@ -520,7 +530,7 @@ class SlackFileSharedEvent(SlackChannelEvent):
     )
     file_id: str
 
-    def matches(self, target: SlackWebhookEventFilter) -> bool:
+    def matches(self, target: SlackSemanticEventFilter) -> bool:
         """Return whether this file share matches a file-share target.
 
         Args:
@@ -784,16 +794,23 @@ class SlackWebhookProvider(BaseWebhookProvider):
             The matching triggers and any parsed semantic event.
         """
         semantic = self.parse_semantic_event(event)
-        if semantic is None:
-            return WebhookTriggerMatch(triggers=[])
+        semantic_matcher = semantic.matches if semantic is not None else None
         matches: list[WebhookTriggerResponse] = []
         for trigger in candidates:
             targets = self._cast_runtime_targets(trigger)
-            if any(semantic.matches(target) for target in targets):
+            if any(
+                matches_webhook_target(
+                    target=target,
+                    event_type=event.event_type,
+                    payload=event.payload,
+                    semantic_matcher=semantic_matcher,
+                )
+                for target in targets
+            ):
                 matches.append(trigger)
         return WebhookTriggerMatch(
             triggers=matches,
-            event=semantic.model_dump(mode="json"),
+            event=(semantic.model_dump(mode="json") if semantic else None),
         )
 
     def parse_semantic_event(

--- a/tests/integration/functional/webhooks/test_slack.py
+++ b/tests/integration/functional/webhooks/test_slack.py
@@ -430,11 +430,6 @@ def test_slack_configuration_accepts_all_typed_targets() -> None:
                 }
             ]
         },
-        {
-            "target_events": [
-                {"type": "file_shared", "file_id": "matches:F123"}
-            ]
-        },
     ],
 )
 def test_slack_configuration_rejects_invalid_targets(
@@ -618,6 +613,39 @@ def test_slack_matches_app_mention_targets() -> None:
     assert matches.event is not None
     assert matches.event["type"] == SlackWebhookEventType.APP_MENTION
     assert matches.event["text"] == "<@APP123> investigate this"
+
+
+def test_slack_dynamic_target_filters_complete_callback_body() -> None:
+    """Dynamic Slack targets use the inner type and complete outer payload."""
+    event = _slack_webhook_event(
+        event_type="channel_archive",
+        event_payload={
+            "type": "channel_archive",
+            "channel": "C123",
+        },
+    )
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "channel_archive",
+                    "filters": {
+                        "team_id": "T123",
+                        "event.channel": "startswith:C",
+                    },
+                }
+            ]
+        },
+    )
+
+    result = SlackWebhookProvider().match_triggers(
+        event=event, candidates=[matching]
+    )
+
+    assert result.triggers == [matching]
+    assert result.event is None
 
 
 def test_slack_parses_and_matches_regular_messages() -> None:

--- a/tests/unit/models/test_trigger_models.py
+++ b/tests/unit/models/test_trigger_models.py
@@ -61,6 +61,7 @@ def test_trigger_execution_info_parses_webhook_upstream_event() -> None:
                 "github": {
                     "webhook_id": str(webhook_id),
                     "delivery_id": "delivery-001",
+                    "event_type": "push",
                     "event": {
                         "type": "push",
                         "repo": "zenml-io/zenml",
@@ -75,6 +76,7 @@ def test_trigger_execution_info_parses_webhook_upstream_event() -> None:
         "github": WebhookTriggerExecutionInfo(
             webhook_id=webhook_id,
             delivery_id="delivery-001",
+            event_type="push",
             event={
                 "type": "push",
                 "repo": "zenml-io/zenml",
@@ -103,6 +105,7 @@ def test_trigger_execution_info_allows_missing_semantic_event() -> None:
         "custom": WebhookTriggerExecutionInfo(
             webhook_id=webhook_id,
             delivery_id="delivery-001",
+            event_type=None,
             event=None,
         )
     }

--- a/tests/unit/utils/test_trigger_utils.py
+++ b/tests/unit/utils/test_trigger_utils.py
@@ -50,6 +50,7 @@ def test_get_webhook_upstream_event_returns_plain_dict() -> None:
             "github": WebhookTriggerExecutionInfo(
                 webhook_id=webhook_id,
                 delivery_id="delivery-001",
+                event_type="push",
                 event={"type": "push", "commit": None},
             )
         }
@@ -61,6 +62,7 @@ def test_get_webhook_upstream_event_returns_plain_dict() -> None:
         "github": {
             "webhook_id": str(webhook_id),
             "delivery_id": "delivery-001",
+            "event_type": "push",
             "event": {"type": "push", "commit": None},
         }
     }

--- a/tests/unit/webhooks/test_dynamic_filters.py
+++ b/tests/unit/webhooks/test_dynamic_filters.py
@@ -1,0 +1,194 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for dynamic webhook target filters."""
+
+import pytest
+from pydantic import ValidationError
+
+from zenml.webhooks import DynamicWebhookTargetEvent
+
+
+def test_dynamic_target_matches_event_type_and_body_filters() -> None:
+    """Every body filter is required and JSON scalars are canonicalized."""
+    target = DynamicWebhookTargetEvent(
+        event_type="startswith:pull_",
+        filters={
+            "action": ["opened", "reopened"],
+            "pull_request.merged": "false",
+            "pull_request.number": "42",
+            "pull_request.milestone": "null",
+            'metadata["build.version"]': "equals:v1:beta",
+            '["123"].value': "root-key",
+            "history_items[0].after.status": "contains:progress",
+        },
+    )
+    payload = {
+        "action": "opened",
+        "pull_request": {
+            "merged": False,
+            "number": 42,
+            "milestone": None,
+        },
+        "metadata": {"build.version": "v1:beta"},
+        "123": {"value": "root-key"},
+        "history_items": [{"after": {"status": "in progress"}}],
+    }
+
+    assert target.matches(event_type="pull_request", payload=payload)
+    assert not target.matches(event_type="issues", payload=payload)
+    assert not target.matches(
+        event_type="pull_request", payload={**payload, "action": "closed"}
+    )
+    assert target.model_dump(mode="json") == {
+        "type": "dynamic",
+        "event_type": "startswith:pull_",
+        "filters": {
+            "action": ["opened", "reopened"],
+            "pull_request.merged": "false",
+            "pull_request.number": "42",
+            "pull_request.milestone": "null",
+            'metadata["build.version"]': "equals:v1:beta",
+            '["123"].value': "root-key",
+            "history_items[0].after.status": "contains:progress",
+        },
+    }
+
+
+def test_dynamic_target_wildcard_collection_semantics() -> None:
+    """Positive predicates use any and negative predicates use all."""
+    payload = {
+        "labels": [
+            {"name": "bug"},
+            {"missing": "ignored"},
+            {"name": "priority-high"},
+        ]
+    }
+
+    assert DynamicWebhookTargetEvent(
+        event_type="issues", filters={"labels[*].name": "contains:priority"}
+    ).matches(event_type="issues", payload=payload)
+    assert DynamicWebhookTargetEvent(
+        event_type="issues",
+        filters={"labels[*].name": "notcontains:documentation"},
+    ).matches(event_type="issues", payload=payload)
+    assert not DynamicWebhookTargetEvent(
+        event_type="issues", filters={"labels[*].name": "notcontains:bug"}
+    ).matches(event_type="issues", payload=payload)
+
+
+def test_dynamic_wildcard_filters_are_independent() -> None:
+    """Separate wildcard paths do not require one correlated array item."""
+    target = DynamicWebhookTargetEvent(
+        event_type="users.changed",
+        filters={
+            "users[*].role": "admin",
+            "users[*].active": "true",
+        },
+    )
+
+    assert target.matches(
+        event_type="users.changed",
+        payload={
+            "users": [
+                {"role": "admin", "active": False},
+                {"role": "viewer", "active": True},
+            ]
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"items": []},
+        {"items": [{"name": "expected"}]},
+        {"items": {"0": {"name": "expected"}}},
+        {"items": [["expected"]]},
+    ],
+)
+def test_dynamic_target_payload_mismatches_are_silent(
+    payload: dict[str, object],
+) -> None:
+    """Missing, mismatched, and non-scalar terminal values do not match."""
+    target = DynamicWebhookTargetEvent(
+        event_type="event", filters={"items[1].name": "expected"}
+    )
+
+    assert not target.matches(event_type="event", payload=payload)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "",
+        ".event",
+        "event..type",
+        "items[-1].name",
+        "items.0.name",
+        "items[*].children[*].name",
+        "a.b.c.d.e.f.g.h.i",
+        "a" * 513,
+        "metadata['single-quotes']",
+        'metadata["unterminated]',
+    ],
+)
+def test_dynamic_target_rejects_invalid_paths(path: str) -> None:
+    """Configured paths must follow the constrained path grammar."""
+    with pytest.raises(ValidationError):
+        DynamicWebhookTargetEvent(event_type="event", filters={path: "value"})
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"event_type": None},
+        {"event_type": ""},
+        {"event_type": []},
+        {"event_type": [str(index) for index in range(11)]},
+        {"event_type": "x" * 513},
+        {"event_type": 'oneof:["0","1","2","3","4","5","6","7","8","9","10"]'},
+        {"event_type": "event", "filters": {"key": None}},
+        {"event_type": "event", "filters": {"key": []}},
+        {
+            "event_type": "event",
+            "filters": {f"key{index}": "value" for index in range(11)},
+        },
+    ],
+)
+def test_dynamic_target_rejects_configuration_over_limits(
+    kwargs: dict[str, object],
+) -> None:
+    """Dynamic target input is bounded independently of payload size."""
+    with pytest.raises(ValidationError):
+        DynamicWebhookTargetEvent.model_validate(kwargs)
+
+
+def test_unrecognized_operator_prefix_is_literal_equality() -> None:
+    """Colon-containing values are operators only for recognized prefixes."""
+    target = DynamicWebhookTargetEvent(
+        event_type="event",
+        filters={
+            "url": "https://example.com/hook",
+            "state": "equals:startswith:queued",
+        },
+    )
+
+    assert target.matches(
+        event_type="event",
+        payload={
+            "url": "https://example.com/hook",
+            "state": "startswith:queued",
+        },
+    )

--- a/tests/unit/webhooks/test_providers.py
+++ b/tests/unit/webhooks/test_providers.py
@@ -22,7 +22,7 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from zenml.webhooks import WebhookEvent
+from zenml.webhooks import DynamicWebhookTargetEvent, WebhookEvent
 from zenml.webhooks.providers import (
     BaseWebhookProvider,
     BuiltinWebhookType,
@@ -104,6 +104,14 @@ def test_generic_webhook_string_filter_operators(
     )
 
 
+def test_unrecognized_string_filter_prefix_matches_literally() -> None:
+    """Only recognized operator prefixes activate expression parsing."""
+    assert matches_string_filter(
+        actual="matches:main", configured="matches:main"
+    )
+    assert not matches_string_filter(actual="main", configured="matches:main")
+
+
 @pytest.mark.parametrize(
     "configured",
     [
@@ -131,7 +139,7 @@ def test_filtered_providers_accept_all_generic_string_operators(
 
 @pytest.mark.parametrize(
     "configured",
-    ["matches:main", "equals:", "oneof:not-json", "notoneof:[]"],
+    ["equals:", "oneof:not-json", "notoneof:[]"],
 )
 def test_generic_webhook_string_filters_reject_invalid_expressions(
     configured: str,
@@ -141,6 +149,23 @@ def test_generic_webhook_string_filters_reject_invalid_expressions(
     Args:
         configured: The invalid filter expression under test.
     """
+    with pytest.raises(ValidationError):
+        PushEvent(branch=configured)
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        [],
+        [str(index) for index in range(11)],
+        "x" * 513,
+        'oneof:["0","1","2","3","4","5","6","7","8","9","10"]',
+    ],
+)
+def test_typed_webhook_string_filters_enforce_common_limits(
+    configured: str | list[str],
+) -> None:
+    """Existing typed filters share the bounded string-filter contract."""
     with pytest.raises(ValidationError):
         PushEvent(branch=configured)
 
@@ -281,10 +306,24 @@ def test_github_matching_returns_serialized_semantic_event() -> None:
             ]
         },
     )
+    dynamic_trigger = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "push",
+                    "filters": {"ref": "refs/heads/main"},
+                }
+            ]
+        },
+    )
 
-    result = provider.match_triggers(event=event, candidates=[trigger])
+    result = provider.match_triggers(
+        event=event, candidates=[trigger, dynamic_trigger]
+    )
 
-    assert result.triggers == [trigger]
+    assert result.triggers == [trigger, dynamic_trigger]
     assert result.event == {
         "type": "push",
         "repo": "zenml-io/zenml",
@@ -497,19 +536,19 @@ async def test_github_pre_validation_rejects_missing_or_empty_event_header(
 
 @pytest.mark.parametrize(
     "event_type",
-    ["pull request", "pull-request", "PULL_REQUEST"],
+    ["pull request", "pull-request", "PULL_REQUEST", "future_event"],
 )
-async def test_github_pre_validation_ignores_unsupported_event_type(
+async def test_github_pre_validation_processes_open_event_type(
     event_type: str,
 ) -> None:
-    """GitHub pre-validation explicitly ignores unsupported families."""
+    """GitHub pre-validation accepts event families unknown to ZenML."""
     provider = GitHubWebhookProvider()
 
     result = await provider.pre_validate(
         headers={GITHUB_EVENT_HEADER: event_type}
     )
 
-    assert result == WebhookPreValidationResult.IGNORE
+    assert result == WebhookPreValidationResult.PROCESS
 
 
 @pytest.mark.parametrize(
@@ -738,17 +777,89 @@ def test_provider_configuration_ignores_removed_fields() -> None:
     )
 
 
-def test_custom_configuration_ignores_unknown_fields() -> None:
-    """Custom V1 configuration remains intentionally unfiltered."""
+def test_custom_configuration_preserves_legacy_match_all_forms() -> None:
+    """Missing, null, and empty custom targets remain unfiltered."""
     provider = CustomWebhookProvider()
 
     assert provider.validate_configuration({}) == CustomWebhookConfiguration()
     assert (
-        provider.validate_configuration(
-            {"target_events": [{"type": "pipeline.ready"}]}
-        )
+        provider.validate_configuration({"target_events": None})
         == CustomWebhookConfiguration()
     )
+    assert provider.validate_configuration(
+        {"target_events": []}
+    ) == CustomWebhookConfiguration(target_events=[])
+    assert (
+        provider.validate_configuration({"removed_provider_option": True})
+        == CustomWebhookConfiguration()
+    )
+
+
+def test_custom_configuration_rejects_non_dynamic_targets() -> None:
+    """Custom target entries use the explicit dynamic discriminator."""
+    with pytest.raises(ValueError):
+        CustomWebhookProvider().validate_configuration(
+            {"target_events": [{"type": "pipeline.ready"}]}
+        )
+
+
+def test_custom_dynamic_targets_and_legacy_match_all() -> None:
+    """Custom filtering is opt-in through a non-empty dynamic target list."""
+    provider = CustomWebhookProvider()
+    event = WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="custom",
+        event_type="pipeline.ready",
+        payload={"pipeline": {"name": "training"}, "successful": True},
+    )
+    legacy = SimpleNamespace(id=uuid4(), configuration={})
+    empty = SimpleNamespace(id=uuid4(), configuration={"target_events": []})
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "pipeline.ready",
+                    "filters": {
+                        "pipeline.name": "training",
+                        "successful": "true",
+                    },
+                }
+            ]
+        },
+    )
+    non_matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "pipeline.failed",
+                }
+            ]
+        },
+    )
+
+    result = provider.match_triggers(
+        event=event,
+        candidates=[legacy, empty, matching, non_matching],
+    )
+
+    assert result.triggers == [legacy, empty, matching]
+    assert result.event is None
+
+
+def test_provider_configurations_limit_total_target_events() -> None:
+    """Typed and dynamic targets share one bounded provider target list."""
+    targets = [
+        DynamicWebhookTargetEvent(event_type=f"event-{index}")
+        for index in range(11)
+    ]
+
+    with pytest.raises(ValidationError):
+        GitHubWebhookConfiguration(target_events=targets)
 
 
 def test_runtime_matching_rejects_stale_github_configuration() -> None:
@@ -810,6 +921,48 @@ def test_runtime_empty_target_events_are_rejected() -> None:
         provider.match_triggers(event=event, candidates=[trigger]).triggers
         == []
     )
+
+
+def test_github_dynamic_target_matches_without_semantic_event() -> None:
+    """Raw GitHub variants can match independently of curated semantics."""
+    provider = GitHubWebhookProvider()
+    event = WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="github",
+        event_type="pull_request",
+        payload={
+            "action": "opened",
+            "pull_request": {
+                "merged": False,
+                "base": {"ref": "develop"},
+            },
+        },
+    )
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "pull_request",
+                    "filters": {
+                        "action": "opened",
+                        "pull_request.base.ref": "develop",
+                    },
+                }
+            ]
+        },
+    )
+    typed = SimpleNamespace(
+        id=uuid4(),
+        configuration={"target_events": [{"type": "merged_pull_request"}]},
+    )
+
+    result = provider.match_triggers(event=event, candidates=[matching, typed])
+
+    assert result.triggers == [matching]
+    assert result.event is None
 
 
 def _clickup_signature(secret: str, body: bytes) -> str:
@@ -989,6 +1142,39 @@ def test_clickup_match_filters_list_events() -> None:
     assert result.event is not None
     assert result.event["type"] == "listCreated"
     assert result.event["list_id"] == "162641285"
+
+
+def test_clickup_dynamic_target_matches_unknown_event_type() -> None:
+    """ClickUp event types outside the semantic catalog remain matchable."""
+    provider = ClickUpWebhookProvider()
+    event = WebhookEvent(
+        project_id=uuid4(),
+        webhook_id=uuid4(),
+        webhook_type="clickup",
+        event_type="futureEvent",
+        payload={
+            "event": "futureEvent",
+            "webhook_id": "wh-1",
+            "history_items": [{"after": {"status": "ready"}}],
+        },
+    )
+    matching = SimpleNamespace(
+        id=uuid4(),
+        configuration={
+            "target_events": [
+                {
+                    "type": "dynamic",
+                    "event_type": "startswith:future",
+                    "filters": {"history_items[0].after.status": "ready"},
+                }
+            ]
+        },
+    )
+
+    result = provider.match_triggers(event=event, candidates=[matching])
+
+    assert result.triggers == [matching]
+    assert result.event is None
 
 
 def test_clickup_configuration_accepts_typed_configuration() -> None:


### PR DESCRIPTION
## Describe changes

This PR adds dynamic event filters to webhook triggers, giving users an escape hatch when ZenML’s typed event catalog does not yet expose the event or payload field they need.

Users can now match a provider’s raw event type and fields from the authenticated JSON body without waiting for a ZenML release to add a new typed filter.

The following trigger matches newly opened GitHub pull requests targeting the develop branch:

```
target_events:
  - type: dynamic
    event_type: pull_request
    filters:
      action: opened
      repository.full_name: zenml-io/zenml
      pull_request.base.ref: develop
```

The equivalent SDK configuration is:

```
from zenml.webhooks import DynamicWebhookTargetEvent
from zenml.webhooks.providers.github import GitHubWebhookConfiguration

configuration = GitHubWebhookConfiguration(
    target_events=[
        DynamicWebhookTargetEvent(
            event_type="pull_request",
            filters={
                "action": "opened",
                "repository.full_name": "zenml-io/zenml",
                "pull_request.base.ref": "develop",
            },
        )
    ]
)
```

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

