### PR TITLE
[DB growth initiative #7] Paginate pipeline runs by IDs before loading full rows

### DIFF
--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1401,6 +1401,7 @@ class SqlZenStore(BaseZenStore):
         hydrate: bool = False,
         apply_query_options_from_schema: bool = False,
         query_options_kwargs: Optional[Dict[str, Any]] = None,
+        paginate_by_ids: bool = False,
     ) -> Page[AnyResponse]:
         """Given a query, return a Page instance with a list of filtered Models.
 
@@ -1425,6 +1426,8 @@ class SqlZenStore(BaseZenStore):
                 query options defined on the schema.
             query_options_kwargs: Extra keyword arguments forwarded to the
                 schema's `get_query_options`.
+            paginate_by_ids: Fetch page IDs before loading rows. Only use for
+                single-entity queries sorted on columns of that entity.
 
         Returns:
             The Domain Model representation of the DB resource
@@ -1492,6 +1495,25 @@ class SqlZenStore(BaseZenStore):
         else:
             query = filter_model.apply_sorting(query=query, table=table)
 
+            if paginate_by_ids:
+                # Keep filtering (including RBAC) and deduplication inside the
+                # page. MySQL needs the sort column selected with DISTINCT.
+                sort_column = getattr(table, filter_model.sorting_params[0])
+                page_query = query.with_only_columns(
+                    col(table.id), sort_column, maintain_column_froms=True
+                )
+                if cls._query_requires_distinct(query):
+                    page_query = page_query.distinct()
+                page_ids = (
+                    page_query.limit(filter_model.size)
+                    .offset(filter_model.offset)
+                    .subquery("page_ids")
+                )
+                query = select(table).join(
+                    page_ids, col(table.id) == page_ids.c.id
+                )
+                query = filter_model.apply_sorting(query=query, table=table)
+
             query_options = table.get_query_options(
                 include_metadata=hydrate,
                 include_resources=True,
@@ -1507,9 +1529,11 @@ class SqlZenStore(BaseZenStore):
             if cls._query_requires_distinct(query):
                 query = query.distinct()
 
-            query_result = session.exec(
-                query.limit(filter_model.size).offset(filter_model.offset)
-            )
+            if not paginate_by_ids:
+                query = query.limit(filter_model.size).offset(
+                    filter_model.offset
+                )
+            query_result = session.exec(query)
             item_schemas = query_result.all()
 
         # Convert this page of items from schemas to models.
@@ -7454,6 +7478,8 @@ class SqlZenStore(BaseZenStore):
                 query_options_kwargs={
                     "include_full_metadata": include_full_metadata
                 },
+                paginate_by_ids=runs_filter_model.sorting_params[0]
+                not in {"pipeline", "stack", "model", "model_version"},
             )
 
     def update_run(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -1426,8 +1426,11 @@ class SqlZenStore(BaseZenStore):
                 query options defined on the schema.
             query_options_kwargs: Extra keyword arguments forwarded to the
                 schema's `get_query_options`.
-            paginate_by_ids: Fetch page IDs before loading rows. Only use for
-                single-entity queries sorted on columns of that entity.
+            paginate_by_ids: Fetch the IDs of the page first and load only
+                those rows, so that deep offsets do not load the rows they
+                skip. Applies to single-entity queries; sorting on a related
+                entity (the filter's custom sorting options) falls back to
+                loading the page directly.
 
         Returns:
             The Domain Model representation of the DB resource
@@ -1495,22 +1498,32 @@ class SqlZenStore(BaseZenStore):
         else:
             query = filter_model.apply_sorting(query=query, table=table)
 
+            sort_by = filter_model.sorting_params[0]
+            paginate_by_ids = (
+                paginate_by_ids
+                and sort_by not in filter_model.CUSTOM_SORTING_OPTIONS
+            )
             if paginate_by_ids:
                 # Keep filtering (including RBAC) and deduplication inside the
                 # page. MySQL needs the sort column selected with DISTINCT.
-                sort_column = getattr(table, filter_model.sorting_params[0])
                 page_query = query.with_only_columns(
-                    col(table.id), sort_column, maintain_column_froms=True
-                )
-                if cls._query_requires_distinct(query):
+                    col(table.id),
+                    getattr(table, sort_by),
+                    maintain_column_froms=True,
+                ).options(noload("*"))
+                if query_requires_distinct:
                     page_query = page_query.distinct()
+                # A derived table, because MySQL rejects LIMIT directly inside
+                # IN (SELECT ...). Filtering on `IN` instead of joining the
+                # page keeps the outer query a single-table select, so it is
+                # not wrapped in a DISTINCT over every row column.
                 page_ids = (
                     page_query.limit(filter_model.size)
                     .offset(filter_model.offset)
                     .subquery("page_ids")
                 )
-                query = select(table).join(
-                    page_ids, col(table.id) == page_ids.c.id
+                query = select(table).where(
+                    col(table.id).in_(select(page_ids.c.id))
                 )
                 query = filter_model.apply_sorting(query=query, table=table)
 
@@ -7478,8 +7491,7 @@ class SqlZenStore(BaseZenStore):
                 query_options_kwargs={
                     "include_full_metadata": include_full_metadata
                 },
-                paginate_by_ids=runs_filter_model.sorting_params[0]
-                not in {"pipeline", "stack", "model", "model_version"},
+                paginate_by_ids=True,
             )
 
     def update_run(

--- a/tests/unit/zen_stores/test_run_pagination.py
+++ b/tests/unit/zen_stores/test_run_pagination.py
@@ -1,0 +1,134 @@
+"""Run pages preserve filtering and response content when IDs are fetched first."""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, select
+
+from zenml.client import Client
+from zenml.enums import TaggableResourceTypes
+from zenml.models import PipelineRunFilter
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    PipelineSchema,
+    TagResourceSchema,
+    TagSchema,
+)
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+@pytest.fixture
+def populated_store(clean_client: Client) -> SqlZenStore:
+    """Seed tied ordering, overlapping tags and both status values."""
+    store = clean_client.zen_store
+    assert isinstance(store, SqlZenStore)
+    project_id = clean_client.active_project.id
+    with Session(store.engine) as session:
+        pipeline = PipelineSchema(
+            name="pagination", project_id=project_id, run_count=9
+        )
+        tags = [TagSchema(name=name, color="blue") for name in ("a", "b")]
+        session.add_all([pipeline, *tags])
+        session.flush()
+        for i in range(9):
+            run = PipelineRunSchema(
+                id=UUID(int=i + 1),
+                name=f"page-{i}",
+                index=i + 1,
+                project_id=project_id,
+                user_id=clean_client.active_user.id,
+                pipeline_id=pipeline.id,
+                in_progress=False,
+                enable_heartbeat=False,
+                pipeline_configuration='{"name": "pagination"}',
+                created=datetime(2026, 1, 1),
+                start_time=datetime(2026, 1, 1),
+                status="completed" if i % 2 else "failed",
+            )
+            session.add(run)
+            session.flush()
+            for tag in tags[: 1 + i % 2]:
+                session.add(
+                    TagResourceSchema(
+                        tag_id=tag.id,
+                        resource_id=run.id,
+                        resource_type=TaggableResourceTypes.PIPELINE_RUN.value,
+                    )
+                )
+        session.commit()
+    return store
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    ["asc:created", "desc:created", "asc:id", "desc:index", "asc:pipeline"],
+)
+@pytest.mark.parametrize(
+    "criteria",
+    [
+        {},
+        {"status": "completed"},
+        {"tags": ["a", "b"]},
+        {"status": "completed", "name": "page-0", "logical_operator": "or"},
+    ],
+)
+@pytest.mark.parametrize("hydrate", [False, True])
+def test_pages_match_existing_query(
+    populated_store: SqlZenStore,
+    sort_by: str,
+    criteria: dict[str, Any],
+    hydrate: bool,
+) -> None:
+    """All projected fields, totals, resources and metadata retain parity."""
+    store = populated_store
+    first = store.list_runs(
+        PipelineRunFilter(size=2, sort_by=sort_by, **criteria), hydrate=hydrate
+    )
+    seen: list[UUID] = []
+    for page in range(1, first.total_pages + 1):
+        filters = PipelineRunFilter(
+            size=2, page=page, sort_by=sort_by, **criteria
+        )
+        actual = store.list_runs(
+            filters, hydrate=hydrate, include_full_metadata=True
+        )
+        with Session(store.engine) as session:
+            expected = store.filter_and_paginate(
+                session,
+                select(PipelineRunSchema),
+                PipelineRunSchema,
+                filters,
+                hydrate=hydrate,
+                apply_query_options_from_schema=True,
+                custom_schema_to_model_conversion=lambda row: row.to_model(
+                    include_metadata=hydrate,
+                    include_resources=True,
+                    include_full_metadata=True,
+                ),
+            )
+        assert actual.model_dump() == expected.model_dump()
+        seen.extend(row.id for row in actual.items)
+    assert len(seen) == len(set(seen)) == first.total
+    if not criteria and sort_by.endswith("created"):
+        assert seen == sorted(seen, reverse=sort_by.startswith("desc"))
+
+
+def test_authorization_is_applied_before_pagination(
+    populated_store: SqlZenStore,
+) -> None:
+    """A small authorized set gets full pages, without leaking skipped rows."""
+    filters = PipelineRunFilter(size=2, page=2, sort_by="asc:created")
+    filters.configure_rbac(uuid4(), id={UUID(int=i) for i in (2, 4, 6, 8)})
+    page = populated_store.list_runs(filters)
+    assert page.total == 4
+    assert [run.id for run in page.items] == [UUID(int=6), UUID(int=8)]
+
+
+def test_empty_and_out_of_range_pages(populated_store: SqlZenStore) -> None:
+    """An empty filter still has one page and invalid pages are refused."""
+    page = populated_store.list_runs(PipelineRunFilter(name="missing"))
+    assert page.total == 0 and page.total_pages == 1 and page.items == []
+    with pytest.raises(ValueError, match="Invalid page"):
+        populated_store.list_runs(PipelineRunFilter(size=2, page=6))

--- a/tests/unit/zen_stores/test_run_pagination.py
+++ b/tests/unit/zen_stores/test_run_pagination.py
@@ -62,19 +62,35 @@ def populated_store(clean_client: Client) -> SqlZenStore:
 
 
 @pytest.mark.parametrize(
-    "sort_by",
-    ["asc:created", "desc:created", "asc:id", "desc:index", "asc:pipeline"],
-)
-@pytest.mark.parametrize(
-    "criteria",
+    "sort_by, criteria, hydrate",
     [
-        {},
-        {"status": "completed"},
-        {"tags": ["a", "b"]},
-        {"status": "completed", "name": "page-0", "logical_operator": "or"},
+        # Sorts on run columns take the ID-first path.
+        *(
+            (sort_by, criteria, hydrate)
+            for sort_by in [
+                "asc:created",
+                "desc:created",
+                "asc:id",
+                "desc:index",
+            ]
+            for criteria in [
+                {},
+                {"status": "completed"},
+                {"tags": ["a", "b"]},
+                {
+                    "status": "completed",
+                    "name": "page-0",
+                    "logical_operator": "or",
+                },
+            ]
+            for hydrate in [False, True]
+        ),
+        # Sorts on related entities fall back to loading the page directly.
+        ("asc:pipeline", {}, False),
+        ("asc:user", {}, False),
+        ("desc:tags", {"tags": ["a", "b"]}, False),
     ],
 )
-@pytest.mark.parametrize("hydrate", [False, True])
 def test_pages_match_existing_query(
     populated_store: SqlZenStore,
     sort_by: str,
@@ -91,9 +107,8 @@ def test_pages_match_existing_query(
         filters = PipelineRunFilter(
             size=2, page=page, sort_by=sort_by, **criteria
         )
-        actual = store.list_runs(
-            filters, hydrate=hydrate, include_full_metadata=True
-        )
+        actual = store.list_runs(filters, hydrate=hydrate)
+        # The same query through the paginator without ID-first fetching.
         with Session(store.engine) as session:
             expected = store.filter_and_paginate(
                 session,
@@ -102,13 +117,9 @@ def test_pages_match_existing_query(
                 filters,
                 hydrate=hydrate,
                 apply_query_options_from_schema=True,
-                custom_schema_to_model_conversion=lambda row: row.to_model(
-                    include_metadata=hydrate,
-                    include_resources=True,
-                    include_full_metadata=True,
-                ),
+                query_options_kwargs={"include_full_metadata": False},
             )
-        assert actual.model_dump() == expected.model_dump()
+        assert actual == expected
         seen.extend(row.id for row in actual.items)
     assert len(seen) == len(set(seen)) == first.total
     if not criteria and sort_by.endswith("created"):

--- a/tests/unit/zen_stores/test_run_pagination.py
+++ b/tests/unit/zen_stores/test_run_pagination.py
@@ -119,7 +119,9 @@ def test_pages_match_existing_query(
                 apply_query_options_from_schema=True,
                 query_options_kwargs={"include_full_metadata": False},
             )
-        assert actual == expected
+        # Response equality only compares IDs, so compare the serialized
+        # pages to cover every projected field, resource and metadata.
+        assert actual.model_dump() == expected.model_dump()
         seen.extend(row.id for row in actual.items)
     assert len(seen) == len(set(seen)) == first.total
     if not criteria and sort_by.endswith("created"):


### PR DESCRIPTION
## Describe changes

Deep run-list offsets currently load wide execution rows before discarding the skipped matches. Select the filtered, ordered page IDs first, then load only those runs. Filtering, RBAC and deduplication stay inside page selection; related-entity sorts retain the existing path. Counts, returned models and the public API are unchanged.

The outer query uses `id IN (SELECT ...)` through a derived table, avoiding a wide outer DISTINCT and MySQL's LIMIT-in-IN restriction. Only pipeline-run listing enables this path.

## Validation

- `python -m pytest tests/unit/zen_stores/test_run_pagination.py -q`: 37 passed on the exact PR head. Covers serialized page parity, filters, RBAC and related-entity sort fallbacks.
- Targeted Ruff and mypy checks pass.
- Local MySQL 8.4, two anonymized production-derived datasets: 14 scenarios and 168 calls returned matching serialized pages. Last-page median improved from 1,179 to 267 ms and from 590 to 152 ms. Page 2,001 improved from 490 to 210 ms and from 425 to 154 ms.
- A separate combined-change experiment reproduced the deep-page benefit and matching responses. It is not used to attribute other changes' effects to this PR.

The timings are local warm-cache measurements, not a production SLA. This does not remove exact-count costs, make offset traversal constant-time, or reduce database storage. Pipeline-history counts remain a separate bottleneck. CI status is reported by this PR's checks; local validation is not a CI claim.

## Pre-requisites

- [x] Read CONTRIBUTING.md.
- [x] Added tests covering the change.
- [x] Branch based on develop; PR targets develop.
- [x] No client, dashboard, template or project changes required; response behavior is unchanged.

## Types of changes

- [x] Other: query-performance improvement with unchanged responses.
