### PR TITLE
Add a __repr__ to the Tag model

### DIFF
--- a/spec/plans/factory-add-a-repr-to-the-tag-model.md
+++ b/spec/plans/factory-add-a-repr-to-the-tag-model.md
@@ -1,0 +1,100 @@
+# Plan: Add `__repr__` to `TagResponse`
+
+## Root cause
+
+`src/zenml/models/v2/core/tag.py` defines `TagResponse` (the client-facing
+`Tag` model), which subclasses `UserScopedResponse` → `BaseIdentifiedResponse`
+→ `BaseResponse` → `BaseZenModel` (Pydantic `BaseModel`). None of these base
+classes define `__repr__` or `__str__`, so printing a `TagResponse` instance
+falls back to Pydantic's default `BaseModel.__repr__`, which dumps every
+field (`id`, `body`, `metadata`, `resources`, `permission_denied`, `name`,
+etc.). That's noisy and unhelpful in a REPL — a `Tag` should print as
+something short like `Tag(name=docs, color=purple)`.
+
+The fix is localized: add a `__repr__` method directly on `TagResponse`. No
+other model in `src/zenml/models/` currently overrides `__repr__`/`__str__`
+(confirmed via grep), so this is a net-new, self-contained addition with no
+risk of clashing with an existing override.
+
+## Code changes
+
+File: `src/zenml/models/v2/core/tag.py`
+
+Add a `__repr__` method to the `TagResponse` class (after `get_hydrated_version`
+or alongside the `color`/`exclusive`/`tagged_count` properties, ~line 166-193).
+`color` is already exposed as a property on `TagResponse` that reads
+`self.get_body().color` and returns a `ColorVariants` enum, so use
+`self.color.value` to get the plain string value (e.g. `"purple"` instead of
+`ColorVariants.PURPLE`):
+
+```python
+def __repr__(self) -> str:
+    """String representation of the tag.
+
+    Returns:
+        A string representation of the tag.
+    """
+    return f"Tag(name={self.name}, color={self.color.value})"
+```
+
+Notes:
+- Use `self.name` (a plain top-level field on `TagResponse`, always set —
+  doesn't require hydration) and `self.color` (a property backed by
+  `TagResponseBody`, which is populated even in the unhydrated response since
+  `color` is a required field on `TagResponseBody`). Both are safe to access
+  without triggering `get_hydrated_version()`.
+- Follow the repo's docstring convention (Google style, `Returns:` section)
+  per `CLAUDE.md`.
+- No changes needed to `TagRequest`, `TagUpdate`, or `TagFilter` — the issue
+  only asks for the response/`Tag` model's repr.
+
+## Tests
+
+New file: `tests/unit/models/test_tag_models.py`
+
+Follow the construction pattern used in `tests/unit/models/test_model_models.py`
+(directly instantiating a `*Response` with `id`, `name`, `body`, `metadata`
+args) since there's no existing tag-specific test file or fixture.
+
+```python
+from datetime import datetime
+from uuid import uuid4
+
+from zenml.enums import ColorVariants
+from zenml.models import TagResponse, TagResponseBody, TagResponseMetadata
+
+
+def test_tag_response_repr():
+    """Test that a tag's repr is short and human-readable."""
+    tag = TagResponse(
+        id=uuid4(),
+        name="my_tag",
+        body=TagResponseBody(
+            created=datetime.now(),
+            updated=datetime.now(),
+            color=ColorVariants.PURPLE,
+            exclusive=False,
+        ),
+        metadata=TagResponseMetadata(tagged_count=0),
+    )
+
+    assert repr(tag) == "Tag(name=my_tag, color=purple)"
+```
+
+Steps:
+1. Verify `TagResponse`, `TagResponseBody`, `TagResponseMetadata` are exported
+   from `zenml.models` (they should be, alongside the other `Tag*` models —
+   confirm with `grep -n "Tag" src/zenml/models/__init__.py`; import from
+   `zenml.models.v2.core.tag` directly if not exported at the top level).
+2. Add the test above to the new `tests/unit/models/test_tag_models.py`,
+   including the standard Apache license header used by sibling files in
+   that directory.
+3. Run `pytest tests/unit/models/test_tag_models.py -v` to confirm it passes.
+
+## Validation checklist
+
+- [ ] `bash scripts/format.sh`
+- [ ] `pytest tests/unit/models/test_tag_models.py`
+- [ ] `mypy src/zenml/models/v2/core/tag.py`
+- [ ] Manually sanity check in a REPL: `TagResponse(...)` prints
+      `Tag(name=..., color=...)` instead of the full Pydantic dump.

--- a/src/zenml/models/v2/core/tag.py
+++ b/src/zenml/models/v2/core/tag.py
@@ -192,6 +192,14 @@ class TagResponse(
         """
         return self.get_metadata().tagged_count
 
+    def __repr__(self) -> str:
+        """String representation of the tag.
+
+        Returns:
+            A string representation of the tag.
+        """
+        return f"Tag(name={self.name}, color={self.color.value})"
+
 
 # ------------------ Filter Model ------------------
 

--- a/tests/unit/models/test_tag_models.py
+++ b/tests/unit/models/test_tag_models.py
@@ -1,0 +1,36 @@
+#  Copyright (c) ZenML GmbH 2023. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from datetime import datetime
+from uuid import uuid4
+
+from zenml.enums import ColorVariants
+from zenml.models import TagResponse, TagResponseBody, TagResponseMetadata
+
+
+def test_tag_response_repr():
+    """Test that a tag's repr is short and human-readable."""
+    tag = TagResponse(
+        id=uuid4(),
+        name="my_tag",
+        body=TagResponseBody(
+            created=datetime.now(),
+            updated=datetime.now(),
+            color=ColorVariants.PURPLE,
+            exclusive=False,
+        ),
+        metadata=TagResponseMetadata(tagged_count=0),
+    )
+
+    assert repr(tag) == "Tag(name=my_tag, color=purple)"


### PR DESCRIPTION
## Summary

- Added `__repr__` to `TagResponse` in `src/zenml/models/v2/core/tag.py`, returning `Tag(name=<name>, color=<color>)` using the existing `name` field and `color` property.
- Added `tests/unit/models/test_tag_models.py` with `test_tag_response_repr`, which constructs a `TagResponse` and asserts its `repr()` output matches the expected short format.
- Verified with `pytest tests/unit/models/test_tag_models.py` (passing) and `ruff check`/`ruff format` on both changed files (clean).

Plan: `spec/plans/factory-add-a-repr-to-the-tag-model.md`

Run: https://staging.cloud.zenml.io/workspaces/dev/projects/244365c2-3a52-4ca1-a37d-80e58cda182e/runs/010c30a2-d7b1-4727-af04-3f9f51ec4e25
