### PR TITLE
Prepare execution retention identities and archive catalog

### DIFF
--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -2948,6 +2948,8 @@ class Client(metaclass=ClientMetaClass):
         tags: StringFilterOption = None,
         hydrate: bool = False,
         trigger_id: UUID | None = None,
+        archived: Optional[bool] = None,
+        archived_at: DatetimeFilterOption = None,
     ) -> Page[PipelineSnapshotResponse]:
         """List all snapshots.
 
@@ -2976,11 +2978,16 @@ class Client(metaclass=ClientMetaClass):
             hydrate: Flag deciding whether to hydrate the output model(s)
                 by including metadata fields in the response.
             trigger_id: Filter by trigger ID (attached trigger to snapshot).
+            archived: Whether to return only archived entities (True) or
+                only live ones (False). Both are returned when unset.
+            archived_at: Filter on the time the entity was archived.
 
         Returns:
             A page with snapshots fitting the filter description
         """
         snapshot_filter_model = PipelineSnapshotFilter(
+            archived_at=archived_at,
+            archived=archived,
             sort_by=sort_by,
             page=page,
             size=size,
@@ -5231,6 +5238,8 @@ class Client(metaclass=ClientMetaClass):
         trigger_id: UUIDFilterOption = None,
         parent_run_id: UUIDFilterOption = None,
         root_runs_only: Optional[bool] = None,
+        archived: Optional[bool] = None,
+        archived_at: DatetimeFilterOption = None,
     ) -> Page[PipelineRunResponse]:
         """List all pipeline runs.
 
@@ -5286,11 +5295,16 @@ class Client(metaclass=ClientMetaClass):
             trigger_id: The ID of the trigger that generated this run.
             parent_run_id: The parent run ID for nested child pipeline runs.
             root_runs_only: Whether to include only root runs. Ignored if False.
+            archived: Whether to return only archived entities (True) or
+                only live ones (False). Both are returned when unset.
+            archived_at: Filter on the time the entity was archived.
 
         Returns:
             A page with Pipeline Runs fitting the filter description
         """
         runs_filter_model = PipelineRunFilter(
+            archived_at=archived_at,
+            archived=archived,
             sort_by=sort_by,
             page=page,
             size=size,
@@ -5505,6 +5519,8 @@ class Client(metaclass=ClientMetaClass):
         exclude_retried: Optional[bool] = None,
         version: IntegerFilterOption = None,
         hydrate: bool = False,
+        archived: Optional[bool] = None,
+        archived_at: DatetimeFilterOption = None,
     ) -> Page[StepRunResponse]:
         """List all pipelines.
 
@@ -5538,11 +5554,16 @@ class Client(metaclass=ClientMetaClass):
             version: The version of the step run to filter by.
             hydrate: Flag deciding whether to hydrate the output model(s)
                 by including metadata fields in the response.
+            archived: Whether to return only archived entities (True) or
+                only live ones (False). Both are returned when unset.
+            archived_at: Filter on the time the entity was archived.
 
         Returns:
             A page with Pipeline fitting the filter description
         """
         step_run_filter_model = StepRunFilter(
+            archived_at=archived_at,
+            archived=archived,
             sort_by=sort_by,
             page=page,
             size=size,

--- a/src/zenml/enums.py
+++ b/src/zenml/enums.py
@@ -619,6 +619,22 @@ class ServiceState(StrEnum):
     SCALED_TO_ZERO = "scaled_to_zero"
 
 
+class ArchiveBundleStatus(StrEnum):
+    """Lifecycle of an execution archive bundle catalog row.
+
+    The catalog row is created as PENDING before any object is uploaded, so a
+    crash at any point leaves either SQL authoritative (PENDING or FAILED) or
+    a cataloged, restorable bundle (COMPLETE). RESTORING and RESTORED mark
+    the inverse operation.
+    """
+
+    PENDING = "pending"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    RESTORING = "restoring"
+    RESTORED = "restored"
+
+
 class DeploymentStatus(StrEnum):
     """Status of a deployment."""
 

--- a/src/zenml/models/v2/base/scoped.py
+++ b/src/zenml/models/v2/base/scoped.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Scoped model definitions."""
 
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -35,12 +36,14 @@ from zenml.models.v2.base.base import (
     BaseDatedResponseBody,
     BaseIdentifiedResponse,
     BaseRequest,
+    BaseResponseBody,
     BaseResponseMetadata,
     BaseResponseResources,
 )
 from zenml.models.v2.base.filter import (
     AnyQuery,
     BaseFilter,
+    DatetimeFilterOption,
     StringFilterOption,
     UUIDFilterOption,
 )
@@ -609,6 +612,109 @@ class TaggableFilter(BaseFilter):
             return query
 
         return super().apply_sorting(query=query, table=table)
+
+
+class ArchivableResponseBody(BaseResponseBody):
+    """Response body fields shared by entities whose detail can be archived."""
+
+    archived_at: Optional[datetime] = Field(
+        default=None,
+        title="When the detail of this entity was moved to an archive "
+        "bundle. Unset while the entity is live.",
+    )
+    archive_bundle_id: Optional[UUID] = Field(
+        default=None,
+        title="The archive bundle that holds the archived detail, if any.",
+    )
+
+
+class ArchivableResponse:
+    """Response mixin exposing the execution archive markers of the body."""
+
+    def get_body(self) -> ArchivableResponseBody:
+        """The body accessor supplied by the concrete response class.
+
+        Returns:
+            The response body.
+
+        Raises:
+            NotImplementedError: Always; the response class provides it.
+        """
+        raise NotImplementedError
+
+    @property
+    def archived_at(self) -> Optional[datetime]:
+        """The `archived_at` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().archived_at
+
+    @property
+    def archive_bundle_id(self) -> Optional[UUID]:
+        """The `archive_bundle_id` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().archive_bundle_id
+
+
+class ArchivableFilterMixin(BaseFilter):
+    """Model to enable filtering by execution archive state.
+
+    `archived_at` is a regular datetime filter on the marker column and
+    supports every datetime operation, including `isnull:` and
+    `isnotnull:`. `archived` is shorthand for those two operations.
+    """
+
+    FILTER_EXCLUDE_FIELDS: ClassVar[List[str]] = [
+        *BaseFilter.FILTER_EXCLUDE_FIELDS,
+        "archived",
+    ]
+    API_SINGLE_INPUT_PARAMS: ClassVar[List[str]] = [
+        *BaseFilter.API_SINGLE_INPUT_PARAMS,
+        "archived",
+    ]
+
+    archived_at: DatetimeFilterOption = Field(
+        default=None,
+        description="When the detail of the entity was archived.",
+    )
+    archived: Optional[bool] = Field(
+        default=None,
+        description="Whether to return only archived entities (True) or only "
+        "live ones (False). Both are returned when unset.",
+    )
+
+    @model_validator(mode="after")
+    def translate_archived_flag(self) -> "ArchivableFilterMixin":
+        """Turn the `archived` shorthand into an `archived_at` operation.
+
+        Returns:
+            self
+
+        Raises:
+            ValueError: If both `archived` and `archived_at` are set.
+        """
+        if self.archived is None:
+            return self
+        if self.archived_at is not None:
+            raise ValueError(
+                "`archived` and `archived_at` cannot be combined; use "
+                "`archived_at` with `isnull:`/`isnotnull:` instead."
+            )
+        operation = (
+            GenericFilterOps.IS_NOT_NULL
+            if self.archived
+            else GenericFilterOps.IS_NULL
+        )
+        self.archived_at = f"{operation.value}:"
+        # Send only the canonical datetime filter to REST stores, so the
+        # server does not receive two mutually exclusive inputs.
+        self.archived = None
+        return self
 
 
 class RunMetadataFilterMixin(BaseFilter):

--- a/src/zenml/models/v2/core/pipeline_run.py
+++ b/src/zenml/models/v2/core/pipeline_run.py
@@ -41,6 +41,9 @@ from zenml.models.v2.base.filter import (
     UUIDFilterOption,
 )
 from zenml.models.v2.base.scoped import (
+    ArchivableFilterMixin,
+    ArchivableResponse,
+    ArchivableResponseBody,
     ProjectScopedFilter,
     ProjectScopedRequest,
     ProjectScopedResponse,
@@ -266,6 +269,10 @@ class PipelineRunUpdate(BaseUpdate):
     add_logs: Optional[List[LogsRequest]] = Field(
         default=None, title="New logs to add to the pipeline run."
     )
+    retain: Optional[bool] = Field(
+        default=None,
+        title="Whether to pin the run so it is never archived.",
+    )
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -273,7 +280,9 @@ class PipelineRunUpdate(BaseUpdate):
 # ------------------ Response Model ------------------
 
 
-class PipelineRunResponseBody(ProjectScopedResponseBody):
+class PipelineRunResponseBody(
+    ProjectScopedResponseBody, ArchivableResponseBody
+):
     """Response body for pipeline runs."""
 
     status: ExecutionStatus = Field(
@@ -302,6 +311,10 @@ class PipelineRunResponseBody(ProjectScopedResponseBody):
     root_run_id: Optional[UUID] = Field(
         default=None,
         title="The ID of the top-level parent run of this run's nesting tree.",
+    )
+    retain: bool = Field(
+        default=False,
+        title="Whether the run is pinned and excluded from archival.",
     )
 
     model_config = ConfigDict(protected_namespaces=())
@@ -448,7 +461,8 @@ class PipelineRunResponse(
         PipelineRunResponseBody,
         PipelineRunResponseMetadata,
         PipelineRunResponseResources,
-    ]
+    ],
+    ArchivableResponse,
 ):
     """Response model for pipeline runs."""
 
@@ -841,12 +855,24 @@ class PipelineRunResponse(
         """
         return self.get_body().root_run_id
 
+    @property
+    def retain(self) -> bool:
+        """The `retain` property.
+
+        Returns:
+            the value of the property.
+        """
+        return self.get_body().retain
+
 
 # ------------------ Filter Model ------------------
 
 
 class PipelineRunFilter(
-    ProjectScopedFilter, TaggableFilter, RunMetadataFilterMixin
+    ProjectScopedFilter,
+    TaggableFilter,
+    RunMetadataFilterMixin,
+    ArchivableFilterMixin,
 ):
     """Model to enable advanced filtering of all pipeline runs."""
 
@@ -863,6 +889,7 @@ class PipelineRunFilter(
         *ProjectScopedFilter.FILTER_EXCLUDE_FIELDS,
         *TaggableFilter.FILTER_EXCLUDE_FIELDS,
         *RunMetadataFilterMixin.FILTER_EXCLUDE_FIELDS,
+        *ArchivableFilterMixin.FILTER_EXCLUDE_FIELDS,
         "code_repository_id",
         "build_id",
         "schedule_id",
@@ -891,6 +918,7 @@ class PipelineRunFilter(
         *ProjectScopedFilter.API_SINGLE_INPUT_PARAMS,
         *TaggableFilter.API_SINGLE_INPUT_PARAMS,
         *RunMetadataFilterMixin.API_SINGLE_INPUT_PARAMS,
+        *ArchivableFilterMixin.API_SINGLE_INPUT_PARAMS,
         "in_progress",
         "templatable",
         "root_runs_only",

--- a/src/zenml/models/v2/core/pipeline_snapshot.py
+++ b/src/zenml/models/v2/core/pipeline_snapshot.py
@@ -40,6 +40,9 @@ from zenml.models.v2.base.filter import (
     UUIDFilterOption,
 )
 from zenml.models.v2.base.scoped import (
+    ArchivableFilterMixin,
+    ArchivableResponse,
+    ArchivableResponseBody,
     ProjectScopedFilter,
     ProjectScopedRequest,
     ProjectScopedResponse,
@@ -229,7 +232,9 @@ class PipelineSnapshotUpdate(BaseUpdate):
 # ------------------ Response Model ------------------
 
 
-class PipelineSnapshotResponseBody(ProjectScopedResponseBody):
+class PipelineSnapshotResponseBody(
+    ProjectScopedResponseBody, ArchivableResponseBody
+):
     """Response body for pipeline snapshots."""
 
     runnable: bool = Field(
@@ -362,7 +367,8 @@ class PipelineSnapshotResponse(
         PipelineSnapshotResponseBody,
         PipelineSnapshotResponseMetadata,
         PipelineSnapshotResponseResources,
-    ]
+    ],
+    ArchivableResponse,
 ):
     """Response model for pipeline snapshots."""
 
@@ -652,12 +658,15 @@ class PipelineSnapshotResponse(
 # ------------------ Filter Model ------------------
 
 
-class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
+class PipelineSnapshotFilter(
+    ProjectScopedFilter, TaggableFilter, ArchivableFilterMixin
+):
     """Model for filtering pipeline snapshots."""
 
     FILTER_EXCLUDE_FIELDS: ClassVar[List[str]] = [
         *ProjectScopedFilter.FILTER_EXCLUDE_FIELDS,
         *TaggableFilter.FILTER_EXCLUDE_FIELDS,
+        *ArchivableFilterMixin.FILTER_EXCLUDE_FIELDS,
         "named_only",
         "pipeline",
         "stack",
@@ -680,6 +689,7 @@ class PipelineSnapshotFilter(ProjectScopedFilter, TaggableFilter):
     API_SINGLE_INPUT_PARAMS: ClassVar[List[str]] = [
         *ProjectScopedFilter.API_SINGLE_INPUT_PARAMS,
         *TaggableFilter.API_SINGLE_INPUT_PARAMS,
+        *ArchivableFilterMixin.API_SINGLE_INPUT_PARAMS,
         "named_only",
         "runnable",
         "deployable",

--- a/src/zenml/models/v2/core/step_run.py
+++ b/src/zenml/models/v2/core/step_run.py
@@ -46,6 +46,9 @@ from zenml.models.v2.base.filter import (
     UUIDFilterOption,
 )
 from zenml.models.v2.base.scoped import (
+    ArchivableFilterMixin,
+    ArchivableResponse,
+    ArchivableResponseBody,
     ProjectScopedFilter,
     ProjectScopedRequest,
     ProjectScopedResponse,
@@ -229,7 +232,7 @@ class StepRunUpdate(BaseUpdate):
 
 
 # ------------------ Response Model ------------------
-class StepRunResponseBody(ProjectScopedResponseBody):
+class StepRunResponseBody(ProjectScopedResponseBody, ArchivableResponseBody):
     """Response body for step runs."""
 
     type: Optional[StepType] = Field(
@@ -375,7 +378,8 @@ class StepRunResponseResources(ProjectScopedResponseResources):
 class StepRunResponse(
     ProjectScopedResponse[
         StepRunResponseBody, StepRunResponseMetadata, StepRunResponseResources
-    ]
+    ],
+    ArchivableResponse,
 ):
     """Response model for step runs."""
 
@@ -772,12 +776,15 @@ class StepRunResponse(
 # ------------------ Filter Model ------------------
 
 
-class StepRunFilter(ProjectScopedFilter, RunMetadataFilterMixin):
+class StepRunFilter(
+    ProjectScopedFilter, RunMetadataFilterMixin, ArchivableFilterMixin
+):
     """Model to enable advanced filtering of step runs."""
 
     FILTER_EXCLUDE_FIELDS: ClassVar[List[str]] = [
         *ProjectScopedFilter.FILTER_EXCLUDE_FIELDS,
         *RunMetadataFilterMixin.FILTER_EXCLUDE_FIELDS,
+        *ArchivableFilterMixin.FILTER_EXCLUDE_FIELDS,
         "model",
         "exclude_retried",
         "cache_expired",
@@ -789,6 +796,7 @@ class StepRunFilter(ProjectScopedFilter, RunMetadataFilterMixin):
     API_SINGLE_INPUT_PARAMS: ClassVar[List[str]] = [
         *ProjectScopedFilter.API_SINGLE_INPUT_PARAMS,
         *RunMetadataFilterMixin.API_SINGLE_INPUT_PARAMS,
+        *ArchivableFilterMixin.API_SINGLE_INPUT_PARAMS,
         "exclude_retried",
         "cache_expired",
     ]

--- a/src/zenml/zen_stores/migrations/versions/7a1c3d9e2b4f_add_execution_archive_markers.py
+++ b/src/zenml/zen_stores/migrations/versions/7a1c3d9e2b4f_add_execution_archive_markers.py
@@ -1,0 +1,118 @@
+"""Add execution archive markers [7a1c3d9e2b4f].
+
+Revision ID: 7a1c3d9e2b4f
+Revises: 9f2b8c7d6e5a
+Create Date: 2026-09-07 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+revision = "7a1c3d9e2b4f"
+down_revision = "9f2b8c7d6e5a"
+branch_labels = None
+depends_on = None
+
+
+ARCHIVABLE_TABLES = (
+    "pipeline_run",
+    "step_run",
+    "pipeline_snapshot",
+)
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    op.create_table(
+        "archive_bundle",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=False),
+        sa.Column("updated", sa.DateTime(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("root_run_id", sa.Uuid(), nullable=True),
+        sa.Column("uri", sa.TEXT(), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False),
+        sa.Column("row_counts", sa.TEXT(), nullable=False),
+        sa.Column(
+            "manifest_hash",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+        ),
+        sa.Column("format_version", sa.Integer(), nullable=False),
+        sa.Column(
+            "schema_revision",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+        ),
+        sa.Column(
+            "status", sqlmodel.sql.sqltypes.AutoString(), nullable=False
+        ),
+        sa.Column(
+            "claimed_by", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
+        sa.Column("status_reason", sa.TEXT(), nullable=True),
+        sa.Column("restored_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["project.id"],
+            name="fk_archive_bundle_project_id_project",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["root_run_id"],
+            ["pipeline_run.id"],
+            name="fk_archive_bundle_root_run_id_pipeline_run",
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # The marker columns carry no foreign key and no index on purpose: these
+    # are among the largest tables, so index and constraint rollout needs its
+    # own migration timing. The server default on `retain` lets older
+    # server replicas keep inserting runs during a rolling upgrade.
+    for table in ARCHIVABLE_TABLES:
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column("archived_at", sa.DateTime(), nullable=True)
+            )
+            batch_op.add_column(
+                sa.Column("archive_bundle_id", sa.Uuid(), nullable=True)
+            )
+            if table == "step_run":
+                batch_op.add_column(
+                    sa.Column(
+                        "step_type",
+                        sqlmodel.sql.sqltypes.AutoString(),
+                        nullable=True,
+                    )
+                )
+                batch_op.add_column(
+                    sa.Column("substitutions", sa.TEXT(), nullable=True)
+                )
+            if table == "pipeline_run":
+                batch_op.add_column(
+                    sa.Column(
+                        "retain",
+                        sa.Boolean(),
+                        nullable=False,
+                        server_default=sa.false(),
+                    )
+                )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    for table in ARCHIVABLE_TABLES:
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            if table == "step_run":
+                batch_op.drop_column("substitutions")
+                batch_op.drop_column("step_type")
+            if table == "pipeline_run":
+                batch_op.drop_column("retain")
+            batch_op.drop_column("archive_bundle_id")
+            batch_op.drop_column("archived_at")
+
+    op.drop_table("archive_bundle")

--- a/src/zenml/zen_stores/schemas/__init__.py
+++ b/src/zenml/zen_stores/schemas/__init__.py
@@ -18,6 +18,9 @@ from zenml.zen_stores.schemas.api_transaction_schemas import (
     ApiTransactionResultSchema,
     ApiTransactionSchema,
 )
+from zenml.zen_stores.schemas.archive_bundle_schemas import (
+    ArchiveBundleSchema,
+)
 from zenml.zen_stores.schemas.artifact_schemas import (
     ArtifactSchema,
     ArtifactVersionSchema,
@@ -103,6 +106,7 @@ from zenml.zen_stores.schemas.webhook_schemas import (
 )
 
 __all__ = [
+    "ArchiveBundleSchema",
     "APIKeySchema",
     "ArtifactSchema",
     "ArtifactVersionSchema",

--- a/src/zenml/zen_stores/schemas/archive_bundle_schemas.py
+++ b/src/zenml/zen_stores/schemas/archive_bundle_schemas.py
@@ -1,0 +1,83 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""SQL Model for the execution archive bundle catalog."""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy import TEXT, BigInteger, Column
+from sqlmodel import Field
+
+from zenml.zen_stores.schemas.base_schemas import BaseSchema
+from zenml.zen_stores.schemas.pipeline_run_schemas import PipelineRunSchema
+from zenml.zen_stores.schemas.project_schemas import ProjectSchema
+from zenml.zen_stores.schemas.schema_utils import build_foreign_key_field
+
+
+class ArchiveBundleSchema(BaseSchema, table=True):
+    """Catalog row for one archived execution tree.
+
+    A bundle holds the detail rows of a single root pipeline run tree that
+    were moved out of the database. Archived identity rows point back here
+    through their `archive_bundle_id` column, which is a plain UUID without a
+    foreign key: the index and foreign-key rollout on the three large identity
+    tables is deferred until it has been timed. Readers can identify archived
+    rows without joining the catalog. Application code must never delete a catalog row while
+    identity rows reference it; rows disappear only through the project
+    cascade or after the retention job reclaims a bundle.
+
+    `root_run_id` is SET NULL rather than CASCADE because a snapshot archived
+    in the same bundle can outlive the root run; a restore of a deleted run is
+    refused, never resurrected. Reclaiming catalog rows whose root run is gone
+    is the retention job's decision, not a database cascade.
+    """
+
+    __tablename__ = "archive_bundle"
+
+    project_id: UUID = build_foreign_key_field(
+        source=__tablename__,
+        target=ProjectSchema.__tablename__,
+        source_column="project_id",
+        target_column="id",
+        ondelete="CASCADE",
+        nullable=False,
+    )
+    root_run_id: Optional[UUID] = build_foreign_key_field(
+        source=__tablename__,
+        target=PipelineRunSchema.__tablename__,
+        source_column="root_run_id",
+        target_column="id",
+        ondelete="SET NULL",
+        nullable=True,
+    )
+
+    uri: str = Field(sa_column=Column(TEXT, nullable=False))
+    size_bytes: int = Field(sa_column=Column(BigInteger, nullable=False))
+    row_counts: str = Field(sa_column=Column(TEXT, nullable=False))
+    manifest_hash: str = Field(nullable=False)
+    # Restore compatibility is decided by the archive format version and its
+    # adapters, never by replaying migrations; the schema revision is kept as
+    # a diagnostic only.
+    format_version: int = Field(nullable=False)
+    schema_revision: str = Field(nullable=False)
+    status: str = Field(nullable=False)
+    # Who holds the claim while the row is pending or restoring, and why a
+    # row ended up failed or restored with conflicts. `updated` is the claim
+    # time.
+    claimed_by: Optional[str] = Field(nullable=True, default=None)
+    status_reason: Optional[str] = Field(
+        sa_column=Column(TEXT, nullable=True), default=None
+    )
+    restored_at: Optional[datetime] = Field(nullable=True, default=None)

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -162,6 +162,12 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
         )
     )
     child_key: Optional[str] = Field(nullable=True, default=None)
+    # Pinned runs are never eligible for archival, whatever their age.
+    retain: bool = Field(nullable=False, default=False)
+
+    # Execution archive markers; the contract lives on `ArchiveBundleSchema`.
+    archived_at: Optional[datetime] = Field(nullable=True, default=None)
+    archive_bundle_id: Optional[UUID] = Field(nullable=True, default=None)
 
     # Foreign keys
     snapshot_id: Optional[UUID] = build_foreign_key_field(
@@ -727,6 +733,9 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             pipeline_id=self.pipeline_id,
             child_key=self.child_key,
             root_run_id=self.root_run_id,
+            retain=self.retain,
+            archived_at=self.archived_at,
+            archive_bundle_id=self.archive_bundle_id,
         )
         metadata = None
         if include_metadata:
@@ -913,6 +922,9 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
 
         if run_update.exception_info:
             self.exception_info = run_update.exception_info.model_dump_json()
+
+        if run_update.retain is not None:
+            self.retain = run_update.retain
 
         self.updated = utc_now()
         return self

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -14,6 +14,7 @@
 """Pipeline snapshot schemas."""
 
 import json
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Sequence
 from uuid import UUID
 
@@ -127,6 +128,10 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
     )
     source_code: Optional[str] = Field(sa_column=Column(TEXT, nullable=True))
     code_path: Optional[str] = Field(nullable=True)
+
+    # Execution archive markers; the contract lives on `ArchiveBundleSchema`.
+    archived_at: Optional[datetime] = Field(nullable=True, default=None)
+    archive_bundle_id: Optional[UUID] = Field(nullable=True, default=None)
 
     # Foreign keys
     user_id: Optional[UUID] = build_foreign_key_field(
@@ -534,6 +539,8 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             deployable=deployable,
             is_dynamic=self.is_dynamic,
             pipeline_id=self.pipeline_id,
+            archived_at=self.archived_at,
+            archive_bundle_id=self.archive_bundle_id,
         )
         metadata = None
         if include_metadata:

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -113,6 +113,12 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
     )
     status: str = Field(nullable=False)
 
+    # Archived lists cannot recover these projections from cleared configuration.
+    step_type: Optional[str] = Field(nullable=True, default=None)
+    substitutions: Optional[str] = Field(
+        sa_column=Column(TEXT, nullable=True), default=None
+    )
+
     docstring: Optional[str] = Field(sa_column=Column(TEXT, nullable=True))
     cache_key: Optional[str] = Field(nullable=True)
     cache_expires_at: Optional[datetime] = Field(nullable=True)
@@ -130,6 +136,11 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         )
     )
     heartbeat_threshold: Optional[int] = Field(nullable=True)
+
+    # Execution archive markers; the contract lives on `ArchiveBundleSchema`.
+    archived_at: Optional[datetime] = Field(nullable=True, default=None)
+    archive_bundle_id: Optional[UUID] = Field(nullable=True, default=None)
+
     # Foreign keys
     original_step_run_id: Optional[UUID] = build_foreign_key_field(
         source=__tablename__,
@@ -476,6 +487,8 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             resource_request_id=self.resource_request_id,
             substitutions=step.config.substitutions,
             heartbeat_threshold=self.heartbeat_threshold,
+            archived_at=self.archived_at,
+            archive_bundle_id=self.archive_bundle_id,
         )
         metadata = None
         if include_metadata:

--- a/tests/unit/zen_stores/test_execution_archive_markers.py
+++ b/tests/unit/zen_stores/test_execution_archive_markers.py
@@ -1,0 +1,262 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for the execution archive markers and `archived` filters."""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from zenml.config.step_configurations import Step, StepConfiguration, StepSpec
+from zenml.enums import ArchiveBundleStatus, ExecutionStatus
+from zenml.models import (
+    PipelineRunFilter,
+    PipelineRunUpdate,
+    PipelineSnapshotFilter,
+    ProjectFilter,
+    StepRunFilter,
+)
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.schemas import (
+    ArchiveBundleSchema,
+    PipelineRunSchema,
+    PipelineSchema,
+    PipelineSnapshotSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.sql_zen_store import (
+    Session,
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+
+@pytest.fixture
+def sql_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[SqlZenStore]:
+    """Create a fresh SQLite-backed SqlZenStore for tests.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Environment isolation fixture.
+
+    Yields:
+        The isolated store.
+    """
+    db_dir = tmp_path / "zenml-cfg"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ZENML_CONFIG_PATH", str(db_dir))
+    config = SqlZenStoreConfiguration(url=f"sqlite:///{db_dir / 'test.db'}")
+    yield SqlZenStore(config=config, skip_default_registrations=False)
+
+
+def _project_id(store: SqlZenStore) -> UUID:
+    return (
+        store.list_projects(project_filter_model=ProjectFilter()).items[0].id
+    )
+
+
+def _create_bundle(store: SqlZenStore, project_id: UUID) -> UUID:
+    bundle = ArchiveBundleSchema(
+        project_id=project_id,
+        uri="s3://archive/bundle",
+        size_bytes=1,
+        row_counts="{}",
+        manifest_hash="sha256:0",
+        format_version=1,
+        schema_revision="7a1c3d9e2b4f",
+        status=ArchiveBundleStatus.COMPLETE.value,
+    )
+    with Session(store.engine, expire_on_commit=False) as session:
+        session.add(bundle)
+        session.commit()
+    return bundle.id
+
+
+def _create_tree(
+    store: SqlZenStore,
+    project_id: UUID,
+    *,
+    archived_at: Optional[datetime],
+    bundle_id: Optional[UUID],
+) -> dict[str, UUID]:
+    """Create a snapshot, run and step carrying the same archive markers.
+
+    Args:
+        store: The test store.
+        project_id: Project owning the tree.
+        archived_at: Archival timestamp, if archived.
+        bundle_id: Catalog identifier, if archived.
+
+    Returns:
+        The snapshot, run and step identifiers.
+    """
+    marker = {"archived_at": archived_at, "archive_bundle_id": bundle_id}
+    pipeline = PipelineSchema(
+        project_id=project_id, name=f"p-{uuid4().hex[:8]}", run_count=0
+    )
+    snapshot = PipelineSnapshotSchema(
+        project_id=project_id,
+        pipeline_id=pipeline.id,
+        pipeline_configuration='{"name": "p"}',
+        client_environment="{}",
+        run_name_template="t",
+        client_version="0.0.0",
+        server_version="0.0.0",
+        step_count=0,
+        **marker,
+    )
+    run = PipelineRunSchema(
+        project_id=project_id,
+        name=f"run-{uuid4().hex[:8]}",
+        pipeline_id=pipeline.id,
+        snapshot_id=snapshot.id,
+        status=ExecutionStatus.COMPLETED.value,
+        index=1,
+        in_progress=False,
+        enable_heartbeat=False,
+        **marker,
+    )
+    step = StepRunSchema(
+        project_id=project_id,
+        pipeline_run_id=run.id,
+        name="step",
+        status=ExecutionStatus.COMPLETED.value,
+        version=1,
+        is_retriable=False,
+        step_configuration=Step(
+            spec=StepSpec(source="tests.step", upstream_steps=[]),
+            config=StepConfiguration(name="step"),
+        ).model_dump_json(),
+        **marker,
+    )
+    with Session(store.engine, expire_on_commit=False) as session:
+        session.add_all([pipeline, snapshot, run, step])
+        session.commit()
+    return {
+        "snapshot": snapshot.id,
+        "run": run.id,
+        "step": step.id,
+    }
+
+
+def test_archived_filter_splits_live_and_archived_rows(
+    sql_store: SqlZenStore,
+) -> None:
+    """`archived` selects live or archived rows and responses carry markers.
+
+    Args:
+        sql_store: The isolated store.
+    """
+    project_id = _project_id(sql_store)
+    bundle_id = _create_bundle(sql_store, project_id)
+    live = _create_tree(
+        sql_store, project_id, archived_at=None, bundle_id=None
+    )
+    archived = _create_tree(
+        sql_store, project_id, archived_at=utc_now(), bundle_id=bundle_id
+    )
+
+    listings = {
+        "run": lambda **kw: sql_store.list_runs(
+            PipelineRunFilter(project=project_id, **kw)
+        ),
+        "step": lambda **kw: sql_store.list_run_steps(
+            StepRunFilter(project=project_id, **kw)
+        ),
+        "snapshot": lambda **kw: sql_store.list_snapshots(
+            PipelineSnapshotFilter(project=project_id, **kw)
+        ),
+    }
+
+    for entity, list_fn in listings.items():
+        ids_unset = {item.id for item in list_fn().items}
+        assert {live[entity], archived[entity]} <= ids_unset, entity
+
+        live_items = list_fn(archived=False).items
+        assert {item.id for item in live_items} == {live[entity]}, entity
+        assert live_items[0].archived_at is None, entity
+        assert live_items[0].archive_bundle_id is None, entity
+
+        archived_items = list_fn(archived=True).items
+        assert {item.id for item in archived_items} == {archived[entity]}
+        assert archived_items[0].archived_at is not None, entity
+        assert archived_items[0].archive_bundle_id == bundle_id, entity
+
+        by_operation = list_fn(archived_at="isnotnull:").items
+        assert {item.id for item in by_operation} == {archived[entity]}
+
+
+def test_archived_flag_and_archived_at_cannot_be_combined() -> None:
+    """The shorthand refuses to silently override an explicit operation."""
+    with pytest.raises(ValueError, match="cannot be combined"):
+        PipelineRunFilter(archived=True, archived_at="isnull:")
+
+
+@pytest.mark.parametrize(
+    "filter_class", [PipelineRunFilter, StepRunFilter, PipelineSnapshotFilter]
+)
+@pytest.mark.parametrize("archived", [True, False])
+def test_archived_filter_survives_rest_serialization(
+    filter_class: type[
+        PipelineRunFilter | StepRunFilter | PipelineSnapshotFilter
+    ],
+    archived: bool,
+) -> None:
+    """The client sends a filter the server can reconstruct.
+
+    Args:
+        filter_class: Resource filter sent by the REST store.
+        archived: Requested archive state.
+    """
+    request = filter_class(archived=archived)
+    params = request.model_dump(exclude_none=True)
+    assert "archived" not in params
+    restored = filter_class.model_validate(params)
+    assert restored.archived_at == ("isnotnull:" if archived else "isnull:")
+    assert (
+        filter_class.model_validate(request).archived_at
+        == restored.archived_at
+    )
+
+
+def test_retain_defaults_false_and_is_updatable(
+    sql_store: SqlZenStore,
+) -> None:
+    """`retain` starts false and only changes when an update names it.
+
+    Args:
+        sql_store: The isolated store.
+    """
+    project_id = _project_id(sql_store)
+    tree = _create_tree(
+        sql_store, project_id, archived_at=None, bundle_id=None
+    )
+
+    run = sql_store.get_run(tree["run"])
+    assert run.retain is False
+
+    updated = sql_store.update_run(
+        run_id=tree["run"], run_update=PipelineRunUpdate(retain=True)
+    )
+    assert updated.retain is True
+
+    # Updates that do not mention `retain` leave the pin in place.
+    untouched = sql_store.update_run(
+        run_id=tree["run"], run_update=PipelineRunUpdate(add_tags=["x"])
+    )
+    assert untouched.retain is True


### PR DESCRIPTION
## Describe changes

Prepare SQL identities for execution retention with nullable `archived_at` and `archive_bundle_id` on pipeline runs, step runs and snapshots, a run `retain` pin, and an internal bundle catalog. Step runs also gain nullable `step_type` and JSON-text `substitutions` projections, identified by the reader inventory. No production path writes archive markers or projections yet, and the migration does not backfill live rows.

The archive pointer deliberately has neither a foreign key nor an index (design decision 6). Adding indexes and constraints to these large identity tables needs a separately timed rollout; listing an archived identity does not require a catalog join. This preparation does not export, retire, or restore data.

The three list filters accept `archived` and `archived_at`. The shorthand is normalized before REST serialization so the server receives one canonical filter. Responses expose the markers; run updates accept `retain`.

Internal design, reader inventory and saved-data investigations are maintained outside this PR. This diff contains source and tests only.

## Migration and rollout

`retain` has a server default so older replicas can insert during rolling upgrades. Column additions on the three tables are eligible for INSTANT DDL on supported MySQL 8 tables (8.0.12+, subject to table restrictions); MySQL 5.7 rebuilds tables. The migration does not force an algorithm. The local MySQL 8.4.11 rehearsal below covers this dataset. MySQL 5.7 timing remains unmeasured; SQLite validation does not establish MySQL timing.

Revision `7a1c3d9e2b4f` chains from develop's `9f2b8c7d6e5a`. Re-point it if #5165 (`e50a6a75e6b4`) or #5170 (`b02cab3094ca`) merges first, then rerun the Alembic branch check. No existing develop migration was edited.

### Frozen-copy rehearsal (2026-09-08)

Executed the unchanged migration with `Alembic(engine).upgrade("7a1c3d9e2b4f")` on a disposable copy of Tenant A's uncompressed, schema-aligned local database. The source control remained unchanged. MySQL 8.4.11; 8 CPUs, 8 GiB container memory, 4 GiB buffer pool; DYNAMIC tables, no FULLTEXT indexes. No concurrent application workload.

| Table/operation | Exact rows before and after | DDL statements | Time |
|---|---:|---:|---:|
| Bundle catalog | 0 | 1 CREATE | 0.029s |
| Pipeline runs | 321,353 | 3 ADD COLUMN | 0.260s |
| Step runs | 540,232 | 4 ADD COLUMN | 0.186s |
| Pipeline snapshots | 391,864 | 2 ADD COLUMN | 0.145s |

**Whole R1 upgrade: 0.663s.** The prerequisite upgrade to `9f2b8c7d6e5a` took 0.363s separately and is excluded. The batch syntax emits nine separate column-add statements across the three tables.

InnoDB `TOTAL_ROW_VERSIONS` increments were +3/+4/+2 and tablespace IDs stayed unchanged, confirming instant additions on this copy ([MySQL counter reference](https://dev.mysql.com/doc/refman/8.4/en/information-schema-innodb-tables-table.html)). Final revision is `7a1c3d9e2b4f`; row counts stayed equal; markers/projections stayed null, retain stayed false, and the catalog stayed empty. This is one local measurement, not a production lock-wait guarantee or MySQL 5.7 acceptance.

## Validation

Locally, with the worktree explicitly on PYTHONPATH:
- `pytest tests/unit/models tests/unit/zen_stores -q`: **226 passed**.
- Changed-file Ruff format/check, isolated F401/F841, pydoclint, and mypy: passed.
- `bash scripts/check-alembic-branches.sh`: no diverging branches.
- SQLite database created with develop and opened with this branch: migrated to `7a1c3d9e2b4f`; markers, retain/default, and both step projections verified.

The draft passed link/label and security checks; the main test, lint and migration CI jobs were skipped. Full CI is not established. Dashboard source consumers remain unverified; reader tolerance is the next branch, not claimed by this preparation.

## Pre-requisites
- [x] Read CONTRIBUTING.md.
- [x] Added tests.
- [x] Based on develop and targeting develop.
- [x] Internal design and field inventory reviewed; kept outside the product diff.
- [ ] Dashboard: coordinate archived display during reader delivery.

## Types of changes
- [x] New feature (preparation only).
