### PR TITLE
Fix the c465032f0ec0 DB migration script to be idempotent

### DIFF
--- a/src/zenml/zen_stores/migrations/versions/c465032f0ec0_add_pagination_indexes_for_pipeline_.py
+++ b/src/zenml/zen_stores/migrations/versions/c465032f0ec0_add_pagination_indexes_for_pipeline_.py
@@ -33,10 +33,6 @@ def upgrade() -> None:
         ["project_id", "created", "id"],
     )
 
-    drop_index_if_exists(
-        "pipeline_snapshot",
-        "ix_pipeline_snapshot_project_id_created_id_name",
-    )
     create_index_if_missing(
         "pipeline_snapshot",
         "ix_pipeline_snapshot_project_id_created_id",
@@ -46,6 +42,12 @@ def upgrade() -> None:
         "pipeline_snapshot",
         "ix_pipeline_snapshot_project_id_name",
         ["project_id", "name"],
+    )
+    # MySQL might use the old index to enforce the project foreign key, so a
+    # replacement that starts with `project_id` must exist before it is dropped.
+    drop_index_if_exists(
+        "pipeline_snapshot",
+        "ix_pipeline_snapshot_project_id_created_id_name",
     )
 
     create_index_if_missing(


### PR DESCRIPTION
## Summary

Fix the `c465032f0ec0` database migration failing on some MySQL databases when replacing the pipeline snapshot pagination index.

## Problem

Some databases use the existing
`ix_pipeline_snapshot_project_id_created_id_name` index to enforce the
`pipeline_snapshot.project_id` foreign key.

The migration previously dropped this index before creating its replacements.
When it was the only suitable index beginning with `project_id`, MySQL rejected
the operation with error 1553:

> Cannot drop index: needed in a foreign key constraint

This could affect databases with partially applied or otherwise non-canonical
index histories.

## Solution

Create the replacement indexes before dropping the obsolete index:

- `ix_pipeline_snapshot_project_id_created_id`
- `ix_pipeline_snapshot_project_id_name`

The existing `create_index_if_missing` and `drop_index_if_exists` helpers make
the operation safe to retry after partially applied MySQL DDL.

The downgrade path is intentionally unchanged.


## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

