### PR TITLE
Clarify agent task boundaries and verification guidance

### DIFF
--- a/.agents/skills/zenml-repo-workflows/SKILL.md
+++ b/.agents/skills/zenml-repo-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zenml-repo-workflows
-description: Use for ZenML repo work involving tests, PRs, migrations, docs, integrations, models, orchestrators, server, or storage.
+description: Use for ZenML tests, PRs, migrations, docs, integrations, models, orchestrators, server, storage, or webhooks. Read only relevant sections.
 ---
 
 # ZenML Repo Workflows
@@ -8,7 +8,9 @@ description: Use for ZenML repo work involving tests, PRs, migrations, docs, int
 Use this skill when work in the ZenML repository needs more detail than the
 always-loaded `AGENTS.md` files provide. The root guide keeps safety rules,
 universal conventions, and the most common commands in memory. This skill keeps
-the longer recipes, examples, and subsystem checklists.
+the longer recipes, examples, and subsystem checklists. Before editing, read
+applicable subtree `AGENTS.md` files even when starting at the root. Follow the
+user's current task scope; this skill does not require running every recipe.
 
 ## Moved Content Index
 
@@ -77,20 +79,38 @@ Former root headings covered here:
 
 ### Formatting, Linting, and Tests
 
-- Format before committing: `bash scripts/format.sh`.
-- Check quality: `bash scripts/lint.sh`.
+- Before committing Python changes, format changed paths with
+  `bash scripts/format.sh <changed-paths> --no-yamlfix`.
+- For focused Python quality checks, use
+  `bash scripts/lint.sh <changed-path> --no-yamlfix --no-zizmor`. The script
+  accepts one path argument for Python checks; run it per affected package
+  when necessary.
+- Without a path, both scripts cover broad repository directories. Formatting
+  also runs yamlfix on `.github` and `tests` unless `--no-yamlfix` is set;
+  passing Python paths alone does not restrict YAML formatting.
+- For YAML/workflow changes, run the relevant yamlfix and zizmor checks. Use
+  unscoped scripts when repository-wide validation is intended, and inspect
+  formatting changes before staging.
 - The lint script runs Ruff, pydoclint on `src/zenml tests/harness`, yamlfix,
   zizmor, unused import/variable checks, Ruff formatting checks, and mypy.
 - Full mypy is slow on the whole codebase. For focused work, run mypy on the
   changed file or package.
-- Run targeted pytest files or tests for the component you changed. Avoid the
-  full local test suite unless there is a specific reason.
+- Run targeted pytest files or tests for changed behavior. Avoid the full local
+  test suite unless there is a specific reason.
+- Once relevant checks pass, repeat or broaden them only for subsequent
+  relevant edits, failures, or an unresolved concern. Report unavailable checks
+  and the missing environment. Do not add tests that merely mirror low-impact
+  edits.
+- Documentation-only edits need relevant link/content checks and diff review,
+  not Python tests or repository-wide formatting.
 - Some coverage workflows use `bash scripts/test-coverage-xml.sh`, but that does
   not run every test.
 
 ### Branches and PRs
 
-- `develop` is the primary working branch. PRs should target `develop`.
+- Create new independent branches from current `develop`; PRs should target
+  `develop`. Preserve the branch/base when continuing an existing PR unless a
+  change is requested.
 - `main` is only updated during the release process.
 - PR titles should be human-readable and concise. Avoid prefixes like `feat:`.
 - PR descriptions should explain what changed, why it was needed, important
@@ -168,12 +188,13 @@ Useful utility locations:
 Symbols with a leading underscore are private and should only be called from
 inside their class or module.
 
-When changing a non-underscore symbol, check whether it is exported from
-`zenml.__init__`. Root exports and public methods on those exports are public
-API and generally require deprecation before breaking changes.
+When changing a non-underscore symbol, check `zenml.__init__` exports,
+documented import paths, and supported extension/integration interfaces. Root
+exports are one signal of public API, not an exhaustive list. Preserve supported
+contracts or use deprecation before breaking changes.
 
-Internal non-underscore code that is not exported at the root can usually be
-changed without deprecation, but update all internal usages.
+For code established to be internal, search usages and update affected callers.
+Do not infer that a symbol is internal solely because it lacks a root export.
 
 Integrations should avoid ZenML private methods because future external
 integration packages will not be protected by in-repo mypy checks.
@@ -194,7 +215,11 @@ Preferred patterns:
 
 - Extend existing service or repository classes when behavior belongs there.
 - Keep shared state in FastAPI dependency injection or the application factory.
-- Use synchronous `def` route handlers in OSS Codex contributions.
+- Use synchronous `def` with the established async compatibility wrapper for
+  ordinary store-backed routes. Preserve async handlers for request-body access
+  or other awaited I/O; use the existing thread-pool pattern for blocking work.
+- Set an explicit project filter when listing project-scoped resources through
+  the store; an omitted filter can return resources from other projects.
 - Use descriptive lower_snake_case paths and named exports.
 - Co-locate Pydantic request/response models with consuming routes.
 - Keep reusable behavior in service or repository modules accessed through
@@ -220,7 +245,8 @@ Database schema changes require Alembic migrations.
 Migration rules:
 
 - Create descriptive migrations, e.g. `alembic revision -m "Add X to Y table"`.
-- Test upgrade paths with `alembic upgrade head`.
+- Test upgrades only against a disposable database with isolated ZenML
+  configuration. Never use the user's configured store as a test target.
 - Downgrade testing is optional because ZenML generally does not support
   downgrades.
 - Never modify existing migrations that are already on `main` or `develop`.
@@ -230,10 +256,33 @@ Migration rules:
 
 Migration testing workflow:
 
-1. Check out `develop` or the relevant old release.
-2. Populate the database from that version.
-3. Switch to the feature branch.
-4. Run `alembic upgrade head`.
+1. Choose the old version and database backend relevant to the change. Create
+   a separate checkout and Python environment for that version, leaving the
+   active feature checkout intact.
+2. Create a unique temporary directory and a disposable database. In the test
+   subprocess environment, remove inherited `ZENML_STORE_*`,
+   `ZENML_SECRETS_STORE_*`, and `ZENML_BACKUP_SECRETS_STORE_*` overrides. Set
+   `ZENML_CONFIG_PATH` to a fresh directory there and `ZENML_STORE_URL` to the
+   disposable database URL. For SQLite, use an absolute file path, for example
+   `sqlite:////tmp/<unique-test-directory>/migration.db`. For MySQL, use a
+   dedicated test database and test credentials. Keep analytics disabled with
+   `ZENML_ANALYTICS_OPT_IN=false` and `ZENML_DEBUG=true`.
+3. Verify the effective store target without printing credentials before any
+   population or upgrade command. `migrations/env.py` reads ZenML's configured
+   store, and environment overrides can supersede its saved configuration.
+4. Use the old-version environment to populate representative fixtures. Use a
+   separate fresh configuration directory for the feature version, with the
+   same explicit disposable database URL. Confirm that the feature Python
+   environment imports this checkout.
+5. From the feature repo root, run `alembic upgrade head` in that isolated
+   environment. Check the resulting schema and assert that representative data
+   and relationships survived. Run `bash scripts/check-alembic-branches.sh`.
+6. Remove only the disposable resources created for this test after collecting
+   results. Report any backend or fixture coverage that could not run.
+
+`scripts/test-migrations.sh` provides broader upgrade coverage but uses a fixed
+`/tmp/upgrade-tests` configuration path and changes test environments. Inspect
+its setup before using it; it is not the default for a focused change.
 
 Useful MySQL query for foreign key dependency tracing:
 
@@ -330,20 +379,17 @@ the store layer.
 
 ### Model Compatibility
 
-Usually safe:
+Check requests, updates, and responses separately:
 
-- Adding optional properties.
+- New required request fields break clients that omit them. Optional fields
+  with defaults usually preserve calls; check older servers too.
+- Updates must preserve omitted-field versus explicit-`None` semantics to avoid
+  unintended overwrites.
+- Removed or renamed response fields, incompatible types, and newly nullable
+  values can break consumers that rely on the old guarantees.
 
-Risky or breaking:
-
-- Deleting properties.
-- Renaming properties.
-- Making required fields optional in a way older code cannot tolerate.
-- Changing property types.
-
-Safe evolution pattern: add optional fields, deprecate before removal, use
-defaults when adding required behavior, and consider versioned responses for
-major changes.
+Check persisted data and rolling client/server versions. Use defaults and
+deprecation periods when evolving supported contracts.
 
 ## CLI Work
 
@@ -438,7 +484,9 @@ Dependency updates:
 
 - Prefer inclusive lower bounds and exclusive upper bounds.
 - Check Python version compatibility.
-- Test locally with realistic integration scenarios.
+- Test realistic integration scenarios when services and credentials are
+  available. Otherwise run applicable local checks and report the unverified
+  scenarios and required CI coverage.
 - Treat dropping support for an old version as breaking.
 - Mention breaking dependency changes in release notes.
 
@@ -509,7 +557,9 @@ Rules:
 - Keep fields aligned with domain models.
 - Schema changes usually require migrations.
 - Export new schemas from `src/zenml/zen_stores/schemas/__init__.py`.
-- General string column limit is about 250 characters because of MySQL.
+- Use `zenml.constants.STR_FIELD_MAX_LENGTH` (currently 255) for standard string
+  fields. Match existing column types and MySQL index/charset constraints;
+  this is a repository convention, not a universal database limit.
 
 Foreign keys:
 
@@ -536,9 +586,21 @@ Import rule: code outside `zen_stores/` should not import SQL-related code
 directly from this directory. Use `Client`, or `client.zen_store` when lower
 level access is truly needed.
 
+## Webhooks
+
+Read `src/zenml/webhooks/AGENTS.md` for provider, semantic-event, and handler
+changes, including when editing HTTP intake under `zen_server/`. Also read the
+server guide when changing routes.
+
+Authenticate exact raw body bytes before dispatch. Never expose unauthenticated
+payloads to handlers or perform provider side effects during intake. A success
+response confirms intake acceptance only, not trigger matching or execution.
+Preserve the isolated, non-durable background handoff and its failure reporting.
+
 ## Cross-Area Change Checklist
 
-Some features span many layers. When touching these, trace the whole path:
+Some features span many layers. Trace the dependencies below and update the
+affected layers; the checklist does not require edits to every listed area:
 
 - Dynamic pipelines and nested child pipelines:
   - `src/zenml/execution/pipeline/dynamic/`
@@ -565,8 +627,8 @@ Some features span many layers. When touching these, trace the whole path:
 - Private method changes: all internal usages are updated.
 - Import checks: no `zen_server` imports outside `zen_server`.
 - Import checks: no direct SQL imports outside `zen_stores`.
-- Model changes: adding properties is usually OK; deleting, renaming, or
-  incompatible type changes are risky.
+- Model changes: check request, update, and response contracts, persisted data,
+  and rolling client/server compatibility.
 - Dependency bumps: dropping old version support is breaking.
 - Scheduling changes: update both legacy schedule and trigger stacks where
   relevant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,18 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 - `examples/` - Example projects.
 - `scripts/` - Development utilities.
 
+## Task Scope and Completion
+
+- For implementation requests, continue through the requested change, relevant
+  checks, and final diff review. For audits and proposals, report findings
+  without applying changes unless requested.
+- Make routine choices from repository conventions. Ask when the answer changes
+  behavior, compatibility, or authorization; continue independent authorized
+  work while waiting. Do not ask again for actions already authorized.
+- Current user instructions take precedence over skill guidelines. If a skill
+  would block authorized work, identify the exact file and instruction and
+  explain the conflict rather than silently stopping or expanding the task.
+
 ## Always-Loaded Rules
 
 - Use US English spelling in code, comments, docstrings, and documentation.
@@ -34,18 +46,27 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Common Commands
 
-- Format before committing: `bash scripts/format.sh`.
-- Check quality: `bash scripts/lint.sh`.
+- Before committing Python changes, format only the changed paths:
+  `bash scripts/format.sh <changed-paths> --no-yamlfix`.
+- For focused Python quality checks:
+  `bash scripts/lint.sh <changed-path> --no-yamlfix --no-zizmor`.
+- The unscoped scripts check or format repository-wide files, including YAML
+  and workflows. Use the workflow skill for their scope and required checks.
 - Run targeted tests only: `pytest tests/unit/path/to/test_file.py` or
   `pytest tests/unit/path/to/test_file.py::test_specific_function`.
 - Do NOT run the entire local test suite by default; many tests need special
   environments.
-- If you make changes after running tests, rerun the relevant tests.
+- After relevant checks pass, repeat or broaden them only for subsequent
+  relevant edits, failures, or a specific unresolved concern. Report checks
+  that could not run and why.
+- Documentation-only changes need relevant documentation checks, not Python
+  tests or repository-wide formatting.
 
 ## Branches, Git, and PRs
 
 - `develop` is the primary working branch, not `main`.
-- Always branch off `develop` for new work.
+- Branch off current `develop` for new independent work. When continuing an
+  existing PR, preserve its branch and base unless a change is requested.
 - PRs should target `develop`.
 - `main` is only updated during releases.
 - Use targeted `git add`; do not stage unrelated files.
@@ -62,25 +83,31 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 - NEVER commit secrets, API keys, tokens, passwords, or credentials.
 - Use environment variables or ZenML secret management for sensitive data.
 - Validate and sanitize user inputs.
-- If secrets are accidentally committed, notify the team immediately.
+- If secrets are accidentally committed, inform the user immediately without
+  repeating the secret. Prepare incident details; send external notifications
+  only when authorized.
 
 ## Architecture and API Safety
 
-- Check whether a class or function is exported in `zenml.__init__` before
-  changing a public-looking interface.
+- Before changing a public-looking interface, check root exports in
+  `zenml.__init__`, documented import paths, and supported extension/integration
+  interfaces. Absence from root exports does not establish that it is internal.
 - Public APIs need backward-compatible evolution or deprecation.
 - For internal non-underscore methods, search for usages and update all
   internal callers.
 - The term "model" can mean Pydantic models, machine learning models, or ZenML
   model namespaces. Be explicit when writing or reviewing.
 - When changing cross-cutting features, trace the full path through CLI,
-  client, server, models, schemas, migrations, tests, and docs.
+  client, server, models, schemas, migrations, tests, and docs. Inspect these
+  dependencies and update the affected layers; do not edit every layer by default.
 
 ## FastAPI and Runtime Rules
 
 - ZenML OSS FastAPI work expects FastAPI, SQLModel, SQLAlchemy 2.0, and
   Pydantic v2 patterns.
-- Implement synchronous `def` route handlers for OSS Codex contributions.
+- Use synchronous `def` handlers with the existing compatibility wrapper for
+  ordinary store-backed endpoints. Preserve async handlers for request-body
+  access or other awaited I/O; keep blocking store work off the event loop.
 - Keep shared state inside FastAPI dependency injection or the application
   factory; never introduce fresh global variables outside initialization.
 - Start routes, dependencies, and services with guard clauses.
@@ -92,6 +119,11 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
   require coordinated OTel updates. Keep OTel SDK/exporter versions aligned with
   the matching OpenTelemetry instrumentation beta line.
 - Code outside `src/zenml/zen_server/` should NEVER import from `zen_server/`.
+- Set an explicit project filter on store list calls for project-scoped
+  resources; omitting it queries across projects.
+- Authenticate exact webhook body bytes before dispatch. Never pass
+  unauthenticated payloads to handlers or perform provider side effects during
+  intake. Acceptance does not confirm downstream execution.
 
 ## Database and Storage Rules
 
@@ -99,8 +131,9 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 - Database schema changes require Alembic migrations.
 - Never modify existing migrations that are already on `main` or `develop`.
 - Always consider backward compatibility for rolling deployments.
-- Test migration upgrade paths with `alembic upgrade head` for meaningful
-  schema changes.
+- Test meaningful schema upgrades against a disposable database with isolated
+  ZenML configuration. Never use the user's configured store as a test target.
+  Follow the migration setup in the workflow skill before running Alembic.
 - Code outside `zen_stores/` should not import SQL-related code directly from
   `zen_stores`; use `Client` or, rarely, `client.zen_store`.
 
@@ -108,15 +141,18 @@ subsystem recipes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 Load `.agents/skills/zenml-repo-workflows/SKILL.md` for detailed guidance on
 tests, PRs, migrations, docs, integrations, models, orchestrators, FastAPI,
-server code, and storage.
+server code, storage, and webhooks. Load only the relevant sections.
 
-Directory-specific reminders:
+Before editing a subtree, read its applicable `AGENTS.md` files, even when the
+session started at the repository root. Read guidance for other affected
+subtrees when a change crosses their boundaries. Paths below are repo-relative:
 
 - `docs/book/AGENTS.md` - documentation source, GitBook links, and docs checks.
 - `src/zenml/cli/AGENTS.md` - CLI import rules and filter/client coupling.
 - `src/zenml/integrations/AGENTS.md` - integration flavor import rules.
 - `src/zenml/models/AGENTS.md` - domain model compatibility and filter fields.
 - `src/zenml/orchestrators/AGENTS.md` - orchestrator IDs and dynamic pipelines.
+- `src/zenml/webhooks/AGENTS.md` - authentication, intake, and provider contracts.
 - `src/zenml/zen_server/AGENTS.md` - server import boundary and endpoint shape.
 - `src/zenml/zen_stores/migrations/AGENTS.md` - Alembic migration guidance.
 - `src/zenml/zen_stores/schemas/AGENTS.md` - ORM schema and SQL import rules.
@@ -128,10 +164,8 @@ Directory-specific reminders:
   all steps in that run.
 - Filter model changes: matching client method signature and body are updated.
 - Private method changes: all internal usages are updated.
-- Import checks: no `zen_server` imports outside `zen_server`.
-- Import checks: no direct SQL imports outside `zen_stores`.
-- Model changes: adding properties is usually OK; deleting, renaming, or
-  incompatible type changes are risky.
+- Model changes: check request, update, and response compatibility separately;
+  new required inputs and weakened response guarantees can break callers.
 - Dependency bumps: dropping old version support is breaking.
 - Scheduling changes: check both legacy schedule and trigger stacks.
 - Step operator changes: check `BaseStepOperator`, `StepLauncher`, and at least

--- a/docs/book/AGENTS.md
+++ b/docs/book/AGENTS.md
@@ -1,8 +1,8 @@
 # Documentation Agent Guidelines
 
-This file applies when Codex starts in `docs/book/` or below. For detailed
+This file applies to changes in `docs/book/` and below. For detailed
 GitBook URL examples, link-checking notes, and docs workflow recipes, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Source of Truth
 

--- a/src/zenml/cli/AGENTS.md
+++ b/src/zenml/cli/AGENTS.md
@@ -1,8 +1,8 @@
 # ZenML CLI Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/cli/` or below. For detailed
+This file applies to changes in `src/zenml/cli/` and below. For detailed
 CLI examples and command-family notes, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Key Files
 

--- a/src/zenml/integrations/AGENTS.md
+++ b/src/zenml/integrations/AGENTS.md
@@ -1,8 +1,8 @@
 # ZenML Integrations Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/integrations/` or below. For
+This file applies to changes in `src/zenml/integrations/` and below. For
 detailed examples, dependency update guidance, and step-operator notes, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Critical Flavor Import Rule
 
@@ -52,7 +52,9 @@ cancel, and wait can work reliably.
 ## Dependencies
 
 - Prefer inclusive lower bounds and exclusive upper bounds.
-- Test realistic integration scenarios locally when changing dependencies.
+- Test realistic integration scenarios when changing dependencies. If required
+  credentials or services are unavailable, run applicable local checks and
+  report the unverified scenario and required CI coverage.
 - Dropping support for an older dependency version is a breaking change.
 
 ## Import Boundaries

--- a/src/zenml/models/AGENTS.md
+++ b/src/zenml/models/AGENTS.md
@@ -1,8 +1,8 @@
 # ZenML Domain Models Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/models/` or below. For
+This file applies to changes in `src/zenml/models/` and below. For
 detailed model hierarchy notes and examples, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 Models live under `src/zenml/models`. Keep them aligned with ORM schemas and
 store behavior.
@@ -43,15 +43,14 @@ layer.
 
 ## Compatibility
 
-Usually safe:
+Check compatibility separately for each payload role:
 
-- Adding optional properties.
+- Requests: adding a required field breaks callers that omit it. Optional fields
+  with defaults usually preserve existing calls; check older servers too.
+- Updates: preserve the distinction between an omitted field and explicit
+  `None`; changing it can turn a partial update into an unintended overwrite.
+- Responses: removing or renaming fields, changing types, or allowing `None`
+  where callers expect a value can break clients.
 
-Risky or breaking:
-
-- Deleting properties.
-- Renaming properties.
-- Making required fields optional in a way older code cannot tolerate.
-- Changing property types incompatibly.
-
-Use deprecation periods and defaults when evolving public model responses.
+Check old persisted data and rolling client/server versions. Use deprecation
+periods and defaults when evolving supported contracts.

--- a/src/zenml/orchestrators/AGENTS.md
+++ b/src/zenml/orchestrators/AGENTS.md
@@ -1,8 +1,8 @@
 # ZenML Orchestrators Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/orchestrators/` or below. For
+This file applies to changes in `src/zenml/orchestrators/` and below. For
 detailed examples and implementation recipes, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Key Files
 
@@ -43,7 +43,8 @@ parent Kubernetes job name for dynamic runs, falling back only when needed.
 
 ## Dynamic Child Pipelines
 
-When changing dynamic pipeline behavior, check:
+When changing dynamic pipeline behavior, inspect these dependencies and update
+the affected layers:
 
 - `src/zenml/execution/pipeline/dynamic/`
 - `src/zenml/pipelines/dynamic/`

--- a/src/zenml/zen_server/AGENTS.md
+++ b/src/zenml/zen_server/AGENTS.md
@@ -1,7 +1,8 @@
 # ZenML Server Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/zen_server/` or below. For
-detailed FastAPI guidance, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
+This file applies to changes in `src/zenml/zen_server/` and below. For
+detailed FastAPI guidance, use the repo-root
+`.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Critical Import Boundary
 
@@ -25,7 +26,12 @@ Most server endpoints follow this order:
 2. Check entitlements when feature access is gated.
 3. Verify RBAC permissions.
 4. Call `zen_store()` for the data operation.
-5. Use the async compatibility wrapper where existing routes do so.
+
+Ordinary store-backed handlers use synchronous `def` with
+`async_fastapi_endpoint_wrapper`, as neighboring routes do. Keep async handlers
+when they await request-body access or other I/O. For example, webhook intake
+awaits the raw body and uses `run_in_threadpool` for synchronous processing;
+do not move blocking store work onto the event loop.
 
 Non-CRUD endpoints, such as trigger attach/detach, may need permission checks
 across multiple resource domains.

--- a/src/zenml/zen_stores/migrations/AGENTS.md
+++ b/src/zenml/zen_stores/migrations/AGENTS.md
@@ -1,14 +1,15 @@
 # ZenML Migration Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/zen_stores/migrations/` or
+This file applies to changes in `src/zenml/zen_stores/migrations/` and
 below. For detailed migration recipes and SQL inspection queries, use
-`.agents/skills/zenml-repo-workflows/SKILL.md`.
+the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Alembic Rules
 
 - Create migrations with descriptive names, for example
   `alembic revision -m "Add X to Y table"`.
-- Test upgrade paths with `alembic upgrade head`.
+- Test upgrades only against a disposable database with isolated ZenML
+  configuration. Never use the user's configured store as a test target.
 - Downgrade testing is optional because ZenML generally does not support
   downgrades.
 - Never modify existing migrations that are already on `main` or `develop`.
@@ -18,10 +19,11 @@ below. For detailed migration recipes and SQL inspection queries, use
 
 ## Testing Workflow
 
-1. Check out `develop` or the relevant old release.
-2. Populate the database from that version.
-3. Switch to the feature branch.
-4. Run `alembic upgrade head`.
+Follow the isolated migration testing workflow in the repo-root workflow skill.
+Use a separate checkout/environment of the old version to populate test data,
+then run the feature version against the same disposable database. Verify both
+schema changes and preservation of representative data. Do not switch the
+active checkout or run Alembic against an unspecified store.
 
 ## Coordination
 

--- a/src/zenml/zen_stores/schemas/AGENTS.md
+++ b/src/zenml/zen_stores/schemas/AGENTS.md
@@ -1,14 +1,16 @@
 # ZenML ORM Schema Agent Guidelines
 
-This file applies when Codex starts in `src/zenml/zen_stores/schemas/` or
+This file applies to changes in `src/zenml/zen_stores/schemas/` and
 below. For detailed SQLModel examples, relationship patterns, and eager-loading
-notes, use `.agents/skills/zenml-repo-workflows/SKILL.md`.
+notes, use the repo-root `.agents/skills/zenml-repo-workflows/SKILL.md`.
 
 ## Storage Rules
 
 - ZenML uses SQLModel and SQLAlchemy for database operations.
 - No raw SQL unless absolutely necessary.
-- General string column limit is about 250 characters because of MySQL.
+- Use `STR_FIELD_MAX_LENGTH` from `zenml.constants` (currently 255) for fields
+  following the standard string convention. Match existing column types and
+  account for MySQL index/charset constraints; this is not a universal limit.
 - Code outside `zen_stores/` should not import SQL-related code directly from
   this directory.
 - External code should use `Client`; lower-level access should go through


### PR DESCRIPTION
## Describe changes

Agents now have explicit task boundaries and verification scope, reducing unnecessary approval pauses, broad formatting changes, and ambiguous instructions. This applies the [GPT-6 Astra prompting guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra) while retaining ZenML's compatibility and import safeguards.

Migration checks now require isolated configuration and a disposable database because Alembic uses the configured ZenML store. The guidance also distinguishes ordinary synchronous routes from endpoints that await I/O, requires reading applicable subtree instructions from root sessions, and keeps the shared workflow skill consistent with those rules.

Validation: `git diff --check` passed. Exercised the documented formatter/lint scope flags with stub executables and confirmed that only the requested Python path was passed and no YAML/workflow tools ran. Checked instruction paths and skill frontmatter, remeasured context size, and independently reviewed command/configuration claims against source. No migrations, full Python suite, or end-to-end agent behavior evaluation were run.

## Pre-requisites

- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes. Not applicable: guidance-only changes; scoped command dispatch was checked with temporary stubs.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`.
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io): No product documentation change needed.
  - [ ] Dashboard: No impact.
  - [ ] Templates: No impact.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): No impact.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other: Repository agent instructions and workflow guidance.
