### PR TITLE
Read archived execution identities without decoding retired detail

### DIFF
--- a/src/zenml/models/v2/core/pipeline_run.py
+++ b/src/zenml/models/v2/core/pipeline_run.py
@@ -334,7 +334,8 @@ class PipelineRunResponseMetadata(ProjectScopedResponseMetadata):
         default={},
         title="Metadata associated with this pipeline run.",
     )
-    config: PipelineConfiguration = Field(
+    config: Optional[PipelineConfiguration] = Field(
+        default=None,
         title="The pipeline configuration used for this pipeline run.",
     )
     start_time: Optional[datetime] = Field(
@@ -345,14 +346,14 @@ class PipelineRunResponseMetadata(ProjectScopedResponseMetadata):
         title="The end time of the pipeline run.",
         default=None,
     )
-    client_environment: Dict[str, Any] = Field(
+    client_environment: Optional[Dict[str, Any]] = Field(
         default={},
         title=(
             "Environment of the client that initiated this pipeline run "
             "(OS, Python version, etc.)."
         ),
     )
-    orchestrator_environment: Dict[str, Any] = Field(
+    orchestrator_environment: Optional[Dict[str, Any]] = Field(
         default={},
         title=(
             "Environment of the orchestrator that executed this pipeline run "
@@ -561,8 +562,17 @@ class PipelineRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().config
+        value = self.get_metadata().config
+        if value is None:
+            raise ValueError(
+                f"The config of run '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def start_time(self) -> Optional[datetime]:
@@ -597,8 +607,17 @@ class PipelineRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().client_environment
+        value = self.get_metadata().client_environment
+        if value is None:
+            raise ValueError(
+                f"The client_environment of run '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def orchestrator_environment(self) -> Dict[str, Any]:
@@ -606,8 +625,17 @@ class PipelineRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().orchestrator_environment
+        value = self.get_metadata().orchestrator_environment
+        if value is None:
+            raise ValueError(
+                f"The orchestrator_environment of run '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def orchestrator_run_id(self) -> Optional[str]:

--- a/src/zenml/models/v2/core/pipeline_snapshot.py
+++ b/src/zenml/models/v2/core/pipeline_snapshot.py
@@ -274,13 +274,13 @@ class PipelineSnapshotResponseMetadata(ProjectScopedResponseMetadata):
     run_name_template: str = Field(
         title="The run name template for runs created using this snapshot.",
     )
-    pipeline_configuration: PipelineConfiguration = Field(
-        title="The pipeline configuration for this snapshot."
+    pipeline_configuration: Optional[PipelineConfiguration] = Field(
+        default=None, title="The pipeline configuration for this snapshot."
     )
-    step_configurations: Dict[str, Step] = Field(
+    step_configurations: Optional[Dict[str, Step]] = Field(
         default={}, title="The step configurations for this snapshot."
     )
-    client_environment: Dict[str, Any] = Field(
+    client_environment: Optional[Dict[str, Any]] = Field(
         default={}, title="The client environment for this snapshot."
     )
     client_version: Optional[str] = Field(
@@ -450,8 +450,17 @@ class PipelineSnapshotResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().pipeline_configuration
+        value = self.get_metadata().pipeline_configuration
+        if value is None:
+            raise ValueError(
+                f"The pipeline_configuration of snapshot '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def step_configurations(self) -> Dict[str, Step]:
@@ -459,8 +468,17 @@ class PipelineSnapshotResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().step_configurations
+        value = self.get_metadata().step_configurations
+        if value is None:
+            raise ValueError(
+                f"The step_configurations of snapshot '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def client_environment(self) -> Dict[str, Any]:
@@ -468,8 +486,17 @@ class PipelineSnapshotResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().client_environment
+        value = self.get_metadata().client_environment
+        if value is None:
+            raise ValueError(
+                f"The client_environment of snapshot '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def client_version(self) -> Optional[str]:

--- a/src/zenml/models/v2/core/step_run.py
+++ b/src/zenml/models/v2/core/step_run.py
@@ -268,7 +268,7 @@ class StepRunResponseBody(ProjectScopedResponseBody, ArchivableResponseBody):
         "step run.",
         default=None,
     )
-    substitutions: Dict[str, str] = Field(
+    substitutions: Optional[Dict[str, str]] = Field(
         title="The substitutions of the step run.",
         default={},
     )
@@ -289,8 +289,12 @@ class StepRunResponseMetadata(ProjectScopedResponseMetadata):
     ]
 
     # Configuration
-    config: "StepConfiguration" = Field(title="The configuration of the step.")
-    spec: "StepSpec" = Field(title="The spec of the step.")
+    config: Optional[StepConfiguration] = Field(
+        default=None, title="The configuration of the step."
+    )
+    spec: Optional[StepSpec] = Field(
+        default=None, title="The spec of the step."
+    )
 
     # Code related fields
     cache_key: Optional[str] = Field(
@@ -324,8 +328,8 @@ class StepRunResponseMetadata(ProjectScopedResponseMetadata):
     )
 
     # References
-    snapshot_id: UUID = Field(
-        title="The snapshot associated with the step run."
+    snapshot_id: Optional[UUID] = Field(
+        default=None, title="The snapshot associated with the step run."
     )
     pipeline_run_id: UUID = Field(
         title="The ID of the pipeline run that this step run belongs to.",
@@ -569,8 +573,17 @@ class StepRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_body().substitutions
+        value = self.get_body().substitutions
+        if value is None:
+            raise ValueError(
+                f"The substitutions of step '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def config(self) -> "StepConfiguration":
@@ -578,8 +591,17 @@ class StepRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().config
+        value = self.get_metadata().config
+        if value is None:
+            raise ValueError(
+                f"The config of step '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def spec(self) -> "StepSpec":
@@ -587,8 +609,17 @@ class StepRunResponse(
 
         Returns:
             the value of the property.
+
+        Raises:
+            ValueError: If the archived detail is unavailable.
         """
-        return self.get_metadata().spec
+        value = self.get_metadata().spec
+        if value is None:
+            raise ValueError(
+                f"The spec of step '{self.id}' is unavailable. "
+                "Restore its archived execution before accessing this detail."
+            )
+        return value
 
     @property
     def cache_key(self) -> Optional[str]:
@@ -683,7 +714,7 @@ class StepRunResponse(
         return self.get_body().heartbeat_threshold
 
     @property
-    def snapshot_id(self) -> UUID:
+    def snapshot_id(self) -> Optional[UUID]:
         """The `snapshot_id` property.
 
         Returns:

--- a/src/zenml/zen_server/pipeline_execution/utils.py
+++ b/src/zenml/zen_server/pipeline_execution/utils.py
@@ -414,8 +414,17 @@ def prepare_snapshot_run(
         The durable execution request.
 
     Raises:
-        ValueError: If replay execution has no original run.
+        ValueError: If the snapshot is archived or replay execution has no
+            original run.
     """
+    if (
+        snapshot.archived_at is not None
+        or snapshot.archive_bundle_id is not None
+    ):
+        raise ValueError(
+            f"Snapshot {snapshot.id} is archived. Restore its owning run with "
+            "`zenml pipeline runs restore <run-id>` before running it."
+        )
     if replay_configuration and not original_run:
         raise ValueError("Original run is required to replay a pipeline run.")
 

--- a/src/zenml/zen_stores/dag/archived.py
+++ b/src/zenml/zen_stores/dag/archived.py
@@ -1,0 +1,203 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Recorded execution graphs built entirely from retained SQL relationships."""
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set, Tuple
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from zenml.config.source import Source
+from zenml.enums import (
+    ArtifactSaveType,
+    ExecutionStatus,
+    StepRunInputArtifactType,
+)
+from zenml.models import PipelineRunDAG
+from zenml.zen_stores.dag.dag_generator import DAGGeneratorHelper
+from zenml.zen_stores.dag.utils import (
+    load_input_artifact_rows,
+    load_output_artifact_rows,
+    load_step_run_metadata,
+)
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema,
+    StepRunParentsSchema,
+    StepRunSchema,
+)
+
+
+def generate_archived_dag(
+    session: Session,
+    run: PipelineRunSchema,
+    helper: DAGGeneratorHelper,
+    include_step_metadata: Optional[List[str]],
+) -> PipelineRunDAG:
+    """Build the recorded graph without interpreting archived configuration.
+
+    Configuration-only nodes, groups and unrealized outputs are unavailable.
+    Parent rows and artifact links describe what actually ran, including
+    cached outputs, without inventing missing configuration.
+
+    Args:
+        session: The SQL session.
+        run: The archived run with step identities loaded.
+        helper: Graph builder containing retained run context.
+        include_step_metadata: Retained metadata keys to add to step nodes.
+
+    Returns:
+        The graph of recorded steps and their retained relationships.
+    """
+    steps = {
+        step.id: step
+        for step in run.step_runs
+        if step.status != ExecutionStatus.RETRIED.value
+    }
+    parents: Dict[UUID, Set[UUID]] = defaultdict(set)
+    query = (
+        select(StepRunParentsSchema)
+        .join(
+            StepRunSchema,
+            col(StepRunSchema.id) == StepRunParentsSchema.child_id,
+        )
+        .where(col(StepRunSchema.pipeline_run_id) == run.id)
+    )
+    for link in session.exec(query):
+        if link.parent_id in steps and link.child_id in steps:
+            parents[link.child_id].add(link.parent_id)
+
+    metadata = (
+        load_step_run_metadata(session, run.id, include_step_metadata)
+        if include_step_metadata
+        else {}
+    )
+    outputs = load_output_artifact_rows(session, run.id)
+    inputs = load_input_artifact_rows(session, run.id)
+    producers: Dict[UUID, List[Tuple[UUID, str]]] = defaultdict(list)
+    for step in steps.values():
+        details: Dict[str, Any] = {"status": step.status}
+        if step.step_type is not None:
+            details["type"] = step.step_type
+        if step.start_time:
+            details["start_time"] = step.start_time.isoformat()
+            if step.end_time:
+                details["duration"] = (
+                    step.end_time - step.start_time
+                ).total_seconds()
+        if step_metadata := metadata.get(step.id):
+            details["run_metadata"] = step_metadata
+        node = helper.add_step_node(
+            node_id=helper.get_step_node_id(step.name),
+            name=step.name,
+            id=step.id,
+            **details,
+        )
+        for output in outputs.get(step.id, []):
+            artifact = helper.add_artifact_node(
+                node_id=helper.get_artifact_node_id(
+                    name=str(output.artifact_id)
+                    if output.artifact_save_type == ArtifactSaveType.MANUAL
+                    else output.name,
+                    step_name=step.name,
+                    io_type=output.artifact_save_type,
+                    is_input=False,
+                ),
+                id=output.artifact_id,
+                name=output.name,
+                type=output.artifact_type,
+                data_type=Source.model_validate_json(
+                    output.artifact_data_type
+                ).import_path,
+                save_type=output.artifact_save_type,
+            )
+            helper.add_edge(
+                source=node.node_id,
+                target=artifact.node_id,
+                output_name=output.name,
+                type=output.artifact_save_type,
+            )
+            if output.artifact_save_type == ArtifactSaveType.STEP_OUTPUT:
+                producers[output.artifact_id].append(
+                    (step.id, artifact.node_id)
+                )
+
+        for triggered in step.triggered_runs:
+            details = {"status": triggered.status, "index": triggered.index}
+            if triggered.start_time:
+                details["start_time"] = triggered.start_time.isoformat()
+                if triggered.end_time:
+                    details["duration"] = (
+                        triggered.end_time - triggered.start_time
+                    ).total_seconds()
+            triggered_node = helper.add_triggered_run_node(
+                node_id=helper.get_triggered_run_node_id(triggered.name),
+                name=triggered.name,
+                id=triggered.id,
+                **details,
+            )
+            helper.add_edge(source=node.node_id, target=triggered_node.node_id)
+
+    for step in steps.values():
+        node_id = helper.get_step_node_id(step.name)
+        for input in inputs.get(step.id, []):
+            candidates = (
+                [
+                    output_node
+                    for parent_id, output_node in producers[input.artifact_id]
+                    if parent_id in parents[step.id]
+                ]
+                if input.type == StepRunInputArtifactType.STEP_OUTPUT
+                else []
+            )
+            if len(candidates) == 1:
+                input_node_id = candidates[0]
+            else:
+                # SQL links cannot disambiguate two parents or output aliases
+                # publishing the same artifact. Keep that input separate rather
+                # than claiming an unrecorded producer/output association.
+                artifact = helper.add_artifact_node(
+                    node_id=helper.get_artifact_node_id(
+                        name=f"{input.name}/{input.artifact_id}",
+                        step_name=step.name,
+                        io_type=input.type,
+                        is_input=True,
+                    ),
+                    id=input.artifact_id,
+                    name=input.name,
+                    type=input.artifact_type,
+                    data_type=Source.model_validate_json(
+                        input.artifact_data_type
+                    ).import_path,
+                    save_type=input.artifact_save_type,
+                )
+                input_node_id = artifact.node_id
+            helper.add_edge(
+                source=input_node_id,
+                target=node_id,
+                input_name=input.name,
+                type=input.type,
+                index=input.input_index,
+                chunk_index=input.chunk_index,
+                chunk_size=input.chunk_size,
+            )
+        for parent_id in parents[step.id]:
+            helper.add_edge(
+                source=helper.get_step_node_id(steps[parent_id].name),
+                target=node_id,
+            )
+
+    return helper.finalize_dag(
+        pipeline_run_id=run.id, status=ExecutionStatus(run.status)
+    )

--- a/src/zenml/zen_stores/dag/utils.py
+++ b/src/zenml/zen_stores/dag/utils.py
@@ -15,7 +15,7 @@
 
 import json
 from collections import defaultdict
-from typing import Dict, List
+from typing import Any, Dict, List
 from uuid import UUID
 
 from sqlalchemy import select
@@ -24,9 +24,11 @@ from sqlmodel import Session, col
 from zenml.enums import ExecutionStatus, MetadataResourceTypes
 from zenml.metadata.metadata_types import MetadataType
 from zenml.models import RunMetadataEntry
+from zenml.zen_stores.dag.dag_generator import DAGGeneratorHelper
 from zenml.zen_stores.dag.models import InputArtifactRow, OutputArtifactRow
 from zenml.zen_stores.schemas import (
     ArtifactVersionSchema,
+    PipelineRunSchema,
     RunMetadataResourceSchema,
     RunMetadataSchema,
     StepRunInputArtifactSchema,
@@ -173,3 +175,53 @@ def load_step_run_metadata(
         step_id: resolve_metadata_collection(collection)
         for step_id, collection in metadata_collections.items()
     }
+
+
+def add_run_context(
+    helper: DAGGeneratorHelper, run: PipelineRunSchema
+) -> None:
+    """Add retained wait conditions and child runs to either DAG representation.
+
+    Args:
+        helper: The graph being built.
+        run: The SQL run with its retained relationships loaded.
+    """
+    for condition in run.wait_conditions:
+        node_metadata: Dict[str, Any] = {
+            "status": condition.status,
+            "type": condition.type,
+            "created_at": condition.created.isoformat(),
+        }
+        if condition.resolution:
+            node_metadata["resolution"] = condition.resolution
+        if condition.question and not run.is_archived:
+            node_metadata["question"] = condition.question
+        if condition.resolved_at:
+            node_metadata["resolved_at"] = condition.resolved_at.isoformat()
+
+        helper.add_wait_condition_node(
+            node_id=helper.get_wait_condition_node_id(condition.name),
+            id=condition.id,
+            name=condition.name,
+            **node_metadata,
+        )
+
+    for child_run in run.child_runs:
+        child_run_metadata: Dict[str, Any] = {
+            "status": child_run.status,
+        }
+        if child_run.start_time:
+            child_run_metadata["start_time"] = child_run.start_time.isoformat()
+            if child_run.end_time:
+                child_run_metadata["end_time"] = child_run.end_time.isoformat()
+                child_run_metadata["duration"] = (
+                    child_run.end_time - child_run.start_time
+                ).total_seconds()
+
+        helper.add_child_run_node(
+            node_id=helper.get_child_run_node_id(child_run.name),
+            id=child_run.id,
+            name=child_run.name,
+            **child_run_metadata,
+        )
+        # TODO: maybe include nodes for outputs and connect via edges?

--- a/src/zenml/zen_stores/schemas/hook_invocation_schemas.py
+++ b/src/zenml/zen_stores/schemas/hook_invocation_schemas.py
@@ -41,6 +41,7 @@ from zenml.zen_stores.schemas.utils import jl_arg
 if TYPE_CHECKING:
     from zenml.zen_stores.schemas.artifact_schemas import ArtifactVersionSchema
     from zenml.zen_stores.schemas.logs_schemas import LogsSchema
+    from zenml.zen_stores.schemas.pipeline_run_schemas import PipelineRunSchema
     from zenml.zen_stores.schemas.user_schemas import UserSchema
 
 
@@ -100,6 +101,10 @@ class HookInvocationSchema(BaseSchema, table=True):
     )
 
     # Relationships
+    # Archive checks must not change ownership or cascade behavior.
+    run: "PipelineRunSchema" = Relationship(
+        sa_relationship_kwargs={"viewonly": True}
+    )
     user: Optional["UserSchema"] = Relationship()
     output_artifacts: List["HookInvocationOutputArtifactSchema"] = (
         Relationship(
@@ -130,9 +135,20 @@ class HookInvocationSchema(BaseSchema, table=True):
         Returns:
             A list of query options.
         """
-        from zenml.zen_stores.schemas import ArtifactVersionSchema
+        from zenml.zen_stores.schemas import (
+            ArtifactVersionSchema,
+            PipelineRunSchema,
+        )
 
-        options = []
+        options: List[ExecutableOption] = []
+
+        if include_metadata:
+            options.append(
+                selectinload(jl_arg(cls.run)).load_only(
+                    jl_arg(PipelineRunSchema.archived_at),
+                    jl_arg(PipelineRunSchema.archive_bundle_id),
+                )
+            )
 
         if include_resources:
             options.extend(
@@ -219,7 +235,7 @@ class HookInvocationSchema(BaseSchema, table=True):
                 exception_info=ExceptionInfo.model_validate_json(
                     self.exception_info
                 )
-                if self.exception_info
+                if self.exception_info and not self.run.is_archived
                 else None,
             )
 

--- a/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_run_schemas.py
@@ -543,16 +543,35 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             root_run_id=root_run_id,
         )
 
+    @property
+    def is_archived(self) -> bool:
+        """Whether either archive marker identifies archived detail.
+
+        Returns:
+            Whether the run's detail is archived.
+        """
+        return (
+            self.archived_at is not None or self.archive_bundle_id is not None
+        )
+
     def get_pipeline_configuration(self) -> PipelineConfiguration:
         """Get the pipeline configuration for the pipeline run.
 
         Raises:
+            ValueError: If the pipeline configuration is archived.
             RuntimeError: if the pipeline run has no snapshot and no pipeline
                 configuration.
 
         Returns:
             The pipeline configuration.
         """
+        if self.is_archived or (
+            self.snapshot is not None and self.snapshot.is_archived
+        ):
+            raise ValueError(
+                f"Run '{self.id}' has archived configuration. Restore it with "
+                f"`zenml pipeline runs restore {self.id}` before reading it."
+            )
         if self.snapshot:
             pipeline_config = PipelineConfiguration.model_validate_json(
                 self.snapshot.pipeline_configuration
@@ -602,9 +621,17 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
             The list of upstream steps for each step.
 
         Raises:
+            ValueError: If the pipeline specification is archived.
             RuntimeError: If the pipeline run has no snapshot or
                 the snapshot has no pipeline spec.
         """
+        if self.is_archived or (
+            self.snapshot is not None and self.snapshot.is_archived
+        ):
+            raise ValueError(
+                f"Run '{self.id}' has an archived specification. Restore it "
+                f"with `zenml pipeline runs restore {self.id}` before reading it."
+            )
         if self.snapshot and self.snapshot.pipeline_spec:
             pipeline_spec = PipelineSpec.model_validate_json(
                 self.snapshot.pipeline_spec
@@ -694,33 +721,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
 
         Returns:
             The created `PipelineRunResponse`.
-
-        Raises:
-            RuntimeError: if the model creation fails.
         """
-        if self.snapshot is not None:
-            config = PipelineConfiguration.model_validate_json(
-                self.snapshot.pipeline_configuration
-            )
-            client_environment = json.loads(self.snapshot.client_environment)
-        elif self.pipeline_configuration is not None:
-            config = PipelineConfiguration.model_validate_json(
-                self.pipeline_configuration
-            )
-            client_environment = (
-                json.loads(self.client_environment)
-                if self.client_environment
-                else {}
-            )
-        else:
-            raise RuntimeError(
-                "Pipeline run model creation has failed. Each pipeline run "
-                "entry should either have a snapshot_id or "
-                "pipeline_configuration."
-            )
-
-        config.finalize_substitutions(start_time=self.start_time, inplace=True)
-
         body = PipelineRunResponseBody(
             user_id=self.user_id,
             project_id=self.project_id,
@@ -739,24 +740,43 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
         )
         metadata = None
         if include_metadata:
+            config = None
+            client_environment = None
+            orchestrator_environment = None
+            archived = self.is_archived or (
+                self.snapshot is not None and self.snapshot.is_archived
+            )
+            if not archived:
+                config = self.get_pipeline_configuration()
+                if self.snapshot is not None:
+                    client_environment = json.loads(
+                        self.snapshot.client_environment
+                    )
+                else:
+                    client_environment = (
+                        json.loads(self.client_environment)
+                        if self.client_environment
+                        else {}
+                    )
+                orchestrator_environment = (
+                    json.loads(self.orchestrator_environment)
+                    if self.orchestrator_environment
+                    else {}
+                )
+                if not include_python_packages:
+                    client_environment.pop("python_packages", None)
+                    orchestrator_environment.pop("python_packages", None)
+
             is_templatable = False
             if (
-                self.snapshot
+                not self.is_archived
+                and self.snapshot
+                and not self.snapshot.is_archived
                 and self.snapshot.build
                 and not self.snapshot.build.is_local
                 and self.snapshot.build.stack_id
             ):
                 is_templatable = True
-
-            orchestrator_environment = (
-                json.loads(self.orchestrator_environment)
-                if self.orchestrator_environment
-                else {}
-            )
-
-            if not include_python_packages:
-                client_environment.pop("python_packages", None)
-                orchestrator_environment.pop("python_packages", None)
 
             trigger_info: Optional[PipelineRunTriggerInfo] = None
             if self.triggered_by and self.triggered_by_type:
@@ -793,7 +813,7 @@ class PipelineRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 trigger_info=trigger_info,
                 enable_heartbeat=self.enable_heartbeat,
                 exception_info=json.loads(self.exception_info)
-                if self.exception_info
+                if self.exception_info and not archived
                 else None,
                 trigger_execution_info=json.loads(self.trigger_execution.info)
                 if self.trigger_execution and self.trigger_execution.info

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -490,6 +490,17 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
         return self
 
     @property
+    def is_archived(self) -> bool:
+        """Whether either archive marker identifies archived detail.
+
+        Returns:
+            Whether the snapshot's detail is archived.
+        """
+        return (
+            self.archived_at is not None or self.archive_bundle_id is not None
+        )
+
+    @property
     def is_runnable(self) -> bool:
         """Implements the `is_runnable` property.
 
@@ -497,7 +508,8 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             True if the snapshot is runnable from server.
         """
         return (
-            self.build is not None
+            not self.is_archived
+            and self.build is not None
             and not self.build.is_local
             and self.build.stack_id is not None
         )
@@ -527,7 +539,12 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             The response.
         """
         deployable = False
-        if self.build and self.stack and self.stack.has_deployer:
+        if (
+            not self.is_archived
+            and self.build
+            and self.stack
+            and self.stack.has_deployer
+        ):
             deployable = True
 
         body = PipelineSnapshotResponseBody(
@@ -543,7 +560,7 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             archive_bundle_id=self.archive_bundle_id,
         )
         metadata = None
-        if include_metadata:
+        if include_metadata and not self.is_archived:
             pipeline_configuration = PipelineConfiguration.model_validate_json(
                 self.pipeline_configuration
             )
@@ -613,6 +630,20 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
                 source_snapshot_id=self.source_snapshot_id,
                 config_schema=config_schema,
                 config_template=config_template,
+            )
+
+        elif include_metadata:
+            metadata = PipelineSnapshotResponseMetadata(
+                run_name_template=self.run_name_template,
+                pipeline_configuration=None,
+                step_configurations=None,
+                client_environment=None,
+                client_version=self.client_version,
+                server_version=self.server_version,
+                pipeline_version_hash=self.pipeline_version_hash,
+                code_path=self.code_path,
+                template_id=self.template_id,
+                source_snapshot_id=self.source_snapshot_id,
             )
 
         resources = None

--- a/src/zenml/zen_stores/schemas/run_wait_condition_schemas.py
+++ b/src/zenml/zen_stores/schemas/run_wait_condition_schemas.py
@@ -212,14 +212,7 @@ class RunWaitConditionSchema(BaseSchema, RunMetadataInterface, table=True):
         Returns:
             The wait condition response model.
         """
-        data_schema: Optional[Dict[str, Any]] = None
-        if self.data_schema_json:
-            data_schema = json.loads(self.data_schema_json)
-
-        result: Optional[Any] = None
-        if self.result_json:
-            result = json.loads(self.result_json)
-
+        archived = self.run.is_archived
         body = RunWaitConditionResponseBody(
             user_id=self.user_id,
             project_id=self.run.project_id,
@@ -227,17 +220,29 @@ class RunWaitConditionSchema(BaseSchema, RunMetadataInterface, table=True):
             updated=self.updated,
             type=RunWaitConditionType(self.type),
             status=RunWaitConditionStatus(self.status),
-            last_polled_at=self.last_polled_at,
-            poller_instance_id=self.poller_instance_id,
-            poller_lease_expires_at=self.poller_lease_expires_at,
+            last_polled_at=self.last_polled_at if not archived else None,
+            poller_instance_id=self.poller_instance_id
+            if not archived
+            else None,
+            poller_lease_expires_at=self.poller_lease_expires_at
+            if not archived
+            else None,
             resolved_at=self.resolved_at,
             resolved_by_user_id=self.resolved_by_user_id,
         )
 
         metadata = None
         if include_metadata:
+            data_schema: Optional[Dict[str, Any]] = None
+            result: Optional[Any] = None
+            if not archived:
+                if self.data_schema_json:
+                    data_schema = json.loads(self.data_schema_json)
+                if self.result_json:
+                    result = json.loads(self.result_json)
+
             metadata = RunWaitConditionResponseMetadata(
-                question=self.question,
+                question=self.question if not archived else None,
                 run_metadata=self.fetch_metadata(),
                 data_schema=data_schema,
                 resolution=self.resolution,

--- a/src/zenml/zen_stores/schemas/step_run_schemas.py
+++ b/src/zenml/zen_stores/schemas/step_run_schemas.py
@@ -15,7 +15,7 @@
 
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, cast
 from uuid import UUID
 
 from pydantic import ConfigDict
@@ -33,6 +33,7 @@ from zenml.enums import (
     MetadataResourceTypes,
     PipelineRunTriggeredByType,
     StepRunInputArtifactType,
+    StepType,
 )
 from zenml.models import (
     ExceptionInfo,
@@ -298,9 +299,13 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             single_loader(jl_arg(StepRunSchema.snapshot)).load_only(
                 jl_arg(PipelineSnapshotSchema.pipeline_configuration),
                 jl_arg(PipelineSnapshotSchema.is_dynamic),
+                jl_arg(PipelineSnapshotSchema.archived_at),
+                jl_arg(PipelineSnapshotSchema.archive_bundle_id),
             ),
             single_loader(jl_arg(StepRunSchema.pipeline_run)).load_only(
-                jl_arg(PipelineRunSchema.start_time)
+                jl_arg(PipelineRunSchema.start_time),
+                jl_arg(PipelineRunSchema.archived_at),
+                jl_arg(PipelineRunSchema.archive_bundle_id),
             ),
             single_loader(jl_arg(StepRunSchema.static_config)),
             single_loader(jl_arg(StepRunSchema.dynamic_config)),
@@ -386,15 +391,76 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             else None,
         )
 
+    @property
+    def is_archived(self) -> bool:
+        """Whether either archive marker identifies archived detail.
+
+        Returns:
+            Whether the step's detail is archived.
+        """
+        return (
+            self.archived_at is not None or self.archive_bundle_id is not None
+        )
+
+    def _has_archived_configuration(self) -> bool:
+        """Check the step and both possible owners of its configuration.
+
+        Returns:
+            Whether configuration decoding requires an execution restore.
+        """
+        return (
+            self.is_archived
+            or self.pipeline_run.is_archived
+            or (self.snapshot is not None and self.snapshot.is_archived)
+        )
+
+    def _get_response_type(self, step: Optional[Step]) -> Optional[StepType]:
+        """Resolve the live step type or its retained projection.
+
+        Args:
+            step: The decoded live configuration, or None for archived detail.
+
+        Returns:
+            The recorded step type, if available.
+        """
+        if step is not None:
+            return step.config.step_type
+        if self.step_type is not None:
+            return StepType(self.step_type)
+        return None
+
+    def _get_response_substitutions(
+        self, step: Optional[Step]
+    ) -> Optional[Dict[str, str]]:
+        """Resolve live substitutions or their retained projection.
+
+        Args:
+            step: The decoded live configuration, or None for archived detail.
+
+        Returns:
+            Recorded substitutions, preserving None for a missing projection.
+        """
+        if step is not None:
+            return step.config.substitutions
+        if self.substitutions is not None:
+            return cast(Dict[str, str], json.loads(self.substitutions))
+        return None
+
     def get_step_configuration(self) -> Step:
         """Get the step configuration for the step run.
 
         Raises:
-            ValueError: If the step run has no step configuration.
+            ValueError: If the step configuration is archived or unavailable.
 
         Returns:
             The step configuration.
         """
+        if self._has_archived_configuration():
+            raise ValueError(
+                f"Step '{self.id}' has archived configuration. Restore its "
+                f"pipeline run '{self.pipeline_run_id}' before reading it."
+            )
+
         step = None
 
         if self.snapshot is not None:
@@ -469,12 +535,13 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         Returns:
             The created StepRunResponse.
         """
-        step = self.get_step_configuration()
+        archived = self._has_archived_configuration()
+        step = None if archived else self.get_step_configuration()
 
         body = StepRunResponseBody(
             user_id=self.user_id,
             project_id=self.project_id,
-            type=step.config.step_type,
+            type=self._get_response_type(step),
             status=ExecutionStatus(self.status),
             version=self.version,
             is_retriable=self.is_retriable,
@@ -485,7 +552,7 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
             updated=self.updated,
             model_version_id=self.model_version_id,
             resource_request_id=self.resource_request_id,
-            substitutions=step.config.substitutions,
+            substitutions=self._get_response_substitutions(step),
             heartbeat_threshold=self.heartbeat_threshold,
             archived_at=self.archived_at,
             archive_bundle_id=self.archive_bundle_id,
@@ -493,8 +560,8 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
         metadata = None
         if include_metadata:
             metadata = StepRunResponseMetadata(
-                config=step.config,
-                spec=step.spec,
+                config=step.config if step else None,
+                spec=step.spec if step else None,
                 cache_key=self.cache_key,
                 cache_expires_at=self.cache_expires_at,
                 code_hash=self.code_hash,
@@ -503,7 +570,7 @@ class StepRunSchema(NamedSchema, RunMetadataInterface, table=True):
                 exception_info=ExceptionInfo.model_validate_json(
                     self.exception_info
                 )
-                if self.exception_info
+                if self.exception_info and not archived
                 else None,
                 snapshot_id=self.snapshot_id,
                 pipeline_run_id=self.pipeline_run_id,

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -404,6 +404,7 @@ from zenml.zen_stores import template_utils
 from zenml.zen_stores.base_zen_store import (
     BaseZenStore,
 )
+from zenml.zen_stores.dag.archived import generate_archived_dag
 from zenml.zen_stores.dag.dag_generator import (
     DAGGeneratorHelper,
 )
@@ -411,6 +412,7 @@ from zenml.zen_stores.dag.models import (
     DAGStepView,
 )
 from zenml.zen_stores.dag.utils import (
+    add_run_context,
     load_input_artifact_rows,
     load_output_artifact_rows,
     load_step_run_metadata,
@@ -6253,11 +6255,15 @@ class SqlZenStore(BaseZenStore):
                 query_options=[
                     load_only(
                         jl_arg(PipelineRunSchema.status),
+                        jl_arg(PipelineRunSchema.archived_at),
+                        jl_arg(PipelineRunSchema.archive_bundle_id),
                         jl_arg(PipelineRunSchema.start_time),
                     ),
                     selectinload(jl_arg(PipelineRunSchema.snapshot)).load_only(
                         jl_arg(PipelineSnapshotSchema.pipeline_configuration),
                         jl_arg(PipelineSnapshotSchema.is_dynamic),
+                        jl_arg(PipelineSnapshotSchema.archived_at),
+                        jl_arg(PipelineSnapshotSchema.archive_bundle_id),
                     ),
                     selectinload(
                         jl_arg(PipelineRunSchema.snapshot)
@@ -6271,6 +6277,9 @@ class SqlZenStore(BaseZenStore):
                         jl_arg(StepRunSchema.status),
                         jl_arg(StepRunSchema.start_time),
                         jl_arg(StepRunSchema.end_time),
+                        jl_arg(StepRunSchema.step_type),
+                        jl_arg(StepRunSchema.archived_at),
+                        jl_arg(StepRunSchema.archive_bundle_id),
                     ),
                     selectinload(
                         jl_arg(PipelineRunSchema.step_runs)
@@ -6297,30 +6306,21 @@ class SqlZenStore(BaseZenStore):
                     ),
                 ],
             )
-            assert run.snapshot is not None
-            snapshot = run.snapshot
-            for condition in run.wait_conditions:
-                node_metadata: Dict[str, Any] = {
-                    "status": condition.status,
-                    "type": condition.type,
-                    "created_at": condition.created.isoformat(),
-                }
-                if condition.resolution:
-                    node_metadata["resolution"] = condition.resolution
-                if condition.question:
-                    node_metadata["question"] = condition.question
-                if condition.resolved_at:
-                    node_metadata["resolved_at"] = (
-                        condition.resolved_at.isoformat()
-                    )
-
-                helper.add_wait_condition_node(
-                    node_id=helper.get_wait_condition_node_id(condition.name),
-                    id=condition.id,
-                    name=condition.name,
-                    **node_metadata,
+            add_run_context(helper=helper, run=run)
+            if (
+                run.is_archived
+                or (run.snapshot is not None and run.snapshot.is_archived)
+                or any(step.is_archived for step in run.step_runs)
+            ):
+                return generate_archived_dag(
+                    session=session,
+                    run=run,
+                    helper=helper,
+                    include_step_metadata=include_step_metadata,
                 )
 
+            assert run.snapshot is not None
+            snapshot = run.snapshot
             step_runs = {
                 step.name: step
                 for step in run.step_runs
@@ -6727,30 +6727,6 @@ class SqlZenStore(BaseZenStore):
                         target=step_node.node_id,
                     )
 
-            for child_run in run.child_runs:
-                child_run_metadata: Dict[str, Any] = {
-                    "status": child_run.status,
-                }
-                if child_run.start_time:
-                    child_run_metadata["start_time"] = (
-                        child_run.start_time.isoformat()
-                    )
-                    if child_run.end_time:
-                        child_run_metadata["end_time"] = (
-                            child_run.end_time.isoformat()
-                        )
-                        child_run_metadata["duration"] = (
-                            child_run.end_time - child_run.start_time
-                        ).total_seconds()
-
-                helper.add_child_run_node(
-                    node_id=helper.get_child_run_node_id(child_run.name),
-                    id=child_run.id,
-                    name=child_run.name,
-                    **child_run_metadata,
-                )
-                # TODO: maybe include nodes for outputs and connect via edges?
-
         return helper.finalize_dag(
             pipeline_run_id=pipeline_run_id, status=ExecutionStatus(run.status)
         )
@@ -6825,6 +6801,7 @@ class SqlZenStore(BaseZenStore):
             The created pipeline run.
 
         Raises:
+            ValueError: If the source snapshot is archived.
             EntityExistsError: If a run with the same name already exists or
                 a log entry with the same source already exists within the
                 scope of the same pipeline run.
@@ -6839,6 +6816,12 @@ class SqlZenStore(BaseZenStore):
             reference_id=pipeline_run.snapshot,
             session=session,
         )
+
+        if snapshot.is_archived:
+            raise ValueError(
+                f"Snapshot {snapshot.id} is archived. Restore its owning run "
+                "with `zenml pipeline runs restore <run-id>` before running it."
+            )
 
         if pipeline_run.original_run_id:
             self._get_reference_schema_by_id(

--- a/tests/unit/zen_server/test_pipeline_execution_utils.py
+++ b/tests/unit/zen_server/test_pipeline_execution_utils.py
@@ -15,8 +15,14 @@ from zenml.zen_server.pipeline_execution.snapshot_run_dispatcher import (
 )
 
 
-def test_invalid_snapshot_does_not_create_or_report_usage(monkeypatch) -> None:
-    """Validation failures happen before preparation becomes billable."""
+def test_invalid_snapshot_does_not_create_or_report_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validation failures happen before preparation becomes billable.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
     create_placeholder_run = MagicMock()
     report_usage = MagicMock()
     monkeypatch.setattr(
@@ -32,7 +38,7 @@ def test_invalid_snapshot_does_not_create_or_report_usage(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="invalid snapshot"):
         utils.run_snapshot(
-            snapshot=MagicMock(),
+            snapshot=MagicMock(archived_at=None, archive_bundle_id=None),
             auth_context=MagicMock(),
         )
 
@@ -41,10 +47,16 @@ def test_invalid_snapshot_does_not_create_or_report_usage(monkeypatch) -> None:
 
 
 def test_async_snapshot_run_returns_placeholder_after_dispatch_acceptance(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Async snapshot runs dispatch durable IDs and return the placeholder."""
-    source_snapshot = SimpleNamespace(id=uuid4())
+    """Async snapshot runs dispatch durable IDs and return the placeholder.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
+    source_snapshot = SimpleNamespace(
+        id=uuid4(), archived_at=None, archive_bundle_id=None
+    )
     target_snapshot = SimpleNamespace(id=uuid4())
     placeholder_run = SimpleNamespace(id=uuid4())
     stack = MagicMock()
@@ -97,10 +109,19 @@ def test_async_snapshot_run_returns_placeholder_after_dispatch_acceptance(
 
 
 def test_synchronous_snapshot_run_executes_without_redispatch(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Synchronous runs report usage and expose submission outcomes."""
-    snapshot = SimpleNamespace(id=uuid4(), source_snapshot_id=None)
+    """Synchronous runs report usage and expose submission outcomes.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
+    snapshot = SimpleNamespace(
+        id=uuid4(),
+        source_snapshot_id=None,
+        archived_at=None,
+        archive_bundle_id=None,
+    )
     placeholder_run = SimpleNamespace(
         id=uuid4(),
         snapshot=snapshot,
@@ -180,10 +201,17 @@ def test_synchronous_snapshot_run_executes_without_redispatch(
 
 @pytest.mark.parametrize("create_new_snapshot", [True, False])
 def test_queue_rejection_removes_prepared_state(
-    monkeypatch, create_new_snapshot: bool
+    monkeypatch: pytest.MonkeyPatch, create_new_snapshot: bool
 ) -> None:
-    """Queue backpressure only removes state created by the request."""
-    source_snapshot = SimpleNamespace(id=uuid4())
+    """Queue backpressure only removes state created by the request.
+
+    Args:
+        monkeypatch: Test patching fixture.
+        create_new_snapshot: Whether execution creates a derived snapshot.
+    """
+    source_snapshot = SimpleNamespace(
+        id=uuid4(), archived_at=None, archive_bundle_id=None
+    )
     target_snapshot = SimpleNamespace(id=uuid4())
     placeholder_run = SimpleNamespace(id=uuid4())
     store = MagicMock()
@@ -229,10 +257,16 @@ def test_queue_rejection_removes_prepared_state(
 
 
 def test_unexpected_dispatch_failure_marks_prepared_run_failed(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unexpected dispatch failures retain a diagnosable failed run."""
-    source_snapshot = SimpleNamespace(id=uuid4())
+    """Unexpected dispatch failures retain a diagnosable failed run.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
+    source_snapshot = SimpleNamespace(
+        id=uuid4(), archived_at=None, archive_bundle_id=None
+    )
     target_snapshot = SimpleNamespace(id=uuid4())
     placeholder_run = SimpleNamespace(id=uuid4())
     store = MagicMock()
@@ -271,8 +305,14 @@ def test_unexpected_dispatch_failure_marks_prepared_run_failed(
     store.delete_snapshot.assert_not_called()
 
 
-def test_prepared_execution_uses_persisted_run_owner(monkeypatch) -> None:
-    """Remote execution reconstructs identity from the placeholder owner."""
+def test_prepared_execution_uses_persisted_run_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote execution reconstructs identity from the placeholder owner.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
     source_snapshot_id = uuid4()
     target_snapshot = SimpleNamespace(
         id=uuid4(), source_snapshot_id=source_snapshot_id
@@ -337,8 +377,14 @@ def test_prepared_execution_uses_persisted_run_owner(monkeypatch) -> None:
     assert build_and_run.call_args.kwargs["wait_for_completion"] is True
 
 
-def test_prepared_execution_skips_stale_or_missing_state(monkeypatch) -> None:
-    """Stale and missing queued state is acknowledged without execution."""
+def test_prepared_execution_skips_stale_or_missing_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stale and missing queued state is acknowledged without execution.
+
+    Args:
+        monkeypatch: Test patching fixture.
+    """
     stale_run = SimpleNamespace(id=uuid4(), status=ExecutionStatus.CANCELLED)
     store = MagicMock()
     store.get_run.return_value = stale_run
@@ -374,3 +420,31 @@ def test_prepared_execution_skips_stale_or_missing_state(monkeypatch) -> None:
     assert executed is False
     store.update_run.assert_not_called()
     build_and_run.assert_not_called()
+
+
+@pytest.mark.parametrize("timestamp_only", [False, True])
+def test_archived_snapshot_cannot_start_execution(
+    monkeypatch: pytest.MonkeyPatch, timestamp_only: bool
+) -> None:
+    """Either archive marker refuses execution before preparation side effects.
+
+    Args:
+        monkeypatch: Test patching fixture.
+        timestamp_only: Exercise the timestamp without a bundle pointer.
+    """
+    from zenml.utils.time_utils import utc_now
+
+    snapshot = SimpleNamespace(
+        id=uuid4(),
+        archived_at=utc_now() if timestamp_only else None,
+        archive_bundle_id=None if timestamp_only else uuid4(),
+    )
+    prepare = MagicMock(
+        side_effect=AssertionError("must not prepare execution")
+    )
+    monkeypatch.setattr(
+        utils, "validate_snapshot_for_server_execution", prepare
+    )
+    with pytest.raises(ValueError, match="zenml pipeline runs restore"):
+        utils.run_snapshot(snapshot=snapshot, auth_context=MagicMock())
+    prepare.assert_not_called()

--- a/tests/unit/zen_stores/test_execution_archive_markers.py
+++ b/tests/unit/zen_stores/test_execution_archive_markers.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Unit tests for the execution archive markers and `archived` filters."""
 
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator, Optional
@@ -144,6 +145,11 @@ def _create_tree(
         ).model_dump_json(),
         **marker,
     )
+    if archived_at is not None or bundle_id is not None:
+        assert step.step_configuration is not None
+        configuration = Step.model_validate_json(step.step_configuration)
+        step.step_type = configuration.config.step_type
+        step.substitutions = json.dumps(configuration.config.substitutions)
     with Session(store.engine, expire_on_commit=False) as session:
         session.add_all([pipeline, snapshot, run, step])
         session.commit()

--- a/tests/unit/zen_stores/test_execution_archive_readers.py
+++ b/tests/unit/zen_stores/test_execution_archive_readers.py
@@ -1,0 +1,904 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Public history-reader scenarios on retained execution identities."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Literal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import select
+
+from zenml.client import Client
+from zenml.config.pipeline_configurations import PipelineConfiguration
+from zenml.config.pipeline_spec import PipelineSpec
+from zenml.config.source import Source
+from zenml.config.step_configurations import (
+    InputSpec,
+    Step,
+    StepConfiguration,
+    StepSpec,
+)
+from zenml.enums import (
+    ArchiveBundleStatus,
+    ExecutionStatus,
+    StepRunInputArtifactType,
+    StepType,
+)
+from zenml.models import (
+    HookInvocationFilter,
+    PipelineRunFilter,
+    PipelineRunRequest,
+    PipelineSnapshotFilter,
+    ProjectFilter,
+    RunWaitConditionFilter,
+    StepRunFilter,
+    StepRunRequest,
+)
+from zenml.orchestrators.cache_utils import get_cached_step_run
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.schemas import (
+    ArchiveBundleSchema,
+    ArtifactSchema,
+    ArtifactVersionSchema,
+    HookInvocationSchema,
+    PipelineRunSchema,
+    PipelineSchema,
+    PipelineSnapshotSchema,
+    RunMetadataResourceSchema,
+    RunMetadataSchema,
+    RunWaitConditionSchema,
+    StepConfigurationSchema,
+    StepRunInputArtifactSchema,
+    StepRunOutputArtifactSchema,
+    StepRunParentsSchema,
+    StepRunSchema,
+)
+from zenml.zen_stores.sql_zen_store import (
+    Session,
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+
+@dataclass(frozen=True)
+class ExecutionTree:
+    """IDs for a producer, consumer, and their retained artifact links."""
+
+    project: UUID
+    run: UUID
+    snapshot: UUID
+    producer: UUID
+    consumer: UUID
+    input_artifact: UUID
+    output_artifact: UUID
+
+
+@pytest.fixture
+def sql_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[SqlZenStore]:
+    """Create a SQLite store without redirecting the editable install.
+
+    Args:
+        tmp_path: Isolated test directory.
+        monkeypatch: Environment isolation fixture.
+
+    Yields:
+        A fresh migrated store.
+    """
+    directory = tmp_path / "config"
+    directory.mkdir()
+    monkeypatch.setenv("ZENML_CONFIG_PATH", str(directory))
+    store = SqlZenStore(
+        config=SqlZenStoreConfiguration(url=f"sqlite:///{directory / 'db'}"),
+        skip_default_registrations=False,
+    )
+    yield store
+    store.engine.dispose()
+
+
+def create_tree(
+    store: SqlZenStore,
+    layout: Literal["static", "dynamic", "legacy"] = "static",
+) -> ExecutionTree:
+    """Create valid hot definitions and a realized two-step graph.
+
+    Args:
+        store: Isolated SQL store.
+        layout: Definition ownership to exercise.
+
+    Returns:
+        The execution and artifact identifiers.
+    """
+    project = store.list_projects(ProjectFilter()).items[0].id
+    configuration = PipelineConfiguration(
+        name="retention", substitutions={"project_label": "retained"}
+    )
+    producer_config = StepConfiguration(
+        name="producer", step_type=StepType.TOOL_CALL
+    )
+    consumer_config = StepConfiguration(
+        name="consumer",
+        step_type=StepType.LLM_CALL,
+        substitutions={"step_label": "kept"},
+    )
+    producer = Step(
+        spec=StepSpec(
+            source="tests.producer",
+            upstream_steps=[],
+            invocation_id="producer",
+        ),
+        config=producer_config,
+        step_config_overrides=producer_config,
+    )
+    consumer = Step(
+        spec=StepSpec(
+            source="tests.consumer",
+            upstream_steps=["producer"],
+            invocation_id="consumer",
+            inputs={
+                "item": InputSpec(step_name="producer", output_name="out")
+            },
+        ),
+        config=consumer_config,
+        step_config_overrides=consumer_config,
+    )
+    now = utc_now()
+    pipeline = PipelineSchema(
+        project_id=project, name=f"pipeline-{uuid4()}", run_count=1
+    )
+    snapshot = PipelineSnapshotSchema(
+        project_id=project,
+        pipeline_id=pipeline.id,
+        pipeline_configuration=configuration.model_dump_json(),
+        pipeline_spec=PipelineSpec(
+            steps=[producer.spec, consumer.spec]
+        ).model_dump_json(),
+        client_environment='{"python": "3.11"}',
+        run_name_template="history",
+        client_version="0.96.3",
+        server_version="0.96.3",
+        step_count=2,
+        is_dynamic=layout == "dynamic",
+    )
+    run = PipelineRunSchema(
+        project_id=project,
+        pipeline_id=pipeline.id,
+        snapshot_id=None if layout == "legacy" else snapshot.id,
+        name=f"run-{uuid4()}",
+        index=1,
+        status=ExecutionStatus.COMPLETED.value,
+        in_progress=False,
+        enable_heartbeat=False,
+        start_time=now,
+        end_time=now,
+        orchestrator_environment='{"orchestrator": "local"}',
+        pipeline_configuration=configuration.model_dump_json()
+        if layout == "legacy"
+        else None,
+        client_environment='{"python": "3.11"}'
+        if layout == "legacy"
+        else None,
+    )
+    steps = [
+        StepRunSchema(
+            project_id=project,
+            pipeline_run_id=run.id,
+            snapshot_id=None if layout == "legacy" else snapshot.id,
+            name=definition.config.name,
+            status=ExecutionStatus.COMPLETED.value,
+            version=1,
+            is_retriable=False,
+            start_time=now,
+            end_time=now,
+            source_code=f"def {definition.config.name}(): return 7",
+            docstring=f"Documentation for {definition.config.name}.",
+            code_hash="code-hash",
+            cache_key=f"cache-{run.id}-{definition.config.name}",
+            step_configuration=definition.model_dump_json()
+            if layout == "legacy"
+            else None,
+        )
+        for definition in (producer, consumer)
+    ]
+    artifact = ArtifactSchema(
+        project_id=project, name=f"artifact-{uuid4()}", has_custom_name=False
+    )
+    versions = [
+        ArtifactVersionSchema(
+            project_id=project,
+            artifact_id=artifact.id,
+            version=str(index),
+            version_number=index,
+            type="DataArtifact",
+            uri=f"s3://retained/{index}",
+            save_type="step_output",
+            materializer=Source.from_import_path(
+                "zenml.materializers.BuiltInMaterializer"
+            ).model_dump_json(),
+            data_type=Source.from_import_path(
+                "builtins.int"
+            ).model_dump_json(),
+        )
+        for index in (1, 2)
+    ]
+    with Session(store.engine) as session:
+        session.add_all([pipeline, snapshot, run, artifact, *steps, *versions])
+        session.flush()
+        if layout != "legacy":
+            session.add_all(
+                [
+                    StepConfigurationSchema(
+                        index=index,
+                        name=definition.config.name,
+                        config=definition.model_dump_json(),
+                        snapshot_id=snapshot.id
+                        if layout == "static"
+                        else None,
+                        step_run_id=step.id if layout == "dynamic" else None,
+                    )
+                    for index, (step, definition) in enumerate(
+                        zip(steps, (producer, consumer))
+                    )
+                ]
+            )
+        metadata = RunMetadataSchema(
+            project_id=project,
+            key="score",
+            value="7",
+            type="int",
+            publisher_step_id=steps[1].id,
+        )
+        session.add(metadata)
+        session.flush()
+        session.add_all(
+            [
+                StepRunParentsSchema(
+                    parent_id=steps[0].id, child_id=steps[1].id
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=steps[0].id, artifact_id=versions[0].id, name="out"
+                ),
+                StepRunInputArtifactSchema(
+                    step_id=steps[1].id,
+                    artifact_id=versions[0].id,
+                    name="item",
+                    type=StepRunInputArtifactType.STEP_OUTPUT.value,
+                    input_index=0,
+                    chunk_index=1,
+                    chunk_size=2,
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=steps[1].id,
+                    artifact_id=versions[1].id,
+                    name="result",
+                ),
+                RunMetadataResourceSchema(
+                    resource_id=steps[1].id,
+                    resource_type="step_run",
+                    run_metadata_id=metadata.id,
+                ),
+                RunMetadataResourceSchema(
+                    resource_id=run.id,
+                    resource_type="pipeline_run",
+                    run_metadata_id=metadata.id,
+                ),
+            ]
+        )
+        result = ExecutionTree(
+            project,
+            run.id,
+            snapshot.id,
+            steps[0].id,
+            steps[1].id,
+            versions[0].id,
+            versions[1].id,
+        )
+        session.commit()
+    return result
+
+
+def archive_tree(
+    store: SqlZenStore,
+    tree: ExecutionTree,
+    marker: Literal["both", "timestamp", "bundle"] = "both",
+) -> UUID:
+    """Set synthetic archived rows after capturing their real projections.
+
+    This is reader coverage, not compactor acceptance: no object is exported.
+
+    Args:
+        store: Isolated SQL store.
+        tree: Execution to mark.
+        marker: Also test incomplete marker pairs fail closed before decoding.
+
+    Returns:
+        The synthetic catalog identifier.
+    """
+    with Session(store.engine) as session:
+        bundle = ArchiveBundleSchema(
+            project_id=tree.project,
+            root_run_id=tree.run,
+            uri="s3://archive/reader-fixture",
+            size_bytes=1,
+            row_counts="{}",
+            manifest_hash="sha256:reader-fixture",
+            format_version=1,
+            schema_revision="7a1c3d9e2b4f",
+            status=ArchiveBundleStatus.COMPLETE.value,
+        )
+        session.add(bundle)
+        rows: list[
+            StepRunSchema | PipelineRunSchema | PipelineSnapshotSchema
+        ] = []
+        for step_id in (tree.producer, tree.consumer):
+            step = session.get(StepRunSchema, step_id)
+            assert step is not None
+            config = step.get_step_configuration().config
+            step.step_type = (
+                config.step_type.value if config.step_type else None
+            )
+            step.substitutions = json.dumps(config.substitutions)
+            step.step_configuration = "{}"
+            step.exception_info = "{}"
+            rows.append(step)
+        snapshot = session.get(PipelineSnapshotSchema, tree.snapshot)
+        run = session.get(PipelineRunSchema, tree.run)
+        assert snapshot is not None and run is not None
+        snapshot.pipeline_configuration = "{}"
+        snapshot.client_environment = "{}"
+        snapshot.pipeline_spec = "{}"
+        snapshot.source_code = None
+        snapshot.description = None
+        run.pipeline_configuration = "{}"
+        run.client_environment = "{}"
+        run.orchestrator_environment = "{}"
+        run.exception_info = "{}"
+        rows.extend([snapshot, run])
+        for row in rows:
+            row.archived_at = utc_now() if marker != "bundle" else None
+            row.archive_bundle_id = (
+                bundle.id if marker != "timestamp" else None
+            )
+        for config_row in session.exec(select(StepConfigurationSchema)).all():
+            if (
+                config_row.snapshot_id == tree.snapshot
+                or config_row.step_run_id in (tree.producer, tree.consumer)
+            ):
+                config_row.config = "{}"
+        bundle_id = bundle.id
+        session.commit()
+    return bundle_id
+
+
+@pytest.mark.parametrize("hydrate", [False, True])
+def test_archived_step_lists_preserve_real_body_and_resources(
+    sql_store: SqlZenStore, hydrate: bool
+) -> None:
+    """Hydrated and unhydrated lists survive cleared detail.
+
+    Args:
+        sql_store: Isolated SQL store.
+        hydrate: Whether metadata is requested.
+    """
+    tree = create_tree(sql_store)
+    before = sql_store.get_run_step(tree.consumer)
+    bundle = archive_tree(sql_store, tree)
+    page = sql_store.list_run_steps(
+        StepRunFilter(pipeline_run_id=tree.run), hydrate=hydrate
+    )
+    assert page.total == 2
+    result = next(step for step in page.items if step.id == tree.consumer)
+    assert result.body is not None
+    assert result.type == before.type == StepType.LLM_CALL
+    assert result.substitutions == before.substitutions
+    assert result.archive_bundle_id == bundle
+    assert result.inputs["item"][0].id == tree.input_artifact
+    assert result.outputs["result"][0].id == tree.output_artifact
+    if hydrate:
+        assert result.metadata is not None
+        assert result.metadata.config is None and result.metadata.spec is None
+        assert result.metadata.exception_info is None
+        assert result.source_code == before.source_code
+        assert result.docstring == before.docstring
+        assert result.cache_key == before.cache_key
+        assert result.original_step_run_id is None
+    else:
+        assert result.metadata is None
+
+
+@pytest.mark.parametrize("layout", ["static", "dynamic", "legacy"])
+@pytest.mark.parametrize("marker", ["both", "timestamp", "bundle"])
+def test_archived_details_do_not_decode_any_configuration(
+    sql_store: SqlZenStore,
+    layout: Literal["static", "dynamic", "legacy"],
+    marker: Literal["both", "timestamp", "bundle"],
+) -> None:
+    """Either marker protects current and legacy cleared JSON paths.
+
+    Args:
+        sql_store: Isolated SQL store.
+        layout: Definition ownership to exercise.
+        marker: Stored marker shape.
+    """
+    tree = create_tree(sql_store, layout)
+    archive_tree(sql_store, tree, marker)
+    run = sql_store.get_run(tree.run)
+    step = sql_store.get_run_step(tree.consumer)
+    snapshot = sql_store.get_snapshot(tree.snapshot)
+    assert run.metadata is not None and run.metadata.config is None
+    assert run.metadata.client_environment is None
+    assert run.metadata.orchestrator_environment is None
+    assert run.metadata.exception_info is None
+    assert run.run_metadata == {"score": 7}
+    assert step.metadata is not None and step.metadata.config is None
+    assert step.metadata.spec is None and step.source_code is not None
+    assert snapshot.metadata is not None
+    assert snapshot.metadata.pipeline_configuration is None
+    assert snapshot.metadata.pipeline_spec is None
+    assert snapshot.metadata.step_configurations is None
+    assert snapshot.metadata.config_template is None
+    assert snapshot.metadata.config_schema is None
+    assert snapshot.runnable is False and snapshot.deployable is False
+
+
+@pytest.mark.parametrize("layout", ["static", "dynamic", "legacy"])
+def test_archived_dag_uses_real_steps_parents_and_artifacts(
+    sql_store: SqlZenStore,
+    layout: Literal["static", "dynamic", "legacy"],
+) -> None:
+    """The realized DAG remains readable without static or dynamic text.
+
+    Args:
+        sql_store: Isolated SQL store.
+        layout: Ownership of the now-archived configurations.
+    """
+    tree = create_tree(sql_store, layout)
+    archive_tree(sql_store, tree)
+    dag = sql_store.get_pipeline_run_dag(
+        tree.run, include_step_metadata=["score"]
+    )
+    steps = {node.name: node for node in dag.nodes if node.type == "step"}
+    assert set(steps) == {"producer", "consumer"}
+    assert steps["consumer"].id == tree.consumer
+    assert steps["consumer"].metadata["type"] == StepType.LLM_CALL.value
+    assert steps["consumer"].metadata["run_metadata"] == {"score": 7}
+    edges = {(edge.source, edge.target) for edge in dag.edges}
+    assert (steps["producer"].node_id, steps["consumer"].node_id) in edges
+    input_nodes = [
+        node for node in dag.nodes if node.id == tree.input_artifact
+    ]
+    assert len(input_nodes) == 1
+    assert (steps["producer"].node_id, input_nodes[0].node_id) in edges
+    assert (input_nodes[0].node_id, steps["consumer"].node_id) in edges
+
+
+def test_missing_archived_projection_is_not_fabricated(
+    sql_store: SqlZenStore,
+) -> None:
+    """Missing projected values remain unknown rather than invented defaults.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    tree = create_tree(sql_store)
+    archive_tree(sql_store, tree)
+    with Session(sql_store.engine) as session:
+        step = session.get(StepRunSchema, tree.consumer)
+        assert step is not None
+        step.step_type = None
+        step.substitutions = None
+        session.commit()
+    response = sql_store.get_run_step(tree.consumer, hydrate=False)
+    assert response.type is None
+    assert response.body is not None and response.body.substitutions is None
+    with pytest.raises(ValueError, match="(?i)restore"):
+        _ = response.substitutions
+
+
+@pytest.mark.parametrize(
+    "alternate_status", [ExecutionStatus.COMPLETED, ExecutionStatus.RETRIED]
+)
+def test_archived_dag_disambiguates_parents_and_omits_retried_steps(
+    sql_store: SqlZenStore,
+    alternate_status: ExecutionStatus,
+) -> None:
+    """Shared output IDs do not invent an edge to one arbitrary producer.
+
+    Args:
+        sql_store: Isolated SQL store.
+        alternate_status: Whether the second producer remains part of the DAG.
+    """
+    tree = create_tree(sql_store)
+    bundle = archive_tree(sql_store, tree)
+    with Session(sql_store.engine) as session:
+        alternate = StepRunSchema(
+            project_id=tree.project,
+            pipeline_run_id=tree.run,
+            snapshot_id=tree.snapshot,
+            name="alternate",
+            version=1,
+            status=alternate_status.value,
+            is_retriable=False,
+            archived_at=utc_now(),
+            archive_bundle_id=bundle,
+            step_configuration="{}",
+            substitutions="{}",
+        )
+        session.add(alternate)
+        session.flush()
+        session.add_all(
+            [
+                StepRunParentsSchema(
+                    parent_id=alternate.id, child_id=tree.consumer
+                ),
+                StepRunOutputArtifactSchema(
+                    step_id=alternate.id,
+                    artifact_id=tree.input_artifact,
+                    name="other_alias",
+                ),
+            ]
+        )
+        session.commit()
+    dag = sql_store.get_pipeline_run_dag(tree.run)
+    steps = {node.name: node for node in dag.nodes if node.type == "step"}
+    inputs = [
+        edge
+        for edge in dag.edges
+        if edge.target == steps["consumer"].node_id
+        and edge.metadata.get("input_name") == "item"
+    ]
+    assert len(inputs) == 1
+    nodes = [node for node in dag.nodes if node.id == tree.input_artifact]
+    edges = {(edge.source, edge.target) for edge in dag.edges}
+    if alternate_status == ExecutionStatus.RETRIED:
+        assert "alternate" not in steps
+        assert len(nodes) == 1
+        assert (steps["producer"].node_id, inputs[0].source) in edges
+    else:
+        assert len(nodes) == 3
+        assert (steps["producer"].node_id, inputs[0].source) not in edges
+        assert (steps["alternate"].node_id, inputs[0].source) not in edges
+        assert (steps["alternate"].node_id, steps["consumer"].node_id) in edges
+        assert (steps["producer"].node_id, steps["consumer"].node_id) in edges
+
+
+def test_archived_dag_keeps_wait_child_and_trigger_context(
+    sql_store: SqlZenStore,
+) -> None:
+    """Retained context survives while the archived wait question disappears.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    tree = create_tree(sql_store)
+    child = create_tree(sql_store)
+    triggered = create_tree(sql_store)
+    with Session(sql_store.engine) as session:
+        child_run = session.get(PipelineRunSchema, child.run)
+        triggered_run = session.get(PipelineRunSchema, triggered.run)
+        assert child_run is not None and triggered_run is not None
+        child_run.parent_run_id = tree.run
+        child_run.root_run_id = tree.run
+        triggered_run.triggered_by = tree.consumer
+        triggered_run.triggered_by_type = "step_run"
+        wait = RunWaitConditionSchema(
+            run_id=tree.run,
+            project_id=tree.project,
+            name="approval",
+            type="external_input",
+            status="resolved",
+            resolution="continue",
+            question="Historical question",
+            resolved_at=utc_now(),
+        )
+        session.add(wait)
+        session.flush()
+        wait_id = wait.id
+        session.commit()
+    before = sql_store.get_pipeline_run_dag(tree.run)
+    before_nodes = {
+        node.id: node for node in before.nodes if node.id is not None
+    }
+    assert before_nodes[wait_id].metadata["question"] == "Historical question"
+    archive_tree(sql_store, tree)
+    after = sql_store.get_pipeline_run_dag(tree.run)
+    after_nodes = {
+        node.id: node for node in after.nodes if node.id is not None
+    }
+    for run_id in (child.run, triggered.run):
+        assert (
+            after_nodes[run_id].model_dump()
+            == before_nodes[run_id].model_dump()
+        )
+    expected_wait = before_nodes[wait_id].metadata.copy()
+    expected_wait.pop("question")
+    assert after_nodes[wait_id].metadata == expected_wait
+    assert (
+        after_nodes[tree.consumer].node_id,
+        after_nodes[triggered.run].node_id,
+    ) in {(edge.source, edge.target) for edge in after.edges}
+
+
+def test_related_snapshot_marker_protects_unmarked_run_and_steps(
+    sql_store: SqlZenStore,
+) -> None:
+    """Related archived configurations are never parsed through a hot marker.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    tree = create_tree(sql_store)
+    archive_tree(sql_store, tree)
+    with Session(sql_store.engine) as session:
+        run = session.get(PipelineRunSchema, tree.run)
+        assert run is not None
+        run.archived_at = None
+        run.archive_bundle_id = None
+        for step_id in (tree.producer, tree.consumer):
+            step = session.get(StepRunSchema, step_id)
+            assert step is not None
+            step.archived_at = None
+            step.archive_bundle_id = None
+        session.commit()
+    run_response = sql_store.get_run(tree.run)
+    step_response = sql_store.get_run_step(tree.consumer)
+    assert (
+        run_response.metadata is not None
+        and run_response.metadata.config is None
+    )
+    assert (
+        step_response.metadata is not None
+        and step_response.metadata.config is None
+    )
+    assert step_response.type == StepType.LLM_CALL
+    assert {
+        node.id for node in sql_store.get_pipeline_run_dag(tree.run).nodes
+    } >= {
+        tree.producer,
+        tree.consumer,
+    }
+
+
+@pytest.mark.parametrize("marker", ["timestamp", "bundle"])
+def test_wait_and_hook_readers_omit_only_archived_detail(
+    sql_store: SqlZenStore,
+    marker: Literal["timestamp", "bundle"],
+) -> None:
+    """Public child-resource reads guard malformed archived JSON.
+
+    Args:
+        sql_store: Isolated SQL store.
+        marker: Either owning-run marker must protect the detail.
+    """
+    tree = create_tree(sql_store)
+    now = utc_now()
+    with Session(sql_store.engine) as session:
+        wait = RunWaitConditionSchema(
+            run_id=tree.run,
+            project_id=tree.project,
+            name="approval",
+            type="external_input",
+            status="resolved",
+            resolution="continue",
+            question="Historical question",
+            data_schema_json='{"type":"integer"}',
+            result_json="7",
+            resolved_at=now,
+            last_polled_at=now,
+            poller_instance_id="old-poller",
+            poller_lease_expires_at=now,
+        )
+        hook = HookInvocationSchema(
+            project_id=tree.project,
+            pipeline_run_id=tree.run,
+            step_run_id=tree.consumer,
+            hook_type="custom",
+            name="retained-hook",
+            status=ExecutionStatus.COMPLETED.value,
+            start_time=now,
+            end_time=now,
+            source="tests.retained_hook",
+            exception_info='{"traceback":"history"}',
+        )
+        session.add_all([wait, hook])
+        session.flush()
+        wait_id, hook_id = wait.id, hook.id
+        session.commit()
+    hot_wait = sql_store.get_run_wait_condition(wait_id)
+    hot_hook = sql_store.get_hook_invocation(hook_id)
+    assert hot_wait.question == "Historical question"
+    assert hot_wait.data_schema == {"type": "integer"} and hot_wait.result == 7
+    assert hot_wait.poller_instance_id == "old-poller"
+    assert hot_hook.exception_info is not None
+    assert hot_hook.exception_info.traceback == "history"
+    archive_tree(sql_store, tree, marker)
+    with Session(sql_store.engine) as session:
+        wait_row = session.get(RunWaitConditionSchema, wait_id)
+        hook_row = session.get(HookInvocationSchema, hook_id)
+        assert wait_row is not None and hook_row is not None
+        wait_row.data_schema_json = "{unrestored"
+        wait_row.result_json = "{unrestored"
+        hook_row.exception_info = "{unrestored"
+        session.commit()
+    waits = [
+        sql_store.get_run_wait_condition(wait_id),
+        *sql_store.list_run_wait_conditions(
+            RunWaitConditionFilter(pipeline_run=tree.run), hydrate=True
+        ).items,
+    ]
+    hooks = [
+        sql_store.get_hook_invocation(hook_id),
+        *sql_store.list_hook_invocations(
+            HookInvocationFilter(pipeline_run_id=tree.run), hydrate=True
+        ).items,
+    ]
+    assert len(waits) == len(hooks) == 2
+    for response in waits:
+        assert (
+            response.id == wait_id
+            and response.resolution == hot_wait.resolution
+        )
+        assert (
+            response.status == hot_wait.status and response.resolved_at == now
+        )
+        assert response.question is None and response.data_schema is None
+        assert response.result is None and response.poller_instance_id is None
+        assert (
+            response.last_polled_at is None
+            and response.poller_lease_expires_at is None
+        )
+    for invocation in hooks:
+        assert (
+            invocation.id == hook_id and invocation.status == hot_hook.status
+        )
+        assert invocation.source == hot_hook.source == "tests.retained_hook"
+        assert invocation.exception_info is None
+
+
+def test_new_run_from_archived_snapshot_requires_restore(
+    sql_store: SqlZenStore,
+) -> None:
+    """Execution refuses archived snapshots before parsing poisoned text.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    tree = create_tree(sql_store)
+    archive_tree(sql_store, tree)
+    with pytest.raises(ValueError, match="zenml pipeline runs restore"):
+        sql_store.get_or_create_run(
+            PipelineRunRequest(
+                project=tree.project,
+                snapshot=tree.snapshot,
+                name="refused",
+                status=ExecutionStatus.INITIALIZING,
+            )
+        )
+    assert sql_store.list_runs(PipelineRunFilter(name="refused")).total == 0
+
+
+@pytest.mark.parametrize("archived", [False, True])
+@pytest.mark.parametrize(
+    "status", [ExecutionStatus.CACHED, ExecutionStatus.SKIPPED]
+)
+def test_cached_and_skipped_creation_copy_hot_and_archived_history(
+    sql_store: SqlZenStore,
+    monkeypatch: pytest.MonkeyPatch,
+    archived: bool,
+    status: ExecutionStatus,
+) -> None:
+    """The cached/skipped copy contract retains inputs, outputs and metadata.
+
+    This covers store-level copying, not the public pipeline replay operation,
+    which requires restored execution configuration.
+
+    Args:
+        sql_store: Isolated SQL store.
+        monkeypatch: Bind the real Client API to the isolated SQL store.
+        archived: Whether the selected original has archived detail.
+        status: Cache or replay creation status.
+    """
+    original = create_tree(sql_store)
+    before = sql_store.get_run_step(original.consumer)
+    destination = create_tree(sql_store, "dynamic")
+    if archived:
+        archive_tree(sql_store, original)
+    project = sql_store.get_project(original.project)
+    monkeypatch.setattr(Client, "zen_store", property(lambda self: sql_store))
+    monkeypatch.setattr(
+        Client, "active_project", property(lambda self: project)
+    )
+    assert before.cache_key is not None
+    selected = get_cached_step_run(before.cache_key)
+    assert selected is not None and selected.id == original.consumer
+    assert selected.source_code == before.source_code
+    assert selected.docstring == before.docstring
+    reused_config = StepConfiguration(name="reused")
+    result = sql_store.create_run_step(
+        StepRunRequest(
+            project=original.project,
+            name="reused",
+            pipeline_run_id=destination.run,
+            original_step_run_id=selected.id,
+            status=status,
+            start_time=utc_now(),
+            end_time=utc_now(),
+            source_code=selected.source_code,
+            docstring=selected.docstring,
+            code_hash=selected.code_hash,
+            cache_key=selected.cache_key,
+            cache_expires_at=selected.cache_expires_at,
+            inputs={
+                "item": [artifact.id for artifact in selected.inputs["item"]]
+            },
+            outputs={
+                "result": [
+                    artifact.id for artifact in selected.outputs["result"]
+                ]
+            },
+            dynamic_config=Step(
+                spec=StepSpec(
+                    source="tests.reused",
+                    upstream_steps=[],
+                    invocation_id="reused",
+                ),
+                config=reused_config,
+                step_config_overrides=reused_config,
+            ),
+        )
+    )
+    assert result.status == status
+    assert result.original_step_run_id == original.consumer
+    assert (
+        result.source_code == before.source_code
+        and result.docstring == before.docstring
+    )
+    assert result.outputs["result"][0].id == original.output_artifact
+    assert result.inputs["item"][0].id == original.input_artifact
+    assert result.inputs["item"][0].chunk_index == 1
+    assert result.inputs["item"][0].chunk_size == 2
+    assert result.run_metadata == {"score": 7}
+
+
+def test_mixed_history_lists_keep_hot_detail_and_archived_metadata(
+    sql_store: SqlZenStore,
+) -> None:
+    """Lists include both histories and only real retained metadata.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    hot = create_tree(sql_store)
+    cold = create_tree(sql_store)
+    archive_tree(sql_store, cold)
+    runs = {
+        run.id: run
+        for run in sql_store.list_runs(PipelineRunFilter(), hydrate=True).items
+    }
+    hot_metadata = runs[hot.run].metadata
+    cold_metadata = runs[cold.run].metadata
+    assert hot_metadata is not None and hot_metadata.config is not None
+    assert cold_metadata is not None and cold_metadata.config is None
+    assert runs[cold.run].run_metadata == {"score": 7}
+    snapshots = sql_store.list_snapshots(
+        PipelineSnapshotFilter(), hydrate=True
+    )
+    assert {snapshot.id for snapshot in snapshots.items} == {
+        hot.snapshot,
+        cold.snapshot,
+    }


### PR DESCRIPTION
## Describe changes

Stacked on #5256; the base is `feature/execution-retention-markers` and should become `develop` after that PR merges.

Archived execution identities remain readable after their configuration text is cleared. Step responses use retained type/substitutions, run and snapshot responses omit archived detail, and cached/skipped step creation retains outputs, metadata, source code and docstrings. Hot configuration merging and cache selection remain unchanged.

Archived DAGs use recorded steps, parent edges and artifact links; configuration-only placeholders are unavailable, and ambiguous artifact producers are not guessed. Snapshot execution is refused before preparation when the snapshot is archived. Wait-condition and hook readers also guard the detail covered by the archive map.

The step schema centralizes its configuration archive check and uses named type/substitution projection helpers. This PR contains source and tests only; internal investigation documents are maintained separately.

## Compatibility and boundaries

Response configuration/spec/environment fields become nullable for archived rows. Python convenience accessors retain their existing return types and give restore guidance when detail is unavailable; serialized metadata contains null. Legacy step snapshot IDs can be null, matching SQL. Older clients that require these fields need compatibility validation before archival is enabled.

Public pipeline replay still needs the original configuration restored. Cached/skipped-step inheritance is preserved; the tests do not claim unrestricted replay of an archived pipeline. Dashboard archived-state behavior remains unverified.

No production path writes archive markers, retires rows, or reads an archive object. Archive and restore delivery must ship together before real rows can be archived; the restore command named by refusal messages belongs to that later delivery.

## Validation

With this worktree explicitly on PYTHONPATH:
- `pytest tests/unit/zen_stores/test_execution_archive_readers.py tests/unit/zen_stores/test_execution_archive_markers.py tests/unit/zen_server/test_pipeline_execution_utils.py -q`: **46 passed in 24.86s**.
- Changed-file format script, Ruff, isolated F401/F841, pydoclint and mypy: passed.
- Scenarios cover current/dynamic/legacy data, either marker, related-owner markers, missing projections, artifact alias ambiguity, retries, wait/child/trigger context, hot/cold cache inheritance and snapshot refusal.

Markers and cleared text in these tests are synthetic reader fixtures, not archive/restore acceptance. CI has not been established for this draft yet.

## Pre-requisites
- [x] Read CONTRIBUTING.md.
- [x] Added behavior tests.
- [x] Stacked on the develop-based prerequisite #5256.
- [ ] Coordinate archived display and nullable fields with dashboard/client consumers.

## Types of changes
- [x] New feature (reader preparation).
- [x] Breaking response optionality for archived data; activation remains gated.
