### PR TITLE
Preview execution retention eligibility and storage inventory

### DIFF
--- a/src/zenml/cli/project.py
+++ b/src/zenml/cli/project.py
@@ -36,6 +36,31 @@ def project() -> None:
     """Commands for project management."""
 
 
+@project.group("retention")
+def retention() -> None:
+    """Preview execution retention; archiving is not available yet."""
+
+
+@retention.command("dry-run")
+@click.option(
+    "--project", "project_name", default=None, help="Project name or ID."
+)
+@click.option("--archive-after-days", type=click.IntRange(min=7), default=None)
+def retention_dry_run(
+    project_name: Optional[str], archive_after_days: Optional[int]
+) -> None:
+    """Report a bounded inventory without changing any data or settings.
+
+    Args:
+        project_name: Project to inspect, or the active project.
+        archive_after_days: What-if age; unconfigured projects use 90 days.
+    """
+    result = Client().retention_dry_run(
+        project=project_name, archive_after_days=archive_after_days
+    )
+    cli_utils.declare(result.model_dump_json(indent=2))
+
+
 @project.command("list")
 @list_options(
     ProjectFilter, default_columns=["active", "id", "name", "description"]

--- a/src/zenml/client.py
+++ b/src/zenml/client.py
@@ -230,6 +230,11 @@ from zenml.models.v2.base.filter import (
     StringFilterOption,
     UUIDFilterOption,
 )
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+    RetentionSettings,
+)
 from zenml.utils import dict_utils, io_utils, source_utils, tag_utils
 from zenml.utils.dict_utils import dict_to_bytes
 from zenml.utils.filesync_model import FileSyncModel
@@ -1121,6 +1126,7 @@ class Client(metaclass=ClientMetaClass):
         new_display_name: Optional[str] = None,
         new_description: Optional[str] = None,
         project_metadata: Optional[Dict[str, Any]] = None,
+        retention: Optional[RetentionSettings] = None,
     ) -> ProjectResponse:
         """Update a project.
 
@@ -1130,6 +1136,7 @@ class Client(metaclass=ClientMetaClass):
             new_display_name: New display name of the project.
             new_description: New description of the project.
             project_metadata: New metadata for the project.
+            retention: Replacement retention settings; does not start archiving.
 
         Returns:
             The updated project.
@@ -1145,10 +1152,30 @@ class Client(metaclass=ClientMetaClass):
             project_update.description = new_description
         if project_metadata is not None:
             project_update.project_metadata = project_metadata
+        if retention is not None:
+            project_update.retention = retention
         return self.zen_store.update_project(
             project_id=project.id,
             project_update=project_update,
         )
+
+    def retention_dry_run(
+        self,
+        project: Optional[Union[UUID, str]] = None,
+        **overrides: Any,
+    ) -> RetentionDryRunResponse:
+        """Preview bounded retention without saving settings or changing data.
+
+        Args:
+            project: Project name/ID/prefix, or the active project.
+            **overrides: Age, model-link policy or max_trees/max_rows/max_bytes.
+
+        Returns:
+            Logical stored-byte estimates and exclusion reasons.
+        """
+        request = RetentionDryRunRequest.model_validate(overrides)
+        selected = self.get_project(project)
+        return self.zen_store.retention_dry_run(selected.id, request)
 
     def delete_project(self, name_id_or_prefix: str) -> None:
         """Delete a project.

--- a/src/zenml/models/__init__.py
+++ b/src/zenml/models/__init__.py
@@ -464,6 +464,13 @@ from zenml.models.v2.misc.param_groups import (
     StepRunIdentifier,
 )
 from zenml.models.v2.misc.pipeline_run_dag import PipelineRunDAG
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+    RetentionLimits,
+    RetentionSettings,
+    RetentionTableEstimate,
+)
 from zenml.models.v2.misc.run_metadata import (
     RunMetadataEntry,
     RunMetadataResource,
@@ -651,8 +658,12 @@ WebhookResponseMetadata.model_rebuild()
 WebhookResponseResources.model_rebuild()
 WebhookResponse.model_rebuild()
 
-
 __all__ = [
+    "RetentionDryRunRequest",
+    "RetentionDryRunResponse",
+    "RetentionLimits",
+    "RetentionSettings",
+    "RetentionTableEstimate",
     # V2 Base
     "BaseRequest",
     "BaseResponse",

--- a/src/zenml/models/v2/core/project.py
+++ b/src/zenml/models/v2/core/project.py
@@ -28,6 +28,7 @@ from zenml.models.v2.base.base import (
     BaseUpdate,
 )
 from zenml.models.v2.base.filter import BaseFilter, StringFilterOption
+from zenml.models.v2.misc.retention import RetentionSettings
 from zenml.utils.pydantic_utils import before_validator_handler
 
 # ------------------ Request Model ------------------
@@ -98,6 +99,8 @@ class ProjectRequest(BaseRequest):
 class ProjectUpdate(BaseUpdate):
     """Update model for projects."""
 
+    retention: Optional[RetentionSettings] = None
+
     name: Optional[str] = Field(
         title="The unique name of the project. The project name must only "
         "contain only lowercase letters, numbers, underscores, and hyphens and "
@@ -137,6 +140,8 @@ class ProjectResponseBody(BaseDatedResponseBody):
 
 class ProjectResponseMetadata(BaseResponseMetadata):
     """Response metadata for projects."""
+
+    retention: RetentionSettings = Field(default_factory=RetentionSettings)
 
     description: str = Field(
         default="",
@@ -205,6 +210,15 @@ class ProjectResponse(
             the value of the property.
         """
         return self.get_metadata().project_metadata
+
+    @property
+    def retention(self) -> RetentionSettings:
+        """Get the saved retention policy, disabled on unconfigured projects.
+
+        Returns:
+            The project's retention settings.
+        """
+        return self.get_metadata().retention
 
 
 # ------------------ Filter Model ------------------

--- a/src/zenml/models/v2/misc/retention.py
+++ b/src/zenml/models/v2/misc/retention.py
@@ -1,0 +1,57 @@
+# Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Project retention settings and bounded, non-destructive inventory models."""
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RetentionLimits(BaseModel):
+    """Proposed per-invocation bounds, including excluded roots examined."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_trees: int = Field(default=200, gt=0)
+    max_rows: int = Field(default=500_000, gt=0)
+    max_bytes: int = Field(default=512 * 1024 * 1024, gt=0)
+
+
+class RetentionSettings(RetentionLimits):
+    """Saved policy; a null age disables retention, regardless of limits."""
+
+    archive_after_days: Optional[int] = Field(default=None, ge=7)
+    archive_model_linked_runs: bool = False
+    restored_grace_days: int = Field(default=30, ge=0)
+
+
+class RetentionDryRunRequest(BaseModel):
+    """Optional what-if overrides; omitted values use saved project settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    archive_after_days: Optional[int] = Field(default=None, ge=7)
+    archive_model_linked_runs: Optional[bool] = None
+    max_trees: Optional[int] = Field(default=None, gt=0)
+    max_rows: Optional[int] = Field(default=None, gt=0)
+    max_bytes: Optional[int] = Field(default=None, gt=0)
+
+
+class RetentionTableEstimate(BaseModel):
+    """Covered rows and stored payload bytes; identity rows remain in SQL."""
+
+    rows: int = 0
+    rows_deleted: int = 0
+    estimated_bytes: int = 0
+
+
+class RetentionDryRunResponse(BaseModel):
+    """Inventory for the examined batch, never a claim to project-wide totals."""
+
+    eligible_tree_count: int
+    examined_tree_count: int
+    truncated: bool
+    tables: Dict[str, RetentionTableEstimate]
+    exclusions: Dict[str, int]
+    retained_details: Dict[str, int]
+    effective_policy: RetentionSettings
+    message: str = "estimates are logical bytes; no data was changed"

--- a/src/zenml/zen_server/routers/projects_endpoints.py
+++ b/src/zenml/zen_server/routers/projects_endpoints.py
@@ -16,7 +16,7 @@
 from typing import Union
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Security
+from fastapi import APIRouter, Body, Depends, Security
 
 from zenml.constants import (
     API,
@@ -35,6 +35,10 @@ from zenml.models import (
     ProjectStatistics,
     ProjectUpdate,
 )
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+)
 from zenml.zen_server.auth import AuthContext, authorize
 from zenml.zen_server.exceptions import error_response
 from zenml.zen_server.feature_gate.endpoint_utils import (
@@ -47,9 +51,10 @@ from zenml.zen_server.rbac.endpoint_utils import (
     verify_permissions_and_list_entities,
     verify_permissions_and_update_entity,
 )
-from zenml.zen_server.rbac.models import ResourceType
+from zenml.zen_server.rbac.models import Action, ResourceType
 from zenml.zen_server.rbac.utils import (
     get_allowed_resource_ids,
+    verify_permission_for_model,
 )
 from zenml.zen_server.utils import (
     async_fastapi_endpoint_wrapper,
@@ -69,6 +74,29 @@ router = APIRouter(
     tags=["projects"],
     responses={401: error_response},
 )
+
+
+@router.post("/{project_name_or_id}/retention/dry-run")
+def retention_dry_run(
+    project_name_or_id: Union[str, UUID],
+    request: RetentionDryRunRequest = Body(
+        default_factory=RetentionDryRunRequest
+    ),
+    _: AuthContext = Security(authorize),
+) -> RetentionDryRunResponse:
+    """Preview a bounded batch after verifying project update permission.
+
+    Args:
+        project_name_or_id: Project name or ID.
+        request: Non-persistent what-if overrides.
+
+    Returns:
+        Inventory estimates for the examined roots, never project-wide totals.
+    """
+    store = zen_store()
+    project = store.get_project(project_name_or_id, hydrate=False)
+    verify_permission_for_model(model=project, action=Action.UPDATE)
+    return store.retention_dry_run(project.id, request)
 
 
 # TODO: kept for backwards compatibility only; to be removed after the migration

--- a/src/zenml/zen_stores/migrations/versions/8b2d4e6f901a_add_project_retention_settings.py
+++ b/src/zenml/zen_stores/migrations/versions/8b2d4e6f901a_add_project_retention_settings.py
@@ -1,0 +1,31 @@
+"""Add project retention settings [8b2d4e6f901a].
+
+Revision ID: 8b2d4e6f901a
+Revises: 7a1c3d9e2b4f
+Create Date: 2026-09-08 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "8b2d4e6f901a"
+down_revision = "7a1c3d9e2b4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add nullable settings without enabling retention or backfilling rows."""
+    # Appended nullable columns qualify for instant DDL on supported MySQL 8
+    # tables. MySQL 5.7 and unsupported table layouts may rebuild the table.
+    with op.batch_alter_table("project") as batch_op:
+        batch_op.add_column(
+            sa.Column("retention_settings", sa.TEXT(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Remove the retention settings column."""
+    # Rebuilding project on SQLite can cascade-delete its dependent rows.
+    # Native DROP requires SQLite 3.35+; older versions fail without data loss.
+    op.drop_column("project", "retention_settings")

--- a/src/zenml/zen_stores/rest_zen_store.py
+++ b/src/zenml/zen_stores/rest_zen_store.py
@@ -308,6 +308,10 @@ from zenml.models import (
     WebhookSecretResponse,
     WebhookUpdate,
 )
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+)
 from zenml.service_connectors.service_connector_registry import (
     service_connector_registry,
 )
@@ -4081,6 +4085,27 @@ class RestZenStore(BaseZenStore):
             resource=project,
             route=PROJECTS,
             response_model=ProjectResponse,
+        )
+
+    def retention_dry_run(
+        self,
+        project_id: UUID,
+        request: RetentionDryRunRequest,
+    ) -> RetentionDryRunResponse:
+        """Request a non-destructive inventory from the server.
+
+        Args:
+            project_id: Project to inspect.
+            request: What-if policy and limit overrides.
+
+        Returns:
+            Bounded inventory and independent exclusion counts.
+        """
+        return RetentionDryRunResponse.model_validate(
+            self.post(
+                f"{PROJECTS}/{project_id}/retention/dry-run",
+                body=request,
+            )
         )
 
     def get_project(

--- a/src/zenml/zen_stores/retention/__init__.py
+++ b/src/zenml/zen_stores/retention/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Non-destructive execution retention discovery."""

--- a/src/zenml/zen_stores/retention/eligibility.py
+++ b/src/zenml/zen_stores/retention/eligibility.py
@@ -1,0 +1,632 @@
+# Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Bounded tree discovery and stored-byte inventory, with no payload decoding.
+
+The root budget bounds examined roots, including excluded trees. Exclusion
+counts overlap: each matching rule is counted once per examined tree. Row
+and byte budgets cover identity/detail rows inspected for admitted trees;
+an over-budget tree is never partially admitted. SQL lengths measure stored
+bytes, including when a column uses CompressedText, not decoded sizes.
+"""
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Set, Union
+from uuid import UUID
+
+from sqlalchemy import (
+    LargeBinary,
+    Select,
+    bindparam,
+    cast,
+    func,
+    literal,
+    or_,
+    select,
+)
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql.elements import BindParameter
+from sqlmodel import Session, col
+
+from zenml.enums import ExecutionStatus, RunWaitConditionStatus
+from zenml.models.v2.misc.retention import (
+    RetentionLimits,
+    RetentionSettings,
+    RetentionTableEstimate,
+)
+from zenml.utils.time_utils import utc_now
+from zenml.zen_stores.schemas import (
+    ArchiveBundleSchema as Bundle,
+)
+from zenml.zen_stores.schemas import (
+    DeploymentSchema as Deployment,
+)
+from zenml.zen_stores.schemas import (
+    HookInvocationSchema as Hook,
+)
+from zenml.zen_stores.schemas import (
+    ModelVersionPipelineRunSchema as ModelLink,
+)
+from zenml.zen_stores.schemas import (
+    ModelVersionSchema as ModelVersion,
+)
+from zenml.zen_stores.schemas import (
+    PipelineRunSchema as Run,
+)
+from zenml.zen_stores.schemas import (
+    PipelineSnapshotSchema as Snapshot,
+)
+from zenml.zen_stores.schemas import (
+    RunMetadataResourceSchema as MetadataLink,
+)
+from zenml.zen_stores.schemas import (
+    RunMetadataSchema as Metadata,
+)
+from zenml.zen_stores.schemas import (
+    RunTemplateSchema as Template,
+)
+from zenml.zen_stores.schemas import (
+    RunWaitConditionSchema as Wait,
+)
+from zenml.zen_stores.schemas import (
+    StepConfigurationSchema as Configuration,
+)
+from zenml.zen_stores.schemas import (
+    StepRunSchema as Step,
+)
+from zenml.zen_stores.schemas import (
+    TriggerSnapshotSchema as TriggerSnapshot,
+)
+
+
+@dataclass
+class ArchivableTree:
+    """Detached identities and estimates for one examined root."""
+
+    root_run_id: UUID
+    tree_run_ids: List[UUID] = field(default_factory=list)
+    snapshot_ids: List[UUID] = field(default_factory=list)
+    metadata_ids: List[UUID] = field(default_factory=list)
+    exclusions: Set[str] = field(default_factory=set)
+    tables: Dict[str, RetentionTableEstimate] = field(default_factory=dict)
+    retained_details: Counter[str] = field(default_factory=Counter)
+
+
+@dataclass
+class RetentionSelection:
+    """A bounded batch, including rejected candidates and overlapping reasons."""
+
+    candidates: List[ArchivableTree] = field(default_factory=list)
+    exclusions: Counter[str] = field(default_factory=Counter)
+    retained_details: Counter[str] = field(default_factory=Counter)
+    truncated: bool = False
+
+
+def _bounded_ids(values: List[UUID]) -> Union[List[UUID], BindParameter[Any]]:
+    """Expand large UUID sets without exceeding SQLite's bind-variable limit.
+
+    Args:
+        values: Previously bounded, typed identities from SQL.
+
+    Returns:
+        Bound parameters for small sets or SQLAlchemy-escaped typed literals.
+    """
+    if len(values) <= 50:
+        return values
+    return bindparam(None, values, expanding=True, literal_execute=True)
+
+
+def _snapshot_query(
+    members: List[UUID], candidates: List[UUID], project_id: UUID
+) -> Select[Any]:
+    """Select exclusively owned snapshot identities.
+
+    Args:
+        members: Run IDs in the tree, including its root.
+        candidates: Bounded snapshot identities referenced by the tree.
+        project_id: Authorized project.
+
+    Returns:
+        Snapshot identity query; shared/operational snapshots stay hot.
+    """
+    child = aliased(Snapshot, name="child_snapshot")
+    owners = (
+        select(col(Deployment.id)).where(
+            col(Deployment.snapshot_id) == col(Snapshot.id)
+        ),
+        select(col(Template.id)).where(
+            col(Template.source_snapshot_id) == col(Snapshot.id)
+        ),
+        select(col(TriggerSnapshot.trigger_id)).where(
+            col(TriggerSnapshot.snapshot_id) == col(Snapshot.id)
+        ),
+        select(col(child.id)).where(
+            col(child.source_snapshot_id) == col(Snapshot.id)
+        ),
+        select(col(Run.id)).where(
+            col(Run.snapshot_id) == col(Snapshot.id),
+            col(Run.id).not_in(_bounded_ids(members)),
+        ),
+        select(col(Step.id)).where(
+            col(Step.snapshot_id) == col(Snapshot.id),
+            col(Step.pipeline_run_id).not_in(_bounded_ids(members)),
+        ),
+    )
+    return select(col(Snapshot.id)).where(
+        col(Snapshot.project_id) == project_id,
+        col(Snapshot.id).in_(_bounded_ids(candidates)),
+        col(Snapshot.name).is_(None),
+        col(Snapshot.schedule_id).is_(None),
+        col(Snapshot.archived_at).is_(None),
+        col(Snapshot.archive_bundle_id).is_(None),
+        *(~q.exists() for q in owners),
+    )
+
+
+def _metadata_query(
+    members: List[UUID], candidates: List[UUID], project_id: UUID
+) -> Select[Any]:
+    """Select values whose every link belongs to a run in this tree.
+
+    Args:
+        members: Complete tree membership.
+        candidates: Bounded metadata identities linked to tree runs.
+        project_id: Authorized project.
+
+    Returns:
+        Owned metadata IDs; step and other resource links always protect values.
+    """
+    external = select(col(MetadataLink.id)).where(
+        col(MetadataLink.run_metadata_id) == col(Metadata.id),
+        or_(
+            col(MetadataLink.resource_type) != "pipeline_run",
+            col(MetadataLink.resource_id).not_in(_bounded_ids(members)),
+        ),
+    )
+    return select(col(Metadata.id)).where(
+        col(Metadata.project_id) == project_id,
+        col(Metadata.id).in_(_bounded_ids(candidates)),
+        ~external.exists(),
+    )
+
+
+def _rules(
+    session: Session,
+    root_id: UUID,
+    members: List[UUID],
+    project_id: UUID,
+    policy: RetentionSettings,
+    now: datetime,
+) -> Set[str]:
+    """Evaluate independent exclusion rules without decoding configuration.
+
+    Args:
+        session: Read session.
+        root_id: Root identity.
+        members: Complete membership query.
+        project_id: Authorized project.
+        policy: Effective policy.
+        now: One timestamp shared by all checks.
+
+    Returns:
+        Every matching rule, counted independently by the caller.
+    """
+    # Reusing one membership subquery avoids repeating huge identity sets
+    # across every EXISTS projection for unusually large nested trees.
+    membership: Union[List[UUID], Select[Any]] = members
+    if len(members) > 50:
+        membership = (
+            select(col(Run.id))
+            .where(
+                or_(col(Run.id) == root_id, col(Run.root_run_id) == root_id)
+            )
+            .correlate(None)
+        )
+    assert policy.archive_after_days is not None
+    cutoff = now - timedelta(days=policy.archive_after_days)
+    terminal = [s.value for s in ExecutionStatus if s.is_finished]
+    runs = select(col(Run.id)).where(col(Run.id).in_(membership))
+    steps = select(col(Step.id)).where(
+        col(Step.pipeline_run_id).in_(membership)
+    )
+    latest_bundle = (
+        select(col(Bundle.id))
+        .where(
+            col(Bundle.root_run_id) == root_id,
+            col(Bundle.project_id) == project_id,
+        )
+        .order_by(col(Bundle.created).desc(), col(Bundle.id).desc())
+        .limit(1)
+        .correlate(None)
+    )
+    checks = {
+        "not_terminal": runs.where(
+            or_(
+                col(Run.status).not_in(terminal),
+                col(Run.in_progress).is_(True),
+            )
+        ),
+        "not_old": runs.where(
+            or_(col(Run.end_time).is_(None), col(Run.end_time) >= cutoff)
+        ),
+        "step_not_terminal_or_old": steps.where(
+            or_(
+                col(Step.status).not_in(terminal),
+                col(Step.end_time).is_(None),
+                col(Step.end_time) >= cutoff,
+            )
+        ),
+        "unresolved_wait": select(col(Wait.id)).where(
+            col(Wait.run_id).in_(membership),
+            col(Wait.status) != RunWaitConditionStatus.RESOLVED,
+        ),
+        "pinned": runs.where(col(Run.retain).is_(True)),
+        "in_progress_dependent": select(col(Run.id)).where(
+            col(Run.original_run_id).in_(membership),
+            col(Run.id).not_in(membership),
+            col(Run.in_progress).is_(True),
+        ),
+        "resumable_failed_root": select(col(Run.id))
+        .join(Snapshot, col(Run.snapshot_id) == col(Snapshot.id))
+        .where(
+            col(Run.id) == root_id,
+            col(Run.status) == ExecutionStatus.FAILED,
+            col(Snapshot.is_dynamic).is_(True),
+            Snapshot.runnable_filter(),
+        ),
+        "restored_grace": select(col(Bundle.id)).where(
+            col(Bundle.id) == latest_bundle.scalar_subquery(),
+            col(Bundle.restored_at)
+            > now - timedelta(days=policy.restored_grace_days),
+        ),
+        "already_archived": runs.where(
+            or_(
+                col(Run.archive_bundle_id).is_not(None),
+                col(Run.archived_at).is_not(None),
+            )
+        ),
+        "project_mismatch": runs.where(col(Run.project_id) != project_id),
+        "step_project_mismatch": steps.where(
+            col(Step.project_id) != project_id
+        ),
+        "archived_step": steps.where(
+            or_(
+                col(Step.archived_at).is_not(None),
+                col(Step.archive_bundle_id).is_not(None),
+            )
+        ),
+        "incomplete_tree": select(col(Run.id)).where(
+            col(Run.parent_run_id).in_(membership),
+            col(Run.id).not_in(membership),
+        ),
+    }
+    if not policy.archive_model_linked_runs:
+        checks["model_link"] = (
+            select(col(ModelLink.id))
+            .join(
+                ModelVersion,
+                col(ModelLink.model_version_id) == col(ModelVersion.id),
+            )
+            .where(col(ModelLink.pipeline_run_id).in_(membership))
+        )
+    # A single row of independent EXISTS results avoids a round trip per rule.
+    row = session.execute(
+        select(*(q.exists().label(reason) for reason, q in checks.items()))
+    ).one()
+    return {reason for reason, matched in zip(checks, row) if matched}
+
+
+def _estimate(
+    session: Session,
+    query: Select[Any],
+    columns: List[Any],
+    max_rows: int,
+    deleted: bool = False,
+) -> RetentionTableEstimate:
+    """Aggregate a limit-plus-one projection of stored byte lengths.
+
+    Args:
+        session: Read session.
+        query: Query selecting the table's identity with ownership predicates.
+        columns: Only the covered text columns.
+        max_rows: Remaining row budget.
+        deleted: Whether these are complete detail rows rather than headers.
+
+    Returns:
+        Bounded row count and stored bytes. A count above the budget rejects
+        the whole tree. Binary casts make SQLite count UTF-8 bytes too.
+    """
+    lengths = [
+        func.coalesce(func.length(cast(c, LargeBinary)), 0) for c in columns
+    ]
+    projection = (
+        query.with_only_columns(sum(lengths, start=literal(0)).label("bytes"))
+        .limit(max_rows + 1)
+        .subquery()
+    )
+    count, size = session.execute(
+        select(
+            func.count(), func.coalesce(func.sum(projection.c.bytes), 0)
+        ).select_from(projection)
+    ).one()
+    return RetentionTableEstimate(
+        rows=count, rows_deleted=count if deleted else 0, estimated_bytes=size
+    )
+
+
+def _inventory(
+    session: Session,
+    tree: ArchivableTree,
+    members: List[UUID],
+    limits: RetentionLimits,
+    project_id: UUID,
+) -> None:
+    """Fill one tree's identity lists and estimates within remaining budgets.
+
+    Args:
+        session: Read session.
+        tree: Detached candidate to fill.
+        members: Complete tree membership.
+        limits: Remaining row and byte allowance.
+        project_id: Authorized project.
+    """
+    # Materialize only bounded identities before reading lengths. Nested
+    # ownership subqueries inside OR/IN made MySQL scan entire detail tables.
+    discovered = len(members)
+    queries = (
+        select(col(Step.id)).where(
+            col(Step.pipeline_run_id).in_(_bounded_ids(members))
+        ),
+        select(col(Run.snapshot_id))
+        .where(
+            col(Run.id).in_(_bounded_ids(members)),
+            col(Run.snapshot_id).is_not(None),
+        )
+        .union(
+            select(col(Step.snapshot_id)).where(
+                col(Step.pipeline_run_id).in_(_bounded_ids(members)),
+                col(Step.snapshot_id).is_not(None),
+            )
+        ),
+        select(col(MetadataLink.run_metadata_id))
+        .where(
+            col(MetadataLink.resource_type) == "pipeline_run",
+            col(MetadataLink.resource_id).in_(_bounded_ids(members)),
+        )
+        .distinct(),
+    )
+    identities = []
+    for query in queries:
+        ids = list(
+            session.execute(
+                query.limit(limits.max_rows - discovered + 1)
+            ).scalars()
+        )
+        discovered += len(ids)
+        if discovered > limits.max_rows:
+            tree.exclusions.add("row_limit")
+            return
+        identities.append(ids)
+    step_ids, snapshot_candidates, metadata_candidates = identities
+    tree.snapshot_ids = list(
+        session.execute(
+            _snapshot_query(members, snapshot_candidates, project_id).order_by(
+                col(Snapshot.id)
+            )
+        ).scalars()
+    )
+    tree.metadata_ids = list(
+        session.execute(
+            _metadata_query(members, metadata_candidates, project_id).order_by(
+                col(Metadata.id)
+            )
+        ).scalars()
+    )
+    tree.retained_details.update(
+        {
+            "snapshot_ownership": len(snapshot_candidates)
+            - len(tree.snapshot_ids),
+            "metadata_ownership": len(metadata_candidates)
+            - len(tree.metadata_ids),
+        }
+    )
+    steps = select(col(Step.id)).where(
+        col(Step.id).in_(_bounded_ids(step_ids))
+    )
+    snapshots = select(col(Snapshot.id)).where(
+        col(Snapshot.id).in_(_bounded_ids(tree.snapshot_ids))
+    )
+    metadata = select(col(Metadata.id)).where(
+        col(Metadata.id).in_(_bounded_ids(tree.metadata_ids))
+    )
+    specs = (
+        (
+            "pipeline_run",
+            select(col(Run.id)).where(col(Run.id).in_(_bounded_ids(members))),
+            [
+                col(Run.orchestrator_environment),
+                col(Run.exception_info),
+                col(Run.pipeline_configuration),
+                col(Run.client_environment),
+            ],
+            False,
+        ),
+        (
+            "step_run",
+            steps,
+            [col(Step.exception_info), col(Step.step_configuration)],
+            False,
+        ),
+        (
+            "pipeline_snapshot",
+            snapshots,
+            [
+                col(Snapshot.pipeline_configuration),
+                col(Snapshot.client_environment),
+                col(Snapshot.pipeline_spec),
+                col(Snapshot.source_code),
+                col(Snapshot.description),
+            ],
+            False,
+        ),
+        (
+            "step_configuration",
+            select(col(Configuration.id)).where(
+                or_(
+                    col(Configuration.snapshot_id).in_(
+                        _bounded_ids(tree.snapshot_ids)
+                    ),
+                    col(Configuration.step_run_id).in_(_bounded_ids(step_ids)),
+                )
+            ),
+            [col(Configuration.config)],
+            True,
+        ),
+        ("run_metadata", metadata, [col(Metadata.value)], True),
+        (
+            "run_metadata_resource",
+            select(col(MetadataLink.id)).where(
+                col(MetadataLink.run_metadata_id).in_(
+                    _bounded_ids(tree.metadata_ids)
+                )
+            ),
+            [
+                col(MetadataLink.id),
+                col(MetadataLink.resource_id),
+                col(MetadataLink.resource_type),
+                col(MetadataLink.run_metadata_id),
+            ],
+            True,
+        ),
+        (
+            "run_wait_condition",
+            select(col(Wait.id)).where(
+                col(Wait.run_id).in_(_bounded_ids(members))
+            ),
+            [
+                col(Wait.question),
+                col(Wait.data_schema_json),
+                col(Wait.result_json),
+                col(Wait.poller_instance_id),
+            ],
+            False,
+        ),
+        (
+            "hook_invocation",
+            select(col(Hook.id)).where(
+                or_(
+                    col(Hook.pipeline_run_id).in_(_bounded_ids(members)),
+                    col(Hook.step_run_id).in_(_bounded_ids(step_ids)),
+                )
+            ),
+            [col(Hook.exception_info)],
+            False,
+        ),
+    )
+    rows = size = 0
+    for name, query, columns, deleted in specs:
+        estimate = _estimate(
+            session, query, columns, limits.max_rows - rows, deleted
+        )
+        rows += estimate.rows
+        size += estimate.estimated_bytes
+        if rows > limits.max_rows or size > limits.max_bytes:
+            tree.exclusions.add(
+                "row_limit" if rows > limits.max_rows else "byte_limit"
+            )
+            tree.tables.clear()
+            return
+        tree.tables[name] = estimate
+
+
+def select_archivable_trees(
+    session: Session,
+    project_id: UUID,
+    policy: RetentionSettings,
+    limits: RetentionLimits,
+    now: Optional[datetime] = None,
+) -> RetentionSelection:
+    """Select a bounded oldest-first batch without changing any data.
+
+    Args:
+        session: Caller-owned read session.
+        project_id: Project whose root candidates may be examined.
+        policy: Retention eligibility settings; null age disables selection.
+        limits: Bounds for examined roots and admitted rows/stored bytes.
+        now: Optional fixed evaluation time for reproducible inventory.
+
+    Returns:
+        Candidates, overlapping exclusion counts, and a truncation indicator.
+    """
+    result = RetentionSelection()
+    if policy.archive_after_days is None:
+        return result
+    now = now or utc_now()
+    roots = list(
+        session.execute(
+            select(col(Run.id))
+            .where(
+                col(Run.project_id) == project_id,
+                col(Run.parent_run_id).is_(None),
+                col(Run.root_run_id).is_(None),
+                col(Run.archive_bundle_id).is_(None),
+                col(Run.archived_at).is_(None),
+            )
+            .order_by(
+                col(Run.end_time).is_(None), col(Run.end_time), col(Run.id)
+            )
+            .limit(limits.max_trees + 1)
+        ).scalars()
+    )
+    result.truncated = len(roots) > limits.max_trees
+    rows = size = 0
+    for root_id in roots[: limits.max_trees]:
+        tree = ArchivableTree(root_id)
+        members = (
+            select(col(Run.id))
+            .where(
+                or_(col(Run.id) == root_id, col(Run.root_run_id) == root_id)
+            )
+            .correlate(None)
+        )
+        tree.tree_run_ids = list(
+            session.execute(
+                members.order_by(col(Run.id)).limit(limits.max_rows - rows + 1)
+            ).scalars()
+        )
+        if len(tree.tree_run_ids) > limits.max_rows - rows:
+            tree.tree_run_ids.clear()
+            tree.exclusions.add("row_limit")
+        else:
+            tree.exclusions = _rules(
+                session, root_id, tree.tree_run_ids, project_id, policy, now
+            )
+            if not tree.exclusions:
+                _inventory(
+                    session,
+                    tree,
+                    tree.tree_run_ids,
+                    RetentionLimits(
+                        max_trees=1,
+                        max_rows=limits.max_rows - rows,
+                        max_bytes=limits.max_bytes - size,
+                    ),
+                    project_id,
+                )
+        result.candidates.append(tree)
+        result.exclusions.update(tree.exclusions)
+        result.retained_details.update(tree.retained_details)
+        if tree.exclusions & {"row_limit", "byte_limit"}:
+            result.truncated = True
+            break
+        if not tree.exclusions:
+            rows += sum(t.rows for t in tree.tables.values())
+            size += sum(t.estimated_bytes for t in tree.tables.values())
+        else:
+            rows += len(tree.tree_run_ids)
+        if rows == limits.max_rows or size == limits.max_bytes:
+            result.truncated = result.truncated or len(
+                result.candidates
+            ) < len(roots)
+            break
+    return result

--- a/src/zenml/zen_stores/retention/eligibility.py
+++ b/src/zenml/zen_stores/retention/eligibility.py
@@ -28,7 +28,11 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql.elements import BindParameter
 from sqlmodel import Session, col
 
-from zenml.enums import ExecutionStatus, RunWaitConditionStatus
+from zenml.enums import (
+    ExecutionStatus,
+    MetadataResourceTypes,
+    RunWaitConditionStatus,
+)
 from zenml.models.v2.misc.retention import (
     RetentionLimits,
     RetentionSettings,
@@ -179,7 +183,8 @@ def _metadata_query(
     external = select(col(MetadataLink.id)).where(
         col(MetadataLink.run_metadata_id) == col(Metadata.id),
         or_(
-            col(MetadataLink.resource_type) != "pipeline_run",
+            col(MetadataLink.resource_type)
+            != MetadataResourceTypes.PIPELINE_RUN,
             col(MetadataLink.resource_id).not_in(_bounded_ids(members)),
         ),
     )
@@ -249,13 +254,9 @@ def _rules(
         "not_old": runs.where(
             or_(col(Run.end_time).is_(None), col(Run.end_time) >= cutoff)
         ),
-        "step_not_terminal_or_old": steps.where(
-            or_(
-                col(Step.status).not_in(terminal),
-                col(Step.end_time).is_(None),
-                col(Step.end_time) >= cutoff,
-            )
-        ),
+        # Run completion sets retention age; cached/skipped steps may have no
+        # end timestamp even though their execution is terminal.
+        "step_not_terminal": steps.where(col(Step.status).not_in(terminal)),
         "unresolved_wait": select(col(Wait.id)).where(
             col(Wait.run_id).in_(membership),
             col(Wait.status) != RunWaitConditionStatus.RESOLVED,
@@ -390,7 +391,8 @@ def _inventory(
         ),
         select(col(MetadataLink.run_metadata_id))
         .where(
-            col(MetadataLink.resource_type) == "pipeline_run",
+            col(MetadataLink.resource_type)
+            == MetadataResourceTypes.PIPELINE_RUN,
             col(MetadataLink.resource_id).in_(_bounded_ids(members)),
         )
         .distinct(),

--- a/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
+++ b/src/zenml/zen_stores/schemas/pipeline_snapshot_schemas.py
@@ -22,6 +22,7 @@ from sqlalchemy import TEXT, CheckConstraint, Column, String, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import defer, object_session, selectinload
 from sqlalchemy.sql.base import ExecutableOption
+from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Field, Relationship, asc, col, desc, select
 
 from zenml.config.pipeline_configurations import PipelineConfiguration
@@ -512,6 +513,24 @@ class PipelineSnapshotSchema(BaseSchema, table=True):
             and self.build is not None
             and not self.build.is_local
             and self.build.stack_id is not None
+        )
+
+    @classmethod
+    def runnable_filter(cls) -> ColumnElement[bool]:
+        """Express the server's runnable-snapshot contract in SQL.
+
+        Returns:
+            Predicate equivalent to ``is_runnable`` without loading a build.
+        """
+        return (
+            col(cls.archived_at).is_(None)
+            & col(cls.archive_bundle_id).is_(None)
+            & col(cls.build_id).in_(
+                select(PipelineBuildSchema.id).where(
+                    col(PipelineBuildSchema.is_local).is_(False),
+                    col(PipelineBuildSchema.stack_id).is_not(None),
+                )
+            )
         )
 
     def to_model(

--- a/src/zenml/zen_stores/schemas/project_schemas.py
+++ b/src/zenml/zen_stores/schemas/project_schemas.py
@@ -16,7 +16,7 @@
 import json
 from typing import TYPE_CHECKING, Any, List, Optional
 
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import TEXT, Column, UniqueConstraint
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlmodel import Field, Relationship, String
 
@@ -29,6 +29,7 @@ from zenml.models import (
     ProjectResponseMetadata,
     ProjectUpdate,
 )
+from zenml.models.v2.misc.retention import RetentionSettings
 from zenml.utils.json_utils import pydantic_encoder
 from zenml.utils.time_utils import utc_now
 from zenml.zen_stores.schemas.base_schemas import NamedSchema
@@ -67,6 +68,9 @@ class ProjectSchema(NamedSchema, table=True):
 
     display_name: str
     description: str
+    retention_settings: Optional[str] = Field(
+        default=None, sa_column=Column(TEXT, nullable=True)
+    )
     project_metadata: Optional[str] = Field(
         default=None,
         sa_column=Column(
@@ -183,7 +187,13 @@ class ProjectSchema(NamedSchema, table=True):
         for field, value in project_update.model_dump(
             exclude_unset=True
         ).items():
-            if field == "project_metadata":
+            if field == "retention":
+                self.retention_settings = (
+                    RetentionSettings.model_validate(value).model_dump_json()
+                    if value is not None
+                    else None
+                )
+            elif field == "project_metadata":
                 if value is not None:
                     self.project_metadata = json.dumps(
                         value, default=pydantic_encoder
@@ -214,6 +224,11 @@ class ProjectSchema(NamedSchema, table=True):
         metadata = None
         if include_metadata:
             metadata = ProjectResponseMetadata(
+                retention=RetentionSettings.model_validate_json(
+                    self.retention_settings
+                )
+                if self.retention_settings
+                else RetentionSettings(),
                 description=self.description,
                 project_metadata=json.loads(self.project_metadata)
                 if self.project_metadata

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -382,6 +382,13 @@ from zenml.models import (
 from zenml.models.v2.core.resource_request import (
     ResourceRequestRenewalRequest,
 )
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+    RetentionLimits,
+    RetentionSettings,
+    RetentionTableEstimate,
+)
 from zenml.service_connectors.service_connector_registry import (
     service_connector_registry,
 )
@@ -496,6 +503,7 @@ if TYPE_CHECKING:
         TriggerExecutionInfo,
         UnScopedTriggerFilter,
     )
+    from zenml.zen_stores.retention.eligibility import RetentionSelection
 AnyNamedSchema = TypeVar("AnyNamedSchema", bound=NamedSchema)
 AnySchema = TypeVar("AnySchema", bound=BaseSchema)
 
@@ -13999,6 +14007,74 @@ class SqlZenStore(BaseZenStore):
             )
 
         return project_model
+
+    def select_archivable_trees(
+        self,
+        project_id: UUID,
+        policy: RetentionSettings,
+        limits: RetentionLimits,
+    ) -> "RetentionSelection":
+        """Inspect a bounded batch of roots without mutating execution rows.
+
+        Args:
+            project_id: Project owning the roots.
+            policy: Effective retention policy.
+            limits: Examined-root, row and stored-byte bounds.
+
+        Returns:
+            Detached candidates and overlapping exclusion counts.
+        """
+        from zenml.zen_stores.retention.eligibility import (
+            select_archivable_trees,
+        )
+
+        self.get_project(project_id, hydrate=False)
+        with Session(self.engine) as session:
+            return select_archivable_trees(session, project_id, policy, limits)
+
+    def retention_dry_run(
+        self,
+        project_id: UUID,
+        request: RetentionDryRunRequest,
+    ) -> RetentionDryRunResponse:
+        """Estimate a batch using saved settings and non-persistent overrides.
+
+        Args:
+            project_id: Project to inspect.
+            request: What-if overrides; unconfigured projects use 90 days.
+
+        Returns:
+            Stored-byte estimates and exclusions, with no data changed.
+        """
+        settings = self.get_project(project_id).retention.model_dump()
+        settings.update(request.model_dump(exclude_none=True))
+        if settings["archive_after_days"] is None:
+            settings["archive_after_days"] = 90
+        policy = RetentionSettings.model_validate(settings)
+        limits = RetentionLimits.model_validate(
+            {k: settings[k] for k in RetentionLimits.model_fields}
+        )
+        selection = self.select_archivable_trees(project_id, policy, limits)
+        tables: Dict[str, RetentionTableEstimate] = {}
+        eligible = 0
+        for tree in selection.candidates:
+            if tree.exclusions:
+                continue
+            eligible += 1
+            for name, estimate in tree.tables.items():
+                total = tables.setdefault(name, RetentionTableEstimate())
+                total.rows += estimate.rows
+                total.rows_deleted += estimate.rows_deleted
+                total.estimated_bytes += estimate.estimated_bytes
+        return RetentionDryRunResponse(
+            eligible_tree_count=eligible,
+            examined_tree_count=len(selection.candidates),
+            truncated=selection.truncated,
+            tables=tables,
+            exclusions=dict(selection.exclusions),
+            retained_details=dict(selection.retained_details),
+            effective_policy=policy,
+        )
 
     def get_project(
         self, project_name_or_id: Union[str, UUID], hydrate: bool = True

--- a/src/zenml/zen_stores/zen_store_interface.py
+++ b/src/zenml/zen_stores/zen_store_interface.py
@@ -175,6 +175,10 @@ from zenml.models import (
     WebhookSecretResponse,
     WebhookUpdate,
 )
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionDryRunResponse,
+)
 from zenml.zen_stores.resource_pools.store_interface import (
     ResourcePoolsStoreInterface,
 )
@@ -2996,6 +3000,22 @@ class ZenStoreInterface(ResourcePoolsStoreInterface, ABC):
         """
 
     # -------------------- Projects --------------------
+
+    @abstractmethod
+    def retention_dry_run(
+        self,
+        project_id: UUID,
+        request: RetentionDryRunRequest,
+    ) -> RetentionDryRunResponse:
+        """Estimate a bounded project retention batch without changing data.
+
+        Args:
+            project_id: Project to inspect.
+            request: Optional what-if overrides.
+
+        Returns:
+            Per-table estimates, effective policy and exclusion counts.
+        """
 
     @abstractmethod
     def create_project(self, project: ProjectRequest) -> ProjectResponse:

--- a/tests/unit/zen_server/endpoints/test_execution_retention_endpoints.py
+++ b/tests/unit/zen_server/endpoints/test_execution_retention_endpoints.py
@@ -1,0 +1,158 @@
+# Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Retention dry runs through HTTP, client and CLI without database writes."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from tests.unit.zen_stores.test_execution_retention_eligibility import (
+    make_tree,
+)
+from tests.unit.zen_stores.test_execution_retention_eligibility import (
+    sql_store as sql_store,
+)
+
+from zenml.cli.project import project
+from zenml.client import Client
+from zenml.models import ProjectUpdate
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionSettings,
+)
+from zenml.zen_server.auth import authorize
+from zenml.zen_server.rbac.models import Action
+from zenml.zen_server.routers import projects_endpoints as endpoints
+from zenml.zen_stores.rest_zen_store import RestZenStore
+from zenml.zen_stores.sql_zen_store import SqlZenStore
+
+
+@pytest.mark.parametrize("allowed", [True, False])
+def test_http_inventory_requires_update_and_never_writes(
+    sql_store: SqlZenStore, monkeypatch: pytest.MonkeyPatch, allowed: bool
+) -> None:
+    """Authorization precedes inventory; all execution and project rows are unchanged.
+
+    Args:
+        sql_store: Isolated SQL store.
+        monkeypatch: Isolated environment and dependency overrides.
+        allowed: Whether project UPDATE permission is granted.
+    """
+    tree = make_tree(sql_store)
+    app = FastAPI()
+    app.include_router(endpoints.router)
+    app.dependency_overrides[authorize] = lambda: Mock()
+    monkeypatch.setattr(endpoints, "zen_store", lambda: sql_store)
+    permission = Mock(
+        side_effect=None if allowed else HTTPException(403, "Forbidden")
+    )
+    monkeypatch.setattr(endpoints, "verify_permission_for_model", permission)
+    statements = []
+
+    def record(
+        conn: Any,
+        cursor: Any,
+        statement: str,
+        parameters: Any,
+        context: Any,
+        executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    with sql_store.engine.connect() as connection:
+        before = "\n".join(connection.connection.driver_connection.iterdump())
+    event.listen(sql_store.engine, "before_cursor_execute", record)
+    try:
+        with TestClient(app) as http:
+            response = http.post(
+                f"/api/v1/projects/{tree['project']}/retention/dry-run",
+                json={"archive_after_days": 90},
+            )
+    finally:
+        event.remove(sql_store.engine, "before_cursor_execute", record)
+    assert response.status_code == (200 if allowed else 403)
+    assert permission.call_args.kwargs["action"] == Action.UPDATE
+    assert permission.call_args.kwargs["model"].id == tree["project"]
+    if allowed:
+        body = response.json()
+        assert body["eligible_tree_count"] == 1
+        assert body["effective_policy"]["archive_after_days"] == 90
+        assert body["tables"]["pipeline_run"]["rows_deleted"] == 0
+        assert (
+            body["message"]
+            == "estimates are logical bytes; no data was changed"
+        )
+    else:
+        assert not any("pipeline_run" in statement for statement in statements)
+    assert all(
+        statement.lstrip().upper().startswith("SELECT")
+        for statement in statements
+    )
+    with sql_store.engine.connect() as connection:
+        assert (
+            "\n".join(connection.connection.driver_connection.iterdump())
+            == before
+        )
+
+
+def test_client_and_cli_preview_same_policy(
+    sql_store: SqlZenStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The client and requested CLI route use the same typed store contract.
+
+    Args:
+        sql_store: Isolated SQL store.
+        monkeypatch: Isolated environment and dependency overrides.
+    """
+    tree = make_tree(sql_store)
+    monkeypatch.setattr(Client, "zen_store", property(lambda _: sql_store))
+    client = Client()
+    sql_store.update_project(
+        tree["project"],
+        ProjectUpdate(retention=RetentionSettings(archive_after_days=180)),
+    )
+    report = client.retention_dry_run(
+        project=tree["project"], archive_after_days=90
+    )
+    assert report.eligible_tree_count == 1
+    assert (
+        sql_store.get_project(tree["project"]).retention.archive_after_days
+        == 180
+    )
+    result = CliRunner().invoke(
+        project,
+        [
+            "retention",
+            "dry-run",
+            "--project",
+            str(tree["project"]),
+            "--archive-after-days",
+            "90",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert '"eligible_tree_count": 1' in result.output
+    assert "no data was changed" in result.output
+
+
+def test_rest_store_uses_inventory_endpoint(sql_store: SqlZenStore) -> None:
+    """REST serialization preserves the request and flat response.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    tree = make_tree(sql_store)
+    request = RetentionDryRunRequest(archive_after_days=90)
+    expected = sql_store.retention_dry_run(tree["project"], request)
+    transport = Mock(spec=RestZenStore)
+    transport.post.return_value = expected.model_dump(mode="json")
+    assert (
+        RestZenStore.retention_dry_run(transport, tree["project"], request)
+        == expected
+    )
+    transport.post.assert_called_once_with(
+        f"/projects/{tree['project']}/retention/dry-run", body=request
+    )

--- a/tests/unit/zen_stores/test_execution_retention_eligibility.py
+++ b/tests/unit/zen_stores/test_execution_retention_eligibility.py
@@ -1,0 +1,760 @@
+# Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+"""Public retention selection, ownership, budgets and settings scenarios."""
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from zenml.models import ProjectFilter, ProjectUpdate, StackFilter
+from zenml.models.v2.misc.retention import (
+    RetentionDryRunRequest,
+    RetentionLimits,
+    RetentionSettings,
+)
+from zenml.zen_stores.retention import eligibility
+from zenml.zen_stores.schemas import (
+    ArchiveBundleSchema,
+    DeploymentSchema,
+    ModelSchema,
+    ModelVersionPipelineRunSchema,
+    ModelVersionSchema,
+    PipelineBuildSchema,
+    PipelineRunSchema,
+    PipelineSchema,
+    PipelineSnapshotSchema,
+    RunMetadataResourceSchema,
+    RunMetadataSchema,
+    RunTemplateSchema,
+    RunWaitConditionSchema,
+    ScheduleSchema,
+    StepConfigurationSchema,
+    StepRunSchema,
+    TriggerSchema,
+    TriggerSnapshotSchema,
+)
+from zenml.zen_stores.sql_zen_store import (
+    SqlZenStore,
+    SqlZenStoreConfiguration,
+)
+
+NOW = datetime(2026, 9, 8)
+
+
+@pytest.fixture
+def sql_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SqlZenStore:
+    """Create isolated SQLite data and a fixed policy evaluation time.
+
+    Args:
+        tmp_path: Temporary test directory.
+        monkeypatch: Isolated environment and dependency overrides.
+
+    Returns:
+        A SQLite store with default identities.
+    """
+    monkeypatch.setenv("ZENML_CONFIG_PATH", str(tmp_path / "cfg"))
+    monkeypatch.setattr(eligibility, "utc_now", lambda: NOW)
+    return SqlZenStore(
+        config=SqlZenStoreConfiguration(url=f"sqlite:///{tmp_path / 'db'}"),
+        skip_default_registrations=False,
+    )
+
+
+def make_tree(
+    store: SqlZenStore, parent: UUID | None = None, age: int = 100
+) -> dict[str, UUID]:
+    """Create valid identities with detail deliberately not decodable as models.
+
+    Args:
+        store: Isolated SQL store.
+        parent: Root identity for a nested run.
+        age: Execution age in days.
+
+    Returns:
+        Identities of the tree and its associated records.
+    """
+    project = store.list_projects(ProjectFilter()).items[0].id
+    pipeline = PipelineSchema(
+        project_id=project, name=str(uuid4()), run_count=0
+    )
+    snapshot = PipelineSnapshotSchema(
+        project_id=project,
+        pipeline_id=pipeline.id,
+        pipeline_configuration='{"description":"é😀"}',
+        client_environment="{}",
+        run_name_template="t",
+        step_count=1,
+    )
+    run = PipelineRunSchema(
+        project_id=project,
+        pipeline_id=pipeline.id,
+        snapshot_id=snapshot.id,
+        name=str(uuid4()),
+        index=1,
+        status="completed",
+        in_progress=False,
+        enable_heartbeat=False,
+        end_time=NOW - timedelta(days=age),
+        parent_run_id=parent,
+        root_run_id=parent,
+        orchestrator_environment="abc",
+    )
+    step = StepRunSchema(
+        project_id=project,
+        pipeline_run_id=run.id,
+        snapshot_id=snapshot.id,
+        name="step",
+        version=1,
+        is_retriable=False,
+        status="completed",
+        end_time=run.end_time,
+        source_code="kept source",
+        docstring="kept docs",
+        exception_info="error",
+    )
+    config = StepConfigurationSchema(
+        name="step", index=0, snapshot_id=snapshot.id, config="configuration"
+    )
+    with Session(store.engine, expire_on_commit=False) as session:
+        session.add_all([pipeline, snapshot, run, step, config])
+        session.commit()
+    return dict(
+        project=project,
+        pipeline=pipeline.id,
+        snapshot=snapshot.id,
+        run=run.id,
+        step=step.id,
+    )
+
+
+def selection(
+    store: SqlZenStore, tree: dict[str, UUID], **limits: int
+) -> eligibility.RetentionSelection:
+    """Select with the agreed 90-day policy.
+
+    Args:
+        store: Isolated SQL store.
+        tree: Identities of the candidate tree.
+        **limits: Per-invocation budget overrides.
+
+    Returns:
+        The bounded selection and exclusion counts.
+    """
+    return store.select_archivable_trees(
+        tree["project"],
+        RetentionSettings(archive_after_days=90),
+        RetentionLimits(**limits),
+    )
+
+
+def test_positive_tree_and_utf8_lengths(sql_store: SqlZenStore) -> None:
+    """Header identities survive and lengths count bytes without decoding JSON.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    root = make_tree(sql_store)
+    child = make_tree(sql_store, root["run"])
+    result = selection(sql_store, root)
+    assert not result.exclusions and not result.truncated
+    tree = result.candidates[0]
+    assert set(tree.tree_run_ids) == {root["run"], child["run"]}
+    assert set(tree.snapshot_ids) == {root["snapshot"], child["snapshot"]}
+    assert tree.tables["pipeline_snapshot"].estimated_bytes == 2 * (
+        len('{"description":"é😀"}'.encode()) + 2
+    )
+    assert tree.tables["step_configuration"].rows_deleted == 2
+    assert tree.tables["step_run"].estimated_bytes == 10
+    assert tree.tables["pipeline_run"].rows_deleted == 0
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        "not_terminal",
+        "not_old",
+        "missing_end",
+        "step_not_terminal_or_old",
+        "pinned",
+        "unresolved_wait",
+        "model_link",
+        "in_progress_dependent",
+        "resumable_failed_root",
+        "restored_grace",
+    ],
+)
+def test_each_exclusion_and_its_release(
+    sql_store: SqlZenStore, rule: str
+) -> None:
+    """Each protection excludes a whole tree and explains why; removing it admits it.
+
+    Args:
+        sql_store: Isolated SQL store.
+        rule: Exclusion to protect and then release.
+    """
+    root = make_tree(sql_store)
+    child = make_tree(sql_store, root["run"])
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        run = session.get(PipelineRunSchema, child["run"])
+        root_run = session.get(PipelineRunSchema, root["run"])
+        assert run and root_run
+        removable = None
+        if rule == "not_terminal":
+            run.in_progress = True
+        elif rule == "not_old":
+            run.end_time = NOW - timedelta(days=90)
+        elif rule == "missing_end":
+            run.end_time = None
+        elif rule == "pinned":
+            run.retain = True
+        elif rule == "step_not_terminal_or_old":
+            step = session.get(StepRunSchema, child["step"])
+            assert step
+            step.status = "running"
+            session.add(step)
+        elif rule == "unresolved_wait":
+            removable = RunWaitConditionSchema(
+                run_id=run.id,
+                project_id=root["project"],
+                name="wait",
+                type="external_input",
+                status="pending",
+            )
+        elif rule == "model_link":
+            model = ModelSchema(
+                project_id=root["project"],
+                name=str(uuid4()),
+                save_models_to_registry=False,
+            )
+            version = ModelVersionSchema(
+                project_id=root["project"],
+                model_id=model.id,
+                name="v",
+                number=1,
+                stage="archived",
+                producer_run_id_if_numeric=run.id,
+            )
+            session.add_all([model, version])
+            session.flush()
+            removable = ModelVersionPipelineRunSchema(
+                model_version_id=version.id, pipeline_run_id=run.id
+            )
+        elif rule == "in_progress_dependent":
+            removable = PipelineRunSchema(
+                project_id=root["project"],
+                name=str(uuid4()),
+                index=2,
+                status="running",
+                in_progress=True,
+                enable_heartbeat=False,
+                original_run_id=run.id,
+            )
+        elif rule == "resumable_failed_root":
+            stack = sql_store.list_stacks(StackFilter()).items[0].id
+            build = PipelineBuildSchema(
+                project_id=root["project"],
+                stack_id=stack,
+                images="{}",
+                is_local=False,
+                contains_code=True,
+            )
+            session.add(build)
+            session.flush()
+            snapshot = session.get(PipelineSnapshotSchema, root["snapshot"])
+            assert snapshot
+            snapshot.is_dynamic = True
+            snapshot.build_id = build.id
+            session.add(snapshot)
+            root_run.status = "failed"
+        elif rule == "restored_grace":
+            removable = ArchiveBundleSchema(
+                project_id=root["project"],
+                root_run_id=root_run.id,
+                uri="unused",
+                size_bytes=0,
+                row_counts="{}",
+                manifest_hash="x",
+                format_version=1,
+                schema_revision="test",
+                status="restored",
+                restored_at=NOW - timedelta(days=1),
+            )
+        session.add_all([run, root_run])
+        if removable is not None:
+            session.add(removable)
+        session.commit()
+    expected = "not_old" if rule == "missing_end" else rule
+    result = selection(sql_store, root)
+    assert result.exclusions[expected] == 1
+    if rule == "model_link":
+        allowed = sql_store.select_archivable_trees(
+            root["project"],
+            RetentionSettings(
+                archive_after_days=90, archive_model_linked_runs=True
+            ),
+            RetentionLimits(),
+        )
+        assert not allowed.exclusions
+    assert (
+        expected
+        in next(
+            t for t in result.candidates if t.root_run_id == root["run"]
+        ).exclusions
+    )
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        if removable is not None:
+            session.delete(session.merge(removable))
+        run = session.get(PipelineRunSchema, child["run"])
+        assert run
+        run.in_progress = False
+        run.retain = False
+        run.end_time = NOW - timedelta(days=100)
+        step = session.get(StepRunSchema, child["step"])
+        assert step
+        step.status = "completed"
+        root_run = session.get(PipelineRunSchema, root["run"])
+        assert root_run
+        root_run.status = "completed"
+        session.add_all([run, step, root_run])
+        session.commit()
+    assert not selection(sql_store, root).candidates[0].exclusions
+
+
+@pytest.mark.parametrize(
+    "owner",
+    [
+        "shared",
+        "deployment",
+        "template",
+        "name",
+        "child_snapshot",
+        "schedule",
+        "trigger",
+    ],
+)
+def test_snapshot_ownership_keeps_tree_eligible(
+    sql_store: SqlZenStore, owner: str
+) -> None:
+    """Operational/shared snapshots stay hot without blocking unrelated detail.
+
+    Args:
+        sql_store: Isolated SQL store.
+        owner: Reference that keeps snapshot detail in SQL.
+    """
+    root = make_tree(sql_store)
+    other = make_tree(sql_store, age=1)
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        snapshot = session.get(PipelineSnapshotSchema, root["snapshot"])
+        assert snapshot
+        if owner == "shared":
+            run = session.get(PipelineRunSchema, other["run"])
+            assert run
+            run.snapshot_id = snapshot.id
+            session.add(run)
+        elif owner == "deployment":
+            session.add(
+                DeploymentSchema(
+                    project_id=root["project"],
+                    name="d",
+                    status="running",
+                    snapshot_id=snapshot.id,
+                )
+            )
+        elif owner == "template":
+            session.add(
+                RunTemplateSchema(
+                    project_id=root["project"],
+                    name="t",
+                    source_snapshot_id=snapshot.id,
+                )
+            )
+        elif owner == "name":
+            snapshot.name = "named"
+        elif owner == "schedule":
+            schedule = ScheduleSchema(
+                project_id=root["project"],
+                name="s",
+                active=True,
+                catchup=False,
+            )
+            session.add(schedule)
+            session.flush()
+            snapshot.schedule_id = schedule.id
+        elif owner == "trigger":
+            trigger = TriggerSchema(
+                project_id=root["project"],
+                name="t",
+                active=True,
+                type="schedule",
+                flavor="native",
+                configuration="{}",
+                concurrency="skip",
+            )
+            session.add(trigger)
+            session.flush()
+            session.add(
+                TriggerSnapshotSchema(
+                    trigger_id=trigger.id, snapshot_id=snapshot.id
+                )
+            )
+        else:
+            child = session.get(PipelineSnapshotSchema, other["snapshot"])
+            assert child
+            child.source_snapshot_id = snapshot.id
+            session.add(child)
+        session.add(snapshot)
+        session.commit()
+    tree = selection(sql_store, root).candidates[0]
+    assert not tree.exclusions and not tree.snapshot_ids
+    assert tree.tables["step_configuration"].rows == 0
+    assert tree.retained_details["snapshot_ownership"] == 1
+
+
+def test_metadata_all_links_and_policy_override(
+    sql_store: SqlZenStore,
+) -> None:
+    """Adding a step link keeps both the metadata value and every link hot.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    root = make_tree(sql_store)
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        value = RunMetadataSchema(
+            project_id=root["project"], key="metric", type="str", value="123"
+        )
+        session.add(value)
+        session.flush()
+        session.add(
+            RunMetadataResourceSchema(
+                resource_id=root["run"],
+                resource_type="pipeline_run",
+                run_metadata_id=value.id,
+            )
+        )
+        session.commit()
+        value_id = value.id
+    assert selection(sql_store, root).candidates[0].metadata_ids == [value_id]
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        session.add(
+            RunMetadataResourceSchema(
+                resource_id=root["step"],
+                resource_type="step_run",
+                run_metadata_id=value_id,
+            )
+        )
+        session.commit()
+    retained = selection(sql_store, root)
+    assert not retained.candidates[0].metadata_ids
+    assert retained.retained_details["metadata_ownership"] == 1
+
+
+@pytest.mark.parametrize(
+    "limits,reason",
+    [
+        ({"max_trees": 1}, None),
+        ({"max_rows": 1}, "row_limit"),
+        ({"max_bytes": 1}, "byte_limit"),
+    ],
+)
+def test_limits_never_admit_partial_trees(
+    sql_store: SqlZenStore, limits: dict[str, int], reason: str | None
+) -> None:
+    """Bounds truncate discovery or reject a whole tree with an explicit reason.
+
+    Args:
+        sql_store: Isolated SQL store.
+        limits: Per-invocation budget overrides.
+        reason: Expected rejection reason.
+    """
+    root = make_tree(sql_store, age=110)
+    make_tree(sql_store)
+    result = selection(sql_store, root, **limits)
+    assert result.truncated and len(result.candidates) == 1
+    assert result.candidates[0].root_run_id == root["run"]
+    if reason:
+        assert (
+            result.exclusions[reason] == 1 and not result.candidates[0].tables
+        )
+
+
+def test_settings_round_trip_and_dry_run_does_not_enable(
+    sql_store: SqlZenStore,
+) -> None:
+    """What-if defaults and settings writes never start or alter executions.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    root = make_tree(sql_store)
+    assert (
+        sql_store.get_project(root["project"]).retention.archive_after_days
+        is None
+    )
+    report = sql_store.retention_dry_run(
+        root["project"], RetentionDryRunRequest()
+    )
+    assert (
+        report.effective_policy.archive_after_days == 90
+        and report.eligible_tree_count == 1
+    )
+    assert (
+        sql_store.get_project(root["project"]).retention.archive_after_days
+        is None
+    )
+    policy = RetentionSettings(archive_after_days=180, max_trees=20)
+    sql_store.update_project(root["project"], ProjectUpdate(retention=policy))
+    assert sql_store.get_project(root["project"]).retention == policy
+    assert not sql_store.select_archivable_trees(
+        root["project"], RetentionSettings(), RetentionLimits()
+    ).candidates
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"archive_after_days": 6},
+        {"max_trees": 0},
+        {"max_rows": -1},
+        {"max_bytes": 0},
+        {"restored_grace_days": -1},
+    ],
+)
+def test_invalid_policy(values: dict[str, int]) -> None:
+    """Invalid settings are rejected before any store access.
+
+    Args:
+        values: Invalid policy values.
+    """
+    with pytest.raises(ValidationError):
+        RetentionSettings(**values)
+
+
+def test_latest_bundle_and_exact_grace_boundary(
+    sql_store: SqlZenStore,
+) -> None:
+    """Old restore history does not override the newest bundle's grace state.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    root = make_tree(sql_store)
+    with Session(sql_store.engine, expire_on_commit=False) as session:
+        old = ArchiveBundleSchema(
+            project_id=root["project"],
+            root_run_id=root["run"],
+            uri="unused",
+            size_bytes=0,
+            row_counts="{}",
+            manifest_hash="x",
+            format_version=1,
+            schema_revision="test",
+            status="restored",
+            created=NOW - timedelta(days=60),
+            restored_at=NOW - timedelta(days=1),
+        )
+        latest = ArchiveBundleSchema(
+            project_id=root["project"],
+            root_run_id=root["run"],
+            uri="unused",
+            size_bytes=0,
+            row_counts="{}",
+            manifest_hash="x",
+            format_version=1,
+            schema_revision="test",
+            status="restored",
+            created=NOW - timedelta(days=40),
+            restored_at=NOW - timedelta(days=30),
+        )
+        session.add_all([old, latest])
+        session.commit()
+    assert not selection(sql_store, root).exclusions
+
+
+@pytest.mark.parametrize("defect", ["incomplete_tree", "archived_step"])
+def test_malformed_or_partially_archived_tree_stays_hot(
+    sql_store: SqlZenStore, defect: str
+) -> None:
+    """Broken membership and archived members cannot become fresh candidates.
+
+    Args:
+        sql_store: Isolated SQL store.
+        defect: Malformed ownership or archive state.
+    """
+    root = make_tree(sql_store)
+    child = make_tree(sql_store, root["run"])
+    with Session(sql_store.engine) as session:
+        if defect == "incomplete_tree":
+            run = session.get(PipelineRunSchema, child["run"])
+            assert run
+            run.root_run_id = None
+            session.add(run)
+        else:
+            step = session.get(StepRunSchema, child["step"])
+            assert step
+            step.archived_at = NOW
+            session.add(step)
+        session.commit()
+    assert selection(sql_store, root).exclusions[defect] == 1
+
+
+@pytest.mark.parametrize(
+    "is_local,has_stack", [(False, True), (True, True), (False, False)]
+)
+def test_runnable_sql_predicate_matches_reader(
+    sql_store: SqlZenStore, is_local: bool, has_stack: bool
+) -> None:
+    """Resume eligibility and the existing reader use the same runnable contract.
+
+    Args:
+        sql_store: Isolated SQL store.
+        is_local: Whether the build runs locally.
+        has_stack: Whether a build has an execution stack.
+    """
+    from sqlalchemy import select
+    from sqlmodel import col
+
+    root = make_tree(sql_store)
+    stack = (
+        sql_store.list_stacks(StackFilter()).items[0].id if has_stack else None
+    )
+    with Session(sql_store.engine) as session:
+        build = PipelineBuildSchema(
+            project_id=root["project"],
+            stack_id=stack,
+            images="{}",
+            is_local=is_local,
+            contains_code=True,
+        )
+        session.add(build)
+        session.flush()
+        snapshot = session.get(PipelineSnapshotSchema, root["snapshot"])
+        assert snapshot
+        snapshot.build_id = build.id
+        session.add(snapshot)
+        session.commit()
+        matching = (
+            session.execute(
+                select(col(PipelineSnapshotSchema.id)).where(
+                    PipelineSnapshotSchema.runnable_filter()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert (
+            (snapshot.id in matching)
+            == snapshot.is_runnable
+            == (not is_local and has_stack)
+        )
+
+
+def test_settings_migration_preserves_disabled_project(
+    sql_store: SqlZenStore,
+) -> None:
+    """The SQLite upgrade adds nullable settings to a pre-R3 project unchanged.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    from sqlalchemy import inspect
+
+    from zenml.zen_stores.migrations.alembic import Alembic
+
+    tree = make_tree(sql_store)
+    project = sql_store.list_projects(ProjectFilter()).items[0]
+    before = sql_store.get_project(project.id)
+    migration = Alembic(sql_store.engine)
+    migration.downgrade("7a1c3d9e2b4f")
+    assert "retention_settings" not in {
+        c["name"] for c in inspect(sql_store.engine).get_columns("project")
+    }
+    migration.upgrade("8b2d4e6f901a")
+    after = sql_store.get_project(project.id)
+    assert after.updated == before.updated
+    assert after.retention == RetentionSettings()
+    column = next(
+        c
+        for c in inspect(sql_store.engine).get_columns("project")
+        if c["name"] == "retention_settings"
+    )
+    assert column["nullable"]
+    with Session(sql_store.engine) as session:
+        assert session.get(PipelineRunSchema, tree["run"]) is not None
+        assert session.get(StepRunSchema, tree["step"]) is not None
+        assert (
+            session.get(PipelineSnapshotSchema, tree["snapshot"]) is not None
+        )
+
+
+def test_project_boundary_is_fail_closed(sql_store: SqlZenStore) -> None:
+    """Foreign project members cannot contribute their identities or bytes.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    from zenml.models import ProjectRequest
+
+    root = make_tree(sql_store)
+    child = make_tree(sql_store, root["run"])
+    other = sql_store.create_project(ProjectRequest(name="other-project"))
+    assert not sql_store.select_archivable_trees(
+        other.id, RetentionSettings(archive_after_days=90), RetentionLimits()
+    ).candidates
+    with Session(sql_store.engine) as session:
+        run = session.get(PipelineRunSchema, child["run"])
+        assert run
+        run.project_id = other.id
+        session.add(run)
+        session.commit()
+    result = selection(sql_store, root)
+    assert result.exclusions["project_mismatch"] == 1
+    assert not result.candidates[0].tables
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="SQLite connection limit API requires Python 3.11",
+)
+def test_large_tree_with_sqlite_parameter_limit(
+    sql_store: SqlZenStore,
+) -> None:
+    """A valid bounded tree works with SQLite's historical 999-variable limit.
+
+    Args:
+        sql_store: Isolated SQL store.
+    """
+    import sqlite3
+
+    root = make_tree(sql_store)
+    with Session(sql_store.engine) as session:
+        session.add_all(
+            [
+                PipelineRunSchema(
+                    project_id=root["project"],
+                    name=str(uuid4()),
+                    index=i,
+                    status="completed",
+                    in_progress=False,
+                    enable_heartbeat=False,
+                    parent_run_id=root["run"],
+                    root_run_id=root["run"],
+                    end_time=NOW - timedelta(days=100),
+                )
+                for i in range(80)
+            ]
+        )
+        session.commit()
+    with sql_store.engine.connect() as connection:
+        raw = connection.connection.driver_connection
+        previous = raw.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+    try:
+        result = selection(sql_store, root)
+        assert not result.exclusions
+        assert len(result.candidates[0].tree_run_ids) == 81
+    finally:
+        raw.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, previous)

--- a/tests/unit/zen_stores/test_execution_retention_eligibility.py
+++ b/tests/unit/zen_stores/test_execution_retention_eligibility.py
@@ -173,12 +173,52 @@ def test_positive_tree_and_utf8_lengths(sql_store: SqlZenStore) -> None:
 
 
 @pytest.mark.parametrize(
+    "status,end_time",
+    [
+        ("cached", None),
+        ("skipped", None),
+        ("completed", None),
+        ("failed", None),
+        ("completed", NOW - timedelta(days=90)),
+        ("skipped", NOW),
+    ],
+)
+def test_terminal_step_timestamps_do_not_set_retention_age(
+    sql_store: SqlZenStore, status: str, end_time: datetime | None
+) -> None:
+    """Old trees remain eligible when terminal steps lack old end timestamps.
+
+    Args:
+        sql_store: Isolated SQL store.
+        status: Terminal child-step status.
+        end_time: Missing or recent step timestamp that must not block retention.
+    """
+    root = make_tree(sql_store)
+    child = make_tree(sql_store, root["run"])
+    with Session(sql_store.engine) as session:
+        step = session.get(StepRunSchema, child["step"])
+        assert step
+        step.status = status
+        step.end_time = end_time
+        session.add(step)
+        session.commit()
+    result = selection(sql_store, root)
+    assert not result.exclusions
+    assert len(result.candidates) == 1
+    assert not result.candidates[0].exclusions
+    assert set(result.candidates[0].tree_run_ids) == {
+        root["run"],
+        child["run"],
+    }
+
+
+@pytest.mark.parametrize(
     "rule",
     [
         "not_terminal",
         "not_old",
         "missing_end",
-        "step_not_terminal_or_old",
+        "step_not_terminal",
         "pinned",
         "unresolved_wait",
         "model_link",
@@ -211,7 +251,7 @@ def test_each_exclusion_and_its_release(
             run.end_time = None
         elif rule == "pinned":
             run.retain = True
-        elif rule == "step_not_terminal_or_old":
+        elif rule == "step_not_terminal":
             step = session.get(StepRunSchema, child["step"])
             assert step
             step.status = "running"


### PR DESCRIPTION
## Describe changes

Operators can preview which historical execution trees would qualify for retention and which detail would leave SQL. Adds bounded eligibility and inventory, saved project settings, `POST /projects/{project}/retention/dry-run`, `Client.retention_dry_run`, and `zenml project retention dry-run`.

**Stacked on #5257; R3 only. Nothing archives or deletes data.** Settings remain disabled until an age is set, and saving them starts nothing: there is no worker, bundle writer, claim, retirement, restore or scheduling here. An unconfigured what-if preview uses 90 days without saving that age.

- Apply age and non-null end times to **runs only**; steps must be terminal but may have missing or recent end times. Protect unresolved waits, every existing model version (including stage `archived`, unless explicitly opted out), pinned children, in-progress dependents, resumable failed dynamic roots, and recently restored trees.
- Shared or operational snapshots and metadata with any step/external owner stay hot without blocking the rest of a tree. Separate `retained_details` counts distinguish these from whole-tree exclusions. Run/step/snapshot headers, step source/docstrings, artifact versions and lineage remain.
- Proposed default limits: 200 examined roots, 500,000 rows, 512 MiB. Oldest end time then ID; exclusion counts overlap; `truncated` identifies a partial project inventory. An oversized tree is never partly admitted. `LENGTH()` reports stored text bytes, including compressed values, not decoded or physical bytes.
- The route verifies project `UPDATE` permission before inventory. SQLite tests compare the complete database dump before/after the HTTP preview, including timestamps and counts.

## Measurement and migration

On the isolated frozen Tenant A copy (MySQL 8.4.11; 321,353 runs, 540,232 steps, 391,864 snapshots), the 90-day default preview at `2141ecdbc1` (before the step-timestamp review fix) took **7.81 seconds on the first measured pass and 3.92 seconds on the immediate repeat**. Both returned 200 eligible roots, 2,310 affected rows, 1,609 whole detail rows, and 2,096,957 estimated bytes; 26 snapshot details stayed hot. Counts of all eight checked tables were unchanged. The clock was frozen to the preceding census, `2026-09-06T12:27:29.136410Z`.

**The default preview exceeds a few seconds on the first pass.** Oldest-root discovery dominates the first pass; this copy has no index matching project/end-time ordering. There are 3,003 SQL statements per 200-root preview. Bounded ID discovery fixes the initial broad detail-table scans, but this is not a claim of constant query work or customer listing acceleration. No new index or background-job infrastructure was added; R4 owns pass progress and execution infrastructure. These are local, serial measurements, not a loaded-server benchmark.

Migration chain: `7a1c3d9e2b4f` → `8b2d4e6f901a`, adding one nullable TEXT column, `project.retention_settings`. The local MySQL upgrade completed in **0.17 seconds**. Re-point the chain when #5165 (`e50a6a75e6b4`) or #5170 (`b02cab3094ca`) merges. SQLite upgrade/rollback preserves existing project-linked executions; rollback uses native DROP COLUMN (SQLite 3.35+) because rebuilding this referenced table cascaded deletions in the regression fixture. On older SQLite, downgrade fails rather than rebuilding it.

**Measurement qualification after review:** `eligibility.sql` lines 15–17 did reject missing/recent step end times. The 1.513 GiB / 300.85 MiB figures measure that stricter cohort. The corrected policy checks step status only and applies age to runs; its expanded full-cohort total has not been remeasured. The earlier batch timing remains attributed to `2141ecdbc1`.

R4 must advance beyond excluded roots between batches and revisit them on later passes. Repeating the same oldest-root preview can starve eligible work; R4 must settle a persistent cursor or selective discovery approach. The preview timing does not establish a fixed hourly archive-throughput ceiling.

Design decisions and the full internal investigation remain outside Git. The [eligibility report review copy](https://github.com/zenml-io/zenml/pull/5258#issuecomment-5577549838) is attached to this PR; source report: `/private/tmp/zenml-retention-eligibility-20260908/REPORT.md` and its `eligibility.sql`.

## Validation

- Before the review fix, 304 tests passed: `tests/unit/models`, `tests/unit/zen_stores`, the new HTTP/client/CLI tests, and existing pipeline-execution utility tests.
- Review fix: 47 targeted eligibility and HTTP/client/CLI tests passed, including six regressions for terminal steps with missing/recent timestamps and the existing nonterminal-step exclusion.
- Ruff format/check, isolated F401/F841, pydoclint, mypy on all changed source modules, and `scripts/check-alembic-branches.sh`: passed.
- Local SQLite and MySQL checks are complete; remote CI is separate.

## Pre-requisites

- [x] Read CONTRIBUTING.md; added tests for each eligibility rule, ownership, budgets, settings, authorization and migrations.
- [x] Intentionally stacked on R2 (#5257), per the agreed retention sequence; retarget after dependencies merge.
- [x] Internal design sections 10, 15 and 17 updated outside the PR. Dashboard/templates/projects require no changes for this preview.

## Types of changes

- [x] New feature (additive, non-destructive inventory and policy settings).
- [ ] Breaking change.
