### PR TITLE
Fix lint failures introduced by the software factory example

### DIFF
--- a/examples/software_factory/README.md
+++ b/examples/software_factory/README.md
@@ -280,7 +280,9 @@ An `app_mention` target works the same way without the extra scope, since the me
 `open_workspace` clones the repository once and returns the session id as an artifact. Every later step that touches the checkout calls `attach_or_recreate(workspace, repo, branch)`, which reattaches to that session and resets it to the pushed branch:
 
 ```python
-def attach_or_recreate(workspace: str, repo: str, branch: str) -> SandboxSession:
+def attach_or_recreate(
+    workspace: str, repo: str, branch: str
+) -> SandboxSession:
     try:
         session = attach_sandbox(workspace)
     except (KeyError, RuntimeError):

--- a/examples/software_factory/factory_utils.py
+++ b/examples/software_factory/factory_utils.py
@@ -619,7 +619,8 @@ def slack_message_text(channel: str, ts: str) -> str:
         f"https://slack.com/api/conversations.replies?{query}",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    # The URL is a fixed https literal, so no other scheme can be opened.
+    with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310
         payload = json.load(response)
     messages = payload.get("messages") or []
     match = next((m for m in messages if m.get("ts") == ts), None)


### PR DESCRIPTION
## Problem

Every open pull request fails the `linting` and `small-checks` jobs on
code that came from `develop` with the software factory example (#5246):

- ruff 0.16.5, which CI installs because `pyproject.toml` pins no upper
  bound, formats Python code blocks in Markdown. `ruff format --check`
  fails on one long function signature in
  `examples/software_factory/README.md`.
- Bandit reports B310 on `urllib.request.urlopen` in
  `examples/software_factory/factory_utils.py`. The URL is a fixed
  `https://slack.com/...` literal, so no other scheme can be opened.

`develop` itself has not run these jobs since the example merged, which
is why it still shows green.

## Changes

- Reformat the README code block the way ruff 0.16 wants it.
- Suppress B310 on that one call with a comment stating why.

Verified locally with `ruff@0.16.5 format --check src/zenml tests
examples` (all files formatted) and `bandit -c pyproject.toml -r
examples/software_factory -ll` (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)