### PR TITLE
Evaluate and train terminal agents with ZenML and Modal

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,14 @@ materialized form of one of our project templates. If you like any of the
 examples here, and you want to set up something similar, just grab the template 
 and kickstart your own example. It's that simple!          |
 
+## Terminal Agent Evaluation and Training
+
+The [Endless Terminals example](endless_terminals/README.md) qualifies Docker
+tasks, evaluates a model checkpoint, trains a LoRA adapter with SkyRL, and
+publishes transcripts, audited scores, and an HTML report through ZenML
+pipelines. Native Modal and Kubernetes examples run task sandboxes and GPU
+training separately.
+
 ## More Projects & Practical Examples
 
 If you're eager to discover more projects leveraging ZenML, you can check out 
@@ -32,4 +40,3 @@ If you have questions or need assistance with any of the examples, feel free to
 [reach out to us on Slack](https://zenml.io/slack/)!
 
 Happy experimenting with ZenML!
-

--- a/examples/endless_terminals/.gitignore
+++ b/examples/endless_terminals/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+.local/
+__pycache__/
+*.pyc
+data/
+runs/
+*.local.json

--- a/examples/endless_terminals/Dockerfile.modal
+++ b/examples/endless_terminals/Dockerfile.modal
@@ -1,0 +1,12 @@
+# Use the published Dockerfile.native dependency image as the explicit base.
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+COPY zenml-*.whl /tmp/zenml-wheels/
+RUN set -eu; \
+    set -- /tmp/zenml-wheels/zenml-*.whl; \
+    test "$#" -eq 1; \
+    test -f "$1"; \
+    pip install --no-cache-dir modal==1.5.5; \
+    pip install --no-cache-dir --no-deps --force-reinstall "$1"; \
+    rm -rf /tmp/zenml-wheels; \
+    pip check

--- a/examples/endless_terminals/Dockerfile.modal-agent
+++ b/examples/endless_terminals/Dockerfile.modal-agent
@@ -1,0 +1,4 @@
+# Seed and grade with the original task image; mount seeded data into this image.
+ARG TASK_IMAGE
+FROM ${TASK_IMAGE}
+RUN rm -rf /home/user && mkdir -p /home/user

--- a/examples/endless_terminals/Dockerfile.native
+++ b/examples/endless_terminals/Dockerfile.native
@@ -1,0 +1,9 @@
+FROM python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea
+
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements-native.txt /tmp/requirements-native.txt
+RUN pip install --no-cache-dir torch==2.11.0+cpu --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r /tmp/requirements-native.txt \
+    && pip check
+ENV ZENML_ANALYTICS_OPT_IN=false ZENML_DEBUG=true

--- a/examples/endless_terminals/Dockerfile.sandbox
+++ b/examples/endless_terminals/Dockerfile.sandbox
@@ -1,0 +1,7 @@
+FROM python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea
+
+RUN apt-get update && apt-get install -y --no-install-recommends iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements-sandbox.txt /tmp/requirements-sandbox.txt
+RUN pip install --no-cache-dir -r /tmp/requirements-sandbox.txt
+ENV ZENML_ANALYTICS_OPT_IN=false ZENML_DEBUG=true

--- a/examples/endless_terminals/README.md
+++ b/examples/endless_terminals/README.md
@@ -1,0 +1,254 @@
+# Evaluate and train terminal agents with ZenML
+
+This example runs a real ZenML pipeline: prepare and qualify terminal tasks, evaluate an agent, and produce an `HTMLString` report. ZenML records task provenance and episode evidence as artifacts so a later run can compare against a previous evaluation. A separate bounded RL pipeline uses SkyRL to train a LoRA adapter and produce a fresh before/after comparison.
+
+The default is a reviewed ten-task subset of [Endless Terminals](https://huggingface.co/datasets/obiwan96/endless-terminals), pinned in `tasks.json`. This small subset is a starting point for evaluation, not a representative benchmark.
+
+## Modal training pilot
+
+For unchanged-model screening, `run_modal_baseline.py --bundle BUNDLE --config CONFIG` accepts a `BaselineConfig` JSON containing up to 20 task IDs and an immutable `modal_agent_images` entry for every task. Use the same controller, service, and sandbox settings as the training pilot. Each task must pass initial-state, reference, and no-op checks on Modal before evaluation; rejected tasks remain visible in qualification evidence. The baseline uses one zero-update sampler for three round-robin attempts per accepted task, preserves partial results at the service deadline, and reports infrastructure failures separately from task failures. The GPU lifetime remains capped at 90 minutes, including startup. CPU qualification has a 60-minute step timeout, and the overall submission has a three-hour timeout.
+
+A verified DNS extraction run on September 8, 2026 used Qwen2.5-7B-Instruct on one H200. Ten evaluation attempts passed 9/10 before training and 10/10 afterward. Four training groups of eight scored 6/8, 6/8, 8/8, and 8/8; the first two groups produced optimizer updates and the equal-reward groups skipped updates. All 392 exported adapter tensors changed, file hashes matched, and all 52 model episodes and cloud resources cleaned up. These are observed counts on the training task, not evidence of held-out generalization or a statistically established improvement.
+
+Set `training.evaluation_attempts` to repeat each selected task before and after training; it defaults to one and accepts up to 20. The report matches task and attempt IDs. The service reserves time for final evaluation and export using all evaluation interaction budgets and observed overhead; this is a heuristic, and infrastructure stalls can still exhaust the hard lifetime. Final evaluation runs before export so a transfer failure preserves both evaluations. Native checkpoint transfers retry transient errors up to three times, with a 420-second parent-process deadline.
+
+`run_modal_training.py` runs the orchestrator, terminal sandboxes and GPU training service in the workspace and environment specified by `service.workspace` and `service.modal_environment`. Configure both Modal stack components with explicit credentials for that workspace and the same environment. The runner verifies the authenticated workspace before submission; CPU sandboxes and the GPU service also check placement before allocation. Keep a remote artifact store, registry and image builder accessible to the stack. Connect your submission environment to your ZenML server, select the Modal stack, and check it with `zenml stack describe`.
+
+Build the controller from this checkout so it includes the Modal sandbox settings used here. From the repository root, build a wheel into a clean directory:
+
+```bash
+uv build --wheel --out-dir examples/endless_terminals/.local/controller-build
+cd examples/endless_terminals
+cp Dockerfile.modal .local/controller-build/Dockerfile
+```
+
+Build and publish the native dependency image, then use its immutable digest as the Modal controller base. Replace the registry names and digest below. [Dockerfile.modal](Dockerfile.modal) requires exactly one ZenML wheel in its build context and installs it over the native dependency environment.
+
+```bash
+docker buildx build --platform linux/amd64 -f Dockerfile.native \
+  -t YOUR_REGISTRY/endless-native:latest --push .
+docker buildx build --platform linux/amd64 \
+  --build-arg BASE_IMAGE=YOUR_REGISTRY/endless-native@sha256:YOUR_DIGEST \
+  -t YOUR_REGISTRY/endless-modal:latest --push .local/controller-build
+```
+
+Also build and publish [Dockerfile.sandbox](Dockerfile.sandbox) as the CPU helper and the [training server image](training_server/README.md). Install the built ZenML wheel and `modal==1.5.5` in the Python 3.12 submission environment; use [requirements-native.txt](requirements-native.txt) for its training-client dependencies, installing the CPU PyTorch wheel from the index shown in [Dockerfile.native](Dockerfile.native). Install the repository wheel after those dependencies. This is separate from the lighter local evaluator environment below.
+
+Prepare a task bundle using the following section, then copy [modal-training.example.json](modal-training.example.json) to `.local/modal-training.json`. Replace every image placeholder with a published immutable digest. Set `service.workspace` and `sandbox.modal_workspace` to your workspace, and set `service.modal_environment` and `sandbox.modal_environment` to the same environment as both stack components. The training pilot accepts only the DNS task `task_000000_0228cd64`.
+
+```bash
+ZENML_ACTIVE_STACK_ID=YOUR_MODAL_STACK_ID python run_modal_training.py \
+  --bundle .local/sandbox-bundle --config .local/modal-training.json
+```
+
+After a successful registry import, `service.imported_image_id` can reuse that exact Modal image without downloading it again. Set it only after checking the Modal build log maps the image ID to the configured immutable `training_image`; the registry digest remains the source provenance.
+
+The configuration requests one H200, eight CPU cores and 256 GiB host memory for the pinned Qwen2.5-7B model. CPU qualification must establish valid initial grading, a successful reference solution and a failing no-op before the GPU is allocated. The service has a 90-minute deadline including startup. The example attempts one group of eight training episodes, with at most one optimizer update; any equal-reward group produces no update.
+
+Modal rejects volume mounts over nonempty directories. Build [Dockerfile.modal-agent](Dockerfile.modal-agent) with `--build-arg TASK_IMAGE=YOUR_ORIGINAL_TASK_DIGEST` and set `sandbox.modal_agent_image` to its published immutable digest. This derived image empties only `/home/user`; initialization copies that directory from the original task image into the episode Volume, and grading still uses the original image.
+
+Each terminal episode uses a unique Modal Volume for home-directory data, separate seed, agent and reader sandboxes, and a fresh verifier without a volume mount. Task sandboxes block external networking and receive no injected environment values or secrets. Cleanup confirms sandbox termination before removing the episode Volume. The GPU service clears the image’s inherited entrypoint, starts one backend from the uploaded source, and requires that exact process to remain alive during readiness checks. It exposes an authenticated TLS proxy, retains diagnostics and confirms termination during cleanup. Inspect the recorded resource identities after an interrupted controller run.
+
+## Prepare a portable task bundle
+
+Run this from the example directory in the local evaluator environment described below, with Docker running and registry push credentials configured. It downloads the pinned DNS task, builds and qualifies its original image, publishes that image, and records its immutable registry digest. Set `TASK_IMAGE` to a new tag in your own registry. The native pipeline repeats qualification on the remote backend before allocating a GPU.
+
+```bash
+export TASK_IMAGE=YOUR_REGISTRY/endless-dns:initial
+python - <<'PYTHON'
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from dataset import prepare_tasks
+
+bundle = Path(".local/sandbox-bundle")
+manifest = prepare_tasks(bundle, ["task_000000_0228cd64"])
+task = manifest["tasks"][0]
+image = os.environ["TASK_IMAGE"]
+subprocess.run(["docker", "tag", task["local_image_id"], image], check=True)
+subprocess.run(["docker", "push", image], check=True)
+details = json.loads(subprocess.check_output(["docker", "inspect", image]))[0]
+repository = image.rsplit(":", 1)[0]
+task["image_ref"] = next(
+    digest for digest in details["RepoDigests"]
+    if digest.startswith(repository + "@sha256:")
+)
+(bundle / "task-manifest.json").write_text(json.dumps(manifest, indent=2))
+PYTHON
+```
+
+For Modal, additionally build and publish the derived agent image, using the original `image_ref` from this manifest as `TASK_IMAGE`:
+
+```bash
+docker buildx build --platform linux/amd64 -f Dockerfile.modal-agent \
+  --build-arg TASK_IMAGE=YOUR_REGISTRY/endless-dns@sha256:YOUR_DIGEST \
+  -t YOUR_REGISTRY/endless-dns-agent:initial --push .
+```
+
+Set `sandbox.modal_agent_image` to the derived digest and leave the manifest's `image_ref` pointing to the original. Keep the downloaded task files unchanged: the loader verifies their recorded hashes. For baseline screening, prepare each selected task from `tasks.json` in the same bundle, publish each original image, and supply its derived image in `modal_agent_images`. `prepare_tasks` rejects IDs outside the checked-in selection; a larger custom selection requires its own reviewed, hash-pinned manifest.
+
+## Native Kubernetes sandbox pilot
+
+`run_sandbox.py` submits a CPU-only pipeline through ZenML's Kubernetes orchestrator and Kubernetes sandbox component. It uploads a task bundle as a ZenML artifact, runs initial-state qualification plus reference and empty-solution episodes in separate steps, and produces structured evidence and an HTML report. This path was verified on EKS with passing initial/reference checks, a failing no-op, and complete cleanup. A live probe confirmed disabled external networking and no mounted Kubernetes token. This does not train a model.
+
+Build the small CPU helper image with `docker buildx build --platform linux/amd64 -f Dockerfile.sandbox -t YOUR_HELPER_IMAGE .` and publish it to the stack's registry. Set `helper_image` in `sandbox.example.json` to its immutable registry digest. Publish the qualified task image separately and retain its digest as `image_ref` in the task manifest. The uploaded bundle must contain `task-manifest.json` with the pinned `dataset_revision` and selected entry from `tasks.json`, plus that task's directory and original hashed files. The pilot currently accepts one task.
+
+Use a stack containing the existing Kubernetes orchestrator, artifact store, registry and image builder plus a Kubernetes sandbox configured with `incluster=true` in the orchestrator namespace. The controller service account needs the permissions shown in [sandbox-rbac.yaml](sandbox-rbac.yaml). Those permissions apply throughout that namespace, so review them before applying the manifest to a shared cluster. The supplied CPU placement settings select and tolerate `pool=workloads`.
+
+```bash
+python run_sandbox.py --bundle ./sandbox-bundle \
+  --config sandbox.local.json \
+  --service-account endless-terminal-controller
+```
+
+Each episode uses a temporary 1 GiB PVC. A trusted seed pod copies the initial home directory, an agent pod modifies it, and a fresh reader exports it after agent termination. A separate verifier pod receives only the audited home archive and trusted tests. Task pods disable non-loopback network interfaces through a trusted init container, omit service-account tokens, and exclude host namespaces. Cleanup records pod identities and volume removal. CPU autoscaling and volume storage may incur costs; GPU capacity is not requested by this pilot.
+
+## Native Kubernetes training pilot
+
+`run_native_training.py` reuses the portable bundle and CPU qualification steps above. After qualification passes, one CPU step creates an internal GPU Job and ClusterIP Service, evaluates the initial adapter, attempts training groups, evaluates the resulting policy, and downloads the final sampling adapter. Terminal episodes and graders still run in separate CPU Kubernetes sandboxes. The GPU pod runs SkyRL on loopback behind a proxy requiring a random per-run API key. The CPU controller uses in-cluster Kubernetes authentication; it does not need local `aws`, `kubectl`, a port forward, or AWS administrator credentials for GPU lifecycle operations.
+
+Build and publish [Dockerfile.native](Dockerfile.native) as the controller image. Its [requirements-native.txt](requirements-native.txt) pins Python 3.12 dependencies, CPU-only PyTorch, and `s3fs==2026.6.0` for compatibility with the pinned Tinker Cookbook dependency set. The Dockerfile installs the CPU PyTorch wheel explicitly and runs `pip check`; use this environment rather than combining the older local training requirements with the native controller. Publish the [training server image](training_server/README.md), helper image, task image and an nginx-unprivileged proxy image separately, and use immutable registry digests for every image.
+
+```bash
+docker buildx build --platform linux/amd64 -f Dockerfile.native \
+  -t YOUR_CONTROLLER_IMAGE --push .
+cp native-training.example.json native-training.local.json
+# Replace every image placeholder with its published immutable digest.
+python run_native_training.py --bundle ./sandbox-bundle \
+  --config native-training.local.json \
+  --service-account endless-native-training-controller
+```
+
+Use the same Kubernetes stack and namespace as the CPU pilot, with the sandbox configured as `incluster=true`. [native-rbac.yaml](native-rbac.yaml) adds namespaced Service and Secret creation/deletion plus event reads to the CPU sandbox permissions; [sandbox-rbac.yaml](sandbox-rbac.yaml) alone is insufficient. Set both manifest namespaces before applying the native manifest. The GPU pool, device plugin and autoscaler must already support the configured resource request and `pool=gpu` placement. The controller stays on `pool=workloads`.
+
+The supplied configuration selects only `task_000000_0228cd64` and attempts at most two groups of four episodes. Reward remains binary: 1 for an audited pass and 0 for an audited failure. Equal-reward groups skip the optimizer update; two such groups stop this configuration. A completed run with zero optimizer steps demonstrates execution and export, not learning. The controller also stops adding groups when its remaining service budget cannot cover the group, paired evaluation and export.
+
+For response-format experiments, set `training.prompt_variant` to `concise_xml_v1`. This opt-in prompt gives short XML action instructions and a task-independent `pwd` example. The default remains `upstream`, and the parser and grader stay unchanged. Before, training and after episodes use the selected prompt; its variant and SHA-256 are recorded in the comparison protocol. Reports reject comparisons between different prompt protocols.
+
+The native run also publishes an `initial_adapter` artifact exported after the initial evaluation and before any training group. Compare its tensors with `trained_adapter` to verify that an optimizer update changed the saved weights. Failed-run diagnostics retain this initial export when it was completed before the failure.
+
+Successful runs retain `native_training_diagnostics`, including service logs, runtime memory measurements and Kubernetes status evidence. Failures attempt to upload `failed_training_evidence` and `failed_training_diagnostics`. The `trained_adapter` model artifact contains sampling adapter files and provenance hashes, not resumable optimizer state. Inspect the optimizer-step count and paired report before interpreting any score change. The Kubernetes path has completed sampling, export, paired evaluation, and artifact publication on an L4. Its tested groups had equal rewards and therefore no optimizer updates. A fresh Transformers/PEFT process loaded the exported adapter and completed local evaluations, confirming export usability across that backend change. Nonzero-gradient training was verified on the Modal H200 configuration above, not the L4. The paired evaluation uses the current in-memory policy; it does not reload the downloaded artifact.
+
+The Job has a finite startup wait and active deadline. Cleanup collects diagnostics, deletes resources with UID ownership checks, and waits for the owned Job, pods, Service and Secret to disappear. Owner references and a finished-Job TTL provide fallback cleanup after controller loss. None of these checks proves that AWS GPU capacity has returned to zero: the cluster autoscaler retires unused workers, and an external operator must verify the dedicated Auto Scaling group's capacity and EC2 termination after each run. Keep AWS administrator credentials outside the CPU pod.
+
+## Set up the local Docker evaluator
+
+Use Python 3.10–3.14 and a running Docker daemon capable of running `linux/amd64` images. On ARM machines, Docker needs AMD64 emulation. Run commands from this directory:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+Connect to your existing ZenML server and select a stack with a **local orchestrator**. The pipeline starts Docker containers on the controller host, so a remote orchestrator is unsupported. Your artifact store can be local or remote, including S3, provided its integration and credentials are configured. Check the active stack with `zenml stack describe`.
+
+The preparation step downloads pinned dataset files, checks their SHA-256 hashes, and builds missing task images. Building images can download base images and packages. Every run performs fresh initial-state, no-op, reference-solution, and corrupted-output qualification in isolated CPU containers. Local caches save downloads and image builds; they do not skip qualification.
+
+## Check the pipeline without inference
+
+```bash
+python run.py --mode fixture \
+  --data-directory ./data \
+  --output-directory ./runs
+```
+
+Fixture mode makes no model requests. It supplies each task's reference solution as a scripted command to exercise the evaluation and report path; its results are **not a model score**. Preparation still needs network access when dataset files or build dependencies are missing.
+
+Omit `--task-id` to use all ten reviewed tasks. For a smaller run, repeat the option with IDs from `tasks.json`:
+
+```bash
+python run.py --mode fixture \
+  --task-id task_000000_009a1afa \
+  --task-id task_000000_00e67104
+```
+
+## Evaluate an existing endpoint
+
+Provide an OpenAI-compatible API base URL. Include `/v1` when the server requires it; the client appends `/chat/completions`.
+
+```bash
+python run.py --mode endpoint \
+  --base-url http://127.0.0.1:8000/v1 \
+  --model-name Qwen/Qwen2.5-1.5B-Instruct \
+  --model-revision 989aa7980e4cf806f80c7fef2b1adb7bc71aa306
+```
+
+The model name and revision above are the defaults. Supply the actual immutable model revision when evaluating another checkpoint. For an existing endpoint, that revision is caller-supplied provenance; the client marks it unverified and excludes the run from checkpoint comparisons because it cannot prove which weights the server loaded. Set `ENDLESS_API_KEY` in the environment if authentication is required. Remote endpoints require HTTPS; credentials in URLs and HTTP redirects are rejected.
+
+Endpoint mode does not start or stop the model server. You remain responsible for its lifecycle and any associated GPU capacity. Requests have a subprocess-enforced deadline and no implicit retries.
+
+## Legacy local evaluation with temporary Kubernetes serving
+
+This optional local-controller mode creates a vLLM serving Job in an existing cluster. It does not provision the cluster, namespace, GPU node group, NVIDIA device plugin, or autoscaler. Install and authenticate the external `aws` and `kubectl` CLIs first. This is separate from the native Kubernetes pipeline above.
+
+Use a dedicated GPU Auto Scaling group that starts empty with minimum and desired capacity zero. The cluster autoscaler must be configured to provision a suitable GPU worker for the Job's node selector and resource request. The supplied Job selects `pool=gpu` and tolerates `pool=gpu:NoSchedule`; override `node_selector` and `tolerations` if your dedicated pool uses different labels or taints. The serving image must have a vLLM-compatible entrypoint and be pinned by an immutable image digest. The example pins vLLM 0.10.2.
+
+```bash
+cp cloud.example.json cloud.local.json
+# Replace every YOUR_* placeholder in cloud.local.json.
+python run.py --mode kubernetes --cloud-config-path cloud.local.json
+```
+
+The example allows 900 seconds for startup and sets a 3600-second serving Job deadline, including startup. Increase that explicit bound if your selected episode budgets require more time. The evaluator refuses to start an episode without sufficient serving time remaining.
+
+Review the cloud settings before running: this mode can provision billable GPU capacity and terminate the dedicated worker during cleanup. It labels the serving Job with a unique ownership token, uses a local port forward, and records cleanup evidence. Normal completion and handled failures remove the owned Job and verify the GPU group returns to zero capacity and the worker reaches EC2 `terminated`. Cleanup refuses ambiguous ownership or a worker carrying other workloads. Forced termination is disabled in the example configuration.
+
+Controller death, `SIGKILL`, or lost cloud access can prevent cleanup. The Kubernetes Job deadline stops serving but does not itself guarantee the worker is terminated. After an interrupted run, inspect the recorded Job identity and cleanup evidence, then verify the dedicated group's capacity in AWS. Do not share this GPU group with unrelated workloads.
+
+## Legacy local RL pilot
+
+This experimental workflow uses a local controller with remote GPU serving. For the native Kubernetes controller and task runners, use `run_native_training.py` above.
+
+Use Python 3.12 for training and install `requirements-training.txt` in an isolated environment. Build and publish the pinned [SkyRL server image](training_server/README.md) on an AMD64 CPU builder with sufficient disk before allocating a GPU. Set `training_image` in your cloud configuration to the published image digest, and set `server_kind` to `skyrl`. The same dedicated GPU lifecycle requirements apply. The single-GPU configuration targets a 24 GiB NVIDIA GPU; actual memory fit must be checked before a longer run.
+
+```bash
+python -m pip install -r requirements-training.txt
+cp training.example.json training.local.json
+python run_training.py --config training.local.json
+```
+
+This local pipeline qualifies tasks in CPU Docker containers, then runs one step that starts remote GPU serving, evaluates the initial adapter, samples training episodes, applies updates, evaluates the resulting policy under the same protocol, downloads the final adapter, and cleans up. A final report step receives the paired evaluation and training artifacts. Keeping these operations within one step avoids passing a live GPU service between independently scheduled steps.
+
+The default is at most 16 groups of four episodes, alternating two simple tasks from the reviewed selection. Reward is exactly 1 for an audited task pass and 0 for an audited failure. Exact sampled token IDs and log probabilities are retained; official Tinker Cookbook code computes group-relative advantages and performs the policy-gradient update. Prompt and terminal-observation tokens do not receive reward advantages. Equal-reward groups produce no optimizer update; four consecutive such groups stop the pilot. A completed pipeline with zero optimizer steps means no learning occurred.
+
+The controller reserves time for the paired evaluation using its full interaction budgets, the observed initial evaluation duration, and an export margin. This is an estimate; the Kubernetes Job deadline remains the hard lifetime bound, and a deadline or infrastructure failure makes the run fail rather than producing a partial success score. Review `serving_deadline` before running and keep the group count small until sampling, updating, and exporting work on the selected GPU.
+
+The `trained_adapter` model artifact contains downloaded sampling adapter weights and file hashes. It is not a resumable optimizer checkpoint. `training_evidence` contains rewards, update metrics, exact sampled tokens, transcripts, and cleanup evidence. The HTML report separates the number of optimizer updates from the before/after task score. These tasks have informed development and are reused for training, so this is a training-set demonstration, not evidence of held-out generalization.
+
+## Inspect and compare artifacts
+
+Open the completed run in ZenML and inspect the HTML report artifact. It shows audited task outcomes, response-format validity, token usage, transcripts, verifier output, and cleanup status. Infrastructure errors remain separate from failed tasks. JSON episode evidence and `report.html` are also written under `<output-directory>/<pipeline-run-id>/`. Failed evaluations retain local evidence and attempt to upload `failed_evaluation_results` and `failed_evaluation_report` before the step fails.
+
+Use the prior **`evaluation_results` artifact version ID**, not its report artifact or pipeline run ID, to compare a later run:
+
+```bash
+python run.py --mode kubernetes \
+  --cloud-config-path cloud.local.json \
+  --baseline-artifact-id YOUR_EVALUATION_ARTIFACT_VERSION_UUID
+```
+
+A comparison requires matching task sets, task image and file hashes, dataset revision, evaluation mode, and protocol, including runtime and serving-code hashes. Existing-endpoint runs have unverified model revisions and cannot be compared. Change the model settings explicitly when comparing checkpoints. Paired outcomes from this subset alone do not establish a training gain.
+
+## Runtime boundaries
+
+The local evaluator runs each task in a network-disabled Docker container with one CPU, 1 GiB memory, and a process limit; native pipelines use the Kubernetes or Modal sandbox isolation described above. A persistent Bash process retains working-directory and shell-variable state between commands. Local defaults allow 16 responses, 10 seconds per terminal command, and 180 seconds of agent interaction. Grading has a separate 120-second execution limit; Docker setup and cleanup also have bounded operations.
+
+During model evaluation, the model sees the task instruction and terminal observations. Final graders and reference solutions remain outside the agent container. Fixture mode explicitly executes the reference solution as described above. After interaction, the runner stops task processes and transfers only regular files and directories from `/home/user` into a clean image for grading. Protected-source hashes are checked independently. A raw grader pass counts as an audited pass only when those checks also pass. Tasks requiring changes outside `/home/user` are unsupported. Containers provide process isolation, not protection against Docker or kernel exploits.
+
+The adapter uses Bash pipes and runs the image's Python and pytest directly in the clean verifier. It does not execute the upstream `tests/test.sh` dependency-installation workflow. Scores therefore belong to this recorded adaptation; they should not be presented as canonical Harbor or upstream SkyRL benchmark results. Rebuilt task images may contain newer base packages, so their immutable image IDs are part of the comparison contract.
+
+## Tests and attribution
+
+Inspired by [Mercor and SkyRL's guide to training knowledge-work agents](https://www.mercor.com/blog/training-frontier-knowledge-work-agents-a-397b-rl-training-guide-with-skyrl/), this example demonstrates a smaller workflow using public terminal tasks. It does not reproduce their APEX-Agents training recipe or results.
+
+From this directory, run the focused tests:
+
+```bash
+python -m pip install pytest
+python -m pytest -q tests runtime/test_runtime.py
+```
+
+Dataset files are distributed under the upstream dataset's MIT license. The minimal system prompt and XML action parser are adapted from [Endless Terminals](https://github.com/kanishkg/endless-terminals) at commit `99f4c74b75faacf21e53d3dc01df170902e924cb`, under Apache-2.0; see `runtime/LICENSE.endless-terminals`. The parser intentionally preserves the pinned implementation's last-command selection and done-action precedence.

--- a/examples/endless_terminals/baseline.py
+++ b/examples/endless_terminals/baseline.py
@@ -1,0 +1,507 @@
+"""Screen qualified tasks with one unchanged sampler and a fixed GPU budget."""
+
+import hashlib
+import html
+import json
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from dataset import sha256
+from modal_service import ModalServiceConfig, ModalTrainingService
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from reporting import render_evaluation_report, summarize_evaluation
+from runtime.contract import CONCISE_XML_V1_SYSTEM_MESSAGE, SYSTEM_MESSAGE
+from runtime.runner import run_episode
+from sandbox_pipeline import (
+    SandboxPipelineConfig,
+    create_environment,
+    evaluate_sandbox_fixture,
+    fixture_matches,
+    load_bundle_task,
+    qualify_sandbox_initial,
+)
+from training_client import TinkerPolicy
+
+from zenml import get_step_context, pipeline, save_artifact, step
+from zenml.client import Client
+from zenml.types import HTMLString
+
+
+class BaselineConfig(BaseModel):
+    """Pin the screening model, task selection, and bounded Modal resources."""
+
+    model_config = ConfigDict(extra="forbid")
+    controller_image: str = Field(pattern=r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+    model_name: Literal["Qwen/Qwen2.5-7B-Instruct"] = (
+        "Qwen/Qwen2.5-7B-Instruct"
+    )
+    model_revision: Literal["a09a35458c702b33eeacc393d103063234e8bc28"] = (
+        "a09a35458c702b33eeacc393d103063234e8bc28"
+    )
+    task_ids: list[str] = Field(min_length=1, max_length=20)
+    sandbox: SandboxPipelineConfig
+    service: ModalServiceConfig
+    modal_agent_images: dict[str, str] = Field(default_factory=dict)
+    attempts_per_task: Literal[3] = 3
+    prompt_variant: Literal["upstream", "concise_xml_v1"] = "concise_xml_v1"
+    temperature: float = Field(default=0.8, ge=0.8, le=0.8)
+    max_tokens: Literal[512] = 512
+    max_actions: Literal[8] = 8
+    episode_timeout: Literal[90] = 90
+    command_timeout: float = Field(default=10, gt=0, le=90)
+    max_context: Literal[8192] = 8192
+
+    @model_validator(mode="after")
+    def validate_selection(self) -> "BaselineConfig":
+        """Reject ambiguous selections and invalid task image overrides.
+
+        Returns:
+            Validated baseline configuration.
+
+        Raises:
+            ValueError: IDs are duplicated or image overrides are invalid.
+        """
+        if (
+            self.sandbox.modal_workspace != self.service.workspace
+            or self.sandbox.modal_environment != self.service.modal_environment
+        ):
+            raise ValueError(
+                "Sandbox and service Modal workspace/environment must match"
+            )
+        if len(set(self.task_ids)) != len(self.task_ids):
+            raise ValueError("Task IDs must be unique")
+        if set(self.modal_agent_images) != set(self.task_ids):
+            raise ValueError(
+                "Every selected task requires its own Modal agent image"
+            )
+        for task_id in self.task_ids:
+            self.task_config(task_id)
+        return self
+
+    def task_config(self, task_id: str) -> SandboxPipelineConfig:
+        """Build validated runtime settings for exactly one selected task.
+
+        Args:
+            task_id: Selected task identifier.
+
+        Returns:
+            Single-task sandbox settings with the correct Modal image.
+        """
+        values = self.sandbox.model_dump()
+        values.update(
+            task_ids=[task_id],
+            episode_timeout=self.episode_timeout,
+            command_timeout=self.command_timeout,
+        )
+        if task_id in self.modal_agent_images:
+            values["modal_agent_image"] = self.modal_agent_images[task_id]
+        return SandboxPipelineConfig.model_validate(values)
+
+
+@step(enable_cache=False, settings={"orchestrator": {"timeout": 3600}})
+def qualify_baseline_tasks(
+    bundle: Path, config: BaselineConfig
+) -> Annotated[dict[str, Any], "baseline_qualification"]:
+    """Run all three CPU checks for each task before any GPU allocation.
+
+    Args:
+        bundle: Immutable uploaded task bundle.
+        config: Task selection and sandbox settings.
+
+    Returns:
+        Per-task checks and explicit qualified and rejected selections.
+    """
+    result: dict[str, Any] = {"tasks": [], "qualified": [], "rejected": []}
+    for task_id in config.task_ids:
+        settings = config.task_config(task_id)
+        task = load_bundle_task(bundle, settings)
+        initial = qualify_sandbox_initial.entrypoint(bundle, settings)
+        reference = evaluate_sandbox_fixture.entrypoint(
+            bundle, initial, settings, "reference"
+        )
+        noop = evaluate_sandbox_fixture.entrypoint(
+            bundle, initial, settings, "noop"
+        )
+        grade = initial.get("grading") or {}
+        valid = (
+            initial.get("task") == task
+            and initial.get("cleanup_complete") is True
+            and grade.get("audited_valid") is True
+            and not grade.get("infrastructure_error")
+            and fixture_matches(reference, 1)
+            and fixture_matches(noop, 0)
+        )
+        result["tasks"].append(
+            {
+                "task": task,
+                "initial": initial,
+                "reference": reference,
+                "noop": noop,
+                "qualified": bool(valid),
+                "rejection_reason": None
+                if valid
+                else "initial, reference, noop, or cleanup check failed",
+            }
+        )
+        result["qualified" if valid else "rejected"].append(task_id)
+        save_artifact(result, name="baseline_qualification_progress")
+    return result
+
+
+def baseline_summary(result: dict[str, Any]) -> dict[str, Any]:
+    """Separate graded task outcomes from invalid and unattempted episodes.
+
+    Args:
+        result: Baseline evidence, including its intended task selection.
+
+    Returns:
+        Aggregate counts and per-task attempt outcomes.
+    """
+    summary = summarize_evaluation(result)
+    summary["tasks"] = {}
+    for task_id in result["selected_task_ids"]:
+        episodes = [e for e in result["episodes"] if e["task_id"] == task_id]
+        counts = summarize_evaluation({"episodes": episodes})
+        summary["tasks"][task_id] = {
+            key: counts[key]
+            for key in (
+                "attempts",
+                "passes",
+                "failures",
+                "infrastructure_errors",
+                "incomplete",
+            )
+        }
+        summary["tasks"][task_id]["unattempted"] = result[
+            "attempts_per_task"
+        ] - len(episodes)
+    summary["status"] = result["status"]
+    summary["unattempted"] = len(result["unattempted"])
+    return summary
+
+
+def render_baseline_report(result: dict[str, Any]) -> HTMLString:
+    """Show attempt coverage and per-task screening outcomes with transcripts.
+
+    Args:
+        result: Complete or bounded baseline evidence.
+
+    Returns:
+        Self-contained baseline screening report.
+    """
+    summary = baseline_summary(result)
+    rows = "".join(
+        "<tr><td>"
+        + html.escape(task_id)
+        + "</td>"
+        + "".join(
+            f"<td>{counts[key]}</td>"
+            for key in (
+                "passes",
+                "failures",
+                "infrastructure_errors",
+                "incomplete",
+                "unattempted",
+            )
+        )
+        + "</tr>"
+        for task_id, counts in summary["tasks"].items()
+    )
+    coverage = (
+        "<h2>Unchanged-model screening</h2>"
+        "<p>Optimizer updates: 0. Three planned attempts per qualified task. "
+        "Infrastructure-invalid and unattempted episodes are not task failures.</p>"
+        "<table><tr><th>Task</th><th>Passes</th><th>Failures</th>"
+        "<th>Infrastructure errors</th><th>Incomplete</th><th>Unattempted</th></tr>"
+        + rows
+        + "</table><details><summary>CPU qualification and rejected tasks</summary><pre>"
+        + html.escape(json.dumps(result["qualification"], indent=2))
+        + "</pre></details>"
+    )
+    display = {
+        **result,
+        "episodes": [
+            {
+                **episode,
+                "task_id": f"{episode['task_id']} / attempt {episode['attempt_index']}",
+            }
+            for episode in result["episodes"]
+        ],
+    }
+    report = str(render_evaluation_report(display))
+    return HTMLString(
+        report.replace(
+            "<h2>Task results</h2>", coverage + "<h2>Task results</h2>"
+        )
+    )
+
+
+def execute_baseline(
+    bundle: Path,
+    qualification: dict[str, Any],
+    config: BaselineConfig,
+    run_id: str,
+    output: Path,
+) -> dict[str, Any]:
+    """Evaluate one zero-update snapshot and retain evidence through failures.
+
+    Args:
+        bundle: Materialized task directory.
+        qualification: Completed CPU check evidence for every selected task.
+        config: Pinned baseline limits and resources.
+        run_id: Unique pipeline run identifier.
+        output: New persistent local evidence directory.
+
+    Returns:
+        Completed or budget-limited baseline evidence.
+
+    Raises:
+        RuntimeError: Qualification, provider execution, or cleanup is invalid.
+    """  # noqa: DOC503
+    entries = qualification.get("tasks", [])
+    if [entry["task"]["task_id"] for entry in entries] != config.task_ids:
+        raise RuntimeError(
+            "CPU qualification missing tasks; GPU service was not started"
+        )
+    accepted = []
+    for entry in entries:
+        task = entry["task"]
+        if (
+            load_bundle_task(bundle, config.task_config(task["task_id"]))
+            != task
+        ):
+            raise RuntimeError(
+                "Qualified task identities changed; GPU service was not started"
+            )
+        if not all(
+            entry[phase].get("cleanup_complete") is True
+            for phase in ("initial", "reference", "noop")
+        ):
+            raise RuntimeError(
+                "CPU cleanup failed; GPU service was not started"
+            )
+        grade = entry["initial"].get("grading") or {}
+        valid = (
+            entry["initial"].get("task") == task
+            and grade.get("audited_valid") is True
+            and not grade.get("infrastructure_error")
+            and fixture_matches(entry["reference"], 1)
+            and fixture_matches(entry["noop"], 0)
+        )
+        if valid:
+            accepted.append(task)
+    if not accepted:
+        raise RuntimeError("No tasks qualified; GPU service was not started")
+    tasks = accepted
+    accepted_ids = [task["task_id"] for task in tasks]
+    output.mkdir(parents=True, exist_ok=False)
+    system_message = (
+        CONCISE_XML_V1_SYSTEM_MESSAGE
+        if config.prompt_variant == "concise_xml_v1"
+        else SYSTEM_MESSAGE
+    )
+    schedule = [
+        {"task_id": task_id, "attempt_index": index}
+        for index in range(1, config.attempts_per_task + 1)
+        for task_id in accepted_ids
+    ]
+    result: dict[str, Any] = {
+        "run_id": run_id,
+        "mode": "model",
+        "status": "running",
+        "model": {
+            "name": config.model_name,
+            "revision": config.model_revision,
+            "revision_verified": True,
+        },
+        "dataset_revision": tasks[0]["dataset_revision"],
+        "selected_task_ids": accepted_ids,
+        "requested_task_ids": config.task_ids,
+        "qualification": qualification,
+        "attempts_per_task": config.attempts_per_task,
+        "optimizer_steps": 0,
+        "episodes": [],
+        "unattempted": schedule.copy(),
+        "cleanup": {"complete": False},
+        "task_hashes": {
+            task["task_id"]: {
+                "files": task["task_file_sha256"],
+                "image": task["image_ref"],
+            }
+            for task in tasks
+        },
+        "protocol": {
+            "backend": "skyrl_tinker",
+            "prompt_variant": config.prompt_variant,
+            "system_prompt_sha256": hashlib.sha256(
+                system_message.encode()
+            ).hexdigest(),
+            "max_actions": config.max_actions,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "max_context": config.max_context,
+            "episode_timeout": config.episode_timeout,
+            "command_timeout": config.command_timeout,
+            "serving_deadline": config.service.serving_deadline,
+            "training_image": config.service.training_image,
+            "source_sha256": {
+                str(path.relative_to(Path(__file__).parent)): sha256(path)
+                for path in sorted(Path(__file__).parent.rglob("*.py"))
+                if "tests" not in path.parts
+            },
+        },
+    }
+    session = ModalTrainingService(
+        config.service, result["model"], run_id, output / "service"
+    )
+    error: BaseException | None = None
+    in_flight: dict[str, Any] | None = None
+    try:
+        with session:
+            policy = TinkerPolicy(
+                session.base_url,
+                config.model_name,
+                config.model_revision,
+                max_tokens=config.max_tokens,
+                temperature=config.temperature,
+                max_context=config.max_context,
+                api_key=session.api_key,
+                trusted_service_host=session.service_host,
+            )
+            snapshot = policy.snapshot(
+                "baseline", timeout=min(600, session.serving_seconds_remaining)
+            )
+            if (
+                policy.optimizer_steps != 0
+                or snapshot["identity"]["optimizer_steps"] != 0
+            ):
+                raise RuntimeError(
+                    "Baseline sampler must have zero optimizer updates"
+                )
+            result["model"]["checkpoint"] = snapshot["identity"]
+            result["inference"] = session.identity
+            (output / "evaluation.json").write_text(
+                json.dumps(result, indent=2)
+            )
+            by_id = {task["task_id"]: task for task in tasks}
+            for attempt in schedule:
+                if (
+                    session.serving_seconds_remaining
+                    < config.episode_timeout + 300
+                ):
+                    result["status"] = "bounded_partial"
+                    result["stop_reason"] = "serving_deadline_reserve"
+                    break
+                task = by_id[attempt["task_id"]]
+                settings = config.task_config(task["task_id"])
+                in_flight = attempt
+                episode = run_episode(
+                    task,
+                    bundle / task["task_id"],
+                    policy.episode_model(snapshot),
+                    output
+                    / task["task_id"]
+                    / f"attempt-{attempt['attempt_index']:02d}",
+                    identity=result["model"],
+                    system_message=system_message,
+                    max_actions=config.max_actions,
+                    command_timeout=config.command_timeout,
+                    episode_timeout=config.episode_timeout,
+                    environment_factory=lambda image, command, duration: (
+                        create_environment(
+                            {**task, "image_ref": image},
+                            settings.model_copy(
+                                update={
+                                    "command_timeout": command,
+                                    "episode_timeout": duration,
+                                }
+                            ),
+                        )
+                    ),
+                )
+                episode["attempt_index"] = attempt["attempt_index"]
+                result["episodes"].append(episode)
+                in_flight = None
+                result["unattempted"].pop(0)
+                (output / "evaluation.json").write_text(
+                    json.dumps(result, indent=2)
+                )
+                save_artifact(result, name="baseline_progress")
+                if episode.get("cleanup_complete") is not True:
+                    raise RuntimeError(
+                        "Episode cleanup incomplete; baseline stopped"
+                    )
+            else:
+                result["status"] = "completed"
+                result["stop_reason"] = "all_attempts_recorded"
+            if policy.optimizer_steps != 0:
+                raise RuntimeError("Baseline policy unexpectedly changed")
+    except BaseException as exc:
+        error = exc
+        result["status"] = "failed"
+        result["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    finally:
+        result["cleanup"] = dict(session.cleanup_report)
+        result["cleanup"]["interrupted_attempt"] = in_flight
+        result["cleanup"]["sandboxes_complete"] = in_flight is None and all(
+            episode.get("cleanup_complete") is True
+            for episode in result["episodes"]
+        )
+        result["cleanup"]["complete"] = (
+            result["cleanup"].get("complete") is True
+            and result["cleanup"]["sandboxes_complete"]
+        )
+        if not result["cleanup"]["complete"]:
+            result["status"] = "failed"
+        result["summary"] = baseline_summary(result)
+        (output / "evaluation.json").write_text(json.dumps(result, indent=2))
+        (output / "report.html").write_text(
+            str(render_baseline_report(result))
+        )
+        save_artifact(result, name="baseline_results")
+        save_artifact(output, name="baseline_diagnostics")
+    if error is not None:
+        raise error
+    if result["status"] == "failed":
+        raise RuntimeError(
+            "Baseline cleanup incomplete; inspect retained evidence"
+        )
+    return result
+
+
+@step(enable_cache=False, settings={"orchestrator": {"timeout": 6000}})
+def evaluate_baseline(
+    bundle: Path, qualification: dict[str, Any], config: BaselineConfig
+) -> Annotated[dict[str, Any], "baseline_evaluation"]:
+    """Allocate the bounded GPU service after CPU qualification finishes.
+
+    Args:
+        bundle: Immutable task artifact directory.
+        qualification: CPU qualification dependency.
+        config: Pinned run configuration.
+
+    Returns:
+        Baseline evidence with explicit attempt coverage.
+    """
+    run_id = str(get_step_context().pipeline_run.id)
+    output = Path(tempfile.mkdtemp(prefix="endless-baseline-")) / run_id
+    result = execute_baseline(bundle, qualification, config, run_id, output)
+    save_artifact(render_baseline_report(result), name="baseline_report")
+    return result
+
+
+@pipeline(enable_cache=False)
+def endless_terminals_modal_baseline(
+    bundle_artifact_id: UUID, config: BaselineConfig
+) -> None:
+    """Qualify the complete selection before evaluating the unchanged model.
+
+    Args:
+        bundle_artifact_id: Uploaded immutable task bundle artifact version.
+        config: Screening configuration.
+    """
+    bundle = Client().get_artifact_version(bundle_artifact_id)
+    qualification = qualify_baseline_tasks(bundle, config)
+    evaluate_baseline(bundle, qualification, config)

--- a/examples/endless_terminals/checkpoint_download.py
+++ b/examples/endless_terminals/checkpoint_download.py
@@ -1,0 +1,219 @@
+"""Download a bounded adapter archive through the native authenticated proxy."""
+
+import errno
+import json
+import os
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import time
+from http.client import IncompleteRead
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
+DOWNLOAD_ATTEMPTS = 3
+DOWNLOAD_BUDGET_SECONDS = 300
+READ_TIMEOUT_SECONDS = 60
+
+
+class NoRedirect(HTTPRedirectHandler):
+    """Reject redirects so the API key cannot follow another origin."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        """Reject the redirect instead of forwarding credentials.
+
+        Args:
+            req: Original authenticated request.
+            fp: Original response stream.
+            code: Redirect status code.
+            msg: Response reason.
+            headers: Response headers.
+            newurl: Redirect destination that will not be requested.
+        """
+        return None
+
+
+def download_archive(
+    url: str, output: Path, base_url: str, api_key: str
+) -> None:
+    """Fetch and safely extract an archive from the training API origin.
+
+    Args:
+        url: Archive URL returned by the training service.
+        output: Empty destination directory.
+        base_url: Already validated training origin.
+        api_key: Per-run credential.
+
+    Raises:
+        ValueError: The URL, archive paths, or sizes violate the contract.
+        OSError: A download fails after bounded transient retries.
+        IncompleteRead: An incomplete response persists after bounded retries.
+        TimeoutError: Reads time out or the shared download budget expires.
+        tarfile.TarError: The archive cannot be read safely.
+    """  # noqa: DOC503 - Archive parsing errors propagate from tarfile.
+    source, origin = urlsplit(url), urlsplit(base_url)
+    if (
+        (source.scheme, source.hostname, source.port)
+        != (origin.scheme, origin.hostname, origin.port)
+        or source.username
+        or source.password
+        or source.fragment
+    ):
+        raise ValueError("Checkpoint archive must use the training origin")
+    if any(output.iterdir()):
+        raise ValueError("Checkpoint destination must be empty")
+    request = Request(url, headers={"X-API-Key": api_key})
+    deadline = time.monotonic() + DOWNLOAD_BUDGET_SECONDS
+    for attempt in range(DOWNLOAD_ATTEMPTS):
+        # A failed response must never contribute bytes to the next attempt.
+        with tempfile.TemporaryFile() as downloaded:
+            try:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("Checkpoint download budget exhausted")
+                with build_opener(NoRedirect()).open(
+                    request, timeout=min(READ_TIMEOUT_SECONDS, remaining)
+                ) as response:
+                    size = 0
+                    while chunk := response.read(1024 * 1024):
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                "Checkpoint download budget exhausted"
+                            )
+                        size += len(chunk)
+                        if size > MAX_ARCHIVE_BYTES:
+                            raise ValueError(
+                                "Checkpoint archive exceeds download limit"
+                            )
+                        downloaded.write(chunk)
+            except (OSError, IncompleteRead) as error:
+                cause = error.reason if isinstance(error, URLError) else error
+                transient = isinstance(
+                    cause, (TimeoutError, ConnectionError, IncompleteRead)
+                ) or (
+                    isinstance(cause, OSError)
+                    and cause.errno
+                    in {errno.ETIMEDOUT, errno.ENETUNREACH, errno.EHOSTUNREACH}
+                )
+                if (
+                    not transient
+                    or attempt + 1 == DOWNLOAD_ATTEMPTS
+                    or time.monotonic() >= deadline
+                ):
+                    raise
+                continue
+            downloaded.seek(0)
+            with (
+                tempfile.TemporaryDirectory(dir=output.parent) as staged,
+                tarfile.open(fileobj=downloaded, mode="r:*") as archive,
+            ):
+                members: list[tarfile.TarInfo] = []
+                paths: set[PurePosixPath] = set()
+                total = 0
+                for member in archive:
+                    path = PurePosixPath(member.name)
+                    total += member.size
+                    if (
+                        path.is_absolute()
+                        or ".." in path.parts
+                        or (not path.parts and not member.isdir())
+                        or path in paths
+                        or not (member.isfile() or member.isdir())
+                        or member.size < 0
+                        or total > MAX_ARCHIVE_BYTES
+                        or len(members) >= 10000
+                    ):
+                        raise ValueError(
+                            "Unsafe or oversized checkpoint archive"
+                        )
+                    paths.add(path)
+                    members.append(member)
+                for member in members:
+                    target = Path(staged).joinpath(
+                        *PurePosixPath(member.name).parts
+                    )
+                    if member.isdir():
+                        target.mkdir(parents=True, exist_ok=True)
+                    else:
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        content = archive.extractfile(member)
+                        if content is None:
+                            raise ValueError("Missing checkpoint file content")
+                        with content, target.open("xb") as destination:
+                            shutil.copyfileobj(content, destination)
+                Path(staged).replace(output)
+            return
+
+
+def checkpoint_coordinates(checkpoint: str) -> tuple[str, str]:
+    """Resolve a sampler path into the pinned SkyRL archive route fields.
+
+    SkyRL returns two path components while Tinker's path convenience method
+    requires three. Its explicit archive method supports SkyRL's route.
+
+    Args:
+        checkpoint: Short SkyRL or canonical sampler checkpoint path.
+
+    Returns:
+        Model ID and bare sampler checkpoint ID.
+
+    Raises:
+        ValueError: The path is not a bounded sampler checkpoint identifier.
+    """
+    match = re.fullmatch(
+        r"tinker://([A-Za-z0-9_-]{1,255})/(?:sampler_weights/)?([A-Za-z0-9_-]{1,255})",
+        checkpoint,
+    )
+    if match is None:
+        raise ValueError("Invalid SkyRL sampler checkpoint path")
+    return match.group(1), match.group(2)
+
+
+def main() -> None:
+    """Resolve a Tinker checkpoint and download it using the per-run key."""
+    import tinker
+
+    checkpoint, destination, base_url = sys.argv[1:]
+    api_key = os.environ["TINKER_API_KEY"]
+    model_id, checkpoint_id = checkpoint_coordinates(checkpoint)
+    client = tinker.ServiceClient(base_url=base_url, api_key=api_key)
+    result = (
+        client.create_rest_client()
+        .get_checkpoint_archive_url(model_id, checkpoint_id)
+        .result(timeout=60)
+    )
+    download_archive(result.url, Path(destination), base_url, api_key)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        # The parent suppresses SDK stderr; retain a bounded, redacted cause.
+        if len(sys.argv) == 4:
+            message = str(error).replace(
+                os.environ.get("TINKER_API_KEY", "[NO_KEY]"), "[REDACTED]"
+            )
+            (
+                Path(sys.argv[2]).parent / "checkpoint-download-error.json"
+            ).write_text(
+                json.dumps(
+                    {"type": type(error).__name__, "message": message[:4096]}
+                )
+                + "\n"
+            )
+        raise

--- a/examples/endless_terminals/cloud.example.json
+++ b/examples/endless_terminals/cloud.example.json
@@ -1,0 +1,15 @@
+{
+  "aws_profile": "YOUR_AWS_PROFILE",
+  "aws_region": "YOUR_AWS_REGION",
+  "kube_context": "YOUR_KUBERNETES_CONTEXT",
+  "namespace": "YOUR_EXISTING_NAMESPACE",
+  "gpu_asg": "YOUR_DEDICATED_GPU_AUTOSCALING_GROUP",
+  "vllm_image": "docker.io/vllm/vllm-openai@sha256:df2607b26bdda2875de4832f4d08da0055b4b6e3570347f3a849bcc652771dd6",
+  "node_selector": {
+    "pool": "gpu"
+  },
+  "startup_timeout": 900,
+  "serving_deadline": 3600,
+  "cleanup_timeout": 240,
+  "force_termination": false
+}

--- a/examples/endless_terminals/cloud.py
+++ b/examples/endless_terminals/cloud.py
@@ -1,0 +1,754 @@
+"""Bounded Kubernetes inference with explicit ownership and GPU teardown."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+
+class KubernetesInference:
+    """Create an isolated serving job and verify its worker is terminated."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        model: dict[str, str],
+        run_id: str,
+        evidence_directory: Path,
+    ) -> None:
+        """Configure a session without contacting cloud services.
+
+        Args:
+            config: Explicit cloud, Kubernetes, image, and timeout settings.
+            model: Hugging Face model name and immutable revision.
+            run_id: Label identifying the evaluation run.
+            evidence_directory: Directory for operational evidence.
+
+        Raises:
+            ValueError: The serving image is not pinned by digest.
+            RuntimeError: A required executable is unavailable.
+        """
+        self.server_kind = config.get("server_kind", "vllm")
+        if self.server_kind not in {"vllm", "skyrl"}:
+            raise ValueError("server_kind must be vllm or skyrl")
+        image_key = (
+            "training_image" if self.server_kind == "skyrl" else "vllm_image"
+        )
+        self.image = config[image_key]
+        if not re.search(r"@sha256:[0-9a-f]{64}$", self.image):
+            raise ValueError(
+                f"{image_key} must use an immutable sha256 digest"
+            )
+        self.config, self.model = dict(config), dict(model)
+        self.directory = evidence_directory
+        self.token = uuid.uuid4().hex
+        self.name = "endless-" + self.token[:20]
+        self.identity = {
+            "run_id": run_id,
+            "job_name": self.name,
+            "ownership_token": self.token,
+            "model": self.model,
+            "server_kind": self.server_kind,
+            "image": self.image,
+            image_key: self.image,
+        }
+        self.cleanup_report: dict[str, Any] = {"complete": False, "errors": []}
+        self.base_url = ""
+        self.uid: str | None = None
+        self.attempted = False
+        self._serving_deadline: float | None = None
+        self.instance_id: str | None = None
+        self.forward: subprocess.Popen[str] | None = None
+        self.forward_log: Any = None
+        self.env = {
+            **os.environ,
+            "AWS_PROFILE": config["aws_profile"],
+            "AWS_DEFAULT_REGION": config["aws_region"],
+            "AWS_REGION": config["aws_region"],
+        }
+        self.aws = shutil.which("aws")
+        self.kubectl = shutil.which("kubectl")
+        if not self.aws or not self.kubectl:
+            raise RuntimeError("aws and kubectl must be available on PATH")
+
+    @property
+    def serving_seconds_remaining(self) -> float:
+        """Return the conservative remaining job lifetime, including startup.
+
+        Returns:
+            Seconds before the serving deadline, or zero before creation.
+            Reserve an additional margin before starting another episode.
+        """
+        if self._serving_deadline is None:
+            return 0.0
+        return max(0.0, self._serving_deadline - time.monotonic())
+
+    def _call(self, args: list[str], timeout: float = 60) -> str:
+        result = subprocess.run(
+            args, env=self.env, capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode:
+            raise RuntimeError(f"{args[0]} failed: {result.stderr[:2000]}")
+        return result.stdout
+
+    def _kube(self, *args: str) -> str:
+        return self._call(
+            [
+                str(self.kubectl),
+                "--context",
+                self.config["kube_context"],
+                *args,
+            ]
+        )
+
+    def _aws(self, *args: str) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            json.loads(
+                self._call(
+                    [
+                        str(self.aws),
+                        "--profile",
+                        self.config["aws_profile"],
+                        "--region",
+                        self.config["aws_region"],
+                        *args,
+                        "--output",
+                        "json",
+                    ]
+                )
+            ),
+        )
+
+    def _group(self) -> dict[str, Any]:
+        groups = self._aws(
+            "autoscaling",
+            "describe-auto-scaling-groups",
+            "--auto-scaling-group-names",
+            self.config["gpu_asg"],
+        )["AutoScalingGroups"]
+        if len(groups) != 1:
+            raise RuntimeError(
+                "Expected exactly one dedicated GPU autoscaling group"
+            )
+        return cast(dict[str, Any], groups[0])
+
+    def _job(self) -> dict[str, Any] | None:
+        raw = self._kube(
+            "get",
+            "job",
+            self.name,
+            "-n",
+            self.config["namespace"],
+            "--ignore-not-found=true",
+            "-o",
+            "json",
+        )
+        return json.loads(raw) if raw.strip() else None
+
+    def _owned(self, job: dict[str, Any]) -> None:
+        metadata = job["metadata"]
+        if metadata.get("labels", {}).get("endless-owner") != self.token:
+            raise RuntimeError(
+                "Job ownership token mismatch; refusing deletion"
+            )
+        if self.uid and metadata["uid"] != self.uid:
+            raise RuntimeError("Job UID changed; refusing deletion")
+        self.uid = metadata["uid"]
+
+    def _manifest(self) -> dict[str, Any]:
+        labels = {
+            "endless-owner": self.token,
+            "endless-run": re.sub(
+                r"[^a-zA-Z0-9_.-]", "-", self.identity["run_id"]
+            )[:63].strip("-_.")
+            or "run",
+        }
+        manifest: dict[str, Any] = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": self.name,
+                "namespace": self.config["namespace"],
+                "labels": labels,
+            },
+            "spec": {
+                "backoffLimit": 0,
+                "activeDeadlineSeconds": self.config.get(
+                    "serving_deadline", 2700
+                ),
+                "template": {
+                    "metadata": {"labels": labels},
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "automountServiceAccountToken": False,
+                        "nodeSelector": self.config.get(
+                            "node_selector", {"pool": "gpu"}
+                        ),
+                        "tolerations": self.config.get(
+                            "tolerations",
+                            [
+                                {
+                                    "key": "pool",
+                                    "operator": "Equal",
+                                    "value": "gpu",
+                                    "effect": "NoSchedule",
+                                }
+                            ],
+                        ),
+                        "volumes": [
+                            {
+                                "name": "shm",
+                                "emptyDir": {
+                                    "medium": "Memory",
+                                    "sizeLimit": "2Gi",
+                                },
+                            }
+                        ],
+                        "containers": [
+                            {
+                                "name": "vllm",
+                                "image": self.image,
+                                "volumeMounts": [
+                                    {"name": "shm", "mountPath": "/dev/shm"}
+                                ],
+                                "args": [
+                                    "--model",
+                                    self.model["name"],
+                                    "--revision",
+                                    self.model["revision"],
+                                    "--host",
+                                    "127.0.0.1",
+                                    "--port",
+                                    "8000",
+                                    "--dtype",
+                                    "bfloat16",
+                                    "--max-model-len",
+                                    "16384",
+                                    "--max-num-seqs",
+                                    "1",
+                                    "--gpu-memory-utilization",
+                                    "0.8",
+                                    "--enforce-eager",
+                                    "--disable-log-requests",
+                                    "--generation-config",
+                                    "vllm",
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "nvidia.com/gpu": "1",
+                                        "cpu": "2",
+                                        "memory": "8Gi",
+                                    },
+                                    "limits": {
+                                        "nvidia.com/gpu": "1",
+                                        "cpu": "6",
+                                        "memory": "24Gi",
+                                    },
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "python3",
+                                            "-c",
+                                            "import urllib.request; "
+                                            "urllib.request.urlopen("
+                                            "'http://127.0.0.1:8000/health', "
+                                            "timeout=2)",
+                                        ]
+                                    },
+                                    "periodSeconds": 5,
+                                    "timeoutSeconds": 3,
+                                },
+                            }
+                        ],
+                    },
+                },
+            },
+        }
+
+        if self.server_kind == "skyrl":
+            container = manifest["spec"]["template"]["spec"]["containers"][0]
+            container["name"] = "skyrl"
+            del container["args"]
+            container["env"] = [
+                {"name": "SKYRL_MODEL_NAME", "value": self.model["name"]},
+                {"name": "SKYRL_DUMP_INFRA_LOG_TO_STDOUT", "value": "1"},
+                {
+                    "name": "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES",
+                    "value": "1073741824",
+                },
+                {
+                    "name": "SKYRL_MODEL_REVISION",
+                    "value": self.model["revision"],
+                },
+            ]
+            container["readinessProbe"]["exec"]["command"] = [
+                "python",
+                "-c",
+                "import urllib.request; "
+                "urllib.request.urlopen("
+                "'http://127.0.0.1:8000/api/v1/healthz', timeout=2)",
+            ]
+        return manifest
+
+    def __enter__(self) -> KubernetesInference:
+        """Start serving and return the session, cleaning up failed starts.
+
+        Returns:
+            This session with a verified local inference URL.
+
+        Raises:
+            RuntimeError: Ownership, startup, or cleanup verification fails.
+            BaseException: Startup interruption, reraised after cleanup.
+        """
+        self.directory.mkdir(parents=True, exist_ok=True)
+        initial = self._group()
+        if (
+            initial["MinSize"] != 0
+            or initial["DesiredCapacity"] != 0
+            or initial["Instances"]
+        ):
+            raise RuntimeError(
+                "GPU group must start empty with minimum and desired zero"
+            )
+        if self._job():
+            raise RuntimeError("Job already exists; refusing to reuse it")
+        path = self.directory / "job.json"
+        path.write_text(json.dumps(self._manifest(), indent=2))
+        try:
+            self._serving_deadline = time.monotonic() + self.config.get(
+                "serving_deadline", 2700
+            )
+            self.attempted = True
+            created = json.loads(
+                self._kube("create", "-f", str(path), "-o", "json")
+            )
+            self._owned(created)
+            self._wait_ready()
+            self._forward()
+            return self
+        except BaseException as exc:
+            try:
+                self._cleanup()
+            except Exception as cleanup_error:
+                raise RuntimeError(
+                    f"Startup failed: {exc}; cleanup failed: {cleanup_error}"
+                ) from exc
+            raise
+
+    def _pods(self) -> list[dict[str, Any]]:
+        return cast(
+            list[dict[str, Any]],
+            json.loads(
+                self._kube(
+                    "get",
+                    "pods",
+                    "-n",
+                    self.config["namespace"],
+                    "-l",
+                    "endless-owner=" + self.token,
+                    "-o",
+                    "json",
+                )
+            )["items"],
+        )
+
+    def _wait_ready(self) -> None:
+        deadline = time.monotonic() + self.config.get("startup_timeout", 900)
+        while time.monotonic() < deadline:
+            for pod in self._pods():
+                node = pod["spec"].get("nodeName")
+                if node:
+                    info = json.loads(
+                        self._kube("get", "node", node, "-o", "json")
+                    )
+                    self.instance_id = info["spec"]["providerID"].rsplit(
+                        "/", 1
+                    )[-1]
+                if pod["status"].get("phase") in {"Failed", "Succeeded"}:
+                    raise RuntimeError("Serving pod ended before readiness")
+                if any(
+                    c["type"] == "Ready" and c["status"] == "True"
+                    for c in pod["status"].get("conditions", [])
+                ):
+                    self.identity.update(
+                        {"job_uid": self.uid, "instance_id": self.instance_id}
+                    )
+                    return
+            time.sleep(5)
+        raise RuntimeError("Serving startup deadline exceeded")
+
+    @staticmethod
+    def _port() -> int:
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    def _forward(self) -> None:
+        port = self._port()
+        self.forward_log = (self.directory / "port-forward.log").open("w")
+        self.forward = subprocess.Popen(
+            [
+                str(self.kubectl),
+                "--context",
+                self.config["kube_context"],
+                "port-forward",
+                "-n",
+                self.config["namespace"],
+                "job/" + self.name,
+                f"{port}:8000",
+                "--address=127.0.0.1",
+            ],
+            env=self.env,
+            stdout=self.forward_log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        origin = f"http://127.0.0.1:{port}"
+        self.base_url = (
+            origin if self.server_kind == "skyrl" else origin + "/v1"
+        )
+        for _ in range(20):
+            if self.forward.poll() is not None:
+                raise RuntimeError("Port forwarding exited")
+            try:
+                self._verify_server()
+                return
+            except OSError:
+                time.sleep(1)
+        raise RuntimeError("Port forwarding never became ready")
+
+    def _verify_server(self) -> None:
+        if self.server_kind == "skyrl":
+            with urllib.request.urlopen(
+                self.base_url + "/api/v1/healthz", timeout=2
+            ):
+                pass
+            identity = json.loads(
+                self._kube(
+                    "exec",
+                    "-n",
+                    self.config["namespace"],
+                    "job/" + self.name,
+                    "--",
+                    "cat",
+                    "/checkpoints/server-identity.json",
+                )
+            )
+            if (
+                identity.get("model_name") != self.model["name"]
+                or identity.get("model_revision") != self.model["revision"]
+            ):
+                raise RuntimeError("Training server model identity mismatch")
+            self.identity["training_server"] = identity
+            (self.directory / "server-identity.json").write_text(
+                json.dumps(identity, indent=2)
+            )
+        else:
+            with urllib.request.urlopen(
+                self.base_url + "/models", timeout=2
+            ) as response:
+                models = json.load(response)
+            if not any(m["id"] == self.model["name"] for m in models["data"]):
+                raise RuntimeError("Served model identity mismatch")
+
+    def _delete_job(self) -> None:
+        job = self._job()
+        if job is None:
+            return
+        self._owned(job)
+        # UID preconditions protect replacements created after this read.
+        options = self.directory / "delete-options.json"
+        options.write_text(
+            json.dumps(
+                {
+                    "apiVersion": "v1",
+                    "kind": "DeleteOptions",
+                    "propagationPolicy": "Foreground",
+                    "preconditions": {"uid": self.uid},
+                }
+            )
+        )
+        url = (
+            f"/apis/batch/v1/namespaces/{self.config['namespace']}"
+            f"/jobs/{self.name}"
+        )
+        self._kube("delete", "--raw", url, "-f", str(options))
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if self._job() is None and not self._pods():
+                self.cleanup_report["job_deleted"] = True
+                return
+            time.sleep(2)
+        raise RuntimeError("Serving job or pods remain after deletion")
+
+    @staticmethod
+    def _stop(process: subprocess.Popen[str]) -> None:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    def _empty_node(self, instance_id: str) -> None:
+        nodes = json.loads(self._kube("get", "nodes", "-o", "json"))["items"]
+        node = next(
+            (
+                n
+                for n in nodes
+                if n["spec"].get("providerID", "").endswith("/" + instance_id)
+            ),
+            None,
+        )
+        if node is None:
+            return
+        name = node["metadata"]["name"]
+        for cordoned in (False, True):
+            pods = json.loads(
+                self._kube(
+                    "get",
+                    "pods",
+                    "-A",
+                    "--field-selector",
+                    "spec.nodeName=" + name,
+                    "-o",
+                    "json",
+                )
+            )["items"]
+            if any(
+                not any(
+                    r.get("kind") == "DaemonSet"
+                    for r in p["metadata"].get("ownerReferences", [])
+                )
+                for p in pods
+            ):
+                raise RuntimeError(
+                    "GPU worker has other workloads; refusing termination"
+                )
+            if not cordoned:
+                self._kube("cordon", name)
+
+    def _gpu_cleanup(self) -> None:
+        state = self._group()
+        instances = state["Instances"]
+        if len(instances) > 1:
+            raise RuntimeError(
+                "Multiple GPU instances; association is ambiguous"
+            )
+        if instances:
+            candidate = instances[0]["InstanceId"]
+            if self.instance_id and candidate != self.instance_id:
+                raise RuntimeError("GPU instance differs from serving worker")
+            self.instance_id = candidate
+            self._empty_node(candidate)
+            if not instances[0]["LifecycleState"].startswith("Terminating"):
+                flag = (
+                    "--should-decrement-desired-capacity"
+                    if state["DesiredCapacity"] > 0
+                    else "--no-should-decrement-desired-capacity"
+                )
+                self._aws(
+                    "autoscaling",
+                    "terminate-instance-in-auto-scaling-group",
+                    "--instance-id",
+                    candidate,
+                    flag,
+                )
+        deadline = time.monotonic() + self.config.get("cleanup_timeout", 240)
+        forced = False
+        while True:
+            state = self._group()
+            ec2_states: dict[str, str] = {}
+            if self.instance_id:
+                reservations = self._aws(
+                    "ec2",
+                    "describe-instances",
+                    "--instance-ids",
+                    self.instance_id,
+                )["Reservations"]
+                ec2_states = {
+                    i["InstanceId"]: i["State"]["Name"]
+                    for r in reservations
+                    for i in r["Instances"]
+                }
+            self.cleanup_report.update(
+                {
+                    "gpu_desired": state["DesiredCapacity"],
+                    "gpu_instances": state["Instances"],
+                    "ec2_states": ec2_states,
+                }
+            )
+            if (
+                state["DesiredCapacity"] == 0
+                and not state["Instances"]
+                and (
+                    not self.instance_id
+                    or ec2_states.get(self.instance_id) == "terminated"
+                )
+            ):
+                return
+            if time.monotonic() >= deadline:
+                if (
+                    self.config.get("force_termination", False)
+                    and not forced
+                    and self.instance_id
+                ):
+                    self._empty_node(self.instance_id)
+                    self.cleanup_report["force_termination_used"] = True
+                    self._aws(
+                        "ec2",
+                        "terminate-instances",
+                        "--instance-ids",
+                        self.instance_id,
+                        "--force",
+                        "--skip-os-shutdown",
+                    )
+                    forced = True
+                    deadline = time.monotonic() + self.config.get(
+                        "cleanup_timeout", 240
+                    )
+                else:
+                    raise RuntimeError(
+                        "GPU teardown did not reach verified zero capacity"
+                    )
+            time.sleep(5)
+
+    def _capture_training_logs(self) -> None:
+        """Retain bounded Ray and SkyRL log tails before removing the owned job.
+
+        Raises:
+            RuntimeError: Ownership or remote diagnostic collection fails.
+        """  # noqa: DOC502
+        job = self._job()
+        if job is None:
+            return
+        self._owned(job)
+        script = r"""
+import json, os
+from pathlib import Path
+roots = [Path('/tmp/skyrl-logs'), Path('/tmp/ray/session_latest/logs')]
+critical = {'raylet.out', 'raylet.err', 'gcs_server.out', 'gcs_server.err'}
+candidates = []
+for name in ('memory.events', 'memory.current', 'memory.peak', 'memory.max'):
+    path = Path('/sys/fs/cgroup') / name
+    if path.is_file():
+        candidates.append((-2, 0, path))
+for root in roots:
+    if not root.exists():
+        continue
+    root = root.resolve()
+    for directory, _, names in os.walk(root, followlinks=False):
+        for name in names:
+            path = Path(directory) / name
+            if path.suffix not in {'.err', '.out', '.log'} or path.is_symlink():
+                continue
+            try:
+                if not path.resolve().is_relative_to(root) or not path.is_file():
+                    continue
+                priority = -1 if name in critical else 0 if 'engine' in name.lower() else 1 if 'worker' in name.lower() else 2
+                candidates.append((priority, -path.stat().st_mtime, path))
+            except OSError:
+                continue
+remaining = 1024 * 1024
+logs = {}
+for priority, _, path in sorted(candidates)[:20]:
+    if remaining <= 0:
+        break
+    try:
+        limit = min(4096 if priority == -2 else 65536, remaining)
+        with path.open('rb') as source:
+            source.seek(max(0, path.stat().st_size - limit))
+            data = source.read(limit)
+        remaining -= len(data)
+        logs[str(path)] = data.decode('utf-8', errors='replace')
+    except OSError as exc:
+        logs[str(path)] = 'Unable to read log: ' + type(exc).__name__
+print(json.dumps({'log_tails': logs, 'max_files': 20, 'max_bytes': 1048576}))
+"""
+        output = self._call(
+            [
+                str(self.kubectl),
+                "--context",
+                self.config["kube_context"],
+                "exec",
+                "-n",
+                self.config["namespace"],
+                "job/" + self.name,
+                "--",
+                "python3",
+                "-c",
+                script,
+            ],
+            timeout=20,
+        )
+        (self.directory / "training-worker-logs.json").write_text(output)
+
+    def _cleanup(self) -> None:
+        errors = self.cleanup_report["errors"]
+        try:
+            if self.forward:
+                self._stop(self.forward)
+        except Exception as exc:
+            errors.append(f"Port forwarding: {exc}")
+        finally:
+            if self.forward_log:
+                try:
+                    self.forward_log.close()
+                except Exception as exc:
+                    errors.append(f"Closing port-forward log: {exc}")
+        if self.attempted:
+            try:
+                log = self._kube(
+                    "logs",
+                    "-n",
+                    self.config["namespace"],
+                    "job/" + self.name,
+                    "--tail=500",
+                )
+                (self.directory / "server.log").write_text(log)
+            except Exception as exc:
+                self.cleanup_report["diagnostic_error"] = str(exc)
+            if self.server_kind == "skyrl":
+                try:
+                    self._capture_training_logs()
+                except Exception as exc:
+                    self.cleanup_report["training_diagnostic_error"] = str(exc)
+            try:
+                self._delete_job()
+                self._gpu_cleanup()
+            except Exception as exc:
+                errors.append(str(exc))
+        self.cleanup_report["complete"] = not errors
+        try:
+            (self.directory / "cleanup.json").write_text(
+                json.dumps(self.cleanup_report, indent=2)
+            )
+        except OSError as exc:
+            errors.append(f"Writing cleanup evidence: {exc}")
+            self.cleanup_report["complete"] = False
+        if errors:
+            raise RuntimeError("; ".join(errors))
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        """Stop serving and verify teardown, raising if cleanup is incomplete.
+
+        Args:
+            exc_type: Exception type from the context body, if any.
+            exc: Exception from the context body, if any.
+            traceback: Context body's traceback, if any.
+
+        Raises:
+            RuntimeError: Cleanup could not be verified.
+        """  # noqa: DOC502
+        self._cleanup()

--- a/examples/endless_terminals/config.py
+++ b/examples/endless_terminals/config.py
@@ -1,0 +1,97 @@
+"""Validated configuration for bounded terminal-agent evaluations."""
+
+from pathlib import Path
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class EvaluationConfig(BaseModel):
+    """Select the task snapshot, inference backend, and evaluation limits."""
+
+    mode: Literal["fixture", "endpoint", "kubernetes", "native"] = "fixture"
+    data_directory: str = "data"
+    output_directory: str = "runs"
+    task_ids: list[str] = Field(default_factory=list)
+    model_name: str = "Qwen/Qwen2.5-1.5B-Instruct"
+    model_revision: str = "989aa7980e4cf806f80c7fef2b1adb7bc71aa306"
+    base_url: Optional[str] = None
+    cloud_config_path: Optional[str] = None
+    baseline_artifact_id: Optional[UUID] = None
+    max_actions: int = Field(default=16, ge=1, le=16)
+    max_tokens: int = Field(default=2048, ge=1, le=2048)
+    temperature: float = Field(default=0.6, ge=0, le=2)
+    command_timeout: float = Field(default=10, gt=0, le=90)
+    episode_timeout: float = Field(default=180, gt=0, le=1200)
+
+    @model_validator(mode="after")
+    def validate_backend(self) -> "EvaluationConfig":
+        """Require the backend-specific configuration before any work starts.
+
+        Returns:
+            The validated configuration.
+
+        Raises:
+            ValueError: Required backend configuration is absent.
+        """
+        if (
+            self.model_name != "Qwen/Qwen2.5-1.5B-Instruct"
+            and "model_revision" not in self.model_fields_set
+        ):
+            raise ValueError(
+                "A custom model requires its explicit model_revision"
+            )
+        if self.mode == "endpoint" and not self.base_url:
+            raise ValueError("Endpoint mode requires base_url")
+        if self.mode == "native" and type(self) is EvaluationConfig:
+            raise ValueError("Native mode requires a training configuration")
+        if self.mode == "kubernetes" and not self.cloud_config_path:
+            raise ValueError("Kubernetes mode requires cloud_config_path")
+        if len(self.model_revision) != 40 or any(
+            character not in "0123456789abcdef"
+            for character in self.model_revision
+        ):
+            raise ValueError("Use a pinned 40-character model revision")
+        if len(self.task_ids) != len(set(self.task_ids)):
+            raise ValueError("Task IDs must be unique")
+        return self
+
+    def resolve_directories(self) -> "EvaluationConfig":
+        """Resolve paths before ZenML changes execution context.
+
+        Returns:
+            A copy with absolute data, output, and cloud configuration paths.
+        """
+        values = {
+            "data_directory": str(Path(self.data_directory).resolve()),
+            "output_directory": str(Path(self.output_directory).resolve()),
+        }
+        if self.cloud_config_path:
+            values["cloud_config_path"] = str(
+                Path(self.cloud_config_path).resolve()
+            )
+        return self.model_copy(update=values)
+
+
+class TrainingConfig(EvaluationConfig):
+    """Bound a small training-set demonstration with paired evaluations."""
+
+    mode: Literal["kubernetes", "native"] = "kubernetes"
+    prompt_variant: Literal["upstream", "concise_xml_v1"] = "upstream"
+    training_task_ids: list[str] = Field(
+        default_factory=lambda: [
+            "task_000000_0228cd64",
+            "task_000000_010b99da",
+        ]
+    )
+    evaluation_attempts: int = Field(default=1, ge=1, le=20)
+    groups: int = Field(default=16, ge=1, le=32)
+    group_size: int = Field(default=4, ge=2, le=8)
+    training_max_actions: int = Field(default=4, ge=1, le=16)
+    zero_signal_patience: int = Field(default=4, ge=1, le=8)
+    learning_rate: float = Field(default=1e-4, gt=0, le=1e-3)
+    lora_rank: int = Field(default=8, ge=1, le=16)
+    max_tokens: int = Field(default=1024, ge=1, le=2048)
+    max_context: int = Field(default=8192, ge=4096, le=16384)
+    temperature: float = Field(default=0.8, gt=0, le=2)

--- a/examples/endless_terminals/dataset.py
+++ b/examples/endless_terminals/dataset.py
@@ -1,0 +1,223 @@
+"""Fetch, verify, build, and qualify the fixed ten-task pilot dataset."""
+
+import hashlib
+import json
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+from runtime.docker_env import DockerEnvironment
+from runtime.grading import grade_environment
+
+TASK_MANIFEST = Path(__file__).parent / "tasks.json"
+
+
+def sha256(path: Path) -> str:
+    """Hash the exact bytes of a task file.
+
+    Args:
+        path: File to hash.
+
+    Returns:
+        Lowercase SHA-256 digest.
+    """
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def download_task(
+    task: dict[str, Any], directory: Path, revision: str
+) -> None:
+    """Download only pinned, reviewed files and verify their hashes.
+
+    Args:
+        task: Task ID and expected file hashes.
+        directory: Local directory for this task.
+        revision: Pinned Hugging Face dataset revision.
+
+    Raises:
+        ValueError: A downloaded or existing file differs from its pinned hash.
+    """
+    for relative, expected in task["task_file_sha256"].items():
+        path = directory / relative
+        if path.exists():
+            if sha256(path) != expected:
+                raise ValueError(f"Task file hash mismatch: {path}")
+            continue
+        url = (
+            "https://huggingface.co/datasets/obiwan96/endless-terminals/resolve/"
+            f"{revision}/{task['task_id']}/{relative}"
+        )
+        with urlopen(url, timeout=30) as response:
+            data = response.read(2_000_001)
+        if (
+            len(data) > 2_000_000
+            or hashlib.sha256(data).hexdigest() != expected
+        ):
+            raise ValueError(f"Downloaded task hash mismatch: {relative}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+
+def task_image(task: dict[str, Any], directory: Path) -> str:
+    """Reuse a known local image or build the pinned task Dockerfile.
+
+    Args:
+        task: Task identity and optional previously qualified local image ID.
+        directory: Verified task directory.
+
+    Returns:
+        The immutable local AMD64 image ID.
+
+    Raises:
+        RuntimeError: Docker is unavailable or the build fails.
+    """
+    docker = shutil.which("docker")
+    if docker is None:
+        raise RuntimeError("Docker must be installed and running")
+    preferred = task.get("qualified_image_id")
+    if preferred:
+        existing = subprocess.run(
+            [docker, "image", "inspect", preferred],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if existing.returncode == 0:
+            details = json.loads(existing.stdout)[0]
+            if details["Architecture"] == "amd64" and details["Os"] == "linux":
+                return str(details["Id"])
+    tag = f"endless-example:{task['task_id']}"
+    with (directory / "build.log").open("w") as log:
+        build = subprocess.run(
+            [
+                docker,
+                "build",
+                "--platform",
+                "linux/amd64",
+                "-t",
+                tag,
+                str(directory / "environment"),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            timeout=600,
+            check=False,
+        )
+    if build.returncode:
+        raise RuntimeError(
+            f"Task image build failed; inspect {directory / 'build.log'}"
+        )
+    return subprocess.check_output(
+        [docker, "image", "inspect", "--format", "{{.Id}}", tag],
+        text=True,
+        timeout=30,
+    ).strip()
+
+
+def qualify_task(task: dict[str, Any], directory: Path) -> dict[str, Any]:
+    """Check initial state, reference success, and unsolved/corrupted rejection.
+
+    Args:
+        task: Task with a resolved immutable image and source guards.
+        directory: Verified task files.
+
+    Returns:
+        Structured qualification results from fresh isolated containers.
+
+    Raises:
+        RuntimeError: A task does not meet the qualification contract.
+    """
+    results = {}
+    probe = task.get("corrupted_output_probe")
+    if (
+        not probe
+        or not probe.startswith("/home/user/")
+        or ".." in Path(probe).parts
+    ):
+        raise RuntimeError(
+            "Qualification requires a corruption probe inside /home/user"
+        )
+    for phase in ("initial", "noop", "reference", "corrupted"):
+        with DockerEnvironment(
+            task["local_image_id"], command_timeout=30
+        ) as env:
+            if phase in ("reference", "corrupted"):
+                success, output = env.execute(
+                    (directory / "solution/solve.sh").read_text()
+                )
+                if not success:
+                    raise RuntimeError(
+                        f"Reference command failed: {output[:1000]}"
+                    )
+            if phase == "corrupted":
+                command = "printf 'INVALID_OUTPUT\\n' > " + shlex.quote(probe)
+                success, output = env.execute(command)
+                if not success:
+                    raise RuntimeError(
+                        f"Output corruption failed: {output[:1000]}"
+                    )
+            test = directory / (
+                "environment/test_initial_state.py"
+                if phase == "initial"
+                else "tests/test_final_state.py"
+            )
+            grade = grade_environment(
+                env, test, task.get("protected_sources", {})
+            )
+            expected = phase in ("initial", "reference")
+            if (
+                grade.get("infrastructure_error")
+                or grade["audited_valid"] != expected
+            ):
+                raise RuntimeError(
+                    f"{task['task_id']} failed {phase} qualification: {grade}"
+                )
+            if not expected and (
+                grade["raw_reward"] != 0
+                or not grade["test_counts"]["failure"]
+                or grade["test_counts"]["skipped"]
+                or grade["test_counts"]["error"]
+                or not all(
+                    source.get("unchanged") is True
+                    for source in grade.get("protected_sources", {}).values()
+                )
+            ):
+                raise RuntimeError(
+                    f"{phase} state did not produce valid failing tests"
+                )
+            results[phase] = grade
+    return results
+
+
+def prepare_tasks(
+    data_directory: Path, selected_ids: list[str]
+) -> dict[str, Any]:
+    """Prepare the selected tasks for a real pipeline evaluation.
+
+    Args:
+        data_directory: Persistent local task cache.
+        selected_ids: Explicit subset, or empty for all ten reviewed tasks.
+
+    Returns:
+        Pinned task and image identities with fresh CPU qualification evidence.
+
+    Raises:
+        ValueError: A selected task is outside the reviewed pilot subset.
+    """
+    manifest = json.loads(TASK_MANIFEST.read_text())
+    known = {task["task_id"]: task for task in manifest["tasks"]}
+    if set(selected_ids) - known.keys():
+        raise ValueError("Only task IDs in tasks.json may be evaluated")
+    tasks = []
+    for task_id in selected_ids or list(known):
+        task = dict(known[task_id])
+        directory = data_directory / task_id
+        download_task(task, directory, manifest["dataset_revision"])
+        task["local_image_id"] = task_image(task, directory)
+        task["qualification"] = qualify_task(task, directory)
+        tasks.append(task)
+    return {"dataset_revision": manifest["dataset_revision"], "tasks": tasks}

--- a/examples/endless_terminals/modal-training.example.json
+++ b/examples/endless_terminals/modal-training.example.json
@@ -1,0 +1,47 @@
+{
+  "controller_image": "REGISTRY/controller@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "training": {
+    "mode": "native",
+    "task_ids": [
+      "task_000000_0228cd64"
+    ],
+    "training_task_ids": [
+      "task_000000_0228cd64"
+    ],
+    "groups": 1,
+    "group_size": 8,
+    "max_actions": 8,
+    "training_max_actions": 8,
+    "max_tokens": 512,
+    "episode_timeout": 90,
+    "max_context": 8192,
+    "zero_signal_patience": 1,
+    "prompt_variant": "concise_xml_v1",
+    "model_name": "Qwen/Qwen2.5-7B-Instruct",
+    "model_revision": "a09a35458c702b33eeacc393d103063234e8bc28"
+  },
+  "sandbox": {
+    "modal_workspace": "YOUR_WORKSPACE",
+    "modal_environment": "dev",
+    "helper_image": "REGISTRY/helper@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "startup_timeout": 600,
+    "cleanup_timeout": 120,
+    "command_timeout": 30,
+    "episode_timeout": 300,
+    "task_ids": [
+      "task_000000_0228cd64"
+    ],
+    "modal_agent_image": "REGISTRY/modal-agent@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "service": {
+    "backend": "modal",
+    "training_image": "REGISTRY/training@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "workspace": "YOUR_WORKSPACE",
+    "modal_environment": "dev",
+    "gpu": "H200",
+    "memory_mib": 262144,
+    "cpu": 8,
+    "serving_deadline": 5400,
+    "inference_gpu_memory_utilization": 0.5
+  }
+}

--- a/examples/endless_terminals/modal_service.py
+++ b/examples/endless_terminals/modal_service.py
@@ -1,0 +1,525 @@
+"""Bound one authenticated Modal GPU sandbox to a native training run."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import secrets
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+from checkpoint_download import NoRedirect
+from pydantic import BaseModel, ConfigDict, Field
+
+# The backend stays on loopback. Only this authenticated port gets a tunnel.
+PROXY_SOURCE = r"""
+import hmac
+import http.client
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+KEY = os.environ.pop("ENDLESS_API_KEY")
+HOP = {"connection", "transfer-encoding", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "upgrade"}
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def forward(self):
+        self.connection.settimeout(600)
+        if not hmac.compare_digest(self.headers.get("X-API-Key", ""), KEY):
+            self.send_error(401)
+            return
+        if self.headers.get("Transfer-Encoding"):
+            self.send_error(400)
+            return
+        try:
+            size = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_error(400)
+            return
+        if not 0 <= size <= 64 * 1024 * 1024:
+            self.send_error(413)
+            return
+        if not self.path.startswith("/") or self.path.startswith("//"):
+            self.send_error(400)
+            return
+        headers = {k: v for k, v in self.headers.items() if k.lower() not in HOP | {"x-api-key", "x-forwarded-proto", "x-forwarded-host"}}
+        headers["X-Forwarded-Proto"] = "https"
+        connection = http.client.HTTPConnection("127.0.0.1", 8000, timeout=600)
+        started = False
+        try:
+            connection.request(self.command, self.path, self.rfile.read(size), headers)
+            response = connection.getresponse()
+            self.send_response(response.status)
+            for key, value in response.getheaders():
+                if key.lower() not in HOP:
+                    self.send_header(key, value)
+            self.send_header("Connection", "close")
+            self.end_headers()
+            started = True
+            if self.command != "HEAD":
+                while chunk := response.read(1024 * 1024):
+                    self.wfile.write(chunk)
+        except (OSError, http.client.HTTPException):
+            if not started:
+                self.send_error(502)
+        finally:
+            connection.close()
+            self.close_connection = True
+
+    do_GET = do_POST = do_PUT = do_PATCH = do_DELETE = do_OPTIONS = do_HEAD = forward
+
+ThreadingHTTPServer(("0.0.0.0", 8001), Handler).serve_forever()
+"""
+
+
+class ModalServiceConfig(BaseModel):
+    """Pin the workspace and resources for the bounded 7B pilot."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    backend: Literal["modal"] = "modal"
+    training_image: str = Field(pattern=r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+    imported_image_id: str | None = Field(
+        default=None,
+        pattern=r"^im-[A-Za-z0-9]+$",
+        description="Previously verified Modal import of training_image. This "
+        "is an explicit operational pairing; the adapter does not infer or "
+        "verify the registry digest associated with an existing Modal image.",
+    )
+    workspace: str = Field(default="zenml-io", pattern=r"^\S+$")
+    modal_environment: str = Field(default="dev", pattern=r"^\S+$")
+    gpu: Literal["H200"] = "H200"
+    memory_mib: int = Field(default=262144, ge=262144, le=262144)
+    cpu: int = Field(default=8, ge=8, le=16)
+    startup_timeout: int = Field(default=1800, gt=0, le=1800)
+    serving_deadline: int = Field(default=5400, gt=0, le=5400)
+    cleanup_timeout: int = Field(default=180, gt=0, le=300)
+    inference_gpu_memory_utilization: float = Field(default=0.5, gt=0, le=0.95)
+
+
+class ModalTrainingService:
+    """Start, verify, diagnose, and terminate one authenticated GPU service."""
+
+    def __init__(
+        self,
+        config: ModalServiceConfig,
+        model: dict[str, str],
+        run_id: str,
+        directory: Path,
+    ) -> None:
+        """Prepare a service without allocating remote resources.
+
+        Args:
+            config: Pinned resource and placement settings.
+            model: Immutable model name and revision.
+            run_id: Owning ZenML run ID.
+            directory: Local lifecycle evidence directory.
+
+        Raises:
+            ValueError: Model identity is not immutable.
+        """
+        import re
+
+        if not model.get("name") or not re.fullmatch(
+            r"[0-9a-f]{40}", model.get("revision", "")
+        ):
+            raise ValueError(
+                "An immutable model name and revision are required"
+            )
+        self.config, self.model, self.directory = (
+            config,
+            dict(model),
+            directory,
+        )
+        self.api_key = "tml-native-" + secrets.token_hex(32)
+        self.name = "endless-training-" + secrets.token_hex(8)
+        self.base_url = self.service_host = ""
+        self.identity: dict[str, Any] = {
+            "server_kind": "skyrl",
+            "backend": "modal_sandbox",
+            "run_id": run_id,
+            "training_image": config.training_image,
+            "resources": {
+                "gpu": config.gpu,
+                "memory_mib": config.memory_mib,
+                "cpu": config.cpu,
+            },
+        }
+        self.cleanup_report: dict[str, Any] = {
+            "complete": False,
+            "errors": [],
+            "diagnostic_errors": [],
+        }
+        self._sandbox: Any = None
+        self._backend_process: Any = None
+        self._allocation_attempted = False
+        self._deadline = 0.0
+        self._startup_deadline = 0.0
+        self._entered = False
+        self._closed = False
+        self._backend_config: dict[str, Any] = {}
+        self._source_hashes: dict[str, str] = {}
+
+    @property
+    def serving_seconds_remaining(self) -> float:
+        """Return the remaining GPU lifetime including startup."""
+        return max(0.0, self._deadline - time.monotonic())
+
+    def __enter__(self) -> ModalTrainingService:
+        """Create and authenticate the service, cleaning up failed startup.
+
+        Returns:
+            This ready service.
+
+        Raises:
+            RuntimeError: This service instance has already been entered.
+            BaseException: Placement, allocation, startup, or verification fails.
+        """
+        if self._entered:
+            raise RuntimeError("Training service sessions cannot be reused")
+        self._entered = True
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._deadline = time.monotonic() + self.config.serving_deadline
+        self._startup_deadline = min(
+            self._deadline, time.monotonic() + self.config.startup_timeout
+        )
+        try:
+            self._start()
+            self._wait_ready()
+            self._write("native-service-identity.json", self.identity)
+            return self
+        except BaseException:
+            self._finish()
+            raise
+
+    def _start(self) -> None:
+        import modal
+
+        from zenml.client import Client
+        from zenml.integrations.modal import sandbox_utils
+        from zenml.integrations.modal.sandboxes.modal_sandbox import (
+            ModalSandbox,
+        )
+
+        stack = Client().active_stack
+        component = stack.sandbox
+        if not isinstance(component, ModalSandbox):
+            raise TypeError("Select a Modal sandbox in the active stack")
+        if component.config.modal_environment != self.config.modal_environment:
+            raise ValueError(
+                f"Active sandbox must select Modal environment {self.config.modal_environment}"
+            )
+        if not component.config.token_id or not component.config.token_secret:
+            raise ValueError("Modal sandbox requires explicit credentials")
+        client = sandbox_utils.create_modal_client_from_credentials(
+            token_id=component.config.token_id,
+            token_secret=component.config.token_secret,
+        )
+        workspace = modal.Workspace.from_context(client=client).hydrate()
+        if workspace.name != self.config.workspace:
+            raise ValueError(
+                f"Authenticated Modal workspace must be {self.config.workspace}"
+            )
+        modal.Environment.from_name(
+            self.config.modal_environment,
+            create_if_missing=False,
+            client=client,
+        ).hydrate()
+        self.identity.update(
+            workspace=workspace.name,
+            modal_environment=self.config.modal_environment,
+        )
+        app = modal.App.lookup(
+            component.config.app_name,
+            create_if_missing=True,
+            environment_name=self.config.modal_environment,
+            client=client,
+        )
+        if self.config.imported_image_id:
+            image = modal.Image.from_id(
+                self.config.imported_image_id, client=client
+            )
+            self.identity["image_selection"] = "explicit_operational_pairing"
+        else:
+            registry = stack.container_registry
+            credentials = (
+                registry.credentials
+                if registry
+                and registry.is_valid_image_name_for_registry(
+                    self.config.training_image
+                )
+                else None
+            )
+            image = sandbox_utils.get_modal_image_from_registry(
+                self.config.training_image, registry_credentials=credentials
+            )
+            self.identity["image_selection"] = "registry_import"
+        imported_image = image
+        # Sandbox command arguments otherwise append to the Docker entrypoint,
+        # which would start the baked server before current sources are uploaded.
+        image = image.entrypoint([])
+        self._allocation_attempted = True
+        self._sandbox = modal.Sandbox.create(
+            "sleep",
+            "infinity",
+            app=app,
+            image=image,
+            gpu=self.config.gpu,
+            cpu=self.config.cpu,
+            memory=self.config.memory_mib,
+            timeout=max(1, math.floor(self.serving_seconds_remaining)),
+            encrypted_ports=[8001],
+            env={
+                "SKYRL_MODEL_NAME": self.model["name"],
+                "SKYRL_MODEL_REVISION": self.model["revision"],
+                "SKYRL_DUMP_INFRA_LOG_TO_STDOUT": "1",
+                "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES": "1073741824",
+            },
+            client=client,
+            environment_name=self.config.modal_environment,
+            name=self.name,
+        )
+        self.identity["sandbox_id"] = self._sandbox.object_id
+        self.identity["imported_modal_image_id"] = imported_image.object_id
+        self.identity["modal_image_id"] = image.object_id
+        self._write("native-service-identity.json", self.identity)
+        self._exec(
+            [
+                "mkdir",
+                "-p",
+                "/tmp/terminal-training",
+                "/models",
+                "/checkpoints",
+            ]
+        )
+        source = Path(__file__).with_name("training_server")
+        files = {
+            name: (source / name).read_text()
+            for name in (
+                "entrypoint.py",
+                "backend_config.json",
+                "diagnostics.py",
+            )
+        }
+        self._backend_config = json.loads(files["backend_config.json"])
+        self._backend_config[
+            "generator.inference_engine.gpu_memory_utilization"
+        ] = self.config.inference_gpu_memory_utilization
+        files["backend_config.json"] = (
+            json.dumps(self._backend_config, indent=2) + "\n"
+        )
+        self._source_hashes = {
+            name: hashlib.sha256(value.encode()).hexdigest()
+            for name, value in files.items()
+        }
+        self.identity["source_sha256"] = self._source_hashes
+        files["proxy.py"] = PROXY_SOURCE
+        for name, value in files.items():
+            self._sandbox.filesystem.write_text(
+                value, "/tmp/terminal-training/" + name
+            )
+        self.identity["proxy_sha256"] = hashlib.sha256(
+            PROXY_SOURCE.encode()
+        ).hexdigest()
+        self._write(
+            "training-capacity.json",
+            self._exec(
+                [
+                    "python",
+                    "/tmp/terminal-training/diagnostics.py",
+                    "--collect",
+                ]
+            ),
+        )
+        self._sandbox.exec(
+            "bash",
+            "-c",
+            "exec python /tmp/terminal-training/proxy.py > /checkpoints/proxy.log 2>&1",
+            secrets=[
+                modal.Secret.from_dict({"ENDLESS_API_KEY": self.api_key})
+            ],
+        )
+        self._backend_process = self._sandbox.exec(
+            "bash",
+            "-c",
+            "exec python /tmp/terminal-training/entrypoint.py > /checkpoints/training.log 2>&1",
+            workdir="/opt/skyrl",
+        )
+        self.base_url = self._sandbox.tunnels(timeout=60)[8001].url.rstrip("/")
+        self.service_host = urlsplit(self.base_url).hostname or ""
+        self.identity["service_url"] = self.base_url
+        self._write("native-service-identity.json", self.identity)
+        from training_client import validate_training_url
+
+        validate_training_url(self.base_url, self.service_host)
+
+    def _exec(
+        self, command: list[str], limit: int = 2097152, timeout: int = 60
+    ) -> str:
+        process = self._sandbox.exec(*command, timeout=timeout)
+        # Output is bounded at its trusted producer; do not collect Ray's full logs.
+        stdout, stderr = process.stdout.read(), process.stderr.read()
+        process.wait()
+        if process.returncode:
+            raise RuntimeError(
+                f"Training diagnostic command failed: {stderr[:2000]}"
+            )
+        if len(stdout.encode()) > limit:
+            raise RuntimeError("Remote evidence exceeded its bound")
+        return str(stdout)
+
+    def _wait_ready(self) -> None:
+        deadline = self._startup_deadline
+        opener = urllib.request.build_opener(NoRedirect())
+        while time.monotonic() < deadline:
+            if self._sandbox.poll() is not None:
+                raise RuntimeError(
+                    "Modal training sandbox exited during startup"
+                )
+            self._check_backend_running()
+            try:
+                request = urllib.request.Request(
+                    self.base_url + "/api/v1/healthz",
+                    headers={"X-API-Key": self.api_key},
+                )
+                with opener.open(
+                    request,
+                    timeout=min(10, max(1, deadline - time.monotonic())),
+                ) as response:
+                    if response.status == 200:
+                        break
+            except (urllib.error.URLError, TimeoutError):
+                pass
+            time.sleep(2)
+        else:
+            raise TimeoutError("Modal training service did not become ready")
+        try:
+            opener.open(self.base_url + "/api/v1/healthz", timeout=10)
+        except urllib.error.HTTPError as error:
+            if error.code != 401:
+                raise RuntimeError(
+                    "Training proxy did not reject missing credentials"
+                ) from error
+        else:
+            raise RuntimeError(
+                "Training proxy accepted an unauthenticated request"
+            )
+        identity = json.loads(
+            self._exec(
+                ["cat", "/checkpoints/server-identity.json"], limit=65536
+            )
+        )
+        if (
+            identity.get("model_name") != self.model["name"]
+            or identity.get("model_revision") != self.model["revision"]
+            or identity.get("backend_config") != self._backend_config
+            or identity.get("source_sha256") != self._source_hashes
+        ):
+            raise RuntimeError(
+                "Training server model, configuration, or source identity mismatch"
+            )
+        self.identity["training_server"] = identity
+        self._check_backend_running()
+
+    def _check_backend_running(self) -> None:
+        if self._backend_process is None:
+            raise RuntimeError(
+                "The owned training backend has not been launched"
+            )
+        code = self._backend_process.poll()
+        if code is not None:
+            raise RuntimeError(
+                f"The owned training backend exited during startup (exit {code})"
+            )
+
+    def _write(self, name: str, value: Any) -> None:
+        text = (
+            value
+            if isinstance(value, str)
+            else json.dumps(value, indent=2, default=str)
+        )
+        (self.directory / name).write_text(
+            text.replace(self.api_key, "[REDACTED]")[:2097152] + "\n"
+        )
+
+    def _finish(self) -> None:
+        if self._closed:
+            return
+        try:
+            if self._sandbox is not None:
+                for name, command in (
+                    (
+                        "training-main.log",
+                        ["tail", "-c", "65536", "/checkpoints/training.log"],
+                    ),
+                    (
+                        "training-proxy.log",
+                        ["tail", "-c", "8192", "/checkpoints/proxy.log"],
+                    ),
+                    (
+                        "training-worker-logs.json",
+                        [
+                            "python",
+                            "/tmp/terminal-training/diagnostics.py",
+                            "--collect",
+                        ],
+                    ),
+                ):
+                    try:
+                        self._write(name, self._exec(command, timeout=30))
+                    except Exception as error:
+                        self.cleanup_report["diagnostic_errors"].append(
+                            type(error).__name__
+                        )
+        finally:
+            try:
+                if self._sandbox is not None:
+                    self._sandbox.terminate()
+                    deadline = time.monotonic() + self.config.cleanup_timeout
+                    while self._sandbox.poll() is None:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                "Modal GPU sandbox termination was not confirmed"
+                            )
+                        time.sleep(1)
+                if self._sandbox is None and self._allocation_attempted:
+                    raise RuntimeError(
+                        "Modal allocation outcome is unknown; cleanup cannot be confirmed "
+                        f"for sandbox {self.name} in {self.config.workspace}/{self.config.modal_environment}"
+                    )
+                self.cleanup_report["complete"] = True
+                self._closed = True
+            except Exception as error:
+                self.cleanup_report["errors"].append(
+                    str(error).replace(self.api_key, "[REDACTED]")[:2000]
+                )
+            self._write("native-service-cleanup.json", self.cleanup_report)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Collect evidence and confirm termination after success or failure.
+
+        Args:
+            exc_type: Original exception class.
+            exc: Original exception instance.
+            traceback: Original traceback.
+
+        Raises:
+            RuntimeError: Cleanup remains incomplete after successful training.
+        """
+        self._finish()
+        if not self.cleanup_report["complete"] and exc is None:
+            raise RuntimeError(
+                "Modal training cleanup incomplete; inspect cleanup report"
+            )

--- a/examples/endless_terminals/native-rbac.yaml
+++ b/examples/endless_terminals/native-rbac.yaml
@@ -1,0 +1,45 @@
+# CPU controller permissions plus the authenticated native GPU service lifecycle.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: endless-native-training-controller
+  namespace: aws-k8s-8b16c2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: endless-native-training-controller
+  namespace: aws-k8s-8b16c2
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services", "secrets"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: endless-native-training-controller
+  namespace: aws-k8s-8b16c2
+subjects:
+  - kind: ServiceAccount
+    name: endless-native-training-controller
+    namespace: aws-k8s-8b16c2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: endless-native-training-controller

--- a/examples/endless_terminals/native-training.example.json
+++ b/examples/endless_terminals/native-training.example.json
@@ -1,0 +1,30 @@
+{
+  "controller_image": "REGISTRY/controller@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "training": {
+    "mode": "native",
+    "task_ids": [
+      "task_000000_0228cd64"
+    ],
+    "training_task_ids": [
+      "task_000000_0228cd64"
+    ],
+    "groups": 2,
+    "group_size": 4,
+    "max_actions": 4,
+    "training_max_actions": 4,
+    "max_tokens": 512,
+    "episode_timeout": 90,
+    "max_context": 8192,
+    "zero_signal_patience": 2
+  },
+  "sandbox": {
+    "helper_image": "REGISTRY/helper@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "task_ids": [
+      "task_000000_0228cd64"
+    ]
+  },
+  "service": {
+    "training_image": "REGISTRY/training@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "proxy_image": "REGISTRY/proxy@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}

--- a/examples/endless_terminals/native_service.py
+++ b/examples/endless_terminals/native_service.py
@@ -1,0 +1,847 @@
+"""Bounded, authenticated GPU training service in the active native sandbox."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import time
+import urllib.error
+import urllib.request
+from functools import partial
+from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+        KubernetesSandbox,
+    )
+
+
+class NativeServiceConfig(BaseModel):
+    """Immutable images and finite resource limits for one GPU service."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    training_image: str = Field(pattern=r"^[^\s]+@sha256:[0-9a-f]{64}$")
+    proxy_image: str = Field(pattern=r"^[^\s]+@sha256:[0-9a-f]{64}$")
+    startup_timeout: int = Field(default=1500, gt=0, le=1800)
+    serving_deadline: int = Field(default=3600, gt=0, le=5400)
+    cleanup_timeout: int = Field(default=180, gt=0, le=300)
+    node_selector: dict[str, str] = Field(
+        default_factory=lambda: {"pool": "gpu"}
+    )
+    tolerations: list[dict[str, str]] = Field(
+        default_factory=lambda: [
+            {
+                "key": "pool",
+                "operator": "Equal",
+                "value": "gpu",
+                "effect": "NoSchedule",
+            }
+        ]
+    )
+    cpu_request: str = "4"
+    memory_request: str = "26Gi"
+    memory_limit: str = "28Gi"
+    inference_gpu_memory_utilization: float = Field(
+        default=0.35, gt=0, le=0.95
+    )
+
+
+def build_proxy_config(api_key: str) -> str:
+    """Build nginx configuration authenticating every route.
+
+    Args:
+        api_key: Random native service credential, never written as evidence.
+
+    Returns:
+        Configuration suitable for nginx-unprivileged with read-only rootfs.
+
+    Raises:
+        ValueError: The credential is not a generated native service key.
+    """
+    if not re.fullmatch(r"tml-native-[0-9a-f]{64}", api_key):
+        raise ValueError("Expected a generated native service key")
+    return f"""worker_processes 1;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+events {{ worker_connections 1024; }}
+http {{
+    access_log off;
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path /tmp/proxy_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+    map $http_x_api_key $authenticated {{
+        default 0;
+        ~^{api_key}$ 1;
+    }}
+    server {{
+        listen 8001;
+        if ($authenticated = 0) {{ return 401; }}
+        client_max_body_size 64m;
+        location / {{
+            proxy_pass http://127.0.0.1:8000;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-API-Key "";
+            proxy_buffering off;
+            proxy_read_timeout 600s;
+        }}
+    }}
+}}
+"""
+
+
+class _NoHealthRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+class NativeTrainingService:
+    """Create one GPU Job and capture evidence before UID-guarded cleanup."""
+
+    def __init__(
+        self,
+        config: NativeServiceConfig,
+        model: dict[str, str],
+        run_id: str,
+        directory: Path,
+    ) -> None:
+        """Prepare a service without contacting Kubernetes.
+
+        Args:
+            config: Validated service settings.
+            model: Exact Hugging Face model name and immutable revision.
+            run_id: Training run identifier for evidence.
+            directory: Directory for sanitized lifecycle evidence.
+
+        Raises:
+            ValueError: The model lacks an immutable revision or name.
+        """
+        if not model.get("name") or not re.fullmatch(
+            r"[0-9a-f]{40}", model.get("revision", "")
+        ):
+            raise ValueError(
+                "Model name and immutable 40-character revision are required"
+            )
+        self.config = config
+        self.model = dict(model)
+        self.directory = directory
+        self.token = secrets.token_hex(16)
+        self.name = "endless-training-" + self.token[:16]
+        self.api_key = "tml-native-" + secrets.token_hex(32)
+        self._sandbox = self._select_sandbox()
+        self.namespace = self._sandbox.config.kubernetes_namespace
+        self.service_host = f"{self.name}.{self.namespace}.svc.cluster.local"
+        self.base_url = f"http://{self.service_host}:8001"
+        self.identity: dict[str, Any] = {
+            "server_kind": "skyrl",
+            "backend": "kubernetes_sandbox",
+            "run_id": run_id,
+            "job_name": self.name,
+            "training_image": config.training_image,
+            "proxy_image": config.proxy_image,
+        }
+        self.cleanup_report: dict[str, Any] = {
+            "complete": False,
+            "errors": [],
+            "diagnostic_errors": [],
+        }
+        self._attempted: set[str] = set()
+        self._uids: dict[str, str] = {}
+        self._serving_deadline = 0.0
+        self._operation_deadline = 0.0
+        self._pod_name: str | None = None
+        self._closed = False
+        self._entered = False
+        self._backend_config: dict[str, Any] = {}
+        self._source_hashes: dict[str, str] = {}
+        self._client: Any = None
+
+    @property
+    def serving_seconds_remaining(self) -> float:
+        """Remaining total Job lifetime, including startup time."""
+        return max(0.0, self._serving_deadline - time.monotonic())
+
+    def __enter__(self) -> NativeTrainingService:
+        """Start the service and verify its exact model and source identity.
+
+        Returns:
+            This authenticated service session.
+
+        Raises:
+            RuntimeError: Startup, identity verification, or ownership fails.
+            BaseException: Startup fails or is interrupted; cleanup runs first.
+        """
+        if self._entered:
+            raise RuntimeError("Native service sessions cannot be reused")
+        self._entered = True
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._serving_deadline = (
+            time.monotonic() + self.config.serving_deadline
+        )
+        self._operation_deadline = min(
+            self._serving_deadline,
+            time.monotonic() + self.config.startup_timeout,
+        )
+        try:
+            self._connect()
+            job, secret, service = self._manifests()
+            self._create("job", job)
+            owner = self._owner_reference("Job", self.name, self._uids["job"])
+            for kind, body in (("secret", secret), ("service", service)):
+                body["metadata"]["ownerReferences"] = [owner]
+                self._create(kind, body)
+            self._wait_ready()
+            self._write("native-service-identity.json", self.identity)
+            return self
+        except BaseException:
+            self._finish()
+            raise
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Capture diagnostics and delete owned resources.
+
+        Args:
+            exc_type: Exception type raised by the training operation.
+            exc: Original training exception, if any.
+            traceback: Original exception traceback.
+
+        Raises:
+            RuntimeError: Cleanup is incomplete after an otherwise successful run.
+        """
+        self._finish()
+        if not self.cleanup_report["complete"] and exc is None:
+            raise RuntimeError(
+                "Native service cleanup incomplete; inspect cleanup report"
+            )
+
+    @staticmethod
+    def _select_sandbox() -> KubernetesSandbox:
+        from zenml.client import Client
+        from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+            KubernetesSandbox,
+        )
+
+        sandbox = Client().active_stack.sandbox
+        if (
+            not isinstance(sandbox, KubernetesSandbox)
+            or not sandbox.config.incluster
+        ):
+            raise RuntimeError(
+                "Native training requires an in-cluster KubernetesSandbox"
+            )
+        return sandbox
+
+    def _connect(self) -> None:
+        from kubernetes import client as k8s
+
+        controller = os.environ.get("HOSTNAME")
+        if not controller or not os.environ.get("KUBERNETES_SERVICE_HOST"):
+            raise RuntimeError(
+                "Native training must run inside its Kubernetes controller pod"
+            )
+        self._client = self._sandbox.build_kube_client()
+        self._client.configuration.retries = 0
+        self._core = k8s.CoreV1Api(self._client)
+        self._batch = k8s.BatchV1Api(self._client)
+        pod = self._call(
+            self._core.read_namespaced_pod, controller, self.namespace
+        )
+        if pod.metadata.name != controller or not pod.metadata.uid:
+            raise RuntimeError("Controller pod identity is missing")
+        self._controller_owner = self._owner_reference(
+            "Pod", controller, pod.metadata.uid
+        )
+        self.identity.update(
+            namespace=self.namespace,
+            controller_pod=controller,
+            controller_uid=pod.metadata.uid,
+            service_host=self.service_host,
+        )
+
+    @staticmethod
+    def _owner_reference(kind: str, name: str, uid: str) -> dict[str, Any]:
+        return {
+            "apiVersion": "batch/v1" if kind == "Job" else "v1",
+            "kind": kind,
+            "name": name,
+            "uid": uid,
+            "blockOwnerDeletion": False,
+        }
+
+    def _call(
+        self, function: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        remaining = self._operation_deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Native service operation deadline exceeded")
+        return function(*args, **kwargs, _request_timeout=min(15.0, remaining))
+
+    def _manifests(
+        self,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        source = Path(__file__).with_name("training_server")
+        files = {
+            name: (source / name).read_text()
+            for name in (
+                "entrypoint.py",
+                "backend_config.json",
+                "diagnostics.py",
+            )
+        }
+        self._backend_config = json.loads(files["backend_config.json"])
+        self._backend_config[
+            "generator.inference_engine.gpu_memory_utilization"
+        ] = self.config.inference_gpu_memory_utilization
+        files["backend_config.json"] = (
+            json.dumps(self._backend_config, indent=2) + "\n"
+        )
+        self._source_hashes = {
+            name: hashlib.sha256(content.encode()).hexdigest()
+            for name, content in files.items()
+        }
+        self.identity["source_sha256"] = self._source_hashes
+        metadata = {"name": self.name, "labels": {"endless-owner": self.token}}
+        source_items = [{"key": name, "path": name} for name in files]
+        security = {
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+        }
+        main = {
+            "name": "main",
+            "image": self.config.training_image,
+            "command": ["python", "/opt/terminal-training/entrypoint.py"],
+            "securityContext": security,
+            "env": [
+                {"name": key, "value": value}
+                for key, value in {
+                    "SKYRL_MODEL_NAME": self.model["name"],
+                    "SKYRL_MODEL_REVISION": self.model["revision"],
+                    "SKYRL_DUMP_INFRA_LOG_TO_STDOUT": "1",
+                    "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES": "1073741824",
+                }.items()
+            ],
+            "resources": {
+                "requests": {
+                    "cpu": self.config.cpu_request,
+                    "memory": self.config.memory_request,
+                    "nvidia.com/gpu": "1",
+                },
+                "limits": {
+                    "memory": self.config.memory_limit,
+                    "nvidia.com/gpu": "1",
+                },
+            },
+            "volumeMounts": [
+                {
+                    "name": "source",
+                    "mountPath": "/opt/terminal-training",
+                    "readOnly": True,
+                },
+                {"name": "models", "mountPath": "/models"},
+                {"name": "checkpoints", "mountPath": "/checkpoints"},
+                {"name": "shm", "mountPath": "/dev/shm"},
+            ],
+        }
+        proxy = {
+            "name": "auth-proxy",
+            "image": self.config.proxy_image,
+            "command": [
+                "nginx",
+                "-c",
+                "/etc/nginx/nginx.conf",
+                "-g",
+                "daemon off;",
+            ],
+            "securityContext": {
+                **security,
+                "runAsUser": 101,
+                "readOnlyRootFilesystem": True,
+            },
+            "resources": {
+                "requests": {"cpu": "50m", "memory": "32Mi"},
+                "limits": {"cpu": "500m", "memory": "128Mi"},
+            },
+            "ports": [{"containerPort": 8001}],
+            "volumeMounts": [
+                {
+                    "name": "proxy-config",
+                    "mountPath": "/etc/nginx",
+                    "readOnly": True,
+                },
+                {"name": "proxy-tmp", "mountPath": "/tmp"},
+            ],
+        }
+        job = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                **metadata,
+                "ownerReferences": [self._controller_owner],
+            },
+            "spec": {
+                "backoffLimit": 0,
+                "activeDeadlineSeconds": self.config.serving_deadline,
+                "ttlSecondsAfterFinished": 180,
+                "template": {
+                    "metadata": {"labels": metadata["labels"]},
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "automountServiceAccountToken": False,
+                        "hostNetwork": False,
+                        "hostPID": False,
+                        "hostIPC": False,
+                        "securityContext": {
+                            "fsGroup": 1000,
+                            "seccompProfile": {"type": "RuntimeDefault"},
+                        },
+                        "nodeSelector": self.config.node_selector,
+                        "tolerations": self.config.tolerations,
+                        "containers": [main, proxy],
+                        "volumes": [
+                            {
+                                "name": "source",
+                                "secret": {
+                                    "secretName": self.name,
+                                    "items": source_items,
+                                },
+                            },
+                            {
+                                "name": "proxy-config",
+                                "secret": {
+                                    "secretName": self.name,
+                                    "items": [
+                                        {
+                                            "key": "nginx.conf",
+                                            "path": "nginx.conf",
+                                        }
+                                    ],
+                                },
+                            },
+                            {"name": "models", "emptyDir": {}},
+                            {"name": "checkpoints", "emptyDir": {}},
+                            {
+                                "name": "shm",
+                                "emptyDir": {
+                                    "medium": "Memory",
+                                    "sizeLimit": "8Gi",
+                                },
+                            },
+                            {
+                                "name": "proxy-tmp",
+                                "emptyDir": {"sizeLimit": "128Mi"},
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        secret = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": dict(metadata),
+            "immutable": True,
+            "type": "Opaque",
+            "stringData": {
+                **files,
+                "nginx.conf": build_proxy_config(self.api_key),
+            },
+        }
+        service = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": dict(metadata),
+            "spec": {
+                "type": "ClusterIP",
+                "selector": metadata["labels"],
+                "ports": [
+                    {
+                        "name": "authenticated-api",
+                        "port": 8001,
+                        "targetPort": 8001,
+                    }
+                ],
+            },
+        }
+        return job, secret, service
+
+    def _resource_api(self, kind: str, operation: str) -> Callable[..., Any]:
+        # Kubernetes generated methods have no common resource protocol.
+        return cast(
+            Callable[..., Any],
+            getattr(
+                self._batch if kind == "job" else self._core,
+                f"{operation}_namespaced_{kind}",
+            ),
+        )
+
+    def _read(self, kind: str) -> Any:
+        from kubernetes.client.rest import ApiException
+
+        try:
+            obj = self._call(
+                self._resource_api(kind, "read"), self.name, self.namespace
+            )
+        except ApiException as error:
+            if error.status == 404:
+                return None
+            raise
+        if not obj.metadata.uid or obj.metadata.name != self.name:
+            raise RuntimeError(f"Refusing {kind}: resource identity missing")
+        if (obj.metadata.labels or {}).get("endless-owner") != self.token:
+            raise RuntimeError(f"Refusing {kind}: ownership token mismatch")
+        if kind in self._uids and obj.metadata.uid != self._uids[kind]:
+            raise RuntimeError(f"Refusing {kind}: UID changed")
+        self._uids[kind] = obj.metadata.uid
+        return obj
+
+    def _create(self, kind: str, body: dict[str, Any]) -> None:
+        self._attempted.add(kind)
+        # Register the name before sending: a transport failure may mean the
+        # object exists. Cleanup reconciles it using the unguessable owner token.
+        obj = self._call(
+            self._resource_api(kind, "create"), self.namespace, body
+        )
+        if (
+            not obj.metadata.uid
+            or obj.metadata.labels.get("endless-owner") != self.token
+        ):
+            raise RuntimeError(f"Created {kind} has an invalid identity")
+        self._uids[kind] = obj.metadata.uid
+        self.identity[f"{kind}_uid"] = obj.metadata.uid
+
+    def _pods(self) -> list[Any]:
+        pods = self._call(
+            self._core.list_namespaced_pod,
+            self.namespace,
+            label_selector=f"endless-owner={self.token}",
+        ).items
+        for pod in pods:
+            if pod.metadata.labels.get(
+                "endless-owner"
+            ) != self.token or not any(
+                owner.kind == "Job"
+                and owner.name == self.name
+                and owner.uid == self._uids.get("job")
+                for owner in (pod.metadata.owner_references or [])
+            ):
+                raise RuntimeError("Refusing pod: Job ownership mismatch")
+        return cast(list[Any], pods)
+
+    def _wait_ready(self) -> None:
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), _NoHealthRedirect()
+        )
+        while time.monotonic() < self._operation_deadline:
+            job = self._read("job")
+            if job is None:
+                raise RuntimeError("Training Job disappeared during startup")
+            if any(
+                condition.type == "Failed" and condition.status == "True"
+                for condition in (job.status.conditions or [])
+            ):
+                raise RuntimeError("Training Job failed during startup")
+            pods = self._pods()
+            if len(pods) > 1:
+                raise RuntimeError(
+                    "Training Job unexpectedly created multiple pods"
+                )
+            if pods:
+                pod = pods[0]
+                self._pod_name = pod.metadata.name
+                self.identity.update(
+                    pod_name=pod.metadata.name, pod_uid=pod.metadata.uid
+                )
+                for container in pod.status.container_statuses or []:
+                    if container.state.terminated:
+                        raise RuntimeError(
+                            f"Training container {container.name} terminated before readiness"
+                        )
+                request = urllib.request.Request(
+                    self.base_url + "/api/v1/healthz",
+                    headers={"X-API-Key": self.api_key},
+                )
+                try:
+                    with opener.open(
+                        request,
+                        timeout=min(
+                            5,
+                            max(
+                                0.1,
+                                self._operation_deadline - time.monotonic(),
+                            ),
+                        ),
+                    ) as response:
+                        healthy = response.status == 200
+                except (OSError, urllib.error.URLError):
+                    healthy = False
+                if healthy:
+                    self._verify_server()
+                    return
+            time.sleep(
+                min(2.0, max(0.0, self._operation_deadline - time.monotonic()))
+            )
+        raise TimeoutError("Native training service startup deadline exceeded")
+
+    def _exec(self, command: list[str], max_bytes: int = 1048576) -> str:
+        from kubernetes import client as k8s
+        from kubernetes.stream import stream
+
+        if not self._pod_name:
+            raise RuntimeError(
+                "No owned training pod available for diagnostics"
+            )
+        deadline = min(self._operation_deadline, time.monotonic() + 15)
+        # stream changes ApiClient's transport; never reuse the REST client.
+        with self._sandbox.build_kube_client() as api_client:
+            api_client.configuration.retries = 0
+            api = k8s.CoreV1Api(api_client)
+            socket = self._call(
+                stream,
+                api.connect_get_namespaced_pod_exec,
+                self._pod_name,
+                self.namespace,
+                container="main",
+                command=command,
+                stdout=True,
+                stderr=True,
+                stdin=False,
+                tty=False,
+                _preload_content=False,
+            )
+            output = ""
+            try:
+                while socket.is_open() and time.monotonic() < deadline:
+                    socket.update(
+                        timeout=min(1, max(0.01, deadline - time.monotonic()))
+                    )
+                    output += cast(str, socket.read_stdout())
+                    if len(output.encode()) > max_bytes:
+                        raise RuntimeError(
+                            "Remote output exceeded evidence bound"
+                        )
+                output += cast(str, socket.read_stdout())
+                if socket.is_open():
+                    raise TimeoutError("Training pod exec deadline exceeded")
+                if socket.returncode != 0:
+                    raise RuntimeError("Training pod exec failed")
+                if len(output.encode()) > max_bytes:
+                    raise RuntimeError("Remote output exceeded evidence bound")
+                return output
+            finally:
+                socket.close()
+
+    def _verify_server(self) -> None:
+        identity = json.loads(
+            self._exec(
+                ["cat", "/checkpoints/server-identity.json"], max_bytes=65536
+            )
+        )
+        if (
+            identity.get("model_name") != self.model["name"]
+            or identity.get("model_revision") != self.model["revision"]
+        ):
+            raise RuntimeError("Training server model identity mismatch")
+        if identity.get("backend_config") != self._backend_config:
+            raise RuntimeError(
+                "Training server backend configuration mismatch"
+            )
+        if identity.get("source_sha256") != self._source_hashes:
+            raise RuntimeError("Training server source identity mismatch")
+        self.identity["training_server"] = identity
+
+    def _write(self, name: str, value: Any) -> None:
+        data = (
+            value
+            if isinstance(value, str)
+            else json.dumps(value, indent=2, default=str)
+        )
+        data = data.replace(self.api_key, "[REDACTED]")
+        (self.directory / name).write_text(data[:2097152] + "\n")
+
+    def _diagnostic(self, name: str, collect: Callable[[], Any]) -> None:
+        try:
+            self._write(name, collect())
+        except Exception as error:
+            self.cleanup_report["diagnostic_errors"].append(
+                f"{name}: {type(error).__name__}: {error}".replace(
+                    self.api_key, "[REDACTED]"
+                )
+            )
+
+    def _capture(self) -> None:
+        self._operation_deadline = time.monotonic() + 60
+        pods = self._pods()
+        for pod in pods[:1]:
+            self._pod_name = pod.metadata.name
+            self._write(
+                "training-pod-status.json",
+                {
+                    "name": pod.metadata.name,
+                    "uid": pod.metadata.uid,
+                    "node": pod.spec.node_name,
+                    "phase": pod.status.phase,
+                    "reason": pod.status.reason,
+                    "message": pod.status.message,
+                    "containers": [
+                        {
+                            "name": status.name,
+                            "ready": status.ready,
+                            "restart_count": status.restart_count,
+                            "state": status.state.to_dict(),
+                        }
+                        for status in (pod.status.container_statuses or [])
+                    ],
+                },
+            )
+            for container in ("main", "auth-proxy"):
+                self._diagnostic(
+                    f"training-{container}.log",
+                    partial(
+                        self._call,
+                        self._core.read_namespaced_pod_log,
+                        pod.metadata.name,
+                        self.namespace,
+                        container=container,
+                        tail_lines=400,
+                        limit_bytes=65536,
+                    ),
+                )
+            self._diagnostic(
+                "training-worker-logs.json",
+                lambda: json.loads(
+                    self._exec(
+                        [
+                            "python",
+                            "/opt/terminal-training/diagnostics.py",
+                            "--collect",
+                        ],
+                        max_bytes=2097152,
+                    )
+                ),
+            )
+            self._diagnostic(
+                "training-pod-events.json",
+                lambda: [
+                    {
+                        "reason": event.reason,
+                        "message": event.message,
+                        "type": event.type,
+                        "count": event.count,
+                    }
+                    for event in self._call(
+                        self._core.list_namespaced_event,
+                        self.namespace,
+                        field_selector=f"involvedObject.uid={pod.metadata.uid}",
+                        limit=100,
+                    ).items
+                ],
+            )
+
+    def _cleanup(self) -> None:
+        from kubernetes.client.rest import ApiException
+
+        self._operation_deadline = (
+            time.monotonic() + self.config.cleanup_timeout
+        )
+        pending = set(self._attempted)
+        for kind in ("service", "job", "secret"):
+            if kind not in pending:
+                continue
+            try:
+                obj = self._read(kind)
+                if obj is None:
+                    pending.remove(kind)
+                    continue
+                self._call(
+                    self._resource_api(kind, "delete"),
+                    self.name,
+                    self.namespace,
+                    body={
+                        "apiVersion": "v1",
+                        "kind": "DeleteOptions",
+                        "propagationPolicy": "Foreground",
+                        "preconditions": {"uid": obj.metadata.uid},
+                    },
+                )
+            except ApiException as error:
+                if error.status != 404:
+                    self.cleanup_report["errors"].append(
+                        f"delete {kind}: {error}"
+                    )
+            except Exception as error:
+                self.cleanup_report["errors"].append(f"delete {kind}: {error}")
+        while time.monotonic() < self._operation_deadline:
+            for kind in list(pending):
+                try:
+                    if self._read(kind) is None:
+                        pending.remove(kind)
+                except Exception as error:
+                    self.cleanup_report["errors"].append(
+                        f"verify {kind}: {error}"
+                    )
+                    pending.remove(kind)
+            try:
+                pods = self._pods() if "job" in self._attempted else []
+            except Exception as error:
+                self.cleanup_report["errors"].append(f"verify pods: {error}")
+                break
+            if not pending and not pods:
+                self.cleanup_report["complete"] = not self.cleanup_report[
+                    "errors"
+                ]
+                return
+            time.sleep(
+                min(1.0, max(0.0, self._operation_deadline - time.monotonic()))
+            )
+        self.cleanup_report["errors"].append(
+            "Cleanup deadline reached or ownership verification failed"
+        )
+
+    def _finish(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._attempted:
+            try:
+                self._capture()
+            except Exception as error:
+                self.cleanup_report["diagnostic_errors"].append(
+                    f"capture: {error}"
+                )
+            try:
+                self._cleanup()
+            except Exception as error:
+                self.cleanup_report["errors"].append(f"cleanup: {error}")
+        else:
+            self.cleanup_report["complete"] = True
+        self.cleanup_report = json.loads(
+            json.dumps(self.cleanup_report, default=str).replace(
+                self.api_key, "[REDACTED]"
+            )
+        )
+        self._write("native-service-cleanup.json", self.cleanup_report)
+        if self._client is not None:
+            self._client.close()

--- a/examples/endless_terminals/native_training.py
+++ b/examples/endless_terminals/native_training.py
@@ -1,0 +1,191 @@
+"""Qualify portable tasks before starting a bounded native GPU training service."""
+
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any
+from uuid import UUID
+
+from config import TrainingConfig
+from modal_service import ModalServiceConfig, ModalTrainingService
+from native_service import NativeServiceConfig, NativeTrainingService
+from pydantic import BaseModel, Field, model_validator
+from sandbox_pipeline import (
+    SandboxPipelineConfig,
+    create_environment,
+    evaluate_sandbox_fixture,
+    fixture_matches,
+    load_bundle_task,
+    qualify_sandbox_initial,
+    report_sandbox_results,
+)
+from training import execute_training, report_training
+
+from zenml import (
+    ArtifactConfig,
+    get_step_context,
+    pipeline,
+    save_artifact,
+    step,
+)
+from zenml.client import Client
+from zenml.enums import ArtifactType
+
+PILOT_TASK = "task_000000_0228cd64"
+
+
+class NativeTrainingConfig(BaseModel):
+    """Combine portable training limits with CPU and GPU runtime settings."""
+
+    controller_image: str = Field(pattern=r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+    training: TrainingConfig
+    sandbox: SandboxPipelineConfig
+    service: NativeServiceConfig | ModalServiceConfig
+
+    @model_validator(mode="after")
+    def validate_pilot(self) -> "NativeTrainingConfig":
+        """Require the canonical single-task pilot and injected native service.
+
+        Returns:
+            Validated native configuration.
+
+        Raises:
+            ValueError: Configuration expands the pilot or uses local cloud paths.
+        """
+        if isinstance(self.service, ModalServiceConfig) and (
+            self.sandbox.modal_workspace != self.service.workspace
+            or self.sandbox.modal_environment != self.service.modal_environment
+        ):
+            raise ValueError(
+                "Sandbox and service Modal workspace/environment must match"
+            )
+        if self.training.mode != "native" or self.training.cloud_config_path:
+            raise ValueError(
+                "Native training requires mode=native and no cloud config"
+            )
+        if any(
+            selection != [PILOT_TASK]
+            for selection in (
+                self.training.task_ids,
+                self.training.training_task_ids,
+                self.sandbox.task_ids,
+            )
+        ):
+            raise ValueError("The native pilot must select only " + PILOT_TASK)
+        return self
+
+
+@step(enable_cache=False)
+def train_native(
+    bundle: Path,
+    initial: dict[str, Any],
+    reference: dict[str, Any],
+    noop: dict[str, Any],
+    config: NativeTrainingConfig,
+) -> tuple[
+    Annotated[dict[str, Any], "before_evaluation"],
+    Annotated[dict[str, Any], "after_evaluation"],
+    Annotated[dict[str, Any], "training_evidence"],
+    Annotated[
+        Path,
+        ArtifactConfig(
+            name="trained_adapter", artifact_type=ArtifactType.MODEL
+        ),
+    ],
+]:
+    """Start training only after initial, reference, and no-op qualification passes.
+
+    Args:
+        bundle: Materialized, immutable task bundle.
+        initial: Initial grading and cleanup evidence.
+        reference: Known-solution episode evidence.
+        noop: Known-failure episode evidence.
+        config: Validated pilot runtime and training limits.
+
+    Returns:
+        Matched evaluations, training evidence, and persistent checkpoint directory.
+
+    Raises:
+        RuntimeError: Qualification, training, export, or cleanup fails.
+    """
+    task = load_bundle_task(bundle, config.sandbox)
+    grading = initial.get("grading") or {}
+    if (
+        initial.get("task") != task
+        or not initial.get("cleanup_complete")
+        or not grading.get("audited_valid")
+        or grading.get("infrastructure_error")
+        or not fixture_matches(reference, 1)
+        or not fixture_matches(noop, 0)
+    ):
+        save_artifact(
+            {"initial": initial, "reference": reference, "noop": noop},
+            name="failed_native_qualification",
+        )
+        raise RuntimeError(
+            "CPU qualification failed; GPU service was not started"
+        )
+    run_id = str(get_step_context().pipeline_run.id)
+    # ZenML materializes Path outputs after this function returns.
+    directory = (
+        Path(tempfile.mkdtemp(prefix="endless-native-training-")) / run_id
+    )
+    model = {
+        "name": config.training.model_name,
+        "revision": config.training.model_revision,
+    }
+    session: NativeTrainingService | ModalTrainingService
+    if isinstance(config.service, ModalServiceConfig):
+        session = ModalTrainingService(
+            config.service, model, run_id, directory / "service"
+        )
+    else:
+        session = NativeTrainingService(
+            config.service, model, run_id, directory / "service"
+        )
+    before, after, evidence, checkpoint = execute_training(
+        {"dataset_revision": task["dataset_revision"], "tasks": [task]},
+        config.training,
+        run_id,
+        session=session,
+        data_directory=bundle,
+        output_directory=directory,
+        environment_factory=lambda image, command, episode: create_environment(
+            {**task, "image_ref": image},
+            config.sandbox.model_copy(
+                update={"command_timeout": command, "episode_timeout": episode}
+            ),
+        ),
+        client_credentials_factory=lambda: (
+            session.api_key,
+            session.service_host,
+        ),
+    )
+    save_artifact(directory / "service", name="native_training_diagnostics")
+    save_artifact(directory / "initial_checkpoint", name="initial_adapter")
+
+    return before, after, evidence, checkpoint
+
+
+@pipeline(enable_cache=False)
+def endless_terminals_native_training(
+    bundle_artifact_id: UUID, config: NativeTrainingConfig
+) -> None:
+    """Link CPU qualification artifacts to native training and paired reporting.
+
+    Args:
+        bundle_artifact_id: Version ID of the uploaded portable task directory.
+        config: Validated pilot runtime and training limits.
+    """
+    bundle = Client().get_artifact_version(bundle_artifact_id)
+    initial = qualify_sandbox_initial(bundle, config.sandbox)
+    reference = evaluate_sandbox_fixture(
+        bundle, initial, config.sandbox, "reference", id="reference_fixture"
+    )
+    noop = evaluate_sandbox_fixture(
+        bundle, initial, config.sandbox, "noop", id="noop_fixture"
+    )
+    report_sandbox_results(initial, reference, noop)
+    before, after, evidence, checkpoint = train_native(
+        bundle, initial, reference, noop, config
+    )
+    report_training(before, after, evidence)

--- a/examples/endless_terminals/pipeline.py
+++ b/examples/endless_terminals/pipeline.py
@@ -1,0 +1,275 @@
+"""Run task qualification, agent evaluation, and reports as native ZenML steps."""
+
+import json
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Annotated, Any, Optional
+
+from cloud import KubernetesInference
+from config import EvaluationConfig
+from dataset import prepare_tasks, sha256
+from reporting import render_evaluation_report, summarize_evaluation
+from runtime.contract import UPSTREAM_COMMIT
+from runtime.models import EndpointModel, FixtureModel
+from runtime.runner import run_episode
+
+from zenml import (
+    ExternalArtifact,
+    get_step_context,
+    log_metadata,
+    pipeline,
+    save_artifact,
+    step,
+)
+from zenml.types import HTMLString
+
+
+@step(enable_cache=False)
+def prepare_evaluation(
+    config: EvaluationConfig,
+) -> Annotated[dict[str, Any], "qualified_tasks"]:
+    """Qualify task images before allocating inference compute.
+
+    Args:
+        config: Evaluation settings.
+
+    Returns:
+        Pinned tasks with CPU qualification evidence.
+    """
+    return prepare_tasks(Path(config.data_directory), config.task_ids)
+
+
+def execute_evaluation(
+    prepared: dict[str, Any], config: EvaluationConfig, run_id: str
+) -> dict[str, Any]:
+    """Evaluate inside a bounded inference session and retain partial evidence.
+
+    Args:
+        prepared: Qualified tasks.
+        config: Evaluation settings.
+        run_id: Unique ZenML pipeline run ID.
+
+    Returns:
+        Complete evaluation evidence.
+
+    Raises:
+        RuntimeError: Evaluation or cleanup is incomplete.
+    """  # noqa: DOC503
+    output = Path(config.output_directory) / run_id
+    output.mkdir(parents=True, exist_ok=False)
+    model_identity = {
+        "name": config.model_name,
+        "revision": config.model_revision,
+        "revision_verified": config.mode == "kubernetes",
+    }
+    runtime = Path(__file__).parent / "runtime"
+    evaluation: dict[str, Any] = {
+        "run_id": run_id,
+        "mode": "fixture" if config.mode == "fixture" else "model",
+        "model": model_identity
+        if config.mode != "fixture"
+        else {"name": "reference fixture", "revision": "scripted"},
+        "dataset_revision": prepared["dataset_revision"],
+        "protocol": {
+            "max_actions": config.max_actions,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "command_timeout": config.command_timeout,
+            "episode_timeout": config.episode_timeout,
+            "upstream_commit": UPSTREAM_COMMIT,
+            "backend": config.mode,
+            "controller_sha256": sha256(Path(__file__)),
+            "runtime_sha256": {
+                p.name: sha256(p) for p in sorted(runtime.glob("*.py"))
+            },
+        },
+        "task_hashes": {
+            t["task_id"]: {
+                "files": t["task_file_sha256"],
+                "image": t["local_image_id"],
+                "protected_sources": t.get("protected_sources", {}),
+            }
+            for t in prepared["tasks"]
+        },
+        "episodes": [],
+        "status": "failed",
+        "cleanup": {"complete": False},
+    }
+    session = None
+    error: Optional[BaseException] = None
+    try:
+        if config.mode == "kubernetes":
+            cloud_config = json.loads(
+                Path(str(config.cloud_config_path)).read_text()
+            )
+            evaluation["protocol"]["serving"] = {
+                "image": cloud_config["vllm_image"],
+                "controller_sha256": sha256(
+                    Path(__file__).parent / "cloud.py"
+                ),
+            }
+            session = KubernetesInference(
+                cloud_config,
+                {"name": config.model_name, "revision": config.model_revision},
+                run_id,
+                output / "inference",
+            )
+        with session if session is not None else nullcontext():
+            if session is not None:
+                evaluation["inference"] = session.identity
+            for task in prepared["tasks"]:
+                if (
+                    session is not None
+                    and session.serving_seconds_remaining
+                    < config.episode_timeout + 240
+                ):
+                    raise RuntimeError(
+                        "Serving deadline cannot accommodate another complete episode"
+                    )
+                directory = Path(config.data_directory) / task["task_id"]
+                model = (
+                    FixtureModel(
+                        [
+                            f"<command>{(directory / 'solution/solve.sh').read_text()}</command>",
+                            "<action>done</action>",
+                        ]
+                    )
+                    if config.mode == "fixture"
+                    else EndpointModel(
+                        session.base_url
+                        if session is not None
+                        else str(config.base_url),
+                        config.model_name,
+                        config.max_tokens,
+                        config.temperature,
+                    )
+                )
+                episode = run_episode(
+                    {**task, "dataset_revision": prepared["dataset_revision"]},
+                    directory,
+                    model,
+                    output / task["task_id"],
+                    identity=evaluation["model"],
+                    max_actions=config.max_actions,
+                    command_timeout=config.command_timeout,
+                    episode_timeout=config.episode_timeout,
+                )
+                evaluation["episodes"].append(episode)
+                (output / "evaluation.json").write_text(
+                    json.dumps(evaluation, indent=2)
+                )
+                summary = summarize_evaluation(evaluation)
+                if summary["infrastructure_errors"] or summary["incomplete"]:
+                    raise RuntimeError(
+                        f"Episode infrastructure failed: {task['task_id']}"
+                    )
+                if config.mode == "fixture" and summary["failures"]:
+                    raise RuntimeError("Reference fixture failed its task")
+        evaluation["status"] = "completed"
+    except BaseException as exc:
+        error = exc
+        evaluation["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    finally:
+        evaluation["cleanup"] = (
+            session.cleanup_report
+            if session is not None
+            else {
+                "complete": all(
+                    e.get("cleanup_complete") is True
+                    for e in evaluation["episodes"]
+                ),
+                "inference": "externally managed"
+                if config.mode == "endpoint"
+                else "not allocated",
+            }
+        )
+        evaluation["cleanup"] = dict(evaluation["cleanup"])
+        evaluation["cleanup"]["sandboxes_complete"] = all(
+            e.get("cleanup_complete") is True for e in evaluation["episodes"]
+        )
+        evaluation["cleanup"]["complete"] = (
+            evaluation["cleanup"]["complete"]
+            and evaluation["cleanup"]["sandboxes_complete"]
+        )
+        if not evaluation["cleanup"]["complete"]:
+            evaluation["status"] = "failed"
+        (output / "evaluation.json").write_text(
+            json.dumps(evaluation, indent=2)
+        )
+        (output / "report.html").write_text(
+            str(render_evaluation_report(evaluation))
+        )
+    if error is not None or evaluation["status"] != "completed":
+        try:
+            save_artifact(evaluation, name="failed_evaluation_results")
+            save_artifact(
+                render_evaluation_report(evaluation),
+                name="failed_evaluation_report",
+            )
+        except Exception as upload_error:
+            print(
+                f"Partial artifact upload failed: {type(upload_error).__name__}; evidence: {output}"
+            )
+        if error is not None:
+            raise error
+        raise RuntimeError(f"Cleanup incomplete; inspect {output}")
+    return evaluation
+
+
+@step(enable_cache=False)
+def evaluate_checkpoint(
+    prepared: dict[str, Any], config: EvaluationConfig
+) -> Annotated[dict[str, Any], "evaluation_results"]:
+    """Allocate inference, run episodes, and finish cleanup in this step.
+
+    Args:
+        prepared: Qualified task artifact from the preceding step.
+        config: Evaluation settings.
+
+    Returns:
+        Complete evaluation with inline transcripts and cleanup evidence.
+    """
+    result = execute_evaluation(
+        prepared, config, str(get_step_context().pipeline_run.id)
+    )
+    log_metadata(metadata=summarize_evaluation(result))
+    return result
+
+
+@step(enable_cache=False)
+def report_evaluation(
+    evaluation: dict[str, Any], baseline: Optional[dict[str, Any]] = None
+) -> tuple[
+    Annotated[dict[str, Any], "evaluation_summary"],
+    Annotated[HTMLString, "evaluation_report"],
+]:
+    """Publish deterministic metrics and a dashboard HTML visualization.
+
+    Args:
+        evaluation: Current checkpoint results.
+        baseline: Optional compatible earlier evaluation artifact.
+
+    Returns:
+        Summary metrics and a self-contained HTML report.
+    """
+    return summarize_evaluation(evaluation), render_evaluation_report(
+        evaluation, baseline
+    )
+
+
+@pipeline(enable_cache=False)
+def endless_terminals_evaluation(config: EvaluationConfig) -> None:
+    """Execute the full evaluation workflow with artifact dependencies.
+
+    Args:
+        config: Task selection and bounded inference configuration.
+    """
+    prepared = prepare_evaluation(config)
+    evaluation = evaluate_checkpoint(prepared, config)
+    if config.baseline_artifact_id:
+        report_evaluation(
+            evaluation,
+            baseline=ExternalArtifact(id=config.baseline_artifact_id),
+        )
+    else:
+        report_evaluation(evaluation)

--- a/examples/endless_terminals/qualification_report.py
+++ b/examples/endless_terminals/qualification_report.py
@@ -1,0 +1,223 @@
+"""Render readable CPU qualification evidence without external assets."""
+
+import html
+import json
+from typing import Any
+
+STYLE = """
+:root{color-scheme:light;--ink:#252334;--muted:#696477;--line:#e8e4ee;
+--purple:#6742bc;--green:#247454;--red:#a33b45}
+*{box-sizing:border-box}body{margin:0;background:#f6f5f9;color:var(--ink);
+font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+main{max-width:1080px;margin:auto;padding:36px 32px 28px}h1,h2,h3,p{margin:0}
+.eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+font-weight:750;color:var(--purple)}h1{font-size:clamp(26px,4vw,38px);
+line-height:1.15;letter-spacing:-.035em;margin:12px 0}
+.lead{max-width:730px;color:var(--muted);font-size:16px}.hero{margin-bottom:28px}
+.task{display:inline-block;margin-top:17px;font:12px ui-monospace,monospace;
+color:#635775;background:#ede8f6;padding:7px 11px;border-radius:6px;
+overflow-wrap:anywhere}.section-title{font-size:17px;letter-spacing:-.02em}
+.section-note{color:var(--muted);font-size:13px;margin-top:3px}
+.readiness,.cleanup{display:flex;gap:16px;align-items:flex-start;background:white;
+border:1px solid var(--line);border-radius:12px;padding:20px;margin-bottom:24px}
+.symbol{font-size:19px;width:34px;height:34px;display:grid;place-items:center;
+flex-shrink:0;border-radius:50%;background:#eaf4ef;color:var(--green)}
+.symbol.bad{background:#fbecee;color:var(--red)}.readiness p,.cleanup p{color:var(--muted);font-size:13px}
+.cards{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin:16px 0 22px}
+.card{background:white;border:1px solid var(--line);border-radius:14px;overflow:hidden}
+.card-top{padding:23px 23px 18px}.card h3{font-size:20px;letter-spacing:-.025em;margin-top:9px}
+.card-description{color:var(--muted);font-size:13px;min-height:41px;margin-top:6px}
+.badge{display:inline-block;font-size:11px;font-weight:700;padding:4px 8px;
+border-radius:5px;background:#eaf4ef;color:var(--green)}.badge.bad{background:#fbecee;color:var(--red)}
+.compare{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:23px}
+.label{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);font-weight:700}
+.value{font-size:21px;font-weight:650;margin-top:2px}.expected .value{color:var(--muted)}
+.testbar{height:6px;display:flex;background:#eeeaf3;border-radius:6px;overflow:hidden;margin:18px 0 9px}
+.testbar span{height:100%}.passed{background:#7e63b1}.failed{background:#d4b75e}
+.error{background:#c1626c}.skipped{background:#b7b1bd}.test-summary{font-size:12px;color:var(--muted)}
+.card-bottom{background:#fbfafc;border-top:1px solid var(--line);padding:12px 23px;
+font-size:12px;color:var(--muted)}.card-bottom strong{color:var(--ink)}
+.issue{margin-top:12px;padding:10px;background:#fff3f3;color:var(--red);font-size:12px;
+border-radius:6px;overflow-wrap:anywhere}.cleanup{margin-bottom:28px}
+.details-title{margin-bottom:12px}details{border-top:1px solid var(--line);padding:13px 0}
+summary{cursor:pointer;font-weight:600;font-size:13px;list-style-position:inside}
+summary span{font-weight:400;color:var(--muted);margin-left:6px}
+pre{white-space:pre-wrap;overflow-wrap:anywhere;background:#fff;border:1px solid var(--line);
+border-radius:8px;padding:16px;max-height:380px;overflow:auto;font:12px/1.6 ui-monospace,monospace;
+margin:12px 0 0}dl{display:grid;grid-template-columns:140px 1fr;gap:8px 16px;font-size:12px}
+dt{color:var(--muted)}dd{margin:0;overflow-wrap:anywhere}footer{font-size:12px;color:var(--muted);
+margin-top:20px;padding-top:15px;border-top:1px solid var(--line)}
+@media(max-width:620px){main{padding:24px 16px}.cards{grid-template-columns:1fr;gap:14px}
+.card-description{min-height:0}.card-top{padding:20px}.readiness,.cleanup{padding:16px}
+.summary span{display:block}dl{grid-template-columns:1fr;gap:3px}dd{margin-bottom:8px}}
+"""
+
+
+def _text(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _counts(grade: dict[str, Any]) -> tuple[str, str]:
+    counts = grade.get("test_counts") or {}
+    keys = ("total", "failure", "error", "skipped")
+    if not all(type(counts.get(key)) is int for key in keys):
+        return "", "Test counts unavailable"
+    total, failed, errors, skipped = (counts[key] for key in keys)
+    passed = total - failed - errors - skipped
+    if min(total, passed, failed, errors, skipped) < 0:
+        return "", "Test counts inconsistent; inspect raw evidence"
+    segments = "".join(
+        f'<span class="{name}" style="width:{100 * count / total:.2f}%"></span>'
+        for name, count in (
+            ("passed", passed),
+            ("failed", failed),
+            ("error", errors),
+            ("skipped", skipped),
+        )
+        if count and total
+    )
+    summary = f"{passed} passed · {failed} failed · {errors} errors · {skipped} skipped"
+    return f'<div class="testbar" aria-hidden="true">{segments}</div>', summary
+
+
+def _card(result: dict[str, Any], reference: bool, matched: bool) -> str:
+    grade = result.get("grading") or {}
+    title = "Reference solution" if reference else "Untouched task"
+    description = (
+        "Run the known solution to check that correct work is accepted."
+        if reference
+        else "Leave the task unsolved to check that missing work is rejected."
+    )
+    expected = "Pass" if reference else "Fail"
+    raw = grade.get("raw_reward")
+    observed = "Pass" if raw == 1 else "Fail" if raw == 0 else "Unavailable"
+    if result.get("skipped"):
+        observed = "Not run"
+    badge = "As expected" if matched else "Needs attention"
+    bar, counts = _counts(grade)
+    cleanup = "Complete" if result.get("cleanup_complete") else "Unconfirmed"
+    if result.get("skipped"):
+        cleanup = "Not run"
+    issue = (
+        result.get("error")
+        or grade.get("infrastructure_error")
+        or result.get("skipped")
+    )
+    issue_html = f'<p class="issue">{_text(issue)}</p>' if issue else ""
+    if not matched and not issue:
+        issue_html = '<p class="issue">The result, execution or cleanup did not meet the fixture contract. Inspect the evidence below.</p>'
+    return f"""<article class="card"><div class="card-top">
+<span class="badge{"" if matched else " bad"}">{badge}</span><h3>{title}</h3>
+<p class="card-description">{description}</p><div class="compare">
+<div class="expected"><div class="label">Expected</div><div class="value">{expected}</div></div>
+<div><div class="label">Observed test outcome</div><div class="value">{observed}</div></div></div>
+{bar}<p class="test-summary">{_text(counts)}</p>{issue_html}</div>
+<div class="card-bottom">Sandbox cleanup <strong>{cleanup}</strong></div></article>"""
+
+
+def render_qualification_report(
+    results: dict[str, Any], reference_passed: bool, noop_passed: bool
+) -> str:
+    """Render outcome-first qualification evidence while retaining full raw data.
+
+    Args:
+        results: Unmodified structured qualification results.
+        reference_passed: Existing reference fixture contract result.
+        noop_passed: Existing no-op fixture contract result.
+
+    Returns:
+        Escaped, responsive HTML with inline styles and no external resources.
+    """
+    initial, reference, noop = (
+        results[key] for key in ("initial", "reference", "noop")
+    )
+    grade = initial.get("grading") or {}
+    ready = bool(
+        grade.get("audited_valid")
+        and not grade.get("infrastructure_error")
+        and initial.get("cleanup_complete")
+    )
+    passed = ready and reference_passed and noop_passed
+    title = (
+        "Sandbox qualification passed"
+        if passed
+        else "Qualification needs attention"
+    )
+    lead = (
+        "The known solution passed and the untouched task failed as expected. The CPU environment is ready for model evaluation."
+        if passed
+        else "One or more qualification checks need review before model evaluation. Check readiness, fixture outcomes and cleanup below."
+    )
+    task = initial.get("task") or {}
+    _, initial_counts = _counts(grade)
+    initial_title = (
+        "Initial environment ready"
+        if ready
+        else "Initial environment not qualified"
+    )
+    initial_note = f"{initial_counts}. Setup checks validate the starting environment; they do not solve the task."
+    initial_issue = initial.get("error") or grade.get("infrastructure_error")
+    if initial_issue:
+        initial_note += " " + str(initial_issue)
+    cleanup_values = [
+        item.get("cleanup_complete") is True
+        for item in (initial, reference, noop)
+    ]
+    all_clean = all(cleanup_values)
+    cleanup_title = (
+        "Cleanup confirmed" if all_clean else "Cleanup needs review"
+    )
+    cleanup_note = " · ".join(
+        name
+        + ": "
+        + (
+            "not run"
+            if item.get("skipped")
+            else "complete"
+            if clean
+            else "unconfirmed"
+        )
+        for name, item, clean in zip(
+            ("Initial checks", "Reference", "Untouched task"),
+            (initial, reference, noop),
+            cleanup_values,
+        )
+    )
+    logs = "".join(
+        f"<details><summary>{name}<span>Verifier output</span></summary><pre>{_text((item.get('grading') or {}).get('verifier_output') or 'No verifier output recorded.')}</pre></details>"
+        for name, item in (
+            ("Initial environment", initial),
+            ("Reference solution", reference),
+            ("Untouched task", noop),
+        )
+    )
+    provenance = "".join(
+        f"<dt>{label}</dt><dd>{_text(value or 'Not recorded')}</dd>"
+        for label, value in (
+            ("Task", task.get("task_id")),
+            ("Dataset revision", task.get("dataset_revision")),
+            (
+                "Task image",
+                task.get("image_ref") or task.get("qualified_image_id"),
+            ),
+        )
+    )
+    return f"""<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title><style>{STYLE}</style></head><body><main>
+<header class="hero"><p class="eyebrow">ZenML · Endless Terminals</p><h1>{title}</h1>
+<p class="lead">{lead}</p><span class="task">{_text(task.get("task_id") or "Task identity unavailable")}</span></header>
+<section class="readiness" aria-label="Initial readiness"><span class="symbol{"" if ready else " bad"}" aria-hidden="true">{"✓" if ready else "!"}</span>
+<div><h2 class="section-title">{initial_title}</h2><p>{_text(initial_note)}</p></div></section>
+<section aria-label="Fixture comparison"><h2 class="section-title">Does the grader distinguish solved from unsolved?</h2>
+<p class="section-note">Both outcomes are required. An untouched-task failure is the expected result.</p>
+<div class="cards">{_card(reference, True, reference_passed)}{_card(noop, False, noop_passed)}</div></section>
+<section class="cleanup"><span class="symbol{"" if all_clean else " bad"}" aria-hidden="true">{"✓" if all_clean else "!"}</span>
+<div><h2 class="section-title">{cleanup_title}</h2><p>{_text(cleanup_note)}</p></div></section>
+<section aria-label="Supporting evidence"><h2 class="section-title details-title">Evidence &amp; provenance</h2>
+{logs}<details><summary>Task provenance<span>Pinned dataset and image</span></summary><dl>{provenance}</dl></details>
+<details><summary>Full structured evidence<span>Results, logs, hashes and runtime identities</span></summary>
+<pre>{_text(json.dumps(results, indent=2))}</pre></details></section>
+<footer>CPU Kubernetes sandbox qualification · Scripted fixtures · No model inference or training.<br>
+This report checks the evaluation environment. It does not measure model quality or learning.</footer>
+</main></body></html>"""

--- a/examples/endless_terminals/reporting.py
+++ b/examples/endless_terminals/reporting.py
@@ -1,0 +1,348 @@
+"""Render deterministic evaluation summaries without model-authored claims."""
+
+import html
+import json
+from typing import Any
+
+from zenml.types import HTMLString
+
+
+def _outcome(episode: dict[str, Any]) -> str:
+    """Classify an episode without treating infrastructure errors as task failures.
+
+    Args:
+        episode: Recorded episode and grading result.
+
+    Returns:
+        Outcome label for the recorded evidence.
+    """
+    grading = episode.get("grading") or {}
+    if (
+        grading.get("infrastructure_error")
+        or (grading.get("test_counts") or {}).get("error", 0) > 0
+        or episode.get("infrastructure_error")
+        or episode.get("cleanup_complete") is False
+        or episode.get("exit_reason")
+        in {"infrastructure_error", "provider_error"}
+    ):
+        return "Infrastructure error"
+    if not grading or grading.get("raw_reward") is None:
+        return "Incomplete"
+    if grading.get("audited_valid") is True:
+        return "Passed"
+    return "Failed"
+
+
+def summarize_evaluation(evaluation: dict[str, Any]) -> dict[str, Any]:
+    """Calculate counts from recorded episodes rather than narrative text.
+
+    Args:
+        evaluation: Evaluation metadata and recorded episodes.
+
+    Returns:
+        Counts, response validity, token totals, and elapsed episode seconds.
+    """
+    episodes = evaluation.get("episodes", [])
+    outcomes = [_outcome(episode) for episode in episodes]
+    turns = [turn for episode in episodes for turn in episode.get("turns", [])]
+    valid_responses = sum(
+        (turn.get("action") or {}).get("type") in {"command", "done"}
+        for turn in turns
+    )
+    usage = [turn.get("usage") or {} for turn in turns]
+    return {
+        "attempts": len(episodes),
+        "passes": outcomes.count("Passed"),
+        "failures": outcomes.count("Failed"),
+        "infrastructure_errors": outcomes.count("Infrastructure error"),
+        "incomplete": outcomes.count("Incomplete"),
+        "responses": len(turns),
+        "valid_responses": valid_responses,
+        "format_errors": len(turns) - valid_responses,
+        "valid_response_percent": (
+            100 * valid_responses / len(turns) if turns else None
+        ),
+        "prompt_tokens": sum(
+            item.get("prompt_tokens", 0) or 0 for item in usage
+        ),
+        "completion_tokens": sum(
+            item.get("completion_tokens", 0) or 0 for item in usage
+        ),
+        "total_tokens": sum(
+            item.get("total_tokens", 0) or 0 for item in usage
+        ),
+        "elapsed_seconds": sum(
+            episode.get("elapsed_seconds", 0) or 0 for episode in episodes
+        ),
+        "cleanup_complete": (evaluation.get("cleanup") or {}).get("complete")
+        is True,
+    }
+
+
+def _validate_comparison(
+    evaluation: dict[str, Any], baseline: dict[str, Any]
+) -> None:
+    """Reject comparisons without matching, explicit evaluation identities.
+
+    Args:
+        evaluation: Current evaluation.
+        baseline: Prior evaluation to compare.
+
+    Raises:
+        ValueError: Evaluation identities are missing, invalid, or different.
+    """
+    if any(
+        item.get("model", {}).get("revision_verified") is False
+        for item in (evaluation, baseline)
+    ):
+        raise ValueError(
+            "Cannot compare evaluations: endpoint revision is unverified"
+        )
+    for key in ("dataset_revision", "protocol", "task_hashes", "mode"):
+        if not evaluation.get(key) or evaluation[key] != baseline.get(key):
+            raise ValueError(
+                f"Cannot compare evaluations: {key} differs or is missing"
+            )
+    task_ids = [
+        _episode_key(episode) for episode in evaluation.get("episodes", [])
+    ]
+    baseline_ids = [
+        _episode_key(episode) for episode in baseline.get("episodes", [])
+    ]
+    if (
+        not task_ids
+        or len(set(task_ids)) != len(task_ids)
+        or len(set(baseline_ids)) != len(baseline_ids)
+        or set(task_ids) != set(baseline_ids)
+    ):
+        raise ValueError(
+            "Cannot compare evaluations: task sets differ or are invalid"
+        )
+    if not {task_id for task_id, _ in task_ids}.issubset(
+        evaluation["task_hashes"]
+    ):
+        raise ValueError("Cannot compare evaluations: task hashes are missing")
+
+
+def _episode_key(episode: dict[str, Any]) -> tuple[str, int]:
+    """Identify an evaluation attempt, including legacy single attempts.
+
+    Args:
+        episode: Recorded task attempt.
+
+    Returns:
+        Task ID and one-based attempt index.
+
+    Raises:
+        ValueError: The attempt index is invalid.
+    """
+    index = episode.get("attempt_index", 1)
+    if type(index) is not int or index < 1:
+        raise ValueError("Cannot compare evaluations: invalid attempt index")
+    return episode["task_id"], index
+
+
+def _episode_label(episode: dict[str, Any]) -> str:
+    """Label individual attempts while preserving legacy task labels.
+
+    Args:
+        episode: Recorded task attempt.
+
+    Returns:
+        Task label with the one-based attempt number when recorded.
+    """
+    if "attempt_index" in episode:
+        return f"{episode['task_id']} (attempt {episode['attempt_index']})"
+    return str(episode["task_id"])
+
+
+def _escape(value: Any) -> str:
+    """Escape all dynamic values, including task identifiers and model output.
+
+    Args:
+        value: Value to display as text.
+
+    Returns:
+        Escaped HTML text.
+    """
+    return html.escape(str(value), quote=True)
+
+
+def _details(label: str, value: Any) -> str:
+    """Render recorded text in a native disclosure element.
+
+    Args:
+        label: Disclosure heading.
+        value: Recorded text or JSON-compatible data.
+
+    Returns:
+        Escaped disclosure HTML.
+    """
+    if not isinstance(value, str):
+        value = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False)
+    return f"<details><summary>{_escape(label)}</summary><pre>{_escape(value)}</pre></details>"
+
+
+def _task_rows(evaluation: dict[str, Any]) -> str:
+    """Render per-task outcomes with their original evidence.
+
+    Args:
+        evaluation: Evaluation containing recorded episodes.
+
+    Returns:
+        Escaped table rows.
+    """
+    rows = []
+    for episode in sorted(evaluation.get("episodes", []), key=_episode_key):
+        turns = episode.get("turns", [])
+        errors = sum(
+            (turn.get("action") or {}).get("type") not in {"command", "done"}
+            for turn in turns
+        )
+        grading = episode.get("grading") or {}
+        evidence = _details(
+            "Verifier output",
+            grading.get("verifier_output", "No verifier output recorded."),
+        )
+        evidence += _details("Transcript", episode.get("transcript", []))
+        evidence += _details(
+            "Grading and exit reason",
+            {
+                "grading": grading,
+                "exit_reason": episode.get("exit_reason"),
+                "cleanup_complete": episode.get("cleanup_complete"),
+            },
+        )
+        values = [
+            _episode_label(episode),
+            _outcome(episode),
+            len(turns),
+            errors,
+            f"{episode.get('elapsed_seconds', 0) or 0:.2f}",
+        ]
+        rows.append(
+            "<tr>"
+            + "".join(f"<td>{_escape(value)}</td>" for value in values)
+            + f"<td>{evidence}</td></tr>"
+        )
+    return (
+        "".join(rows) or '<tr><td colspan="6">No episodes recorded.</td></tr>'
+    )
+
+
+def _comparison(evaluation: dict[str, Any], baseline: dict[str, Any]) -> str:
+    """Render paired task outcomes and aggregate counts for compatible runs.
+
+    Args:
+        evaluation: Current evaluation.
+        baseline: Compatible prior evaluation.
+
+    Returns:
+        Escaped comparison HTML.
+
+    Raises:
+        ValueError: Evaluation identities do not match.
+    """  # noqa: DOC502
+    _validate_comparison(evaluation, baseline)
+    current = summarize_evaluation(evaluation)
+    previous = summarize_evaluation(baseline)
+    previous_tasks = {
+        _episode_key(episode): episode for episode in baseline["episodes"]
+    }
+    rows = "".join(
+        f"<tr><td>{_escape(_episode_label(episode))}</td>"
+        f"<td>{_escape(_outcome(previous_tasks[_episode_key(episode)]))}</td>"
+        f"<td>{_escape(_outcome(episode))}</td></tr>"
+        for episode in sorted(evaluation["episodes"], key=_episode_key)
+    )
+    return (
+        "<h2>Matched evaluation comparison</h2>"
+        f"<p>Baseline model: {_escape(baseline.get('model', {}).get('name', 'Unspecified'))} "
+        f"(revision {_escape(baseline.get('model', {}).get('revision', 'Unspecified'))}). "
+        f"Audited passes: {previous['passes']}/{previous['attempts']} baseline; "
+        f"{current['passes']}/{current['attempts']} current. "
+        "This comparison alone does not establish a training gain.</p>"
+        "<table><thead><tr><th>Task</th><th>Baseline</th><th>Current</th></tr></thead>"
+        f"<tbody>{rows}</tbody></table>"
+    )
+
+
+def render_evaluation_report(
+    evaluation: dict[str, Any], baseline: dict[str, Any] | None = None
+) -> HTMLString:
+    """Build a standalone HTML artifact with escaped, inspectable evidence.
+
+    Args:
+        evaluation: Current evaluation metadata and recorded episodes.
+        baseline: Optional evaluation with matching tasks and protocol.
+
+    Returns:
+        A deterministic HTML document suitable for ZenML artifact visualization.
+
+    Raises:
+        ValueError: Comparison identities differ or required identities are missing.
+    """  # noqa: DOC502
+    summary = summarize_evaluation(evaluation)
+    comparison = (
+        _comparison(evaluation, baseline) if baseline is not None else ""
+    )
+    model = evaluation.get("model") or {}
+    mode = evaluation.get("mode")
+    badge = (
+        "MODEL EVALUATION"
+        if mode == "model"
+        else "FIXTURE CHECK: NOT A MODEL SCORE"
+    )
+    percent = summary["valid_response_percent"]
+    validity = (
+        f"{percent:.1f}%" if percent is not None else "N/A (no responses)"
+    )
+    cleanup = (
+        "Complete" if summary["cleanup_complete"] else "Not confirmed complete"
+    )
+    metadata = {
+        key: evaluation.get(key)
+        for key in (
+            "model",
+            "mode",
+            "dataset_revision",
+            "protocol",
+            "task_hashes",
+            "cleanup",
+            "status",
+        )
+    }
+    return HTMLString(
+        '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+        "<title>Endless Terminals evaluation</title><style>"
+        "body{font:16px/1.5 system-ui,sans-serif;color:#172339;background:#f3f5f8;max-width:1200px;margin:32px auto;padding:0 24px}"
+        "h1,h2{line-height:1.2}.badge{display:inline-block;background:#dce8ff;padding:5px 10px;border-radius:5px;font-weight:700}"
+        ".stats{display:flex;flex-wrap:wrap;gap:16px}.stats p{background:white;border:1px solid #d4dce8;border-radius:8px;padding:14px;margin:0;min-width:140px}"
+        ".stats strong{display:block;font-size:26px}table{border-collapse:collapse;width:100%;background:white;margin:16px 0}"
+        "th,td{text-align:left;border:1px solid #d4dce8;padding:10px;vertical-align:top}"
+        "pre{white-space:pre-wrap;overflow-wrap:anywhere;font:13px/1.5 ui-monospace,monospace;max-height:420px;overflow:auto}"
+        "details{margin:6px 0}summary{cursor:pointer}footer{margin-top:24px;color:#43516a}"
+        "@media(max-width:700px){body{padding:0 10px}table{display:block;overflow:auto}}"
+        "</style></head><body>"
+        f'<p class="badge">{badge}</p><h1>Endless Terminals evaluation</h1>'
+        f"<p>Model: {_escape(model.get('name', 'Unspecified'))}. "
+        f"Revision: {_escape(model.get('revision', 'Unspecified'))}.</p>"
+        f"<p>Run status: {_escape(evaluation.get('status', 'Unspecified'))}. Cleanup: {cleanup}.</p>"
+        '<div class="stats">'
+        f"<p>Audited passes<strong>{summary['passes']}/{summary['attempts']}</strong></p>"
+        f"<p>Task failures<strong>{summary['failures']}</strong></p>"
+        f"<p>Infrastructure errors<strong>{summary['infrastructure_errors']}</strong></p>"
+        f"<p>Incomplete<strong>{summary['incomplete']}</strong></p></div>"
+        f"<p>Valid response format: {validity} ({summary['valid_responses']}/{summary['responses']}). "
+        f"Recorded tokens: {summary['total_tokens']}. "
+        f"Total episode time: {summary['elapsed_seconds']:.2f} seconds.</p>"
+        "<p>All recorded attempts are shown. Infrastructure errors and incomplete episodes are separate from task failures. "
+        "A pass requires the audited grader result. Format validity counts command and done actions.</p>"
+        f"{comparison}<h2>Task results</h2><table><thead><tr><th>Task</th><th>Outcome</th>"
+        "<th>Responses</th><th>Format errors</th><th>Seconds</th><th>Evidence</th></tr></thead>"
+        f"<tbody>{_task_rows(evaluation)}</tbody></table>"
+        f"{_details('Evaluation identity and cleanup', metadata)}"
+        "<footer>This qualified pilot subset does not establish broad benchmark performance. "
+        "Fixture results validate the runner and graders, not model capability.</footer></body></html>"
+    )

--- a/examples/endless_terminals/requirements-native.txt
+++ b/examples/endless_terminals/requirements-native.txt
@@ -1,0 +1,10 @@
+zenml==0.96.4
+kubernetes==25.3.0
+Jinja2==3.1.6
+s3fs==2026.6.0
+boto3==1.43.56
+aws-profile-manager==0.7.3
+tinker==0.24.0
+tinker-cookbook==0.5.7
+transformers==5.5.4
+torch==2.11.0+cpu

--- a/examples/endless_terminals/requirements-sandbox.txt
+++ b/examples/endless_terminals/requirements-sandbox.txt
@@ -1,0 +1,6 @@
+zenml==0.96.4
+kubernetes==25.3.0
+Jinja2==3.1.6
+s3fs==2026.7.0
+boto3==1.43.56
+aws-profile-manager==0.7.3

--- a/examples/endless_terminals/requirements-training.txt
+++ b/examples/endless_terminals/requirements-training.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+tinker==0.24.0
+tinker-cookbook==0.5.7
+transformers==5.5.4

--- a/examples/endless_terminals/requirements.txt
+++ b/examples/endless_terminals/requirements.txt
@@ -1,0 +1,2 @@
+zenml[server]>=0.96.4
+pydantic>=2,<3

--- a/examples/endless_terminals/run.py
+++ b/examples/endless_terminals/run.py
@@ -1,0 +1,54 @@
+"""Launch a real ZenML evaluation using a local orchestrator and Docker."""
+
+import argparse
+
+from config import EvaluationConfig
+from pipeline import endless_terminals_evaluation
+
+from zenml.client import Client
+
+
+def main() -> None:
+    """Parse explicit execution settings and start the pipeline.
+
+    Raises:
+        RuntimeError: The active stack cannot run host Docker tasks.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=["fixture", "endpoint", "kubernetes"],
+        default="fixture",
+    )
+    parser.add_argument(
+        "--task-id", action="append", dest="task_ids", default=[]
+    )
+    for name in (
+        "data-directory",
+        "output-directory",
+        "base-url",
+        "cloud-config-path",
+        "model-name",
+        "model-revision",
+        "baseline-artifact-id",
+    ):
+        parser.add_argument(f"--{name}")
+    for name in ("max-actions", "max-tokens"):
+        parser.add_argument(f"--{name}", type=int)
+    for name in ("temperature", "command-timeout", "episode-timeout"):
+        parser.add_argument(f"--{name}", type=float)
+    values = {
+        key: value
+        for key, value in vars(parser.parse_args()).items()
+        if value is not None
+    }
+    config = EvaluationConfig(**values).resolve_directories()
+    if Client().active_stack.orchestrator.flavor != "local":
+        raise RuntimeError(
+            "Select a local-orchestrator stack: this example uses Docker on this host"
+        )
+    endless_terminals_evaluation(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/run_modal_baseline.py
+++ b/examples/endless_terminals/run_modal_baseline.py
@@ -1,0 +1,102 @@
+"""Submit the bounded unchanged-model baseline to the configured Modal workspace."""
+
+import argparse
+from pathlib import Path
+
+import modal
+from baseline import BaselineConfig, endless_terminals_modal_baseline
+from modal_service import ModalServiceConfig
+from sandbox_pipeline import load_bundle_task
+
+from zenml import save_artifact
+from zenml.client import Client
+from zenml.config import DockerSettings, ResourceSettings
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
+from zenml.integrations.modal.flavors import ModalOrchestratorSettings
+from zenml.integrations.modal.orchestrators.modal_orchestrator import (
+    ModalOrchestrator,
+)
+from zenml.integrations.modal.sandbox_utils import (
+    create_modal_client_from_credentials,
+)
+from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+
+
+def main() -> None:
+    """Validate the active stack and submit the baseline pipeline.
+
+    Raises:
+        RuntimeError: The active stack lacks Modal orchestration or sandbox, or identity differs.
+        ValueError: The bundle directory is missing.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args()
+    config = BaselineConfig.model_validate_json(args.config.read_text())
+    bundle = args.bundle.resolve()
+    if not bundle.is_dir() or not (bundle / "task-manifest.json").is_file():
+        raise ValueError("--bundle must contain task-manifest.json")
+    for task_id in config.task_ids:
+        load_bundle_task(bundle, config.task_config(task_id))
+    stack = Client().active_stack
+    if (
+        not isinstance(stack.orchestrator, ModalOrchestrator)
+        or stack.sandbox is None
+        or not isinstance(stack.sandbox, ModalSandbox)
+    ):
+        raise RuntimeError(
+            "Select a stack with Modal orchestrator and Modal sandbox"
+        )
+    if not isinstance(config.service, ModalServiceConfig):
+        raise ValueError(
+            "Modal submission requires a Modal service configuration"
+        )
+    for component in (stack.orchestrator, stack.sandbox):
+        settings = component.config
+        if settings.modal_environment != config.service.modal_environment:
+            raise RuntimeError(
+                f"Both Modal components must select {config.service.modal_environment}"
+            )
+        if not settings.token_id or not settings.token_secret:
+            raise RuntimeError(
+                "Both Modal components require explicit credentials"
+            )
+        client = create_modal_client_from_credentials(
+            token_id=settings.token_id, token_secret=settings.token_secret
+        )
+        workspace = modal.Workspace.from_context(client=client).hydrate()
+        if workspace.name != config.service.workspace:
+            raise RuntimeError(
+                f"Modal credentials do not target {config.service.workspace}"
+            )
+    print(
+        f"Verified Modal workspace={config.service.workspace} "
+        f"environment={config.service.modal_environment} for both components"
+    )
+    configured = endless_terminals_modal_baseline.with_options(
+        settings={
+            "docker": DockerSettings(
+                parent_image=config.controller_image,
+                install_stack_requirements=False,
+                install_deployment_requirements=False,
+                disable_automatic_requirements_detection=True,
+                replicate_local_python_environment=False,
+                build_config=DockerBuildConfig(
+                    build_options=DockerBuildOptions(platform="linux/amd64")
+                ),
+            ),
+            "orchestrator": ModalOrchestratorSettings(
+                synchronous=False,
+                modal_environment=config.service.modal_environment,
+                timeout=10800,
+            ),
+            "resources": ResourceSettings(cpu_count=2, memory="3GiB"),
+        },
+    )
+    artifact = save_artifact(data=bundle, name="endless-baseline-task-bundle")
+    configured(bundle_artifact_id=artifact.id, config=config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/run_modal_training.py
+++ b/examples/endless_terminals/run_modal_training.py
@@ -1,0 +1,106 @@
+"""Submit the bounded native training pilot to the configured Modal workspace."""
+
+import argparse
+from pathlib import Path
+
+import modal
+from modal_service import ModalServiceConfig
+from native_training import (
+    NativeTrainingConfig,
+    endless_terminals_native_training,
+)
+from sandbox_pipeline import load_bundle_task
+
+from zenml import save_artifact
+from zenml.client import Client
+from zenml.config import DockerSettings, ResourceSettings
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
+from zenml.integrations.modal.flavors import ModalOrchestratorSettings
+from zenml.integrations.modal.orchestrators.modal_orchestrator import (
+    ModalOrchestrator,
+)
+from zenml.integrations.modal.sandbox_utils import (
+    create_modal_client_from_credentials,
+)
+from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+
+
+def main() -> None:
+    """Validate the active stack and submit the native training pipeline.
+
+    Raises:
+        RuntimeError: The active stack lacks Modal orchestration or sandbox, or identity differs.
+        ValueError: The bundle directory is missing.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args()
+    config = NativeTrainingConfig.model_validate_json(args.config.read_text())
+    bundle = args.bundle.resolve()
+    if not bundle.is_dir() or not (bundle / "task-manifest.json").is_file():
+        raise ValueError("--bundle must contain task-manifest.json")
+    load_bundle_task(bundle, config.sandbox)
+    stack = Client().active_stack
+    if (
+        not isinstance(stack.orchestrator, ModalOrchestrator)
+        or stack.sandbox is None
+        or not isinstance(stack.sandbox, ModalSandbox)
+    ):
+        raise RuntimeError(
+            "Select a stack with Modal orchestrator and Modal sandbox"
+        )
+    if not isinstance(config.service, ModalServiceConfig):
+        raise ValueError(
+            "Modal submission requires a Modal service configuration"
+        )
+    for component in (stack.orchestrator, stack.sandbox):
+        settings = component.config
+        if settings.modal_environment != config.service.modal_environment:
+            raise RuntimeError(
+                f"Both Modal components must select {config.service.modal_environment}"
+            )
+        if not settings.token_id or not settings.token_secret:
+            raise RuntimeError(
+                "Both Modal components require explicit credentials"
+            )
+        client = create_modal_client_from_credentials(
+            token_id=settings.token_id, token_secret=settings.token_secret
+        )
+        workspace = modal.Workspace.from_context(client=client).hydrate()
+        if workspace.name != config.service.workspace:
+            raise RuntimeError(
+                f"Modal credentials do not target {config.service.workspace}"
+            )
+    print(
+        f"Verified Modal workspace={config.service.workspace} "
+        f"environment={config.service.modal_environment} for both components"
+    )
+    configured = endless_terminals_native_training.with_options(
+        settings={
+            "docker": DockerSettings(
+                parent_image=config.controller_image,
+                install_stack_requirements=False,
+                install_deployment_requirements=False,
+                disable_automatic_requirements_detection=True,
+                replicate_local_python_environment=False,
+                build_config=DockerBuildConfig(
+                    build_options=DockerBuildOptions(platform="linux/amd64")
+                ),
+            ),
+            "orchestrator": ModalOrchestratorSettings(
+                synchronous=False,
+                modal_environment=config.service.modal_environment,
+                timeout=10800,
+            ),
+            "resources": ResourceSettings(cpu_count=2, memory="3GiB"),
+        },
+    )
+    artifact = save_artifact(
+        data=bundle, name="endless-native-training-task-bundle"
+    )
+    configured(bundle_artifact_id=artifact.id, config=config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/run_native_training.py
+++ b/examples/endless_terminals/run_native_training.py
@@ -1,0 +1,94 @@
+"""Submit the native training pilot with an uploaded bundle artifact."""
+
+import argparse
+from pathlib import Path
+
+from native_training import (
+    NativeTrainingConfig,
+    endless_terminals_native_training,
+)
+from sandbox_pipeline import load_bundle_task
+
+from zenml import save_artifact
+from zenml.client import Client
+from zenml.config import DockerSettings
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
+from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import (
+    KubernetesOrchestratorSettings,
+)
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+
+
+def main() -> None:
+    """Validate the active stack and submit the native training pipeline.
+
+    Raises:
+        RuntimeError: The active stack lacks Kubernetes orchestration or sandbox.
+        ValueError: The bundle directory is missing.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--service-account", required=True)
+    args = parser.parse_args()
+    config = NativeTrainingConfig.model_validate_json(args.config.read_text())
+    bundle = args.bundle.resolve()
+    if not bundle.is_dir() or not (bundle / "task-manifest.json").is_file():
+        raise ValueError("--bundle must contain task-manifest.json")
+    load_bundle_task(bundle, config.sandbox)
+    stack = Client().active_stack
+    if (
+        stack.orchestrator.flavor != "kubernetes"
+        or stack.sandbox is None
+        or stack.sandbox.flavor != "kubernetes"
+    ):
+        raise RuntimeError(
+            "Select a stack with Kubernetes orchestrator and Kubernetes sandbox"
+        )
+    placement = KubernetesPodSettings(
+        node_selectors={"pool": "workloads"},
+        tolerations=[
+            {
+                "key": "pool",
+                "operator": "Equal",
+                "value": "workloads",
+                "effect": "NoSchedule",
+            }
+        ],
+        resources={
+            "requests": {"cpu": "500m", "memory": "1Gi"},
+            "limits": {"cpu": "2", "memory": "3Gi"},
+        },
+    )
+    configured = endless_terminals_native_training.with_options(
+        settings={
+            "docker": DockerSettings(
+                parent_image=config.controller_image,
+                install_stack_requirements=False,
+                install_deployment_requirements=False,
+                disable_automatic_requirements_detection=True,
+                replicate_local_python_environment=False,
+                build_config=DockerBuildConfig(
+                    build_options=DockerBuildOptions(platform="linux/amd64")
+                ),
+            ),
+            "orchestrator": KubernetesOrchestratorSettings(
+                synchronous=False,
+                max_parallelism=1,
+                ttl_seconds_after_finished=3600,
+                active_deadline_seconds=10800,
+                service_account_name=args.service_account,
+                step_pod_service_account_name=args.service_account,
+                pod_settings=placement,
+                orchestrator_pod_settings=placement,
+            ),
+        },
+    )
+    artifact = save_artifact(
+        data=bundle, name="endless-native-training-task-bundle"
+    )
+    configured(bundle_artifact_id=artifact.id, config=config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/run_sandbox.py
+++ b/examples/endless_terminals/run_sandbox.py
@@ -1,0 +1,87 @@
+"""Submit the CPU sandbox pilot with an uploaded bundle artifact."""
+
+import argparse
+from pathlib import Path
+
+from sandbox_pipeline import SandboxPipelineConfig, endless_terminals_sandbox
+
+from zenml import save_artifact
+from zenml.client import Client
+from zenml.config import DockerSettings
+from zenml.config.docker_settings import DockerBuildConfig, DockerBuildOptions
+from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import (
+    KubernetesOrchestratorSettings,
+)
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+
+
+def main() -> None:
+    """Validate the active stack and submit the native sandbox pipeline.
+
+    Raises:
+        RuntimeError: The active stack lacks Kubernetes orchestration or sandbox.
+        ValueError: The bundle directory is missing.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--service-account", required=True)
+    args = parser.parse_args()
+    config = SandboxPipelineConfig.model_validate_json(args.config.read_text())
+    bundle = args.bundle.resolve()
+    if not bundle.is_dir() or not (bundle / "task-manifest.json").is_file():
+        raise ValueError("--bundle must contain task-manifest.json")
+    stack = Client().active_stack
+    if (
+        stack.orchestrator.flavor != "kubernetes"
+        or stack.sandbox is None
+        or stack.sandbox.flavor != "kubernetes"
+    ):
+        raise RuntimeError(
+            "Select a stack with Kubernetes orchestrator and Kubernetes sandbox"
+        )
+    placement = KubernetesPodSettings(
+        node_selectors={"pool": "workloads"},
+        tolerations=[
+            {
+                "key": "pool",
+                "operator": "Equal",
+                "value": "workloads",
+                "effect": "NoSchedule",
+            }
+        ],
+        resources={
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+            "limits": {"cpu": "1", "memory": "2Gi"},
+        },
+    )
+    configured = endless_terminals_sandbox.with_options(
+        settings={
+            "docker": DockerSettings(
+                parent_image=config.helper_image,
+                install_stack_requirements=False,
+                install_deployment_requirements=False,
+                disable_automatic_requirements_detection=True,
+                replicate_local_python_environment=False,
+                build_config=DockerBuildConfig(
+                    build_options=DockerBuildOptions(platform="linux/amd64")
+                ),
+            ),
+            "orchestrator": KubernetesOrchestratorSettings(
+                synchronous=False,
+                max_parallelism=1,
+                ttl_seconds_after_finished=3600,
+                active_deadline_seconds=3600,
+                service_account_name=args.service_account,
+                step_pod_service_account_name=args.service_account,
+                pod_settings=placement,
+                orchestrator_pod_settings=placement,
+            ),
+        },
+    )
+    artifact = save_artifact(data=bundle, name="endless-sandbox-task-bundle")
+    configured(bundle_artifact_id=artifact.id, config=config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/run_training.py
+++ b/examples/endless_terminals/run_training.py
@@ -1,0 +1,32 @@
+"""Launch the bounded native ZenML terminal-agent training pipeline."""
+
+import argparse
+import json
+from pathlib import Path
+
+from config import TrainingConfig
+from training import endless_terminals_training
+
+from zenml.client import Client
+
+
+def main() -> None:
+    """Validate an explicit JSON configuration and launch the training run.
+
+    Raises:
+        RuntimeError: The selected stack does not use the local orchestrator.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    config = TrainingConfig(
+        **json.loads(parser.parse_args().config.read_text())
+    ).resolve_directories()
+    if Client().active_stack.orchestrator.flavor != "local":
+        raise RuntimeError(
+            "Training requires a local orchestrator for host Docker tasks"
+        )
+    endless_terminals_training(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/runtime/LICENSE.endless-terminals
+++ b/examples/endless_terminals/runtime/LICENSE.endless-terminals
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Kanishk Gandhi, Shivam Garg, Noah Goodman, Dimitris Papailiopoulos
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/endless_terminals/runtime/__init__.py
+++ b/examples/endless_terminals/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded terminal evaluation without orchestration dependencies."""

--- a/examples/endless_terminals/runtime/contract.py
+++ b/examples/endless_terminals/runtime/contract.py
@@ -1,0 +1,65 @@
+"""Prompt and parser from Endless Terminals, Apache-2.0.
+
+Pinned source: kanishkg/endless-terminals at
+99f4c74b75faacf21e53d3dc01df170902e924cb, sample_solutions.py.
+The parser deliberately selects the last command despite the prompt wording.
+"""
+
+import re
+
+UPSTREAM_COMMIT = "99f4c74b75faacf21e53d3dc01df170902e924cb"
+
+SYSTEM_MESSAGE = """You are a highly capable Linux terminal agent operating strictly via a single-shell-command interface.
+Goal: Complete the user's task.
+
+Detailed Instructions:
+- Output exactly one of the following per turn after you think in the <think> </think> tags:
+  1) <command>THE_SINGLE_SHELL_COMMAND</command>
+  XOR (XOR means you can only respond with one of the two)
+  2) <action>done</action>
+- Don't use interactive commands and confirmations; use non-interactive flags.
+- Prefer simple, robust CLI tools; write files explicitly when needed.
+- If you believe the task is solved, emit <action>done</action>.
+- You should run commands interactively to see the output and then write the command. Don't just pipe the commands.
+- Only your first command in command tags will be executed. So don't respond with multiple commands.
+- Verify your solution once you are done. Eg: you can use cat to see the input and the output.
+- Do not just write long bash scripts. Write the commands that you would write in a terminal.
+- Only respond with one of <command>...</command> or <action>done</action> after you think in the <think> </think> tags.
+- Plan and simulate your actions in <think> </think> tags before you respond with <command>...</command>.
+""".strip()
+
+CONCISE_XML_V1_SYSTEM_MESSAGE = """You control a Linux terminal. Complete the user's task by running shell commands.
+Each response must contain exactly one XML action and nothing else:
+<command>your shell command</command>
+or, only after completing and checking the task:
+<action>done</action>
+For example, to inspect your current directory, respond:
+<command>pwd</command>
+The tool will execute the command and return its output. Use non-interactive commands. Do not write explanations or Markdown fences.
+""".strip()
+
+DONE_RE = re.compile(r"<action>\s*done\s*</action>", flags=re.IGNORECASE)
+CMD_RE = re.compile(
+    r"<command>\s*(.*?)\s*</command>", flags=re.IGNORECASE | re.DOTALL
+)
+
+
+def extract_action(response: str) -> dict[str, str | None]:
+    """Parse the response using the pinned upstream action precedence.
+
+    Args:
+        response: Assistant text containing XML action tags.
+
+    Returns:
+        Action type and optional command string.
+    """
+    if DONE_RE.search(response):
+        return {"type": "done", "command": None}
+    matches = CMD_RE.findall(response)
+    if matches:
+        # TODO: This changed!!! Models trained with old version used the first match instead of the last.
+        command = matches[-1].strip()
+        if command.lower() == "done":
+            return {"type": "done", "command": None}
+        return {"type": "command", "command": command}
+    return {"type": "invalid", "command": None}

--- a/examples/endless_terminals/runtime/docker_command.py
+++ b/examples/endless_terminals/runtime/docker_command.py
@@ -1,0 +1,86 @@
+"""Bounded Docker subprocess transport."""
+
+import os
+import selectors
+import subprocess
+import time
+from dataclasses import dataclass
+
+MAX_OUTPUT = 256 * 1024
+
+
+@dataclass
+class DockerCommand:
+    """Execute Docker CLI commands using the resolved executable."""
+
+    executable: str
+
+    def __call__(
+        self,
+        args: list[str],
+        *,
+        timeout: float = 30,
+        input_data: bytes | None = None,
+        limit: int = MAX_OUTPUT,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[bytes]:
+        """Run Docker with bounded streamed output and a total deadline.
+
+        Args:
+            args: Docker command arguments.
+            timeout: Maximum subprocess duration in seconds.
+            input_data: Optional bytes sent through a temporary stdin file.
+            limit: Maximum captured output bytes.
+            check: Whether nonzero exit status raises an error.
+
+        Returns:
+            Completed process with bounded output.
+
+        Raises:
+            TimeoutError: Docker exceeded the deadline.
+            RuntimeError: Output exceeded the cap or Docker failed.
+        """
+        import tempfile
+
+        with tempfile.TemporaryFile() as stdin:
+            if input_data is not None:
+                stdin.write(input_data)
+                stdin.seek(0)
+            process = subprocess.Popen(
+                [self.executable, *args],
+                stdin=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            assert process.stdout is not None
+            output = bytearray()
+            end = time.monotonic() + timeout
+            try:
+                with selectors.DefaultSelector() as selector:
+                    selector.register(process.stdout, selectors.EVENT_READ)
+                    while True:
+                        remaining = end - time.monotonic()
+                        if remaining <= 0:
+                            raise TimeoutError(f"Docker {args[0]} timed out")
+                        if not selector.select(min(remaining, 0.2)):
+                            continue
+                        chunk = os.read(process.stdout.fileno(), 65536)
+                        if not chunk:
+                            break
+                        output.extend(chunk)
+                        if len(output) > limit:
+                            raise RuntimeError(
+                                f"Docker {args[0]} output exceeds {limit} bytes"
+                            )
+                code = process.wait(timeout=max(0.01, end - time.monotonic()))
+            finally:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=5)
+                process.stdout.close()
+            result = subprocess.CompletedProcess(args, code, bytes(output))
+            if check and code:
+                raise RuntimeError(
+                    f"Docker {args[0]} failed ({code}): {output.decode(errors='replace')[:2000]}"
+                )
+            return result

--- a/examples/endless_terminals/runtime/docker_env.py
+++ b/examples/endless_terminals/runtime/docker_env.py
@@ -1,0 +1,356 @@
+"""Bounded Docker terminal and independent, clean-runtime final-state grading.
+
+The agent runs as root inside a resource-limited, network-disabled container.
+This is process isolation, not a security boundary against kernel/Docker exploits.
+Only /home/user is transferred to grading; tasks requiring changes elsewhere are
+unsupported. Shell protocol tampering is reported as a failed command/deadline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import re
+import selectors
+import shlex
+import shutil
+import subprocess
+import tarfile
+import time
+import uuid
+from pathlib import Path, PurePosixPath
+
+from .docker_command import MAX_OUTPUT, DockerCommand
+from .environment import MAX_ARCHIVE
+
+
+class DockerEnvironment:
+    """Preserve Bash state across commands, then grade an isolated home snapshot."""
+
+    def __init__(
+        self,
+        image_id: str,
+        command_timeout: float = 10,
+        episode_timeout: float = 1200,
+    ) -> None:
+        """Configure a bounded terminal using an existing immutable image.
+
+        Args:
+            image_id: Immutable local Docker image ID.
+            command_timeout: Maximum seconds per command.
+            episode_timeout: Maximum seconds for agent interaction.
+
+        Raises:
+            ValueError: Image ID or timeouts are invalid.
+            RuntimeError: Docker is not available on PATH.
+        """
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", image_id):
+            raise ValueError("Use a qualified immutable local image ID")
+        if command_timeout <= 0 or episode_timeout <= 0:
+            raise ValueError("Timeouts must be positive")
+        self.image_id = image_id
+        self.provenance = {"backend": "docker", "image_id": image_id}
+        self.command_timeout = command_timeout
+        self.episode_timeout = episode_timeout
+        docker = shutil.which("docker")
+        if docker is None:
+            raise RuntimeError("Docker CLI is required on PATH")
+        self.docker: str = docker
+        self.run_docker = DockerCommand(self.docker)
+        self.container_id: str | None = None
+        self.shell: subprocess.Popen[bytes] | None = None
+        self.deadline = 0.0
+        self.closed = False
+        self.stopped = False
+        self._snapshot: bytes | None = None
+        self._containers: list[str] = []
+
+    def create_container(self) -> str:
+        """Create and start a tracked container with no network or image pull.
+
+        Returns:
+            Unique container name registered for cleanup.
+        """
+        name = "endless-adapter-" + uuid.uuid4().hex
+        # Register the name before create so interrupted/ambiguous creates clean up.
+        self._containers.append(name)
+        self.run_docker(
+            [
+                "create",
+                "--pull=never",
+                "--name",
+                name,
+                "--platform",
+                "linux/amd64",
+                "--network",
+                "none",
+                "--cpus",
+                "1",
+                "--memory",
+                "1g",
+                "--memory-swap",
+                "1g",
+                "--pids-limit",
+                "128",
+                "--cap-drop",
+                "ALL",
+                "--cap-add",
+                "DAC_OVERRIDE",
+                "--cap-add",
+                "FOWNER",
+                "--cap-add",
+                "CHOWN",
+                "--security-opt",
+                "no-new-privileges",
+                "--workdir",
+                "/home/user",
+                "--entrypoint",
+                "/bin/sleep",
+                self.image_id,
+                "infinity",
+            ]
+        )
+        self.run_docker(["start", name])
+        return name
+
+    def __enter__(self) -> DockerEnvironment:
+        """Start the persistent shell.
+
+        Returns:
+            This active environment.
+
+        Raises:
+            RuntimeError: Shell initialization or container cleanup fails.
+            BaseException: Startup errors or interruptions propagate after cleanup.
+        """
+        try:
+            self.container_id = self.create_container()
+            self.deadline = time.monotonic() + self.episode_timeout
+            self.shell = subprocess.Popen(
+                [
+                    self.docker,
+                    "exec",
+                    "-i",
+                    self.container_id,
+                    "/bin/bash",
+                    "--noprofile",
+                    "--norc",
+                ],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            ok, output = self.execute(
+                "export HOME=/home/user; cd /home/user; set -o pipefail"
+            )
+            if not ok:
+                raise RuntimeError("Shell initialization failed: " + output)
+            return self
+        except BaseException:
+            self.close()
+            raise
+
+    def execute(self, command: str) -> tuple[bool, str]:
+        """Run a command while retaining shell cwd and variables.
+
+        Args:
+            command: Shell command from the model.
+
+        Returns:
+            Success flag and bounded terminal output.
+        """
+        if self.stopped or self.shell is None or self.shell.poll() is not None:
+            return False, "Terminal is stopped"
+        remaining = self.deadline - time.monotonic()
+        if remaining <= 0:
+            self._stop()
+            return False, "Episode deadline exceeded"
+        if len(command.encode()) > MAX_OUTPUT:
+            self._stop()
+            return False, "Command size limit exceeded; terminal stopped"
+        token = "ENDLESS_" + uuid.uuid4().hex
+        marker = re.compile(rb"\x1e" + token.encode() + rb":([0-9]+)\x1f\n")
+        script = (
+            "eval "
+            + shlex.quote(command)
+            + "\nbuiltin printf '\\036"
+            + token
+            + ':%s\\037\\n\' "$?"\n'
+        )
+        output = bytearray()
+        end = time.monotonic() + min(self.command_timeout, remaining)
+        try:
+            assert (
+                self.shell.stdin is not None and self.shell.stdout is not None
+            )
+            pending = memoryview(script.encode())
+            os.set_blocking(self.shell.stdin.fileno(), False)
+            with selectors.DefaultSelector() as selector:
+                selector.register(self.shell.stdout, selectors.EVENT_READ)
+                selector.register(self.shell.stdin, selectors.EVENT_WRITE)
+                while time.monotonic() < end:
+                    events = selector.select(max(0, end - time.monotonic()))
+                    if not events:
+                        break
+                    if any(
+                        key.fileobj is self.shell.stdin for key, _ in events
+                    ):
+                        written = os.write(
+                            self.shell.stdin.fileno(), pending[:4096]
+                        )
+                        pending = pending[written:]
+                        if not pending:
+                            selector.unregister(self.shell.stdin)
+                    if not any(
+                        key.fileobj is self.shell.stdout for key, _ in events
+                    ):
+                        continue
+                    chunk = os.read(self.shell.stdout.fileno(), 65536)
+                    if not chunk:
+                        self._stop()
+                        return False, output.decode(
+                            errors="replace"
+                        ) + "\nTerminal exited"
+                    output.extend(chunk)
+                    match = marker.search(output)
+                    if match and match.start() <= MAX_OUTPUT:
+                        return int(match[1]) == 0, output[
+                            : match.start()
+                        ].decode(errors="replace")
+                    if len(output) > MAX_OUTPUT:
+                        self._stop()
+                        return False, output[:MAX_OUTPUT].decode(
+                            errors="replace"
+                        ) + "\nOutput limit exceeded; terminal stopped"
+            self._stop()
+            return False, output.decode(
+                errors="replace"
+            ) + "\nCommand or episode deadline exceeded; terminal stopped"
+        except (BrokenPipeError, OSError):
+            self._stop()
+            return False, "Terminal pipe closed"
+
+    def _stop(self) -> None:
+        if self.container_id and not self.stopped:
+            self.run_docker(["kill", self.container_id], check=False)
+            self.run_docker(["stop", "-t", "0", self.container_id])
+            self.stopped = True
+        if self.shell:
+            if self.shell.poll() is None:
+                self.shell.kill()
+            self.shell.wait(timeout=5)
+            for stream in (self.shell.stdin, self.shell.stdout):
+                if stream:
+                    stream.close()
+
+    def home_snapshot(self) -> bytes:
+        """Stop task processes and obtain a bounded home archive.
+
+        Returns:
+            Docker archive bytes for the task home directory.
+
+        Raises:
+            RuntimeError: No container was started.
+        """
+        self._stop()
+        if self._snapshot is None:
+            if not self.container_id:
+                raise RuntimeError("Environment has not started")
+            self._snapshot = self.run_docker(
+                ["cp", f"{self.container_id}:/home/user/.", "-"],
+                limit=MAX_ARCHIVE,
+            ).stdout
+        return self._snapshot
+
+    def source_hash(self, path: str) -> str:
+        """Hash source bytes without executing any agent-modifiable program.
+
+        Before grading, copy only this path so obtaining initial hashes does not
+        stop the persistent shell. Symlinks and non-regular files are rejected.
+
+        Args:
+            path: Absolute protected file path under /home/user.
+
+        Returns:
+            SHA-256 of the file bytes.
+
+        Raises:
+            ValueError: Path is outside the home or not a regular file.
+            RuntimeError: Environment has not started.
+        """
+        if (
+            not path.startswith("/home/user/")
+            or ".." in PurePosixPath(path).parts
+        ):
+            raise ValueError("Protected sources must be inside /home/user")
+        if not self.container_id:
+            raise RuntimeError("Environment has not started")
+        archive = self.run_docker(
+            ["cp", f"{self.container_id}:{path}", "-"], limit=MAX_ARCHIVE
+        ).stdout
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            members = tar.getmembers()
+            if len(members) != 1 or not members[0].isfile():
+                raise ValueError("Protected source is not a regular file")
+            source = tar.extractfile(members[0])
+            assert source is not None
+            return hashlib.sha256(source.read()).hexdigest()
+
+    def remove_container(self, name: str) -> None:
+        """Forget a successfully removed container.
+
+        Args:
+            name: Container previously removed by the verifier.
+        """
+        self._containers.remove(name)
+
+    def verify_snapshot(
+        self, archive: bytes, test_path: Path
+    ) -> tuple[int, str, bytes]:
+        """Run hidden tests in a fresh container with validated task data.
+
+        Args:
+            archive: Validated task-home archive.
+            test_path: Trusted verifier source.
+
+        Returns:
+            Pytest exit code, output, and JUnit XML bytes.
+        """
+        from .docker_grading import verify_snapshot
+
+        return verify_snapshot(self, archive, test_path)
+
+    def close(self) -> None:
+        """Remove only containers created by this instance, including failed starts.
+
+        Raises:
+            RuntimeError: One or more owned containers could not be removed.
+        """
+        failures = []
+        for name in list(self._containers):
+            try:
+                self.run_docker(["rm", "-f", name])
+                self._containers.remove(name)
+            except Exception as exc:
+                failures.append(str(exc))
+        if self.shell:
+            if self.shell.poll() is None:
+                self.shell.kill()
+            self.shell.wait(timeout=5)
+            for stream in (self.shell.stdin, self.shell.stdout):
+                if stream:
+                    stream.close()
+        self.closed = not self._containers
+        if failures:
+            raise RuntimeError(
+                "Container cleanup failed: " + "; ".join(failures)
+            )
+
+    def __exit__(self, *_args: object) -> None:
+        """Remove containers on context exit.
+
+        Args:
+            *_args: Context exception details.
+        """
+        self.close()

--- a/examples/endless_terminals/runtime/docker_grading.py
+++ b/examples/endless_terminals/runtime/docker_grading.py
@@ -1,0 +1,97 @@
+"""Docker transport for a clean verifier, separate from grading semantics."""
+
+import io
+import tarfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .docker_env import DockerEnvironment
+
+
+def verify_snapshot(
+    env: "DockerEnvironment", archive: bytes, test_path: Path
+) -> tuple[int, str, bytes]:
+    """Load task data and hidden tests into a fresh Docker container.
+
+    Args:
+        env: Environment tracking all containers for cleanup.
+        archive: Validated task-home archive.
+        test_path: Trusted verifier source.
+
+    Returns:
+        Pytest exit code, output, and JUnit XML bytes.
+
+    Raises:
+        RuntimeError: Verifier execution or cleanup fails.
+    """  # noqa: DOC502
+    verifier = env.create_container()
+    try:
+        env.run_docker(
+            [
+                "exec",
+                "--workdir",
+                "/",
+                verifier,
+                "/bin/rm",
+                "-rf",
+                "/home/user",
+            ]
+        )
+        env.run_docker(
+            [
+                "exec",
+                "--workdir",
+                "/",
+                verifier,
+                "/bin/mkdir",
+                "-p",
+                "/home/user",
+                "/opt/endless-grader",
+            ]
+        )
+        env.run_docker(
+            ["cp", "-", f"{verifier}:/home/user"], input_data=archive
+        )
+        env.run_docker(
+            [
+                "cp",
+                str(test_path.resolve()),
+                f"{verifier}:/opt/endless-grader/test_final_state.py",
+            ]
+        )
+        completed = env.run_docker(
+            [
+                "exec",
+                "--workdir",
+                "/opt/endless-grader",
+                verifier,
+                "python3",
+                "-I",
+                "-m",
+                "pytest",
+                "-q",
+                "-p",
+                "no:cacheprovider",
+                "test_final_state.py",
+                "--junitxml=/tmp/endless-results.xml",
+            ],
+            timeout=120,
+            check=False,
+        )
+        report = env.run_docker(
+            ["cp", f"{verifier}:/tmp/endless-results.xml", "-"]
+        ).stdout
+        with tarfile.open(fileobj=io.BytesIO(report)) as tar:
+            member = next(m for m in tar.getmembers() if m.isfile())
+            source = tar.extractfile(member)
+            assert source is not None
+            xml = source.read()
+        return (
+            completed.returncode,
+            completed.stdout.decode(errors="replace"),
+            xml,
+        )
+    finally:
+        env.run_docker(["rm", "-f", verifier])
+        env.remove_container(verifier)

--- a/examples/endless_terminals/runtime/environment.py
+++ b/examples/endless_terminals/runtime/environment.py
@@ -1,0 +1,75 @@
+"""Shared terminal and trusted-verifier contract for episode execution."""
+
+from pathlib import Path
+from typing import Any, Protocol
+
+MAX_ARCHIVE = 64 * 1024 * 1024
+
+
+class TerminalEnvironment(Protocol):
+    """Execute commands and export task data only after stopping the agent."""
+
+    container_id: str | None
+    stopped: bool
+    closed: bool
+    provenance: dict[str, Any]
+
+    def __enter__(self) -> "TerminalEnvironment":
+        """Start the task environment.
+
+        Returns:
+            Active environment.
+        """
+        ...
+
+    def __exit__(self, *_args: Any) -> None:
+        """Remove resources created for the episode.
+
+        Args:
+            *_args: Context exception details.
+        """
+        ...
+
+    def execute(self, command: str) -> tuple[bool, str]:
+        """Execute a command in the persistent shell.
+
+        Args:
+            command: Shell command.
+
+        Returns:
+            Success flag and bounded output.
+        """
+        ...
+
+    def home_snapshot(self) -> bytes:
+        """Stop the agent and export its home using a trusted reader.
+
+        Returns:
+            Bounded tar archive of the task home.
+        """
+        ...
+
+    def source_hash(self, path: str) -> str:
+        """Hash a regular task input through the trusted reader.
+
+        Args:
+            path: Absolute file path inside the task home.
+
+        Returns:
+            SHA-256 digest of the file bytes.
+        """
+        ...
+
+    def verify_snapshot(
+        self, archive: bytes, test_path: Path
+    ) -> tuple[int, str, bytes]:
+        """Run hidden tests in a fresh image containing the validated archive.
+
+        Args:
+            archive: Validated task-home archive.
+            test_path: Trusted test file, never supplied to the agent.
+
+        Returns:
+            Pytest exit code, output, and JUnit XML bytes.
+        """
+        ...

--- a/examples/endless_terminals/runtime/grading.py
+++ b/examples/endless_terminals/runtime/grading.py
@@ -1,0 +1,84 @@
+"""Trusted final-state grading in a fresh runtime after terminal shutdown."""
+
+import io
+import tarfile
+import xml.etree.ElementTree as ET
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .environment import MAX_ARCHIVE, TerminalEnvironment
+
+
+def grade_environment(
+    env: TerminalEnvironment,
+    test_path: Path,
+    protected_sources: dict[str, str],
+) -> dict[str, Any]:
+    """Stop task processes and grade home data in an original clean image.
+
+    Args:
+        env: Active environment whose containers are tracked for cleanup.
+        test_path: Trusted host-side final-state test, hidden during interaction.
+        protected_sources: Paths and expected hashes of immutable source inputs.
+
+    Returns:
+        Raw reward, independent integrity audit, and infrastructure errors.
+        Ordinary grading and cleanup exceptions are captured in this result.
+    """  # noqa: DOC501,DOC503
+    result: dict[str, Any] = {
+        "raw_reward": None,
+        "audited_valid": False,
+        "protected_sources": {},
+        "infrastructure_error": None,
+    }
+    try:
+        archive = env.home_snapshot()
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            members = tar.getmembers()
+            for member in members:
+                archive_path = PurePosixPath(member.name)
+                if (
+                    archive_path.is_absolute()
+                    or ".." in archive_path.parts
+                    or not (member.isfile() or member.isdir())
+                ):
+                    raise ValueError("Unsafe archive member: " + member.name)
+            if sum(member.size for member in members) > MAX_ARCHIVE:
+                raise ValueError("Unpacked home exceeds archive limit")
+        for path, expected in protected_sources.items():
+            try:
+                actual = env.source_hash(path)
+            except (RuntimeError, ValueError):
+                actual = None
+            result["protected_sources"][path] = {
+                "expected": expected,
+                "actual": actual,
+                "unchanged": actual == expected,
+            }
+        exit_code, output, xml = env.verify_snapshot(archive, test_path)
+        result["verifier_exit_code"] = exit_code
+        if exit_code not in (0, 1):
+            raise RuntimeError(
+                f"Verifier infrastructure failure: pytest exit {exit_code}"
+            )
+        result["verifier_output"] = output
+        result["junit_xml"] = xml.decode(errors="replace")
+        cases = ET.fromstring(xml).findall(".//testcase")
+        counts = {
+            name: sum(case.find(name) is not None for case in cases)
+            for name in ("failure", "error", "skipped")
+        }
+        result["test_counts"] = {"total": len(cases), **counts}
+        result["raw_reward"] = int(exit_code == 0)
+        result["audited_valid"] = bool(
+            exit_code == 0
+            and cases
+            and not any(counts.values())
+            and all(
+                item["unchanged"]
+                for item in result["protected_sources"].values()
+            )
+        )
+    except Exception as exc:
+        result["infrastructure_error"] = f"{type(exc).__name__}: {exc}"
+    return result

--- a/examples/endless_terminals/runtime/http_client.py
+++ b/examples/endless_terminals/runtime/http_client.py
@@ -1,0 +1,63 @@
+"""Single model request in a subprocess that the controller can terminate."""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Prevent forwarding endpoint credentials through redirects."""
+
+    def redirect_request(
+        self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str
+    ) -> None:
+        """Decline all HTTP redirects.
+
+        Args:
+            req: Original request.
+            fp: Response stream.
+            code: Redirect status code.
+            msg: HTTP status message.
+            headers: Response headers.
+            newurl: Proposed redirect destination.
+        """
+        return None
+
+
+def main() -> None:
+    """Read request configuration and emit only result JSON or a sanitized error."""
+    try:
+        config = json.load(sys.stdin)
+        request = urllib.request.Request(
+            config["url"],
+            data=json.dumps(config["body"]).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer "
+                + os.environ.get("ENDLESS_API_KEY", "nokey"),
+            },
+        )
+        with urllib.request.build_opener(NoRedirect).open(
+            request, timeout=config["timeout"]
+        ) as response:
+            payload = response.read(4_000_001)
+        if len(payload) > 4_000_000:
+            result = {"error": "Model response exceeds 4 MB limit"}
+        else:
+            result = {"data": json.loads(payload)}
+    except urllib.error.HTTPError as exc:
+        result = {
+            "error": f"Model HTTP error {exc.code}; request was not retried"
+        }
+    except Exception:
+        result = {
+            "error": "Model transport or response decoding failed; request was not retried"
+        }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/runtime/modal_workspace.py
+++ b/examples/endless_terminals/runtime/modal_workspace.py
@@ -1,0 +1,259 @@
+"""Persist only task home data between isolated canonical Modal sessions."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+import modal
+from modal.exception import AlreadyExistsError
+
+from zenml.integrations.modal.flavors.modal_sandbox_flavor import (
+    ModalSandboxSettings,
+    ModalSandboxVolumeMount,
+)
+from zenml.integrations.modal.sandbox_utils import (
+    create_modal_client_from_credentials,
+)
+from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+from zenml.sandboxes.session import SandboxSession
+
+from .sandbox_workspace import SandboxRuntimeConfig, bounded_call
+
+
+class ModalWorkspace:
+    """Use a unique Volume without copying or trusting the agent filesystem."""
+
+    def __init__(
+        self, sandbox: ModalSandbox, config: SandboxRuntimeConfig
+    ) -> None:
+        """Configure the workspace without allocating resources.
+
+        Args:
+            sandbox: Active canonical Modal sandbox component.
+            config: Bounded bootstrap and cleanup settings.
+
+        Raises:
+            ValueError: The component would inject credentials or targets another environment.
+        """
+        if sandbox.config.modal_environment != config.modal_environment:
+            raise ValueError(
+                f"Task sandbox must target Modal environment {config.modal_environment}"
+            )
+        if (
+            sandbox.config.sandbox_environment
+            or sandbox.environment
+            or sandbox.secrets
+        ):
+            raise ValueError(
+                "Task sandbox must not inject environment values or secrets"
+            )
+        if not re.fullmatch(
+            r"[^\s]+@sha256:[0-9a-f]{64}", config.helper_image
+        ):
+            raise ValueError(
+                "Helper image must use an immutable registry digest"
+            )
+        if (
+            min(
+                config.startup_timeout,
+                config.cleanup_timeout,
+                config.api_timeout,
+            )
+            <= 0
+        ):
+            raise ValueError("Workspace timeouts must be positive")
+        if not config.modal_agent_image or not re.fullmatch(
+            r"[^\s@]+@sha256:[0-9a-f]{64}", config.modal_agent_image
+        ):
+            raise ValueError(
+                "Modal requires modal_agent_image pinned by registry digest "
+                "with an empty /home/user mount point"
+            )
+        self.agent_image = config.modal_agent_image
+        self.sandbox = sandbox
+        self.config = config
+        if not sandbox.config.token_id or not sandbox.config.token_secret:
+            raise ValueError(
+                "Task sandbox requires explicit Modal credentials"
+            )
+        self.client = create_modal_client_from_credentials(
+            token_id=sandbox.config.token_id,
+            token_secret=sandbox.config.token_secret,
+        )
+        self.name = "endless-workspace-" + uuid.uuid4().hex
+        self.volume_created = False
+        self.volume_attempted = False
+        self.session_creation_uncertain = False
+        self.sessions: dict[str, SandboxSession] = {}
+        self.provenance: dict[str, Any] = {
+            "backend": "modal_sandbox",
+            "modal_workspace": config.modal_workspace,
+            "modal_environment": config.modal_environment,
+            "workspace_name": self.name,
+            "sandboxes": [],
+            "cleanup_complete": False,
+        }
+
+    def create_volume(self) -> None:
+        """Verify workspace identity before creating this episode's named Volume.
+
+        Raises:
+            RuntimeError: Modal credentials select another workspace.
+            AlreadyExistsError: The generated Volume name already exists.
+        """
+        workspace = bounded_call(
+            lambda: modal.Workspace.from_context(client=self.client).hydrate(),
+            self.config.api_timeout,
+        )
+        if workspace.name != self.config.modal_workspace:
+            raise RuntimeError(
+                f"Modal credentials must select workspace {self.config.modal_workspace}"
+            )
+        # Creation is deliberately synchronous: no abandoned daemon may create a
+        # volume after cleanup has already checked for it.
+        self.volume_attempted = True
+        try:
+            modal.Volume.objects.create(
+                self.name,
+                environment_name=self.config.modal_environment,
+                client=self.client,
+            )
+        except AlreadyExistsError:
+            self.volume_attempted = False
+            raise
+        self.volume_created = True
+
+    def settings(
+        self, image: str, mount: str | None, readonly: bool = False
+    ) -> ModalSandboxSettings:
+        """Request isolated CPU sessions with only the named home data mounted.
+
+        Args:
+            image: Immutable task image.
+            mount: Workspace root, agent home, or no volume for a verifier.
+            readonly: Whether the mounted Volume must reject writes.
+
+        Returns:
+            Canonical Modal sandbox settings.
+        """
+        volumes = {}
+        if mount:
+            volumes[mount] = ModalSandboxVolumeMount(
+                name=self.name,
+                sub_path="/home" if mount == "/home/user" else None,
+                read_only=readonly,
+            )
+        return ModalSandboxSettings(
+            image=self.agent_image if mount == "/home/user" else image,
+            modal_environment=self.config.modal_environment,
+            cpu=1,
+            memory="1GiB",
+            gpu=None,
+            timeout=1800,
+            block_network=True,
+            sandbox_environment={},
+            volumes=volumes,
+        )
+
+    def create_session(
+        self, image: str, mount: str | None, readonly: bool = False
+    ) -> SandboxSession:
+        """Create and record a canonical session before running any commands.
+
+        Args:
+            image: Immutable task image.
+            mount: Optional data volume mount point.
+            readonly: Whether the data volume is read-only.
+
+        Returns:
+            Running canonical sandbox session.
+
+        Raises:
+            RuntimeError: A preceding writer remains active.
+        """
+        if self.sessions or self.session_creation_uncertain:
+            raise RuntimeError(
+                "Terminate the preceding Modal session before creating another"
+            )
+        settings = self.settings(image, mount, readonly)
+        self.session_creation_uncertain = True
+        self.provenance["session_creation_uncertain"] = True
+        session = self.sandbox.create_session(settings=settings)
+        self.sessions[session.id] = session
+        self.session_creation_uncertain = False
+        self.provenance["session_creation_uncertain"] = False
+        self.provenance["sandboxes"].append(
+            {
+                "session_id": session.id,
+                "image": settings.image,
+                "network_blocked": True,
+                "phase": "agent"
+                if mount == "/home/user"
+                else "reader"
+                if readonly
+                else "seed"
+                if mount
+                else "verifier",
+            }
+        )
+        return session
+
+    def destroy_session(self, session: SandboxSession) -> None:
+        """Confirm termination and the backend's final Volume commit before reading.
+
+        Modal documents a final commit on Sandbox termination. This uses the
+        server API, never sync or archive code from the agent container.
+
+        Args:
+            session: Owned canonical session.
+
+        Raises:
+            RuntimeError: Termination was not confirmed.
+        """
+        if session.id not in self.sessions:
+            return
+        remote = modal.Sandbox.from_id(session.id, client=self.client)
+        bounded_call(
+            lambda: remote.terminate(wait=True), self.config.cleanup_timeout
+        )
+        if bounded_call(remote.poll, self.config.api_timeout) is None:
+            raise RuntimeError("Modal sandbox termination was not confirmed")
+        session.close()
+        del self.sessions[session.id]
+        self.provenance.setdefault("terminated_sandbox_ids", []).append(
+            session.id
+        )
+
+    def close(self) -> None:
+        """Delete the episode Volume only after all owned sessions have terminated.
+
+        Raises:
+            RuntimeError: A session could not be terminated.
+        """
+        errors = []
+        if self.session_creation_uncertain:
+            errors.append(
+                "Sandbox creation did not return an ID; a sandbox may still "
+                "exist and requires reconciliation before deleting the Volume"
+            )
+        for session in list(self.sessions.values()):
+            try:
+                self.destroy_session(session)
+            except Exception as exc:
+                errors.append(str(exc))
+        if errors:
+            raise RuntimeError(
+                "Modal workspace cleanup incomplete: " + "; ".join(errors)
+            )
+        if self.volume_attempted or self.volume_created:
+            modal.Volume.objects.delete(
+                self.name,
+                environment_name=self.config.modal_environment,
+                client=self.client,
+                allow_missing=True,
+            )
+            self.volume_created = False
+            self.volume_attempted = False
+        self.provenance["cleanup_complete"] = True

--- a/examples/endless_terminals/runtime/models.py
+++ b/examples/endless_terminals/runtime/models.py
@@ -1,0 +1,171 @@
+"""Explicit fixture or HTTP models, with no implicit retries."""
+
+import json
+import subprocess
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Any, Protocol
+
+ROOT = Path(__file__).resolve().parent
+
+
+class Model(Protocol):
+    """One bounded completion per call, without implicit retries."""
+
+    def complete(
+        self, messages: list[dict[str, str]], timeout: float
+    ) -> tuple[str, dict[str, Any]]:
+        """Return assistant content and usage within the timeout.
+
+        Args:
+            messages: Chat history including the system instruction.
+            timeout: Total request deadline in seconds.
+
+        Returns:
+            Assistant text and provider token counts.
+        """
+        ...
+
+
+class FixtureModel:
+    """Replay scripted responses to test the adapter without inference."""
+
+    def __init__(self, responses: list[str]) -> None:
+        """Configure scripted responses.
+
+        Args:
+            responses: Ordered assistant responses to replay.
+        """
+        self.responses = iter(responses)
+
+    def complete(
+        self, messages: list[dict[str, str]], timeout: float
+    ) -> tuple[str, dict[str, Any]]:
+        """Return the next scripted response.
+
+        Args:
+            messages: Current chat history, unused by this fixture.
+            timeout: Request deadline, unused by this fixture.
+
+        Returns:
+            Scripted text and fixture provenance.
+
+        Raises:
+            RuntimeError: Responses were exhausted.
+        """
+        try:
+            return next(self.responses), {
+                "source": "fixture",
+                "model_calls": 0,
+            }
+        except StopIteration as exc:
+            raise RuntimeError(
+                "Fixture exhausted before episode finished"
+            ) from exc
+
+
+class EndpointModel:
+    """Call a configured OpenAI-compatible endpoint, once per turn."""
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        max_tokens: int = 2048,
+        temperature: float = 0.6,
+    ) -> None:
+        """Configure one explicit endpoint.
+
+        Args:
+            base_url: OpenAI-compatible API base URL, including /v1 if needed.
+            model: Served model name.
+            max_tokens: Maximum response tokens.
+            temperature: Sampling temperature.
+
+        Raises:
+            ValueError: URL is invalid or sends credentials over remote HTTP.
+        """
+        parsed = urllib.parse.urlsplit(base_url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "Endpoint must be an HTTP(S) URL without credentials, query, or fragment"
+            )
+        if parsed.scheme == "http" and parsed.hostname not in {
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        }:
+            raise ValueError("Non-local endpoints require HTTPS")
+        self.url = base_url.rstrip("/") + "/chat/completions"
+        self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+
+    def complete(
+        self, messages: list[dict[str, str]], timeout: float
+    ) -> tuple[str, dict[str, Any]]:
+        """Make one request and retain only content and numeric token usage.
+
+        Args:
+            messages: Chat history to send.
+            timeout: Wall-clock deadline enforced by the parent process.
+
+        Returns:
+            Assistant text and token counts.
+
+        Raises:
+            TimeoutError: The transport worker exceeded its deadline.
+            RuntimeError: The worker or HTTP request failed.
+            ValueError: The response has no text content.
+        """
+        request = {
+            "url": self.url,
+            "body": {
+                "model": self.model,
+                "messages": messages,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+                "n": 1,
+            },
+            "timeout": timeout,
+        }
+        try:
+            completed = subprocess.run(
+                [sys.executable, str(ROOT / "http_client.py")],
+                input=json.dumps(request),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            raise TimeoutError(
+                "Model request exceeded total deadline; request was not retried"
+            ) from None
+        if completed.returncode:
+            raise RuntimeError(
+                "Model transport worker failed; request was not retried"
+            )
+        envelope = json.loads(completed.stdout)
+        if "error" in envelope:
+            raise RuntimeError(envelope["error"])
+        data = envelope["data"]
+        content = data["choices"][0]["message"]["content"]
+        if not isinstance(content, str):
+            raise ValueError("Model response has no text content")
+        usage = {
+            k: v
+            for k, v in (data.get("usage") or {}).items()
+            if k in {"prompt_tokens", "completion_tokens", "total_tokens"}
+            and isinstance(v, int)
+            and v >= 0
+        }
+        return content, usage

--- a/examples/endless_terminals/runtime/runner.py
+++ b/examples/endless_terminals/runtime/runner.py
@@ -1,0 +1,230 @@
+"""Pure bounded episodes that return complete JSON artifact evidence."""
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from .contract import SYSTEM_MESSAGE, UPSTREAM_COMMIT, extract_action
+from .docker_env import DockerEnvironment
+from .environment import TerminalEnvironment
+from .grading import grade_environment
+from .models import Model
+
+ROOT = Path(__file__).resolve().parent
+MAX_OUTPUT = 50_000
+
+
+def verify_task_files(task: dict[str, Any], directory: Path) -> None:
+    """Reject changed, missing, or escaped task files before starting a sandbox.
+
+    Args:
+        task: Manifest entry containing task_file_sha256.
+        directory: Root of this task's files.
+
+    Raises:
+        ValueError: A required file is absent or a hash/path is invalid.
+    """
+    hashes = task["task_file_sha256"]
+    if not {"instruction.md", "tests/test_final_state.py"} <= hashes.keys():
+        raise ValueError("Instruction and final grader hashes are required")
+    for relative, expected in hashes.items():
+        path = (directory / relative).resolve()
+        if not path.is_relative_to(directory.resolve()):
+            raise ValueError("Task file escapes its directory")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            raise ValueError(f"Task file hash mismatch: {relative}")
+
+
+def run_episode(
+    task: dict[str, Any],
+    task_directory: Path,
+    model: Model,
+    output: Path,
+    *,
+    identity: dict[str, Any],
+    system_message: str = SYSTEM_MESSAGE,
+    max_actions: int = 16,
+    command_timeout: float = 10,
+    episode_timeout: float = 180,
+    environment_factory: Callable[[str, float, float], TerminalEnvironment]
+    | None = None,
+) -> dict[str, Any]:
+    """Run an episode, save evidence even on failure, and remove sandboxes.
+
+    Args:
+        task: Manifest entry with immutable image ID and task file hashes.
+        task_directory: Directory containing the instruction and hidden tests.
+        model: Scripted fixture or explicitly configured model endpoint.
+        output: New result directory; existing paths are rejected.
+        identity: Model/fixture provenance recorded with the episode.
+        system_message: Exact system prompt sent to the model and hashed in evidence.
+        max_actions: Maximum model turns, including invalid responses.
+        command_timeout: Maximum seconds for a terminal command.
+        episode_timeout: Agent interaction budget in seconds. Grading has a
+            separate 120-second limit; Docker setup and cleanup are bounded.
+        environment_factory: Optional sandbox constructor receiving immutable
+            image reference, command timeout, and interaction timeout.
+
+    Returns:
+        Result manifest, including audited grading or infrastructure error.
+        Ordinary model, terminal, and grading errors are captured in this result.
+
+    Raises:
+        ValueError: The prompt is blank or limits/task-file integrity are invalid.
+        FileExistsError: The output directory already exists.
+        BaseException: Interruptions propagate after cleanup and evidence writes.
+    """  # noqa: DOC503
+    if not system_message.strip():
+        raise ValueError("system_message must not be blank")
+    if (
+        not 1 <= max_actions <= 16
+        or not 0 < command_timeout <= 90
+        or not 0 < episode_timeout <= 1200
+    ):
+        raise ValueError("Limits must fit the bounded pilot envelope")
+    entry = task
+    task_id = task["task_id"]
+    verify_task_files(task, task_directory)
+    output.mkdir(parents=True, exist_ok=False)
+    start = time.monotonic()
+    messages = [
+        {"role": "system", "content": system_message},
+        {
+            "role": "user",
+            "content": (task_directory / "instruction.md").read_text(),
+        },
+    ]
+    result: dict[str, Any] = {
+        "task_id": task_id,
+        "image_id": entry.get("image_ref") or entry["local_image_id"],
+        "runtime": "sandbox" if environment_factory is not None else "docker",
+        "identity": identity,
+        "upstream_commit": UPSTREAM_COMMIT,
+        "system_prompt_sha256": hashlib.sha256(
+            system_message.encode()
+        ).hexdigest(),
+        "dataset_revision": task.get("dataset_revision"),
+        "limits": {
+            "max_actions": max_actions,
+            "command_timeout": command_timeout,
+            "episode_timeout": episode_timeout,
+        },
+        "turns": [],
+        "exit_reason": "not_started",
+        "grading": None,
+    }
+    result["adapter_sha256"] = {
+        name: hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+        for name in (
+            "runner.py",
+            "docker_env.py",
+            "docker_command.py",
+            "docker_grading.py",
+            "environment.py",
+            "grading.py",
+            "models.py",
+            "http_client.py",
+            "contract.py",
+        )
+    }
+    if environment_factory is not None:
+        result["adapter_sha256"].update(
+            {
+                path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+                for path in ROOT.glob("sandbox_*.py")
+            }
+        )
+    env: TerminalEnvironment | None = None
+    try:
+        env = (
+            environment_factory(
+                result["image_id"], command_timeout, episode_timeout
+            )
+            if environment_factory is not None
+            else DockerEnvironment(
+                entry["local_image_id"],
+                command_timeout=command_timeout,
+                episode_timeout=episode_timeout,
+            )
+        )
+        with env:
+            result["container_id"] = env.container_id
+            result["environment"] = env.provenance
+            interaction_started = time.monotonic()
+            (output / "result.json").write_text(
+                json.dumps(result, indent=2) + "\n"
+            )
+            protected = dict(entry.get("protected_sources", {}))
+            source = entry.get("mutation", {}).get("protected_source")
+            if source:
+                protected[source] = entry["mutation_evidence"]["source_sha256"]
+            for source, expected in protected.items():
+                if env.source_hash(source) != expected:
+                    raise RuntimeError(
+                        "Initial protected source differs from qualified image"
+                    )
+            for turn in range(max_actions):
+                remaining = episode_timeout - (
+                    time.monotonic() - interaction_started
+                )
+                if remaining <= 0:
+                    raise TimeoutError("Episode deadline exceeded")
+                response, usage = model.complete(
+                    messages, timeout=min(remaining, 120)
+                )
+                if time.monotonic() - interaction_started >= episode_timeout:
+                    raise TimeoutError(
+                        "Episode deadline exceeded during model request"
+                    )
+                action = extract_action(response)
+                messages.append({"role": "assistant", "content": response})
+                event = {"turn": turn + 1, "action": action, "usage": usage}
+                result["turns"].append(event)
+                if action["type"] == "done":
+                    result["exit_reason"] = "done"
+                    break
+                if action["type"] == "invalid":
+                    observation = "Could not parse a single <command>...</command> or <action>done</action>. Please respond with exactly one of those."
+                else:
+                    success, terminal = env.execute(action["command"] or "")
+                    truncated = ""
+                    if len(terminal) > MAX_OUTPUT:
+                        terminal = terminal[:MAX_OUTPUT]
+                        # Retain the upstream formatting, including its reported length.
+                        truncated = f"\n[Output truncated: showing first {MAX_OUTPUT} of {len(terminal)} characters]"
+                    observation = f"Command {'executed successfully' if success else 'failed'}. Output: {terminal}{truncated}\n\n(exit_code={0 if success else 1})"
+                messages.append({"role": "user", "content": observation})
+                (output / "transcript.json").write_text(
+                    json.dumps(messages, indent=2) + "\n"
+                )
+                if env.stopped:
+                    result["exit_reason"] = "terminal_stopped"
+                    break
+            else:
+                result["exit_reason"] = "max_actions"
+            result["grading"] = grade_environment(
+                env,
+                task_directory / "tests" / "test_final_state.py",
+                protected,
+            )
+            if result["grading"].get("infrastructure_error"):
+                result["exit_reason"] = "infrastructure_error"
+    except Exception as exc:
+        result["exit_reason"] = "infrastructure_error"
+        result["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    except BaseException:
+        result["exit_reason"] = "interrupted"
+        raise
+    finally:
+        result["transcript"] = messages
+        result["cleanup_complete"] = bool(env is not None and env.closed)
+        result["elapsed_seconds"] = round(time.monotonic() - start, 3)
+        (output / "transcript.json").write_text(
+            json.dumps(messages, indent=2) + "\n"
+        )
+        (output / "result.json").write_text(
+            json.dumps(result, indent=2) + "\n"
+        )
+    return result

--- a/examples/endless_terminals/runtime/sandbox_env.py
+++ b/examples/endless_terminals/runtime/sandbox_env.py
@@ -1,0 +1,370 @@
+"""Run terminal tasks through isolated canonical ZenML sandbox sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import shlex
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+    KubernetesSandbox,
+)
+from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+from zenml.sandboxes.base import BaseSandbox
+from zenml.sandboxes.process import SandboxOutput
+from zenml.sandboxes.session import SandboxSession
+
+from .environment import MAX_ARCHIVE
+from .sandbox_shell import SandboxShell
+from .sandbox_workspace import SandboxRuntimeConfig as SandboxRuntimeConfig
+from .sandbox_workspace import SandboxWorkspace, bounded_call
+
+_ARCHIVE = r"""
+import os, stat, tarfile
+from pathlib import Path
+root = Path(ROOT)
+paths = [root]
+size = 0
+for directory, dirs, files in os.walk(root, followlinks=False):
+    for name in dirs + files:
+        path = Path(directory) / name
+        info = path.lstat()
+        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+            raise ValueError('Workspace contains a non-regular entry')
+        size += info.st_size if stat.S_ISREG(info.st_mode) else 0
+        if size > 64 * 1024 * 1024 or len(paths) >= 20000:
+            raise ValueError('Workspace export limit exceeded')
+        paths.append(path)
+with tarfile.open('/tmp/endless-home.tar', 'w', dereference=True) as tar:
+    for path in paths:
+        tar.add(path, arcname='.' if path == root else str(path.relative_to(root)), recursive=False)
+if Path('/tmp/endless-home.tar').stat().st_size > 64 * 1024 * 1024:
+    raise ValueError('Workspace archive limit exceeded')
+"""
+
+
+class SandboxEnvironment:
+    """Separate model execution, persisted home data, and trusted verification."""
+
+    def __init__(
+        self,
+        image_id: str,
+        config: SandboxRuntimeConfig,
+        command_timeout: float = 10,
+        episode_timeout: float = 180,
+        sandbox: KubernetesSandbox | ModalSandbox | None = None,
+    ) -> None:
+        """Configure a task environment without allocating resources.
+
+        Args:
+            image_id: Task image pinned by registry digest.
+            config: Workspace and helper-image settings.
+            command_timeout: Agent command budget.
+            episode_timeout: Agent interaction budget.
+            sandbox: Optional injected canonical Kubernetes or Modal sandbox component.
+
+        Raises:
+            ValueError: Image or budgets are invalid.
+            TypeError: The selected component is not a supported sandbox.
+        """
+        if not re.fullmatch(r"[^\s]+@sha256:[0-9a-f]{64}", image_id):
+            raise ValueError(
+                "Task image requires an immutable registry digest"
+            )
+        if command_timeout <= 0 or episode_timeout <= 0:
+            raise ValueError("Episode and command budgets must be positive")
+        selected_sandbox: BaseSandbox | None = sandbox
+        if selected_sandbox is None:
+            from zenml.client import Client
+
+            selected_sandbox = Client().active_stack.sandbox
+        if not isinstance(selected_sandbox, (KubernetesSandbox, ModalSandbox)):
+            raise TypeError(
+                "Select a KubernetesSandbox or ModalSandbox in the active ZenML stack"
+            )
+        self.image_id = image_id
+        self.config = config
+        self.command_timeout = command_timeout
+        self.episode_timeout = episode_timeout
+        from .modal_workspace import ModalWorkspace
+
+        self.workspace: SandboxWorkspace | ModalWorkspace
+        if isinstance(selected_sandbox, ModalSandbox):
+            self.workspace = ModalWorkspace(selected_sandbox, config)
+        else:
+            self.workspace = SandboxWorkspace(selected_sandbox, config)
+        self.provenance = self.workspace.provenance
+        self.container_id: str | None = None
+        self.stopped = False
+        self.closed = False
+        self.agent: SandboxSession | None = None
+        self.shell: SandboxShell | None = None
+        self.initial: bytes | None = None
+        self.final: bytes | None = None
+
+    def _exec(
+        self, session: SandboxSession, command: str, timeout: float = 60
+    ) -> SandboxOutput:
+        try:
+            process = bounded_call(
+                lambda: session.exec(["sh", "-c", command]), timeout
+            )
+            return bounded_call(
+                lambda: process.collect(max_chars=256 * 1024), timeout
+            )
+        except BaseException:
+            self.workspace.destroy_session(session)
+            raise
+
+    def _checked(
+        self, session: SandboxSession, command: str, timeout: float = 60
+    ) -> str:
+        output = self._exec(session, command, timeout)
+        if output.exit_code:
+            raise RuntimeError(
+                f"Trusted sandbox command failed: {output.stderr[:2000]}"
+            )
+        return output.stdout
+
+    def _python(
+        self, session: SandboxSession, source: str, timeout: float = 60
+    ) -> str:
+        return self._checked(
+            session, "python3 -I -c " + shlex.quote(source), timeout
+        )
+
+    def _download(
+        self, session: SandboxSession, remote: str, limit: int
+    ) -> bytes:
+        self._python(
+            session,
+            f"from pathlib import Path; assert Path({remote!r}).stat().st_size <= {limit}",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            local = Path(directory) / "download"
+            try:
+                bounded_call(
+                    lambda: session.download_file(remote, str(local)), 60
+                )
+            except BaseException:
+                self.workspace.destroy_session(session)
+                raise
+            data = local.read_bytes()
+            if len(data) > limit:
+                raise ValueError(
+                    "Downloaded sandbox artifact exceeds size limit"
+                )
+            return data
+
+    def _upload(
+        self, session: SandboxSession, data: bytes, remote: str
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            local = Path(directory) / "upload"
+            local.write_bytes(data)
+            try:
+                bounded_call(
+                    lambda: session.upload_file(str(local), remote), 60
+                )
+            except BaseException:
+                self.workspace.destroy_session(session)
+                raise
+
+    def _archive(self, session: SandboxSession, root: str) -> bytes:
+        self._python(session, _ARCHIVE.replace("ROOT", repr(root)))
+        return self._download(session, "/tmp/endless-home.tar", MAX_ARCHIVE)
+
+    def _new(
+        self, mount: str | None, readonly: bool = False
+    ) -> SandboxSession:
+        session = self.workspace.create_session(self.image_id, mount, readonly)
+        if isinstance(self.workspace, SandboxWorkspace):
+            self._python(
+                session,
+                "from pathlib import Path; "
+                "assert all(not(int((p/'flags').read_text(),16)&1) "
+                "for p in Path('/sys/class/net').iterdir() if p.name!='lo'), 'Pod networking remains enabled'",
+            )
+        else:
+            self._python(
+                session,
+                "import socket\n"
+                "try:\n"
+                "    connection = socket.create_connection(('1.1.1.1', 443), timeout=2)\n"
+                "except OSError:\n"
+                "    pass\n"
+                "else:\n"
+                "    connection.close()\n"
+                "    raise RuntimeError('Modal task networking remains enabled')\n",
+            )
+        return session
+
+    def __enter__(self) -> SandboxEnvironment:
+        """Seed task data before exposing the volume to the agent.
+
+        Returns:
+            Prepared terminal environment.
+
+        Raises:
+            BaseException: Setup fails; cleanup is attempted first.
+        """
+        try:
+            self.workspace.create_volume()
+            seed = self._new("/workspace")
+            self.initial = self._archive(seed, "/home/user")
+            self._checked(
+                seed,
+                "mkdir /workspace/home && cp -a /home/user/. /workspace/home/",
+            )
+            self.workspace.destroy_session(seed)
+            self.agent = self._new("/home/user")
+            self.container_id = self.agent.id
+            self.shell = SandboxShell(
+                self.agent, self.command_timeout, self.episode_timeout
+            )
+            self.shell.start()
+            return self
+        except BaseException:
+            self.close()
+            raise
+
+    def execute(self, command: str) -> tuple[bool, str]:
+        """Execute through the persistent public-API shell adapter.
+
+        Args:
+            command: Model-supplied command.
+
+        Returns:
+            Success flag and bounded terminal output.
+        """
+        if self.stopped or self.shell is None:
+            return False, "Terminal is stopped"
+        result = self.shell.execute(command)
+        if self.shell.stopped:
+            self.stopped = True
+            if self.agent:
+                self.workspace.destroy_session(self.agent)
+                self.agent = None
+        return result
+
+    def home_snapshot(self) -> bytes:
+        """Terminate agent processes before a trusted container reads the workspace.
+
+        Returns:
+            Bounded home-directory archive.
+        """
+        if self.final is not None:
+            return self.final
+        if self.shell:
+            self.shell.close()
+        if self.agent:
+            self.workspace.destroy_session(self.agent)
+            self.agent = None
+        self.stopped = True
+        reader = self._new("/workspace", readonly=True)
+        try:
+            self.final = self._archive(reader, "/workspace/home")
+        finally:
+            self.workspace.destroy_session(reader)
+        return self.final
+
+    def source_hash(self, path: str) -> str:
+        """Hash trusted initial or final archive bytes without using agent binaries.
+
+        Args:
+            path: Protected file below /home/user.
+
+        Returns:
+            SHA-256 of the regular source file.
+
+        Raises:
+            ValueError: The source is missing, unsafe, or not a regular file.
+        """
+        absolute = PurePosixPath(path)
+        if not path.startswith("/home/user/") or ".." in absolute.parts:
+            raise ValueError("Protected source must be inside /home/user")
+        archive = self.home_snapshot() if self.stopped else self.initial
+        if archive is None:
+            raise ValueError("Environment has not been initialized")
+        relative = str(absolute.relative_to("/home/user"))
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            matches = [
+                m for m in tar if str(PurePosixPath(m.name)) == relative
+            ]
+            if len(matches) != 1 or not matches[0].isfile():
+                raise ValueError(
+                    "Protected source is absent or not a regular file"
+                )
+            file = tar.extractfile(matches[0])
+            assert file is not None
+            return hashlib.sha256(file.read()).hexdigest()
+
+    def verify_snapshot(
+        self, archive: bytes, test_path: Path
+    ) -> tuple[int, str, bytes]:
+        """Run trusted tests in a clean image after validating all archive members.
+
+        Args:
+            archive: Home archive already audited by the generic grader.
+            test_path: Trusted final-state test on the controller.
+
+        Returns:
+            Verifier exit code, combined output, and JUnit report bytes.
+
+        Raises:
+            ValueError: The archive contains unsafe entries or exceeds limits.
+        """
+        if len(archive) > MAX_ARCHIVE:
+            raise ValueError("Archive exceeds size limit")
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            for member in tar:
+                path = PurePosixPath(member.name)
+                if (
+                    path.is_absolute()
+                    or ".." in path.parts
+                    or not (member.isfile() or member.isdir())
+                ):
+                    raise ValueError("Unsafe workspace archive member")
+        verifier = self._new(None)
+        try:
+            self._upload(verifier, archive, "/tmp/home.tar")
+            self._upload(
+                verifier,
+                test_path.read_bytes(),
+                "/opt/endless-grader/test_final_state.py",
+            )
+            self._checked(
+                verifier,
+                "rm -rf /home/user && mkdir -p /home/user && tar -xf /tmp/home.tar -C /home/user",
+            )
+            result = self._exec(
+                verifier,
+                "cd /opt/endless-grader && python3 -I -m pytest -q -p no:cacheprovider test_final_state.py --junitxml=/tmp/result.xml",
+                120,
+            )
+            junit = self._download(verifier, "/tmp/result.xml", 1024 * 1024)
+            return result.exit_code, result.stdout + result.stderr, junit
+        finally:
+            self.workspace.destroy_session(verifier)
+
+    def close(self) -> None:
+        """Destroy all owned sessions before removing the temporary workspace."""
+        try:
+            if self.shell:
+                self.shell.close()
+        finally:
+            self.workspace.close()
+            self.closed = True
+            self.stopped = True
+
+    def __exit__(self, *_args: object) -> None:
+        """Clean up this environment on context exit.
+
+        Args:
+            _args: Exception type, value, and traceback supplied by the context manager.
+        """
+        self.close()

--- a/examples/endless_terminals/runtime/sandbox_shell.py
+++ b/examples/endless_terminals/runtime/sandbox_shell.py
@@ -1,0 +1,277 @@
+"""Persistent FIFO Bash using public sandbox APIs and bounded controller waits.
+
+Closing a process stream is not proof that remote descendants stopped. The
+session owner must destroy the sandbox before collecting output for grading.
+"""
+
+from __future__ import annotations
+
+import base64
+import queue
+import re
+import shlex
+import tempfile
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from zenml.sandboxes.process import SandboxProcess
+from zenml.sandboxes.session import SandboxSession
+
+MAX_OUTPUT = 256 * 1024
+_FRAME_BYTES = 4096
+_FRAME_LINE_LIMIT = 5500
+_FRAMER = """import base64, sys
+while True:
+    chunk = sys.stdin.buffer.read1(4096)
+    if not chunk:
+        break
+    sys.stdout.buffer.write(base64.b64encode(chunk) + b"\\n")
+    sys.stdout.buffer.flush()
+"""
+_T = TypeVar("_T")
+
+
+class SandboxShell:
+    """Keep one Bash process alive without requiring a public stdin API."""
+
+    def __init__(
+        self,
+        session: SandboxSession,
+        command_timeout: float,
+        episode_timeout: float,
+    ) -> None:
+        """Configure a shell inside an already allocated session.
+
+        Args:
+            session: Caller-owned sandbox session.
+            command_timeout: Total seconds for one command, including transfer.
+            episode_timeout: Shell lifetime in seconds, including startup.
+
+        Raises:
+            ValueError: A timeout is not positive.
+        """
+        if command_timeout <= 0 or episode_timeout <= 0:
+            raise ValueError("Shell timeouts must be positive")
+        self.session = session
+        self.command_timeout = command_timeout
+        self.episode_timeout = episode_timeout
+        self.stopped = False
+        self._started = False
+        self._deadline = 0.0
+        self._control = "/tmp/endless-shell-" + uuid.uuid4().hex
+        self._process: SandboxProcess | None = None
+        self._output: queue.Queue[bytes] = queue.Queue(maxsize=1024)
+        self._queued_bytes = 0
+        self._lock = threading.Lock()
+        self._failure = threading.Event()
+        self._stream_ended = threading.Event()
+        self._closing = threading.Event()
+
+    def _bounded(self, action: Callable[[], _T], deadline: float) -> _T:
+        result: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
+
+        def invoke() -> None:
+            try:
+                result.put((True, action()))
+            except BaseException as exc:
+                result.put((False, exc))
+
+        threading.Thread(target=invoke, daemon=True).start()
+        try:
+            success, value = result.get(
+                timeout=max(0.001, deadline - time.monotonic())
+            )
+        except queue.Empty:
+            raise TimeoutError(
+                "Sandbox operation exceeded controller deadline"
+            ) from None
+        if not success:
+            assert isinstance(value, BaseException)
+            raise value
+        from typing import cast
+
+        return cast(_T, value)
+
+    def _drain(self) -> None:
+        assert self._process is not None
+        try:
+            for text in self._process.stdout():
+                if self._closing.is_set():
+                    break
+                if len(text) > _FRAME_LINE_LIMIT:
+                    self._failure.set()
+                    break
+                chunk = base64.b64decode(text.rstrip("\n"), validate=True)
+                if not chunk or len(chunk) > _FRAME_BYTES:
+                    self._failure.set()
+                    break
+                with self._lock:
+                    if self._queued_bytes + len(chunk) > MAX_OUTPUT + 256:
+                        self._failure.set()
+                        break
+                    self._queued_bytes += len(chunk)
+                try:
+                    self._output.put_nowait(chunk)
+                except queue.Full:
+                    self._failure.set()
+                    break
+        except Exception:
+            self._failure.set()
+        finally:
+            self._stream_ended.set()
+
+    def _run(self, command: list[str], deadline: float) -> None:
+        def run() -> None:
+            process = self.session.exec(command)
+            code = process.wait(
+                timeout=max(0.001, deadline - time.monotonic())
+            )
+            if code != 0:
+                raise RuntimeError(f"Sandbox control command exited {code}")
+
+        self._bounded(run, deadline)
+
+    def start(self) -> None:
+        """Create the FIFO and initialize the persistent shell.
+
+        Raises:
+            RuntimeError: Startup fails or this shell was already used.
+            BaseException: Startup failures propagate after closing handles.
+        """
+        if self._started or self.stopped:
+            raise RuntimeError("Shell instances cannot be restarted")
+        self._started = True
+        self._deadline = time.monotonic() + self.episode_timeout
+        deadline = min(self._deadline, time.monotonic() + self.command_timeout)
+        try:
+            self._run(
+                [
+                    "bash",
+                    "-c",
+                    f"mkdir -m 700 {self._control}; "
+                    f"mkfifo {self._control}/input",
+                ],
+                deadline,
+            )
+
+            def launch() -> SandboxProcess:
+                process = self.session.exec(
+                    [
+                        "bash",
+                        "-c",
+                        f"exec 3<>{self._control}/input; "
+                        "bash --noprofile --norc <&3 2>&1 | "
+                        "python3 -u -c " + shlex.quote(_FRAMER),
+                    ]
+                )
+                return process
+
+            self._process = self._bounded(launch, deadline)
+            threading.Thread(target=self._drain, daemon=True).start()
+            ok, output = self.execute(
+                "export HOME=/home/user; cd /home/user; set -o pipefail"
+            )
+            if not ok:
+                raise RuntimeError("Shell initialization failed: " + output)
+        except BaseException:
+            self.close()
+            raise
+
+    def execute(self, command: str) -> tuple[bool, str]:
+        """Execute one command while preserving Bash state.
+
+        Args:
+            command: Shell command to evaluate.
+
+        Returns:
+            Success flag and bounded output. Transport failure, timeout or
+            output overflow stops this shell; the caller must destroy its
+            sandbox before grading. Ordinary exceptions become failed results.
+        """  # noqa: DOC501,DOC503
+        if self.stopped or self._process is None:
+            return False, "Terminal is stopped"
+        deadline = min(self._deadline, time.monotonic() + self.command_timeout)
+        if deadline <= time.monotonic():
+            self.close()
+            return False, "Episode deadline exceeded; terminal stopped"
+        if len(command.encode()) > MAX_OUTPUT:
+            self.close()
+            return False, "Command size limit exceeded; terminal stopped"
+        token = "ENDLESS_" + uuid.uuid4().hex
+        marker = re.compile(rb"\x1e" + token.encode() + rb":([0-9]+)\x1f\n")
+        script = (
+            "eval "
+            + shlex.quote(command)
+            + "\nbuiltin printf '\\036"
+            + token
+            + ':%s\\037\\n\' "$?"\n'
+        )
+        output = bytearray()
+        try:
+            with tempfile.TemporaryDirectory(
+                prefix="endless-fifo-"
+            ) as directory:
+                path = Path(directory) / "command"
+                path.write_text(script)
+                remote = self._control + "/" + token
+                self._bounded(
+                    lambda: self.session.upload_file(str(path), remote),
+                    deadline,
+                )
+            seconds = max(0.001, deadline - time.monotonic())
+            self._run(
+                [
+                    "timeout",
+                    "--kill-after=1",
+                    str(seconds),
+                    "bash",
+                    "-c",
+                    f"cat {remote} > {self._control}/input; rm -f {remote}",
+                ],
+                deadline,
+            )
+            while time.monotonic() < deadline:
+                if self._failure.is_set():
+                    raise RuntimeError(
+                        "Shell output overflow or stream failure"
+                    )
+                try:
+                    chunk = self._output.get(
+                        timeout=min(
+                            0.05, max(0.001, deadline - time.monotonic())
+                        )
+                    )
+                except queue.Empty:
+                    if self._stream_ended.is_set():
+                        raise RuntimeError("Shell output stream ended")
+                    continue
+                with self._lock:
+                    self._queued_bytes -= len(chunk)
+                output.extend(chunk)
+                match = marker.search(output)
+                if match and match.start() <= MAX_OUTPUT:
+                    return int(match[1]) == 0, output[: match.start()].decode(
+                        errors="replace"
+                    )
+                if len(output) > MAX_OUTPUT:
+                    raise RuntimeError("Shell output limit exceeded")
+            raise TimeoutError("Command or episode deadline exceeded")
+        except Exception as exc:
+            self.close()
+            return False, output[:MAX_OUTPUT].decode(
+                errors="replace"
+            ) + f"\n{exc}; terminal stopped"
+
+    def close(self) -> None:
+        """Stop accepting commands and consuming output.
+
+        The caller must destroy the sandbox to stop remote processes and unblock
+        stream readers. Per-process kill is unsupported on some backends and
+        may destroy the entire session on others.
+        """
+        self.stopped = True
+        self._closing.set()

--- a/examples/endless_terminals/runtime/sandbox_workspace.py
+++ b/examples/endless_terminals/runtime/sandbox_workspace.py
@@ -1,0 +1,580 @@
+"""Own one temporary Kubernetes volume and its public ZenML sandbox sessions."""
+
+from __future__ import annotations
+
+import queue
+import re
+import threading
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, TypeVar, cast
+
+from kubernetes.client import V1DeleteOptions, V1Preconditions
+from kubernetes.client.rest import ApiException
+
+from zenml.integrations.kubernetes.flavors.kubernetes_sandbox_flavor import (
+    KubernetesSandboxSettings,
+)
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+    KubernetesSandbox,
+)
+from zenml.sandboxes.session import SandboxSession
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class SandboxRuntimeConfig:
+    """Bound bootstrap and cleanup for an example-owned temporary workspace."""
+
+    helper_image: str
+    storage_class: str = "gp2"
+    startup_timeout: int = 600
+    cleanup_timeout: int = 120
+    api_timeout: int = 15
+    controller_pod_name: str | None = None
+    modal_agent_image: str | None = None
+    modal_workspace: str = "zenml-io"
+    modal_environment: str = "dev"
+
+
+def bounded_call(action: Callable[[], _T], timeout: float) -> _T:
+    """Wait for public sandbox APIs without relying on private stream controls.
+
+    Args:
+        action: Operation to invoke on a daemon thread.
+        timeout: Maximum controller waiting time.
+
+    Returns:
+        Operation result.
+
+    Raises:
+        TimeoutError: The controller deadline expires.
+        BaseException: The operation fails.
+    """  # noqa: DOC503 - The original exception is raised through `value`.
+    result: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+
+    def invoke() -> None:
+        try:
+            result.put((True, action()))
+        except BaseException as exc:
+            result.put((False, exc))
+
+    threading.Thread(target=invoke, daemon=True).start()
+    try:
+        success, value = result.get(timeout=timeout)
+    except queue.Empty:
+        raise TimeoutError("Sandbox API operation exceeded deadline") from None
+    if not success:
+        raise value
+    return cast(_T, value)
+
+
+class SandboxWorkspace:
+    """Create sessions using only public sandbox APIs and own Kubernetes objects."""
+
+    def __init__(
+        self, sandbox: KubernetesSandbox, config: SandboxRuntimeConfig
+    ) -> None:
+        """Configure a unique workspace without creating cluster resources.
+
+        Args:
+            sandbox: Selected Kubernetes sandbox component.
+            config: Workspace settings.
+
+        Raises:
+            ValueError: The helper image or timeout settings are invalid.
+        """
+        if not re.fullmatch(
+            r"[^\s]+@sha256:[0-9a-f]{64}", config.helper_image
+        ):
+            raise ValueError(
+                "Helper image must use an immutable registry digest"
+            )
+        if (
+            min(
+                config.startup_timeout,
+                config.cleanup_timeout,
+                config.api_timeout,
+            )
+            <= 0
+        ):
+            raise ValueError("Workspace timeouts must be positive")
+        if sandbox.config.sandbox_environment:
+            raise ValueError(
+                "Task sandbox configuration must not inject environment values"
+            )
+        self.sandbox = sandbox
+        self.config = config
+        self.namespace = sandbox.config.kubernetes_namespace
+        self.token = uuid.uuid4().hex
+        self.name = "endless-workspace-" + self.token[:16]
+        self.pvc_uid: str | None = None
+        self.volume_attempted = False
+        self.sessions: dict[str, tuple[SandboxSession, str, str]] = {}
+        self.owner_references: list[dict[str, Any]] = []
+        self.provenance: dict[str, Any] = {
+            "backend": "kubernetes_sandbox",
+            "namespace": self.namespace,
+            "workspace_name": self.name,
+            "pods": [],
+            "cleanup_complete": False,
+        }
+
+    def create_volume(self) -> None:
+        """Create a dedicated volume, optionally owned by the controller pod."""
+        if self.config.controller_pod_name:
+            owner = self.sandbox.core_api.read_namespaced_pod(
+                self.config.controller_pod_name,
+                self.namespace,
+                _request_timeout=self.config.api_timeout,
+            )
+            self.owner_references = [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "name": owner.metadata.name,
+                    "uid": owner.metadata.uid,
+                    "blockOwnerDeletion": False,
+                }
+            ]
+        body = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": self.name,
+                "labels": {"endless-workspace": self.token},
+                "ownerReferences": self.owner_references,
+            },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": self.config.storage_class,
+                "resources": {"requests": {"storage": "1Gi"}},
+            },
+        }
+        self.volume_attempted = True
+        claim = (
+            self.sandbox.core_api.create_namespaced_persistent_volume_claim(
+                self.namespace,
+                body,
+                _request_timeout=self.config.api_timeout,
+            )
+        )
+        self.pvc_uid = claim.metadata.uid
+        self.provenance["pvc_uid"] = self.pvc_uid
+
+    def settings(
+        self, image: str, mount: str | None, readonly: bool = False
+    ) -> KubernetesSandboxSettings:
+        """Build isolated pod settings while retaining CPU placement choices.
+
+        Args:
+            image: Immutable task image.
+            mount: PVC mount location, or None for a clean verifier.
+            readonly: Whether the PVC must be read-only.
+
+        Returns:
+            Explicit sandbox settings with isolated networking and no credentials.
+        """
+        base = self.sandbox.config.pod_settings or KubernetesPodSettings()
+        isolation = (
+            "set -eu; for path in /sys/class/net/*; do name=${path##*/}; "
+            '[ "$name" = lo ] || ip link set dev "$name" down; done; '
+            "ip -j link show"
+        )
+        volumes = (
+            [
+                {
+                    "name": "workspace",
+                    "persistentVolumeClaim": {"claimName": self.name},
+                }
+            ]
+            if mount
+            else []
+        )
+        mounts = (
+            [{"name": "workspace", "mountPath": mount, "readOnly": readonly}]
+            if mount
+            else []
+        )
+        if mount == "/home/user":
+            mounts[0]["subPath"] = "home"
+        pod = KubernetesPodSettings(
+            node_selectors={
+                **base.node_selectors,
+                "kubernetes.io/os": "linux",
+                "kubernetes.io/arch": "amd64",
+            },
+            affinity=base.affinity,
+            tolerations=base.tolerations,
+            image_pull_secrets=base.image_pull_secrets,
+            resources={
+                "requests": {"cpu": "1", "memory": "1Gi"},
+                "limits": {"cpu": "1", "memory": "1Gi"},
+            },
+            labels={"endless-workspace": self.token},
+            volumes=volumes,
+            volume_mounts=mounts,
+            container_security_context={
+                "runAsUser": 0,
+                "privileged": False,
+                "allowPrivilegeEscalation": False,
+                "capabilities": {
+                    "drop": ["ALL"],
+                    "add": ["DAC_OVERRIDE", "FOWNER", "CHOWN"],
+                },
+            },
+            additional_pod_spec_args={
+                "host_network": False,
+                "host_pid": False,
+                "host_ipc": False,
+                "share_process_namespace": False,
+                "enable_service_links": False,
+                "active_deadline_seconds": 1800,
+                "termination_grace_period_seconds": 5,
+                "security_context": {
+                    "seccompProfile": {"type": "RuntimeDefault"}
+                },
+                "init_containers": [
+                    {
+                        "name": "disable-network",
+                        "image": self.config.helper_image,
+                        "command": ["/bin/sh", "-c", isolation],
+                        "securityContext": {
+                            "runAsUser": 0,
+                            "privileged": False,
+                            "allowPrivilegeEscalation": False,
+                            "capabilities": {
+                                "drop": ["ALL"],
+                                "add": ["NET_ADMIN"],
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+        return KubernetesSandboxSettings(
+            image=image,
+            pod_settings=pod,
+            automount_service_account_token=False,
+            privileged=False,
+            sandbox_environment={},
+            pod_startup_timeout=self.config.startup_timeout,
+            api_request_timeout=self.config.api_timeout,
+            max_api_retries=0,
+        )
+
+    def create_session(
+        self, image: str, mount: str | None, readonly: bool = False
+    ) -> SandboxSession:
+        """Create a public sandbox and record its exact pod UID before use.
+
+        Args:
+            image: Task image digest.
+            mount: Optional workspace mount location.
+            readonly: Read-only volume flag.
+
+        Returns:
+            Running session.
+
+        Raises:
+            RuntimeError: Pod identity or admission-mutated security is unexpected.
+        """
+        session = self.sandbox.create_session(
+            settings=self.settings(image, mount, readonly)
+        )
+        pods = self.sandbox.core_api.list_namespaced_pod(
+            self.namespace,
+            label_selector=f"zenml-sandbox-id={session.id},endless-workspace={self.token}",
+            _request_timeout=self.config.api_timeout,
+        ).items
+        if len(pods) != 1:
+            raise RuntimeError("Expected one uniquely labeled sandbox pod")
+        pod = pods[0]
+        self.sessions[session.id] = (
+            session,
+            pod.metadata.name,
+            pod.metadata.uid,
+        )
+        self.provenance["pods"].append(
+            {
+                "session_id": session.id,
+                "pod_name": pod.metadata.name,
+                "pod_uid": pod.metadata.uid,
+                "node": pod.spec.node_name,
+                "image": image,
+                "phase": "agent"
+                if mount == "/home/user"
+                else "reader"
+                if readonly
+                else "seed"
+                if mount
+                else "verifier",
+                "image_ids": [
+                    status.image_id
+                    for status in (pod.status.container_statuses or [])
+                ],
+            }
+        )
+        spec = pod.spec
+        if (
+            spec.host_network
+            or spec.host_pid
+            or spec.host_ipc
+            or spec.share_process_namespace
+            or spec.automount_service_account_token
+            or spec.termination_grace_period_seconds == 0
+            or spec.ephemeral_containers
+            or len(spec.containers) != 1
+            or len(spec.init_containers or []) != 1
+        ):
+            raise RuntimeError("Admission changed sandbox isolation settings")
+        main = spec.containers[0]
+        initializer = spec.init_containers[0]
+        if (
+            main.image != image
+            or initializer.image != self.config.helper_image
+        ):
+            raise RuntimeError("Admission changed sandbox images")
+        for container in [main, initializer]:
+            if container.env_from or any(
+                entry.value_from is not None
+                or entry.name != "ZENML_ENABLE_REPO_INIT_WARNINGS"
+                or entry.value != "False"
+                for entry in (container.env or [])
+            ):
+                raise RuntimeError(
+                    "Admission injected sandbox environment values"
+                )
+            if container.volume_devices:
+                raise RuntimeError("Admission injected sandbox volume devices")
+        if initializer.volume_mounts:
+            raise RuntimeError("Admission injected initializer volume mounts")
+        volumes = spec.volumes or []
+        mounts = main.volume_mounts or []
+        if mount is None:
+            if volumes or mounts:
+                raise RuntimeError(
+                    "Clean verifier received unexpected volumes"
+                )
+        else:
+            if len(volumes) != 1 or len(mounts) != 1:
+                raise RuntimeError(
+                    "Admission changed sandbox workspace volumes"
+                )
+            volume, actual_mount = volumes[0], mounts[0]
+            if (
+                volume.name != "workspace"
+                or volume.persistent_volume_claim is None
+                or volume.persistent_volume_claim.claim_name != self.name
+                or volume.persistent_volume_claim.read_only
+                or any(
+                    value is not None
+                    for key, value in volume.to_dict().items()
+                    if key not in {"name", "persistent_volume_claim"}
+                )
+                or actual_mount.name != "workspace"
+                or actual_mount.mount_path != mount
+                or bool(actual_mount.read_only) != readonly
+                or actual_mount.sub_path
+                != ("home" if mount == "/home/user" else None)
+                or actual_mount.sub_path_expr
+                or actual_mount.mount_propagation not in {None, "None"}
+            ):
+                raise RuntimeError("Admission changed sandbox workspace mount")
+        security = spec.containers[0].security_context
+        if (
+            security.privileged
+            or security.allow_privilege_escalation
+            or set(security.capabilities.add or [])
+            - {"DAC_OVERRIDE", "FOWNER", "CHOWN"}
+            or "ALL" not in (security.capabilities.drop or [])
+        ):
+            raise RuntimeError("Sandbox container capabilities are unsafe")
+        if self.owner_references:
+            self.sandbox.core_api.patch_namespaced_pod(
+                pod.metadata.name,
+                self.namespace,
+                {
+                    "metadata": {
+                        "uid": pod.metadata.uid,
+                        "ownerReferences": self.owner_references,
+                    }
+                },
+                _request_timeout=self.config.api_timeout,
+            )
+        return session
+
+    def destroy_session(self, session: SandboxSession) -> None:
+        """Delete the recorded pod and confirm its original UID is gone.
+
+        Args:
+            session: Owned session to terminate.
+
+        Raises:
+            TimeoutError: The pod remains after the cleanup deadline.
+            RuntimeError: Pod ownership changed.
+            ApiException: A Kubernetes read or delete request fails.
+        """
+        if session.id not in self.sessions:
+            return
+        _, name, uid = self.sessions[session.id]
+        api = self.sandbox.core_api
+        try:
+            pod = api.read_namespaced_pod(
+                name, self.namespace, _request_timeout=self.config.api_timeout
+            )
+            if pod.metadata.uid != uid:
+                raise RuntimeError("Sandbox pod identity changed")
+            api.delete_namespaced_pod(
+                name,
+                self.namespace,
+                body=V1DeleteOptions(
+                    grace_period_seconds=5,
+                    preconditions=V1Preconditions(uid=uid),
+                ),
+                _request_timeout=self.config.api_timeout,
+            )
+        except ApiException as exc:
+            if exc.status != 404:
+                raise
+        deadline = time.monotonic() + self.config.cleanup_timeout
+        while time.monotonic() < deadline:
+            try:
+                pod = api.read_namespaced_pod(
+                    name,
+                    self.namespace,
+                    _request_timeout=self.config.api_timeout,
+                )
+                if pod.metadata.uid != uid:
+                    raise RuntimeError(
+                        "Replacement pod detected during cleanup"
+                    )
+            except ApiException as exc:
+                if exc.status == 404:
+                    session.close()
+                    del self.sessions[session.id]
+                    self.provenance.setdefault("deleted_pod_uids", []).append(
+                        uid
+                    )
+                    return
+                raise
+            time.sleep(0.25)
+        raise TimeoutError("Sandbox pod termination was not confirmed")
+
+    def close(self) -> None:
+        """Remove owned sessions and the volume without hiding incomplete cleanup.
+
+        Raises:
+            RuntimeError: A session or volume could not be removed.
+        """  # noqa: DOC503 - API errors and timeouts are caught and aggregated.
+        errors = []
+        api = self.sandbox.core_api
+        try:
+            pods = api.list_namespaced_pod(
+                self.namespace,
+                label_selector=f"endless-workspace={self.token}",
+                _request_timeout=self.config.api_timeout,
+            ).items
+            tracked = {uid for _, _, uid in self.sessions.values()}
+            for pod in pods:
+                if pod.metadata.uid in tracked:
+                    continue
+                name, uid = pod.metadata.name, pod.metadata.uid
+                api.delete_namespaced_pod(
+                    name,
+                    self.namespace,
+                    body=V1DeleteOptions(
+                        grace_period_seconds=5,
+                        preconditions=V1Preconditions(uid=uid),
+                    ),
+                    _request_timeout=self.config.api_timeout,
+                )
+                deadline = time.monotonic() + self.config.cleanup_timeout
+                while time.monotonic() < deadline:
+                    try:
+                        existing = api.read_namespaced_pod(
+                            name,
+                            self.namespace,
+                            _request_timeout=self.config.api_timeout,
+                        )
+                        if existing.metadata.uid != uid:
+                            raise RuntimeError("Orphan pod identity changed")
+                    except ApiException as exc:
+                        if exc.status == 404:
+                            self.provenance.setdefault(
+                                "deleted_pod_uids", []
+                            ).append(uid)
+                            break
+                        raise
+                    time.sleep(0.25)
+                else:
+                    raise TimeoutError("Failed-start sandbox pod remains")
+            if self.volume_attempted and self.pvc_uid is None:
+                try:
+                    claim = api.read_namespaced_persistent_volume_claim(
+                        self.name,
+                        self.namespace,
+                        _request_timeout=self.config.api_timeout,
+                    )
+                    if (claim.metadata.labels or {}).get(
+                        "endless-workspace"
+                    ) != self.token:
+                        raise RuntimeError(
+                            "Workspace volume ownership differs"
+                        )
+                    self.pvc_uid = claim.metadata.uid
+                except ApiException as exc:
+                    if exc.status != 404:
+                        raise
+        except Exception as exc:
+            errors.append(str(exc))
+        for session, _, _ in list(self.sessions.values()):
+            try:
+                self.destroy_session(session)
+            except Exception as exc:
+                errors.append(str(exc))
+        if not errors and self.pvc_uid:
+            try:
+                self.sandbox.core_api.delete_namespaced_persistent_volume_claim(
+                    self.name,
+                    self.namespace,
+                    body=V1DeleteOptions(
+                        preconditions=V1Preconditions(uid=self.pvc_uid)
+                    ),
+                    _request_timeout=self.config.api_timeout,
+                )
+                deadline = time.monotonic() + self.config.cleanup_timeout
+                while time.monotonic() < deadline:
+                    try:
+                        self.sandbox.core_api.read_namespaced_persistent_volume_claim(
+                            self.name,
+                            self.namespace,
+                            _request_timeout=self.config.api_timeout,
+                        )
+                    except ApiException as exc:
+                        if exc.status == 404:
+                            self.pvc_uid = None
+                            break
+                        raise
+                    time.sleep(0.25)
+                if self.pvc_uid:
+                    raise TimeoutError(
+                        "Workspace PVC deletion was not confirmed"
+                    )
+            except ApiException as exc:
+                if exc.status == 404:
+                    self.pvc_uid = None
+                else:
+                    errors.append(str(exc))
+            except Exception as exc:
+                errors.append(str(exc))
+        self.provenance["cleanup_complete"] = not errors
+        self.provenance["cleanup_errors"] = errors
+        if errors:
+            raise RuntimeError(
+                "Workspace cleanup failed: " + "; ".join(errors)
+            )

--- a/examples/endless_terminals/runtime/test_runtime.py
+++ b/examples/endless_terminals/runtime/test_runtime.py
@@ -1,0 +1,198 @@
+"""Local contract tests that never contact an external endpoint."""
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from . import runner
+from .contract import extract_action
+from .models import EndpointModel, FixtureModel
+
+
+class RuntimeTests(unittest.TestCase):
+    """Exercise observable parser, failure, and grading boundaries."""
+
+    def test_pinned_action_precedence(self) -> None:
+        """Keep the pinned parser's last-command and done precedence."""
+        self.assertEqual(
+            extract_action("<command>first</command><command>last</command>")[
+                "command"
+            ],
+            "last",
+        )
+        for response in (
+            "<command>false</command><action>done</action>",
+            "<command>DONE</command>",
+        ):
+            self.assertEqual(extract_action(response)["type"], "done")
+        self.assertEqual(extract_action("hello")["type"], "invalid")
+
+    def test_endpoint_rejects_credential_leaks(self) -> None:
+        """Reject embedded credentials and remote plaintext transport."""
+        for url in (
+            "http://example.com/v1",
+            "https://user:secret@example.com/v1",
+            "https://example.com/v1?key=secret",
+        ):
+            with self.assertRaises(ValueError):
+                EndpointModel(url, "fixture")
+
+    def test_endpoint_deadline_has_no_retry(self) -> None:
+        """An expired child deadline causes exactly one failed attempt."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired("worker", 1),
+        ) as request:
+            with self.assertRaises(TimeoutError):
+                EndpointModel("http://127.0.0.1/v1", "fixture").complete([], 1)
+            request.assert_called_once()
+
+    def test_episode_failure_and_turn_limits(self) -> None:
+        """Keep model failures separate from rewards and consume invalid turns."""
+        for responses, expected, grading_error in (
+            ([], "infrastructure_error", None),
+            (["invalid", "invalid"], "max_actions", None),
+            (
+                ["<action>done</action>"],
+                "infrastructure_error",
+                "grader failed",
+            ),
+        ):
+            with (
+                self.subTest(responses=responses),
+                tempfile.TemporaryDirectory() as root,
+            ):
+                directory = Path(root)
+                (directory / "tests").mkdir()
+                (directory / "instruction.md").write_text(
+                    "Create an output file."
+                )
+                (directory / "tests/test_final_state.py").write_text(
+                    "hidden grader"
+                )
+                task = {
+                    "task_id": "fixture",
+                    "local_image_id": "sha256:" + "a" * 64,
+                    "task_file_sha256": {
+                        name: hashlib.sha256(
+                            (directory / name).read_bytes()
+                        ).hexdigest()
+                        for name in (
+                            "instruction.md",
+                            "tests/test_final_state.py",
+                        )
+                    },
+                }
+                env = MagicMock()
+                env.__enter__.return_value = env
+                env.container_id = "fixture-container"
+                env.provenance = {"backend": "fixture"}
+                env.closed = True
+                env.stopped = False
+                grading = {
+                    "raw_reward": None if grading_error else 0,
+                    "audited_valid": False,
+                    "infrastructure_error": grading_error,
+                }
+                with (
+                    patch.object(
+                        runner, "DockerEnvironment", return_value=env
+                    ),
+                    patch.object(
+                        runner, "grade_environment", return_value=grading
+                    ) as grade,
+                ):
+                    result = runner.run_episode(
+                        task,
+                        directory,
+                        FixtureModel(responses),
+                        directory / "episode",
+                        identity={"kind": "fixture"},
+                        max_actions=2,
+                    )
+                self.assertEqual(result["exit_reason"], expected)
+                self.assertTrue(result["cleanup_complete"])
+                self.assertNotIn(
+                    "hidden grader", json.dumps(result["transcript"])
+                )
+                env.execute.assert_not_called()
+                env.__exit__.assert_called_once()
+                if not responses:
+                    grade.assert_not_called()
+                    self.assertIsNone(result["grading"])
+                saved = json.loads(
+                    (directory / "episode/result.json").read_text()
+                )
+                self.assertEqual(saved, result)
+
+    def test_supplied_prompt_reaches_model_and_artifact(self) -> None:
+        """Record the hash of the exact system message delivered to the model."""
+        with tempfile.TemporaryDirectory() as root:
+            directory = Path(root)
+            (directory / "instruction.md").write_text("Do the task.")
+            model = MagicMock()
+            model.complete.return_value = ("<action>done</action>", {})
+            env = MagicMock()
+            env.container_id = "fixture"
+            env.provenance = {"backend": "fixture"}
+            env.closed = True
+            message = "Exact custom prompt.\n"
+            with (
+                patch.object(runner, "verify_task_files"),
+                patch.object(runner, "DockerEnvironment", return_value=env),
+                patch.object(runner, "grade_environment", return_value={}),
+            ):
+                result = runner.run_episode(
+                    {"task_id": "fixture", "local_image_id": "image"},
+                    directory,
+                    model,
+                    directory / "episode",
+                    identity={},
+                    system_message=message,
+                )
+            self.assertEqual(
+                model.complete.call_args.args[0][0],
+                {"role": "system", "content": message},
+            )
+            self.assertEqual(
+                result["system_prompt_sha256"],
+                hashlib.sha256(message.encode()).hexdigest(),
+            )
+            saved = json.loads((directory / "episode/result.json").read_text())
+            self.assertEqual(
+                saved["system_prompt_sha256"], result["system_prompt_sha256"]
+            )
+
+    def test_blank_prompt_rejected_before_sandbox(self) -> None:
+        """Reject empty instructions before creating output or a sandbox."""
+        with tempfile.TemporaryDirectory() as root:
+            output = Path(root) / "episode"
+            with (
+                patch.object(runner, "DockerEnvironment") as sandbox,
+                self.assertRaisesRegex(ValueError, "system_message"),
+            ):
+                runner.run_episode(
+                    {},
+                    Path(root),
+                    FixtureModel([]),
+                    output,
+                    identity={},
+                    system_message=" \n",
+                )
+            sandbox.assert_not_called()
+            self.assertFalse(output.exists())
+
+    def test_task_hash_validation_precedes_execution(self) -> None:
+        """Reject changed task evidence before creating a Docker environment."""
+        with tempfile.TemporaryDirectory() as root:
+            task = {"task_file_sha256": {"instruction.md": "bad"}}
+            with self.assertRaises(ValueError):
+                runner.verify_task_files(task, Path(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/endless_terminals/sandbox-rbac.yaml
+++ b/examples/endless_terminals/sandbox-rbac.yaml
@@ -1,0 +1,39 @@
+# Set metadata.namespace and subjects.namespace to the orchestrator namespace.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: endless-terminal-controller
+  namespace: aws-k8s-8b16c2
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: endless-terminal-controller
+  namespace: aws-k8s-8b16c2
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: endless-terminal-controller
+  namespace: aws-k8s-8b16c2
+subjects:
+  - kind: ServiceAccount
+    name: endless-terminal-controller
+    namespace: aws-k8s-8b16c2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: endless-terminal-controller

--- a/examples/endless_terminals/sandbox.example.json
+++ b/examples/endless_terminals/sandbox.example.json
@@ -1,0 +1,9 @@
+{
+  "helper_image": "REGISTRY/terminal-helper@sha256:REPLACE_WITH_BUILT_IMAGE_DIGEST",
+  "storage_class": "gp2",
+  "startup_timeout": 600,
+  "cleanup_timeout": 120,
+  "command_timeout": 30,
+  "episode_timeout": 300,
+  "task_ids": []
+}

--- a/examples/endless_terminals/sandbox_pipeline.py
+++ b/examples/endless_terminals/sandbox_pipeline.py
@@ -1,0 +1,318 @@
+"""Run the CPU qualification pilot with native Kubernetes sandbox artifacts."""
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from qualification_report import render_qualification_report
+from runtime.environment import TerminalEnvironment
+from runtime.grading import grade_environment
+from runtime.models import FixtureModel
+from runtime.runner import run_episode, verify_task_files
+
+from zenml import pipeline, step
+from zenml.client import Client
+from zenml.types import HTMLString
+
+
+class SandboxPipelineConfig(BaseModel):
+    """Bound the single-task CPU sandbox qualification pilot."""
+
+    helper_image: str = Field(pattern=r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+    modal_agent_image: str | None = Field(
+        default=None, pattern=r"^[^\s@]+@sha256:[0-9a-f]{64}$"
+    )
+    modal_workspace: str = Field(default="zenml-io", pattern=r"^\S+$")
+    modal_environment: str = Field(default="dev", pattern=r"^\S+$")
+    storage_class: str = "gp2"
+    startup_timeout: int = Field(default=600, gt=0, le=900)
+    cleanup_timeout: int = Field(default=120, gt=0, le=300)
+    command_timeout: float = Field(default=30, gt=0, le=90)
+    episode_timeout: float = Field(default=300, gt=0, le=1200)
+    task_ids: list[str] = Field(default_factory=list, max_length=1)
+
+
+def load_bundle_task(
+    bundle: Path, config: SandboxPipelineConfig
+) -> dict[str, Any]:
+    """Validate the selected task and its immutable registry image.
+
+    Args:
+        bundle: Materialized bundle artifact directory.
+        config: Task selection.
+
+    Returns:
+        Verified task manifest entry, without a machine-specific file path.
+
+    Raises:
+        ValueError: Selection, file integrity, or registry image is invalid.
+    """
+    manifest = json.loads((bundle / "task-manifest.json").read_text())
+    if not re.fullmatch(r"[0-9a-f]{40}", manifest["dataset_revision"]):
+        raise ValueError("The dataset revision must be a pinned commit")
+    tasks = manifest["tasks"]
+    selected = [
+        t
+        for t in tasks
+        if not config.task_ids or t["task_id"] in config.task_ids
+    ]
+    if not selected or (config.task_ids and len(selected) != 1):
+        raise ValueError("The bundle must contain exactly the requested task")
+    task = dict(selected[0])
+    task_id = task["task_id"]
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", task_id):
+        raise ValueError("Task ID must be a single safe directory name")
+    image = task.get("image_ref", "")
+    if not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", image):
+        raise ValueError("Task image_ref must use a registry digest")
+    required = {
+        "instruction.md",
+        "tests/test_final_state.py",
+        "environment/test_initial_state.py",
+        "solution/solve.sh",
+    }
+    if not required <= task["task_file_sha256"].keys():
+        raise ValueError(
+            "The bundle must hash instructions, graders, and reference solution"
+        )
+    directory = bundle / task_id
+    if not directory.resolve().is_relative_to(bundle.resolve()):
+        raise ValueError("Task directory escapes the bundle")
+    verify_task_files(task, directory)
+    task["dataset_revision"] = manifest["dataset_revision"]
+    return task
+
+
+def create_environment(
+    task: dict[str, Any], config: SandboxPipelineConfig
+) -> TerminalEnvironment:
+    """Create the active Kubernetes or Modal environment without starting it.
+
+    Args:
+        task: Verified task and registry digest.
+        config: Runtime limits and storage configuration.
+
+    Returns:
+        The environment used for interaction and trusted grading.
+    """
+    from runtime.sandbox_env import SandboxEnvironment, SandboxRuntimeConfig
+
+    runtime = SandboxRuntimeConfig(
+        helper_image=config.helper_image,
+        modal_agent_image=config.modal_agent_image,
+        modal_workspace=config.modal_workspace,
+        modal_environment=config.modal_environment,
+        storage_class=config.storage_class,
+        startup_timeout=config.startup_timeout,
+        cleanup_timeout=config.cleanup_timeout,
+        controller_pod_name=(
+            os.environ.get("HOSTNAME")
+            if os.environ.get("KUBERNETES_SERVICE_HOST")
+            else None
+        ),
+    )
+    return SandboxEnvironment(
+        task["image_ref"],
+        config=runtime,
+        command_timeout=config.command_timeout,
+        episode_timeout=config.episode_timeout,
+    )
+
+
+@step(enable_cache=False)
+def qualify_sandbox_initial(
+    bundle: Path, config: SandboxPipelineConfig
+) -> Annotated[dict[str, Any], "sandbox_initial_qualification"]:
+    """Verify initial state in an isolated Kubernetes sandbox.
+
+    Args:
+        bundle: Uploaded task bundle artifact.
+        config: Task selection and runtime limits.
+
+    Returns:
+        Initial grading, immutable task identity, and cleanup evidence.
+    """
+    task = load_bundle_task(bundle, config)
+    env = create_environment(task, config)
+    result: dict[str, Any] = {
+        "task": task,
+        "phase": "initial",
+        "grading": None,
+    }
+    try:
+        with env:
+            result["grading"] = grade_environment(
+                env,
+                bundle / task["task_id"] / "environment/test_initial_state.py",
+                task.get("protected_sources", {}),
+            )
+    except Exception as exc:
+        result["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    finally:
+        result["cleanup_complete"] = env.closed
+        result["runtime"] = env.provenance
+    return result
+
+
+@step(enable_cache=False)
+def evaluate_sandbox_fixture(
+    bundle: Path,
+    initial: dict[str, Any],
+    config: SandboxPipelineConfig,
+    fixture: Literal["reference", "noop"],
+) -> Annotated[dict[str, Any], "sandbox_fixture_episode"]:
+    """Exercise the real agent loop with a known successful or failing fixture.
+
+    Args:
+        bundle: Materialized task bundle artifact.
+        initial: Initial qualification dependency.
+        config: Runtime settings.
+        fixture: Scripted reference solution or intentionally unsolved state.
+
+    Returns:
+        Complete episode evidence, or an explicit qualification failure.
+    """
+    task = load_bundle_task(bundle, config)
+    grade = initial.get("grading") or {}
+    if (
+        not initial.get("cleanup_complete")
+        or not grade.get("audited_valid")
+        or grade.get("infrastructure_error")
+    ):
+        return {
+            "fixture": fixture,
+            "skipped": "initial qualification failed",
+            "cleanup_complete": True,
+        }
+    directory = bundle / task["task_id"]
+    responses = ["<action>done</action>"]
+    if fixture == "reference":
+        responses.insert(
+            0,
+            "<command>"
+            + (directory / "solution/solve.sh").read_text()
+            + "</command>",
+        )
+    with tempfile.TemporaryDirectory(
+        prefix="endless-sandbox-episode-"
+    ) as temporary:
+        result = run_episode(
+            task,
+            directory,
+            FixtureModel(responses),
+            Path(temporary) / "episode",
+            identity={
+                "name": fixture,
+                "kind": "scripted_fixture",
+                "model_calls": 0,
+            },
+            max_actions=2,
+            command_timeout=config.command_timeout,
+            episode_timeout=config.episode_timeout,
+            environment_factory=lambda image, command, episode: (
+                create_environment(
+                    {**task, "image_ref": image},
+                    config.model_copy(
+                        update={
+                            "command_timeout": command,
+                            "episode_timeout": episode,
+                        }
+                    ),
+                )
+            ),
+        )
+    result["fixture"] = fixture
+    result["expected_reward"] = int(fixture == "reference")
+    return result
+
+
+def fixture_matches(result: dict[str, Any], expected: int) -> bool:
+    """Check a fixture's intended result and runtime integrity.
+
+    Args:
+        result: Recorded episode.
+        expected: Expected audited binary reward.
+
+    Returns:
+        Whether execution, grading, and cleanup match the fixture contract.
+    """
+    grade = result.get("grading") or {}
+    if (
+        result.get("exit_reason") != "done"
+        or not result.get("cleanup_complete")
+        or grade.get("infrastructure_error")
+    ):
+        return False
+    if grade.get("raw_reward") != expected or grade.get(
+        "audited_valid"
+    ) != bool(expected):
+        return False
+    if expected == 0:
+        counts = grade.get("test_counts", {})
+        return (
+            bool(counts.get("failure"))
+            and not counts.get("error")
+            and not counts.get("skipped")
+            and all(
+                v.get("unchanged") is True
+                for v in grade.get("protected_sources", {}).values()
+            )
+        )
+    return True
+
+
+@step(enable_cache=False)
+def report_sandbox_results(
+    initial: dict[str, Any], reference: dict[str, Any], noop: dict[str, Any]
+) -> tuple[
+    Annotated[dict[str, Any], "sandbox_qualification_results"],
+    Annotated[HTMLString, "sandbox_qualification_report"],
+]:
+    """Publish a truthful CPU qualification report and complete episode evidence.
+
+    Args:
+        initial: Initial-state qualification evidence.
+        reference: Successful scripted fixture episode.
+        noop: Intentionally failing scripted fixture episode.
+
+    Returns:
+        Structured evidence and a self-contained HTML report.
+    """
+    passed = fixture_matches(reference, 1) and fixture_matches(noop, 0)
+    results: dict[str, Any] = {
+        "status": "passed" if passed else "failed",
+        "scope": "CPU Kubernetes sandbox qualification; no model inference or training",
+        "initial": initial,
+        "reference": reference,
+        "noop": noop,
+    }
+    report = render_qualification_report(
+        results, fixture_matches(reference, 1), fixture_matches(noop, 0)
+    )
+    return results, HTMLString(report)
+
+
+@pipeline(enable_cache=False)
+def endless_terminals_sandbox(
+    bundle_artifact_id: UUID, config: SandboxPipelineConfig
+) -> None:
+    """Run initial qualification and both fixture episodes as artifact-linked steps.
+
+    Args:
+        bundle_artifact_id: Version ID of the uploaded task directory artifact.
+        config: Single-task CPU runtime settings.
+    """
+    bundle = Client().get_artifact_version(bundle_artifact_id)
+    initial = qualify_sandbox_initial(bundle, config)
+    reference = evaluate_sandbox_fixture(
+        bundle, initial, config, "reference", id="reference_fixture"
+    )
+    noop = evaluate_sandbox_fixture(
+        bundle, initial, config, "noop", id="noop_fixture"
+    )
+    report_sandbox_results(initial, reference, noop)

--- a/examples/endless_terminals/tasks.json
+++ b/examples/endless_terminals/tasks.json
@@ -1,0 +1,172 @@
+{
+  "dataset": "obiwan96/endless-terminals",
+  "dataset_revision": "26ecf78458e7f756e4d06780d5fbf3dd78e91815",
+  "license": "MIT",
+  "scope": "Reviewed ten-task pilot, not a representative benchmark",
+  "tasks": [
+    {
+      "task_id": "task_000000_0090c771",
+      "qualified_image_id": "sha256:58cefa6cd7ad7880f71c1d5b308c108e6639ee2b22919562a21a58b413308d28",
+      "task_file_sha256": {
+        "environment/Dockerfile": "d0653be4ae9ddb8e31271093864a4491e59d2cdc163f219d4c8a4719d0aa12f6",
+        "environment/task.json": "7d27858b4f0280e1d02a5665188104c8b1e4e4717a5a66951de04473c3326043",
+        "environment/test_initial_state.py": "51e6bc878f412d50f1b48c7963e2edc0ecc8f722122463ec23a0eec1afeb4cd4",
+        "instruction.md": "24730191d58c5d3946073dd67a31289e69a455a59954097e3ae9c5033cea8a07",
+        "solution/solve.sh": "bae04378d19200aaaf78e96f67ba377e3e9404b80fee88f28b55fd419264796d",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "d6a8a56a669b4d06c11fc1f4b210adbbec1ee5638c8ca496de177c9a6441f6b3"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/backup_logs/integrity_report.log"
+    },
+    {
+      "task_id": "task_000000_009a1afa",
+      "qualified_image_id": "sha256:29a85c0008b66c30206251019a894c068afcc71ecec821d145d11b66e3a2d3c0",
+      "task_file_sha256": {
+        "environment/Dockerfile": "cdefa22e84ade5d6a04c5b77472ebeaabe31b19e0e5b10fa523192e4190b11b9",
+        "environment/task.json": "1f637a5b2630544d58cf29f719e0b1e37b59310b29891ff84671850cdefff050",
+        "environment/test_initial_state.py": "c2f34a963389100b79a78d48c4d689070abeee6d50d521d222821c8f325cf4c3",
+        "instruction.md": "f103555adf659582745f0d513337dd4b175b506670943f8da94d90e55dd0c7da",
+        "solution/solve.sh": "5746060516e00602fb33989e767ba3d1861aebe36af1eb2c4ce386072fab7050",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "0323e2e974308a75c1a3fded6e50924364336424fac33cd16bb94e5826b44237"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/experiments/opt_solver/summary.txt"
+    },
+    {
+      "task_id": "task_000000_00e67104",
+      "qualified_image_id": "sha256:b775748c8fc173848894a13ae3593eea017deb439629deb40c0b562933408cd5",
+      "task_file_sha256": {
+        "environment/Dockerfile": "4e0379256fc88984c500eefddcae4909384bd4319fd14d39a76a11230b34fdd2",
+        "environment/task.json": "7575922ef4aeade3bdb139de5449e024bf16a6e04248612cc6056cd7a50d08a8",
+        "environment/test_initial_state.py": "a853ae8117172e4c2487c7ddcb875ee2348013ef45d16d846138ef74ec579e29",
+        "instruction.md": "753db749489d7f03d37b6188f03fb92e816cf655cfcbf124263dfaeeb01ae14a",
+        "solution/solve.sh": "11a0b36ea723de8cb0a3dbd2074e352590a7940ab6ab7ed5340b2cd62647fb15",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "eec13ef95a9f57b9ae7166ad7505f7fd7ec7e8ae471bbb5976479aac6ca720ad"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/build/reports/warning_frequency.txt"
+    },
+    {
+      "task_id": "task_000000_010b99da",
+      "qualified_image_id": "sha256:208526eacec6418b9a94cd54265d29a2298c6d522e313b39a3a4b2e00b8bd8e1",
+      "task_file_sha256": {
+        "environment/Dockerfile": "f6ef631fc7b6a159b9b72afe7cf9ea8b6c2b1b8edcb3cc71888412a2e2b2d4f3",
+        "environment/task.json": "6fb0de49582349520f017a6a20e6a1814bb9f6c96deb19adfad1ec92523df28c",
+        "environment/test_initial_state.py": "2456cc83295525db7a30d73f1c700abbf170ce6b70bf30d86d16ebefe3c2b2c2",
+        "instruction.md": "e280297e1063035a9375074457ca8629f8fe3bf917490cd79f97d648354576f1",
+        "solution/solve.sh": "f47cd006d930367b9461b4987ef9ccc3566fb19af9220cda9277cb49ab28d51e",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "65400e74404a368ebc06d14c8aa77f1cc09bb98a9fc3db8e3cdd7c82fd2fbc62"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/projects/metrics/defined_services.log"
+    },
+    {
+      "task_id": "task_000000_010d25ed",
+      "qualified_image_id": "sha256:2b0cd41c7c8e16e4a4c6dc99cd7f98a9e3ac07a389f3a21821676fb6e17af377",
+      "task_file_sha256": {
+        "environment/Dockerfile": "aa569039a0eb1cdf054c53edf8276a2358e1823fc71aa87fb19b8217ed89b584",
+        "environment/task.json": "fdafa33b9b96aa24361447ef805a20e400661fa4d137df5b0dd17aae9992c69c",
+        "environment/test_initial_state.py": "2d03ce5e8f769d6e1dd0c1ffdea986d3d28406a311ff65b69ebbaf95494f9f74",
+        "instruction.md": "b94ac7cad1f133b087abe9f8fd908647f81b8b2aee031a985576eeb1839da38d",
+        "solution/solve.sh": "8919e9d348724d386423676e0086cea05ad8d6a073338fa891c4f235e1cbd5ee",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "8f81a79f78a0622b77098acfed1d1f1aacaee78cc0bcf5c50606d627958adaa1"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/firewall/action.log"
+    },
+    {
+      "task_id": "task_000000_010fa6d9",
+      "qualified_image_id": "sha256:a0ee7f23ca810ce7beebded0ddf0e0526cf65d6687676eb9453367527641fc73",
+      "task_file_sha256": {
+        "environment/Dockerfile": "f066ac0b58400e7e163963da5576af71e6f79e082fc6048f6f382e993f8c5f30",
+        "environment/task.json": "d32c851fe5bf8063d1f64f496b00f29131a1bd9f4e2d444f01a5eb82968cecce",
+        "environment/test_initial_state.py": "d8c84831aa66752e41be7133be857d96ce1c7a7db6ddba62162bef738c70076b",
+        "instruction.md": "4b6fea984fb0b46140b7531fa136c1795dc9a8ff6fe678e38e22ada000630793",
+        "solution/solve.sh": "411bac4734618f4d990b16e09be94a94f88479e9fe11179510db52dcb266581f",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "2f3ab2fd1bc32289eab8f9c4f433a7a5bb6fbc8ce9f179b7dd5283dac6e74bc3"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/tickets/ticket-5502/resolution.log"
+    },
+    {
+      "task_id": "task_000000_0228cd64",
+      "qualified_image_id": "sha256:a6ea6015e9257908f60fcd80afa5d2e9836596c6df0ff2bbfe0f8053c0bdc42b",
+      "task_file_sha256": {
+        "environment/Dockerfile": "18bc177626b6693cfd75f560ee68535769f4d6ebd724f5047f29a46c08f3a900",
+        "environment/task.json": "44ac7d659c4bf6039d8412892a7e39fdc6056db8afa17ffa8afcbdf8bd84c542",
+        "environment/test_initial_state.py": "779356a960935c1af87d859a350ad474ea06238ed842efc6b06448bbef6ead29",
+        "instruction.md": "adc72ce1c43383b5b8ae820e36ee7c7b4786f64bcf8d3548422b2b46f62ff1f2",
+        "solution/solve.sh": "4573e6ffcdc6908bbb1a9197ebac9ee493d15c3dae5494a9191c9ef6581ad5cc",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "cccf3561cb7dfc5f3581dc65b3731112edf58dec416bd11bbfa76c2fa90a5445"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/observability/primary_dns.log"
+    },
+    {
+      "task_id": "task_000000_02c76919",
+      "qualified_image_id": "sha256:85521d9f774df0c2993dbf42eba4cde3b52e190c4b2947de3f8e72be724c9302",
+      "task_file_sha256": {
+        "environment/Dockerfile": "ec3ee00a20c2f561022189592a3da42fa9c61786f10febfd8579d6b26fc93dab",
+        "environment/task.json": "e17ab0b0f6c4bb1fb70555783d7705cb23d52d0c7e7b307d92f4025e6ce19fc1",
+        "environment/test_initial_state.py": "b636657cbed4f87b54dafaf86b2e711ca2189bb4219cebf57c82b46a3539681a",
+        "instruction.md": "13cc73be190159417c0b2c14e17765ef8ad3a228c8647b281b5269f54ccd747e",
+        "solution/solve.sh": "2e10ff18a732384d638a73328e1ea7e56fa5184419df3de5f800b678621363ec",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "03d303218ef8740735caa46bc67b9ed452038fdd85789f091200c40be78e5409"
+      },
+      "protected_sources": {},
+      "corrupted_output_probe": "/home/user/deployment/release_manifest.log"
+    },
+    {
+      "task_id": "task_000000_01ee6df4",
+      "qualified_image_id": "sha256:2317586dd3008b5d1f35fbb9a938c52b3d357eaa93de52454d825baf739fcdca",
+      "task_file_sha256": {
+        "environment/Dockerfile": "a60d4e89095329367a1c895f74ab9ef3ca2160cae449f70c1dc14521b6b86286",
+        "environment/task.json": "7c3f5c9b3d6d315ad41527464bf480ffe15aed7cb616dff0caf1c0510b25123f",
+        "environment/test_initial_state.py": "a5a66d578e87858d3d427291da95779d706510a93363d791a4964d684f573f63",
+        "instruction.md": "13cef02885195a4b937e0de9fc8a81af56b8e3a18e418be70d877e1aba68027a",
+        "solution/solve.sh": "f4a3c4f1525a1bf7a4e355df6793fb0775b6bd93b4a6dc273d58130e38dbf5c9",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "b654ab74f42e679a954811a9470e6eebb5c8c8b7e003ab367b562d1fa25692ae"
+      },
+      "protected_sources": {
+        "/home/user/logs/access.log": "e205eee80bec46bd278d81ceee4fc1b2389b0b7b6c64c52b814fe84d987a4d6f"
+      },
+      "corrupted_output_probe": "/home/user/analysis/404_by_ip.txt"
+    },
+    {
+      "task_id": "task_000000_0319faa5",
+      "qualified_image_id": "sha256:fa295eeec8d78b92265fa4cc117d8601e0ff21dab3561f89e408cc76b0c30b90",
+      "task_file_sha256": {
+        "environment/Dockerfile": "d2b391b4158ed792928fed7b2333e8059986d728fc1d969329edf29f21fc0c4d",
+        "environment/task.json": "f4729aa0c1c7fa376a9a677658ec84bf319207e5b55081527ac9e99e7343e5f1",
+        "environment/test_initial_state.py": "3add0daf0c9d460073b9870bb62f2a3526b2186656dde56e9faa0c7627e17b3f",
+        "instruction.md": "bfec0e2a6f991a3e39d6a78c650691de361046e07c8dbdaa626f66e54427511f",
+        "solution/solve.sh": "0a73f645db45cfe6ab342d67ad399e11f59f517432c8ab5387447b00e1df030d",
+        "task.toml": "5e8c77884777068ff42eeac6cccbaa5336c212e92137649eecc38f31dcd11d6d",
+        "tests/test.sh": "52d87e5cb768634d6a7bda203b72ea77c802fdb9e8700d3d7cdcf631080c3298",
+        "tests/test_final_state.py": "8d6400bcb84c0587766bc6ff8888c26e034d4d9715f16c8241f304e2dad0b861"
+      },
+      "protected_sources": {
+        "/home/user/log_samples/auth.log": "a064d5486f484caaff6c77987140df12318caef4e87c464245ac50c8607a6f89"
+      },
+      "corrupted_output_probe": "/home/user/sec_reports/filtered_auth.log"
+    }
+  ]
+}

--- a/examples/endless_terminals/tests/test_baseline.py
+++ b/examples/endless_terminals/tests/test_baseline.py
@@ -1,0 +1,438 @@
+"""Check immutable sampling, budget coverage, qualification, and cleanup."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+from uuid import UUID
+
+import baseline as workflow
+import pytest
+from pydantic import ValidationError
+
+from zenml.models import ArtifactVersionResponse
+
+
+def baseline_config() -> workflow.BaselineConfig:
+    """Return a small representative fixed-protocol configuration.
+
+    Returns:
+        Two-task baseline settings without external resources.
+    """
+    image = "registry/image@sha256:" + "a" * 64
+    return workflow.BaselineConfig(
+        controller_image=image,
+        task_ids=["one", "two"],
+        sandbox={"helper_image": image},
+        service={"training_image": image},
+        modal_agent_images={
+            "one": image,
+            "two": "registry/two@sha256:" + "b" * 64,
+        },
+    )
+
+
+def install_runtime(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Replace external services while preserving executor control flow.
+
+    Args:
+        monkeypatch: Scoped replacements.
+
+    Returns:
+        Inspectable runtime doubles and qualified task evidence.
+    """
+    tasks: list[dict[str, Any]] = [
+        {
+            "task_id": name,
+            "dataset_revision": "c" * 40,
+            "task_file_sha256": {},
+            "image_ref": "registry/" + name + "@sha256:" + "a" * 64,
+        }
+        for name in ("one", "two")
+    ]
+
+    def initial(task: dict[str, Any]) -> dict[str, Any]:
+        """Return clean initial-state qualification evidence.
+
+        Args:
+            task: Immutable task identity.
+
+        Returns:
+            Passing initial-state result.
+        """
+        return {
+            "task": task,
+            "cleanup_complete": True,
+            "grading": {"audited_valid": True},
+        }
+
+    reference = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {"raw_reward": 1, "audited_valid": True},
+    }
+    noop = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {
+            "raw_reward": 0,
+            "audited_valid": False,
+            "test_counts": {"failure": 1},
+        },
+    }
+    qualification = {
+        "qualified": ["one", "two"],
+        "rejected": [],
+        "tasks": [
+            {
+                "task": task,
+                "qualified": True,
+                "initial": initial(task),
+                "reference": reference,
+                "noop": noop,
+            }
+            for task in tasks
+        ],
+    }
+    session = Mock()
+    session.__enter__ = Mock(return_value=session)
+    session.__exit__ = Mock(return_value=False)
+    session.serving_seconds_remaining = 5000
+    session.base_url = "https://service.example"
+    session.api_key = "private"
+    session.service_host = "service.example"
+    session.identity = {"backend": "test"}
+    session.cleanup_report = {"complete": True}
+    constructor = Mock(return_value=session)
+    policy = Mock(optimizer_steps=0)
+    snapshot = {
+        "identity": {"optimizer_steps": 0, "path": "unchanged"},
+        "client": object(),
+    }
+    policy.snapshot.return_value = snapshot
+    calls: list[tuple[str, Path]] = []
+
+    def episode(
+        task: dict[str, Any],
+        directory: Path,
+        model: Any,
+        output: Path,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        calls.append((task["task_id"], output))
+        return {
+            "task_id": task["task_id"],
+            "cleanup_complete": True,
+            "grading": {
+                "audited_valid": task["task_id"] == "one",
+                "raw_reward": int(task["task_id"] == "one"),
+            },
+            "turns": [],
+            "exit_reason": "done",
+        }
+
+    monkeypatch.setattr(workflow, "ModalTrainingService", constructor)
+    monkeypatch.setattr(workflow, "TinkerPolicy", Mock(return_value=policy))
+    monkeypatch.setattr(
+        workflow,
+        "load_bundle_task",
+        lambda bundle, settings: next(
+            task for task in tasks if task["task_id"] == settings.task_ids[0]
+        ),
+    )
+    monkeypatch.setattr(workflow, "run_episode", episode)
+    monkeypatch.setattr(workflow, "save_artifact", Mock())
+    return SimpleNamespace(
+        session=session,
+        constructor=constructor,
+        policy=policy,
+        qualification=qualification,
+        calls=calls,
+    )
+
+
+def test_round_robin_never_updates_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every task receives three independent attempts from one unchanged sampler.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    result = workflow.execute_baseline(
+        tmp_path,
+        runtime.qualification,
+        baseline_config(),
+        "run",
+        tmp_path / "output",
+    )
+    assert [task for task, _ in runtime.calls] == ["one", "two"] * 3
+    assert len({path for _, path in runtime.calls}) == 6
+    assert result["status"] == "completed"
+    assert result["summary"]["tasks"]["one"]["passes"] == 3
+    assert result["summary"]["tasks"]["two"]["failures"] == 3
+    runtime.policy.snapshot.assert_called_once()
+    runtime.policy.update.assert_not_called()
+    runtime.policy.download_checkpoint.assert_not_called()
+    assert (
+        len(
+            {
+                id(call.args[0])
+                for call in runtime.policy.episode_model.call_args_list
+            }
+        )
+        == 1
+    )
+
+
+def test_deadline_retains_unattempted_coverage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exhausted service budget returns explicit partial evidence.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    runtime.session.serving_seconds_remaining = 389
+    result = workflow.execute_baseline(
+        tmp_path,
+        runtime.qualification,
+        baseline_config(),
+        "run",
+        tmp_path / "output",
+    )
+    assert result["status"] == "bounded_partial"
+    assert len(result["unattempted"]) == 6
+    assert not runtime.calls
+    assert result["cleanup"]["complete"] is True
+    assert (
+        json.loads((tmp_path / "output/evaluation.json").read_text())["status"]
+        == "bounded_partial"
+    )
+
+
+@pytest.mark.parametrize("failure", ["qualification", "identity"])
+def test_qualification_failure_prevents_gpu(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    """Rejected or altered tasks cannot allocate a GPU service.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+        failure: Failure case under test.
+    """
+    runtime = install_runtime(monkeypatch)
+    if failure == "qualification":
+        runtime.qualification["tasks"][0]["initial"]["cleanup_complete"] = (
+            False
+        )
+    else:
+        runtime.qualification["tasks"][0]["task"] = {
+            **runtime.qualification["tasks"][0]["task"],
+            "image_ref": "changed",
+        }
+    with pytest.raises(RuntimeError, match="GPU service was not started"):
+        workflow.execute_baseline(
+            tmp_path,
+            runtime.qualification,
+            baseline_config(),
+            "run",
+            tmp_path / "output",
+        )
+    runtime.constructor.assert_not_called()
+
+
+def test_cleanup_failure_is_not_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Incomplete GPU cleanup fails after durable evidence is written.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    runtime.session.cleanup_report = {"complete": False}
+    with pytest.raises(RuntimeError, match="cleanup incomplete"):
+        workflow.execute_baseline(
+            tmp_path,
+            runtime.qualification,
+            baseline_config(),
+            "run",
+            tmp_path / "output",
+        )
+    evidence = json.loads((tmp_path / "output/evaluation.json").read_text())
+    assert evidence["status"] == "failed"
+    assert len(evidence["episodes"]) == 6
+
+
+def test_provider_exception_retains_partial_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected provider failure preserves coverage and closes the service.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    monkeypatch.setattr(
+        workflow,
+        "run_episode",
+        Mock(side_effect=RuntimeError("provider unavailable")),
+    )
+    with pytest.raises(RuntimeError, match="provider unavailable"):
+        workflow.execute_baseline(
+            tmp_path,
+            runtime.qualification,
+            baseline_config(),
+            "run",
+            tmp_path / "output",
+        )
+    runtime.session.__exit__.assert_called_once()
+    evidence = json.loads((tmp_path / "output/evaluation.json").read_text())
+    assert evidence["status"] == "failed"
+    assert len(evidence["unattempted"]) == 6
+    assert evidence["cleanup"]["complete"] is False
+    assert evidence["cleanup"]["interrupted_attempt"] == {
+        "task_id": "one",
+        "attempt_index": 1,
+    }
+
+
+def test_task_images_and_protocol_are_validated() -> None:
+    """Task overrides remain distinct and immutable sampling limits are enforced."""
+    config = baseline_config()
+    assert (
+        config.task_config("one").modal_agent_image
+        == "registry/image@sha256:" + "a" * 64
+    )
+    assert (
+        config.task_config("two").modal_agent_image
+        == "registry/two@sha256:" + "b" * 64
+    )
+    with pytest.raises(ValidationError):
+        workflow.BaselineConfig.model_validate(
+            {**config.model_dump(), "temperature": 1.0}
+        )
+    with pytest.raises(ValidationError):
+        workflow.BaselineConfig.model_validate(
+            {
+                **config.model_dump(),
+                "modal_agent_images": {"one": "mutable:latest"},
+            }
+        )
+
+
+def test_graph_requires_qualification(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Compile the real artifact dependency that gates GPU allocation.
+
+    Args:
+        monkeypatch: Scoped runtime replacements.
+    """
+    identifier = UUID("11111111-1111-4111-8111-111111111111")
+    artifact = ArtifactVersionResponse.model_construct(id=identifier)
+    monkeypatch.setattr(
+        workflow,
+        "Client",
+        lambda: SimpleNamespace(get_artifact_version=lambda _: artifact),
+    )
+    pipeline = workflow.endless_terminals_modal_baseline.with_options()
+    pipeline.prepare(bundle_artifact_id=identifier, config=baseline_config())
+    assert set(pipeline.invocations) == {
+        "qualify_baseline_tasks",
+        "evaluate_baseline",
+    }
+    assert (
+        "qualification"
+        in pipeline.invocations["evaluate_baseline"].input_artifacts
+    )
+
+
+def test_rejected_task_is_excluded_after_clean_qualification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad reference excludes that task while clean tasks remain eligible.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    runtime.qualification["tasks"][0]["reference"] = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {"raw_reward": 0, "audited_valid": False},
+    }
+    result = workflow.execute_baseline(
+        tmp_path,
+        runtime.qualification,
+        baseline_config(),
+        "run",
+        tmp_path / "output",
+    )
+    assert result["selected_task_ids"] == ["two"]
+    assert [task for task, _ in runtime.calls] == ["two"] * 3
+
+
+def test_infrastructure_episode_is_separate_from_task_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid grading cannot become a task failure or pass.
+
+    Args:
+        tmp_path: Isolated evidence directory.
+        monkeypatch: Scoped runtime replacements.
+    """
+    runtime = install_runtime(monkeypatch)
+    monkeypatch.setattr(
+        workflow,
+        "run_episode",
+        lambda task, *args, **kwargs: {
+            "task_id": task["task_id"],
+            "cleanup_complete": True,
+            "exit_reason": "provider_error",
+            "infrastructure_error": "provider unavailable",
+        },
+    )
+    result = workflow.execute_baseline(
+        tmp_path,
+        runtime.qualification,
+        baseline_config(),
+        "run",
+        tmp_path / "output",
+    )
+    assert result["summary"]["infrastructure_errors"] == 6
+    assert result["summary"]["failures"] == 0
+    assert result["summary"]["passes"] == 0
+    report = (tmp_path / "output/report.html").read_text()
+    assert "one / attempt 1" in report
+    assert "Unattempted" in report
+
+
+@pytest.mark.parametrize("field", ["modal_workspace", "modal_environment"])
+def test_modal_baseline_identity_must_agree(field: str) -> None:
+    """Require one workspace and environment throughout baseline execution.
+
+    Args:
+        field: Sandbox identity field to mismatch.
+    """
+    values = baseline_config().model_dump()
+    values["service"].update(
+        workspace="external-team", modal_environment="research"
+    )
+    values["sandbox"].update(
+        modal_workspace="external-team", modal_environment="research"
+    )
+    config = workflow.BaselineConfig.model_validate(values)
+    assert config.task_config("one").modal_workspace == "external-team"
+    assert config.task_config("one").modal_environment == "research"
+    values["sandbox"][field] = "other"
+    with pytest.raises(ValidationError, match="must match"):
+        workflow.BaselineConfig.model_validate(values)

--- a/examples/endless_terminals/tests/test_cloud.py
+++ b/examples/endless_terminals/tests/test_cloud.py
@@ -1,0 +1,410 @@
+"""Cloud lifecycle ownership and failure-path checks without cloud access."""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from cloud import KubernetesInference
+
+
+@pytest.fixture
+def session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> KubernetesInference:
+    """Build a session using fake executable paths.
+
+    Args:
+        tmp_path: Evidence directory supplied by pytest.
+        monkeypatch: Scoped patch helper.
+
+    Returns:
+        A configured session that has made no cloud calls.
+    """
+    monkeypatch.setattr("shutil.which", lambda name: "/fake/" + name)
+    return KubernetesInference(
+        {
+            "aws_profile": "test",
+            "aws_region": "test-region",
+            "kube_context": "test-context",
+            "namespace": "test-namespace",
+            "gpu_asg": "test-group",
+            "vllm_image": "vllm@sha256:" + "a" * 64,
+        },
+        {"name": "model", "revision": "b" * 40},
+        "test-run",
+        tmp_path,
+    )
+
+
+def test_collision_does_not_delete_or_terminate(
+    session: KubernetesInference,
+) -> None:
+    """A same-name job owned by someone else prevents any destructive call.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session._job = Mock(  # type: ignore[method-assign]
+        return_value={
+            "metadata": {"uid": "other", "labels": {"endless-owner": "other"}}
+        }
+    )
+    session._kube = Mock(return_value="logs")  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="ownership token"):
+        session._cleanup()
+    session._gpu_cleanup.assert_not_called()
+    assert all(
+        call.args[0] != "delete" for call in session._kube.call_args_list
+    )
+
+
+def test_log_failure_does_not_prevent_cleanup(
+    session: KubernetesInference,
+) -> None:
+    """Diagnostics cannot prevent job deletion or worker termination.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session._kube = Mock(side_effect=RuntimeError("logs unavailable"))  # type: ignore[method-assign]
+    session._delete_job = Mock()  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    session._cleanup()
+    session._delete_job.assert_called_once()
+    session._gpu_cleanup.assert_called_once()
+    assert session.cleanup_report["complete"]
+    assert "logs unavailable" in session.cleanup_report["diagnostic_error"]
+
+
+def test_cleanup_failure_propagates(session: KubernetesInference) -> None:
+    """An incomplete teardown is never reported as a successful session.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session._kube = Mock(return_value="logs")  # type: ignore[method-assign]
+    session._delete_job = Mock()  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock(side_effect=RuntimeError("instance remains"))  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="instance remains"):
+        session.__exit__(None, None, None)
+    assert not session.cleanup_report["complete"]
+
+
+def test_forward_failure_does_not_skip_worker_cleanup(
+    session: KubernetesInference,
+) -> None:
+    """Port-forward shutdown and GPU cleanup fail independently.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session.forward = Mock()
+    session._stop = Mock(side_effect=RuntimeError("forward stuck"))  # type: ignore[method-assign]
+    session._kube = Mock(return_value="logs")  # type: ignore[method-assign]
+    session._delete_job = Mock()  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="forward stuck"):
+        session._cleanup()
+    session._gpu_cleanup.assert_called_once()
+
+
+def test_delete_has_uid_precondition(session: KubernetesInference) -> None:
+    """The API receives a UID precondition protecting replacement jobs.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    import json
+
+    session._job = Mock(  # type: ignore[method-assign]
+        side_effect=[
+            {
+                "metadata": {
+                    "uid": "owned-uid",
+                    "labels": {"endless-owner": session.token},
+                }
+            },
+            None,
+        ]
+    )
+    session._pods = Mock(return_value=[])  # type: ignore[method-assign]
+    session._kube = Mock(return_value="")  # type: ignore[method-assign]
+    session._delete_job()
+    body = json.loads((session.directory / "delete-options.json").read_text())
+    assert body["preconditions"] == {"uid": "owned-uid"}
+    assert session._kube.call_args.args[:2] == ("delete", "--raw")
+
+
+def test_remaining_serving_time_includes_startup(
+    session: KubernetesInference, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Startup consumes the same finite lifetime as episode execution.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+        monkeypatch: Scoped clock patch helper.
+    """
+    assert session.serving_seconds_remaining == 0
+    session._serving_deadline = 2700.0
+    monkeypatch.setattr("cloud.time.monotonic", lambda: 900.0)
+    assert session.serving_seconds_remaining == 1800.0
+    monkeypatch.setattr("cloud.time.monotonic", lambda: 2800.0)
+    assert session.serving_seconds_remaining == 0
+
+
+def test_manifest_supports_tainted_gpu_nodes_and_shared_memory(
+    session: KubernetesInference,
+) -> None:
+    """Serving can schedule on the GPU pool with sufficient shared memory.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    pod = session._manifest()["spec"]["template"]["spec"]
+    assert pod["tolerations"] == [
+        {
+            "key": "pool",
+            "operator": "Equal",
+            "value": "gpu",
+            "effect": "NoSchedule",
+        }
+    ]
+    assert pod["volumes"] == [
+        {"name": "shm", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}}
+    ]
+    container = pod["containers"][0]
+    assert container["volumeMounts"] == [
+        {"name": "shm", "mountPath": "/dev/shm"}
+    ]
+    assert "--disable-log-requests" in container["args"]
+    assert container["readinessProbe"]["exec"]["command"][0] == "python3"
+    session.config["tolerations"] = []
+    assert session._manifest()["spec"]["template"]["spec"]["tolerations"] == []
+
+
+def test_skyrl_manifest_uses_training_entrypoint(
+    session: KubernetesInference,
+) -> None:
+    """SkyRL receives pinned weights through its own entrypoint.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    config = {
+        **session.config,
+        "server_kind": "skyrl",
+        "training_image": "trainer@sha256:" + "c" * 64,
+    }
+    del config["vllm_image"]
+    training = KubernetesInference(
+        config, session.model, "training", session.directory
+    )
+    container = training._manifest()["spec"]["template"]["spec"]["containers"][
+        0
+    ]
+    assert container["image"] == config["training_image"]
+    assert "args" not in container
+    assert container["env"] == [
+        {"name": "SKYRL_MODEL_NAME", "value": "model"},
+        {"name": "SKYRL_DUMP_INFRA_LOG_TO_STDOUT", "value": "1"},
+        {
+            "name": "RAY_DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES",
+            "value": "1073741824",
+        },
+        {"name": "SKYRL_MODEL_REVISION", "value": "b" * 40},
+    ]
+    assert (
+        "/api/v1/healthz" in container["readinessProbe"]["exec"]["command"][-1]
+    )
+    assert training.identity["server_kind"] == "skyrl"
+    config["training_image"] = "trainer:latest"
+    with pytest.raises(ValueError, match="training_image"):
+        KubernetesInference(
+            config, session.model, "training", session.directory
+        )
+
+
+def test_skyrl_checks_downloaded_model_identity(
+    session: KubernetesInference, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Healthy API with the wrong downloaded weights is rejected.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+        monkeypatch: Scoped HTTP patch helper.
+    """
+    import json
+    from unittest.mock import MagicMock
+
+    session.server_kind = "skyrl"
+    session.base_url = "http://127.0.0.1:8000"
+    monkeypatch.setattr("cloud.urllib.request.urlopen", MagicMock())
+    session._kube = Mock(  # type: ignore[method-assign]
+        return_value=json.dumps(
+            {
+                "model_name": "model",
+                "model_revision": "wrong",
+            }
+        )
+    )
+    with pytest.raises(RuntimeError, match="model identity mismatch"):
+        session._verify_server()
+    session._kube = Mock(  # type: ignore[method-assign]
+        return_value=json.dumps(
+            {
+                "model_name": "model",
+                "model_revision": "b" * 40,
+            }
+        )
+    )
+    session._verify_server()
+    assert session.identity["training_server"]["model_revision"] == "b" * 40
+
+
+def test_skyrl_worker_diagnostic_failure_does_not_block_cleanup(
+    session: KubernetesInference,
+) -> None:
+    """A timed-out worker-log capture must still delete the job and GPU worker.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session.server_kind = "skyrl"
+    session._kube = Mock(return_value="API logs")  # type: ignore[method-assign]
+    session._capture_training_logs = Mock(  # type: ignore[method-assign]
+        side_effect=TimeoutError("diagnostic deadline")
+    )
+    session._delete_job = Mock()  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    session._cleanup()
+    session._delete_job.assert_called_once()
+    session._gpu_cleanup.assert_called_once()
+    assert session.cleanup_report["complete"] is True
+    assert (
+        "diagnostic deadline"
+        in session.cleanup_report["training_diagnostic_error"]
+    )
+
+
+def test_worker_diagnostics_are_bounded_and_captured_before_delete(
+    session: KubernetesInference,
+) -> None:
+    """Collect owned SkyRL log tails before any destructive cleanup operation.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session.server_kind = "skyrl"
+    session._job = Mock(  # type: ignore[method-assign]
+        return_value={
+            "metadata": {
+                "uid": "owned",
+                "labels": {"endless-owner": session.token},
+            }
+        }
+    )
+    session._kube = Mock(return_value="API logs")  # type: ignore[method-assign]
+    session._call = Mock(return_value='{"log_tails": {}}')  # type: ignore[method-assign]
+
+    def delete() -> None:
+        assert (session.directory / "training-worker-logs.json").exists()
+
+    session._delete_job = Mock(side_effect=delete)  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    session._cleanup()
+    assert session._call.call_args.kwargs["timeout"] == 20
+    command = session._call.call_args.args[0]
+    assert command[-3:-1] == ["python3", "-c"]
+    assert "/tmp/skyrl-logs" in command[-1]
+    assert "/tmp/ray/session_latest/logs" in command[-1]
+    assert "65536" in command[-1]
+    session._delete_job.assert_called_once()
+
+
+def test_vllm_cleanup_does_not_request_worker_files(
+    session: KubernetesInference,
+) -> None:
+    """Keep ordinary vLLM cleanup independent of SkyRL's filesystem layout.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+    """
+    session.attempted = True
+    session._kube = Mock(return_value="API logs")  # type: ignore[method-assign]
+    session._capture_training_logs = Mock()  # type: ignore[method-assign]
+    session._delete_job = Mock()  # type: ignore[method-assign]
+    session._gpu_cleanup = Mock()  # type: ignore[method-assign]
+    session._cleanup()
+    session._capture_training_logs.assert_not_called()
+
+
+def test_remote_collector_retains_memory_and_actor_death_evidence(
+    session: KubernetesInference,
+    tmp_path: Path,
+) -> None:
+    """Run the collector locally with enough worker logs to crowd out diagnostics.
+
+    Args:
+        session: Isolated cloud session with mocked operations.
+        tmp_path: Temporary stand-in for remote logs and cgroup files.
+    """
+    import json
+    import subprocess
+    import sys
+
+    ray = tmp_path / "ray"
+    ray.mkdir()
+    cgroup = tmp_path / "cgroup"
+    cgroup.mkdir()
+    critical = ["raylet.out", "raylet.err", "gcs_server.out", "gcs_server.err"]
+    for name in critical:
+        (ray / name).write_text(
+            "Actor died: worker killed by memory monitor\n"
+        )
+    for index in range(30):
+        (ray / f"python-core-worker-{index:02d}.log").write_text(
+            "ordinary worker output\n"
+        )
+    for name in (
+        "memory.events",
+        "memory.current",
+        "memory.peak",
+        "memory.max",
+    ):
+        (cgroup / name).write_text(
+            "oom_kill 1\n" if name == "memory.events" else "1073741824\n"
+        )
+    session._job = Mock(  # type: ignore[method-assign]
+        return_value={
+            "metadata": {
+                "uid": "owned",
+                "labels": {"endless-owner": session.token},
+            }
+        }
+    )
+    session._call = Mock(return_value="{}")  # type: ignore[method-assign]
+    session._capture_training_logs()
+    script = session._call.call_args.args[0][-1]
+    script = script.replace("/tmp/skyrl-logs", str(tmp_path / "absent"))
+    script = script.replace("/tmp/ray/session_latest/logs", str(ray))
+    script = script.replace("/sys/fs/cgroup", str(cgroup))
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=5,
+    )
+    logs = json.loads(completed.stdout)["log_tails"]
+    assert all(str(ray / name) in logs for name in critical)
+    assert "Actor died" in logs[str(ray / "gcs_server.out")]
+    assert logs[str(cgroup / "memory.events")] == "oom_kill 1\n"
+    assert len(logs) <= 20
+    assert sum(len(value.encode()) for value in logs.values()) <= 1048576

--- a/examples/endless_terminals/tests/test_dataset.py
+++ b/examples/endless_terminals/tests/test_dataset.py
@@ -1,0 +1,131 @@
+"""Qualification checks distinguish invalid output from broken verification."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import dataset
+import pytest
+
+Qualification = tuple[
+    dict[str, Any], Path, list[dict[str, Any]], MagicMock, MagicMock
+]
+
+
+def grade(valid: bool) -> dict[str, Any]:
+    """Build a verifier outcome for qualification tests.
+
+    Args:
+        valid: Whether the final state passes its verifier.
+
+    Returns:
+        A complete mocked verifier result.
+    """
+    return {
+        "raw_reward": int(valid),
+        "audited_valid": valid,
+        "infrastructure_error": None,
+        "protected_sources": {},
+        "test_counts": {
+            "total": 2,
+            "failure": int(not valid),
+            "error": 0,
+            "skipped": 0,
+        },
+    }
+
+
+@pytest.fixture
+def qualification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Qualification:
+    """Provide four isolated mock environments and their grading results.
+
+    Args:
+        tmp_path: Temporary task directory.
+        monkeypatch: Scoped patch helper.
+
+    Returns:
+        Task, directory, grading results, environment constructor, and verifier.
+    """
+    solution = tmp_path / "solution"
+    solution.mkdir()
+    (solution / "solve.sh").write_text("echo reference")
+    environments = [MagicMock() for _ in range(4)]
+    for env in environments:
+        env.__enter__.return_value = env
+        env.execute.return_value = (True, "")
+    constructor = MagicMock(side_effect=environments)
+    monkeypatch.setattr(dataset, "DockerEnvironment", constructor)
+    grades = [grade(True), grade(False), grade(True), grade(False)]
+    verifier = MagicMock(side_effect=grades)
+    monkeypatch.setattr(dataset, "grade_environment", verifier)
+    task = {
+        "task_id": "task-a",
+        "local_image_id": "image-id",
+        "corrupted_output_probe": "/home/user/report.txt",
+    }
+    return task, tmp_path, grades, constructor, verifier
+
+
+def test_qualification_requires_corrupted_output_rejection(
+    qualification: Qualification,
+) -> None:
+    """Use a fresh reference-plus-corruption environment after reference success.
+
+    Args:
+        qualification: Mock qualification fixture.
+    """
+    task, directory, _, constructor, verifier = qualification
+    results = dataset.qualify_task(task, directory)
+    assert list(results) == ["initial", "noop", "reference", "corrupted"]
+    assert constructor.call_count == 4
+    corrupt_env = verifier.call_args_list[-1].args[0]
+    commands = [call.args[0] for call in corrupt_env.execute.call_args_list]
+    assert commands == [
+        "echo reference",
+        "printf 'INVALID_OUTPUT\\n' > /home/user/report.txt",
+    ]
+    corrupt_env.__exit__.assert_called_once()
+
+
+@pytest.mark.parametrize("phase", [1, 3])
+@pytest.mark.parametrize(
+    "defect", ["error", "skipped", "no_failure", "accepted", "source_mutation"]
+)
+def test_rejects_invalid_negative_probe(
+    qualification: Qualification, phase: int, defect: str
+) -> None:
+    """Reject accepted corruption and verifier failures that are not assertions.
+
+    Args:
+        qualification: Mock qualification fixture.
+        phase: Negative qualification phase index.
+        defect: Verifier outcome that must invalidate qualification.
+    """
+    task, directory, grades, _, _ = qualification
+    if defect in ("error", "skipped"):
+        grades[phase]["test_counts"][defect] = 1
+    elif defect == "no_failure":
+        grades[phase]["test_counts"]["failure"] = 0
+    elif defect == "source_mutation":
+        grades[phase]["protected_sources"] = {"source": {"unchanged": False}}
+    else:
+        grades[phase].update(raw_reward=1, audited_valid=True)
+    with pytest.raises(RuntimeError):
+        dataset.qualify_task(task, directory)
+
+
+def test_rejects_missing_corruption_probe(
+    qualification: Qualification,
+) -> None:
+    """Fail before containers start when the reviewed probe is absent.
+
+    Args:
+        qualification: Mock qualification fixture.
+    """
+    task, directory, _, constructor, _ = qualification
+    task.pop("corrupted_output_probe")
+    with pytest.raises(RuntimeError, match="corruption probe"):
+        dataset.qualify_task(task, directory)
+    constructor.assert_not_called()

--- a/examples/endless_terminals/tests/test_modal_service.py
+++ b/examples/endless_terminals/tests/test_modal_service.py
@@ -1,0 +1,552 @@
+"""Verify Modal service authentication, endpoint trust, and failure cleanup."""
+
+import http.client
+import json
+import threading
+from email.message import Message
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from modal_service import (
+    PROXY_SOURCE,
+    ModalServiceConfig,
+    ModalTrainingService,
+)
+from training_client import validate_training_url
+
+
+def service(tmp_path: Path) -> ModalTrainingService:
+    """Construct an offline service for lifecycle tests.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+
+    Returns:
+        An unstarted Modal training service.
+    """
+    return ModalTrainingService(
+        ModalServiceConfig(training_image="registry/train@sha256:" + "a" * 64),
+        {"name": "Qwen/model", "revision": "b" * 40},
+        "run",
+        tmp_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "url", ["https://sb-test.modal.host", "https://sb-test.modal.host:443"]
+)
+def test_owned_modal_https_origin(url: str) -> None:
+    """Accept only HTTPS to the exact tunnel supplied by the service.
+
+    Args:
+        url: Owned HTTPS tunnel origin.
+    """
+    validate_training_url(url, "sb-test.modal.host")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://sb-test.modal.host",
+        "https://other.modal.host",
+        "https://sb-test.modal.host:8001",
+        "https://sb-test.modal.host.evil.example",
+        "https://sb-test.modal.host/path",
+        "https://key@sb-test.modal.host",
+        "https://sb-test.modal.host?key=secret",
+    ],
+)
+def test_reject_changed_modal_origin(url: str) -> None:
+    """Prevent credentials from being sent to a substituted endpoint.
+
+    Args:
+        url: Invalid or substituted tunnel origin.
+    """
+    with pytest.raises(ValueError):
+        validate_training_url(url, "sb-test.modal.host")
+
+
+def test_failed_start_terminates_and_records_cleanup(tmp_path: Path) -> None:
+    """A failure after allocation still terminates the owned GPU sandbox.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    instance = service(tmp_path)
+    sandbox = MagicMock()
+    sandbox.poll.return_value = 0
+
+    def fail() -> None:
+        instance._sandbox = sandbox
+        raise RuntimeError("startup failed")
+
+    with (
+        patch.object(instance, "_start", side_effect=fail),
+        patch.object(instance, "_exec", return_value="diagnostics"),
+    ):
+        with pytest.raises(RuntimeError, match="startup failed"):
+            with instance:
+                pass
+    sandbox.terminate.assert_called_once()
+    assert json.loads((tmp_path / "native-service-cleanup.json").read_text())[
+        "complete"
+    ]
+
+
+def test_failed_termination_is_not_success(tmp_path: Path) -> None:
+    """Termination errors remain visible and retryable.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    instance = service(tmp_path)
+    instance._sandbox = MagicMock()
+    instance._sandbox.terminate.side_effect = RuntimeError("cannot terminate")
+    with patch.object(instance, "_exec", return_value="diagnostics"):
+        with pytest.raises(RuntimeError, match="cleanup incomplete"):
+            instance.__exit__(None, None, None)
+    assert not instance.cleanup_report["complete"]
+    assert not instance._closed
+
+
+def test_evidence_redacts_api_key(tmp_path: Path) -> None:
+    """Neither diagnostics nor serialized structures expose the service key.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    instance = service(tmp_path)
+    instance._write("evidence.json", {"error": instance.api_key})
+    assert instance.api_key not in (tmp_path / "evidence.json").read_text()
+
+
+def test_proxy_authenticates_and_streams_without_forwarding_key() -> None:
+    """Exercise the actual proxy against a local HTTP backend."""
+    observed = []
+
+    class Backend(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            observed.append(dict(self.headers))
+            payload = b"checkpoint" * 200000
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    backend = ThreadingHTTPServer(("127.0.0.1", 0), Backend)
+    backend_thread = threading.Thread(
+        target=backend.serve_forever, daemon=True
+    )
+    backend_thread.start()
+    namespace: dict[str, Any] = {}
+    code = PROXY_SOURCE.replace(
+        "8000, timeout=600", f"{backend.server_port}, timeout=600"
+    ).replace(
+        'ThreadingHTTPServer(("0.0.0.0", 8001), Handler).serve_forever()', ""
+    )
+    with patch.dict("os.environ", {"ENDLESS_API_KEY": "test-key"}):
+        exec(compile(code, "proxy.py", "exec"), namespace)
+    proxy = ThreadingHTTPServer(("127.0.0.1", 0), namespace["Handler"])
+    proxy_thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+    proxy_thread.start()
+    try:
+        connection = http.client.HTTPConnection("127.0.0.1", proxy.server_port)
+        connection.request("GET", "/archive")
+        denied = connection.getresponse()
+        assert denied.status == 401
+        denied.read()
+        assert observed == []
+        connection.close()
+        connection = http.client.HTTPConnection("127.0.0.1", proxy.server_port)
+        connection.request(
+            "GET",
+            "/archive",
+            headers={"X-API-Key": "test-key", "Host": "owned.modal.host"},
+        )
+        response = connection.getresponse()
+        assert response.status == 200
+        assert response.read() == b"checkpoint" * 200000
+        assert "X-API-Key" not in observed[0]
+        assert observed[0]["Host"] == "owned.modal.host"
+        assert observed[0]["X-Forwarded-Proto"] == "https"
+        connection.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+        proxy.server_close()
+        backend.server_close()
+        proxy_thread.join()
+        backend_thread.join()
+
+
+def test_ready_server_identity_must_match(tmp_path: Path) -> None:
+    """HTTP health is insufficient when the service loaded another revision.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    import time
+    import urllib.error
+
+    instance = service(tmp_path)
+    instance._sandbox = MagicMock()
+    instance._sandbox.poll.return_value = None
+    instance._backend_process = MagicMock()
+    instance._backend_process.poll.return_value = None
+    instance._startup_deadline = time.monotonic() + 10
+    instance.base_url = "https://owned.modal.host"
+    response = MagicMock()
+    response.__enter__.return_value.status = 200
+    opener = MagicMock()
+    opener.open.side_effect = [
+        response,
+        urllib.error.HTTPError(
+            instance.base_url, 401, "Unauthorized", Message(), None
+        ),
+    ]
+    with (
+        patch("urllib.request.build_opener", return_value=opener),
+        patch.object(
+            instance, "_exec", return_value=json.dumps({"model_name": "wrong"})
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="identity mismatch"):
+            instance._wait_ready()
+
+
+def test_uncertain_allocation_does_not_claim_cleanup(tmp_path: Path) -> None:
+    """A lost allocation response must not be reported as confirmed cleanup.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    instance = service(tmp_path)
+
+    def fail_after_request() -> None:
+        instance._allocation_attempted = True
+        raise TimeoutError("allocation response lost")
+
+    with patch.object(instance, "_start", side_effect=fail_after_request):
+        with pytest.raises(TimeoutError, match="response lost"):
+            with instance:
+                pass
+    report = json.loads((tmp_path / "native-service-cleanup.json").read_text())
+    assert not report["complete"]
+    assert instance.name in report["errors"][0]
+
+
+@pytest.mark.parametrize("imported_image_id", [None, "im-VerifiedImport123"])
+@pytest.mark.parametrize(
+    "identity", [("zenml-io", "dev"), ("external-team", "research")]
+)
+def test_start_uploads_current_sources_through_filesystem(
+    tmp_path: Path,
+    imported_image_id: str | None,
+    identity: tuple[str, str],
+) -> None:
+    """Upload exact source contents without calling the removed file API.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+        imported_image_id: Explicit previously verified image ID, if reused.
+        identity: Expected workspace and environment.
+    """
+    import hashlib
+    import time
+
+    from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+
+    instance = service(tmp_path)
+    instance.config = instance.config.model_copy(
+        update={
+            "imported_image_id": imported_image_id,
+            "workspace": identity[0],
+            "modal_environment": identity[1],
+        }
+    )
+    instance._deadline = time.monotonic() + 5400
+    component = MagicMock(spec=ModalSandbox)
+    component.config.modal_environment = identity[1]
+    component.config.app_name = "test-app"
+    stack = MagicMock()
+    stack.sandbox = component
+    sandbox = MagicMock()
+    sandbox.object_id = "sb-test"
+    sandbox.tunnels.return_value = {
+        8001: MagicMock(url="https://random.w.modal.host")
+    }
+    workspace = MagicMock()
+    workspace.hydrate.return_value.name = identity[0]
+    with (
+        patch("zenml.client.Client") as client,
+        patch("modal.Workspace.from_context", return_value=workspace),
+        patch("modal.Environment.from_name"),
+        patch("modal.App.lookup"),
+        patch("modal.Sandbox.create", return_value=sandbox) as sandbox_create,
+        patch("modal.Secret.from_dict"),
+        patch("modal.Image.from_id") as image_lookup,
+        patch.object(
+            type(stack),
+            "container_registry",
+            new_callable=PropertyMock,
+            create=True,
+            return_value=None,
+        ) as registry_access,
+        patch(
+            "zenml.integrations.modal.sandbox_utils.create_modal_client_from_credentials"
+        ) as modal_client,
+        patch(
+            "zenml.integrations.modal.sandbox_utils.get_modal_image_from_registry"
+        ) as registry_import,
+        patch.object(instance, "_exec", return_value="{}"),
+    ):
+        client.return_value.active_stack = stack
+        image_lookup.return_value.object_id = "im-VerifiedImport123"
+        registry_import.return_value.object_id = "im-NewImport123"
+        selected_image = (
+            image_lookup.return_value
+            if imported_image_id
+            else registry_import.return_value
+        )
+        selected_image.entrypoint.return_value.object_id = (
+            "im-EntrypointCleared123"
+        )
+        instance._start()
+        assert instance.identity["workspace"] == identity[0]
+        assert (
+            sandbox_create.call_args.kwargs["environment_name"] == identity[1]
+        )
+        selected_image.entrypoint.assert_called_once_with([])
+        assert (
+            sandbox_create.call_args.kwargs["image"]
+            is selected_image.entrypoint.return_value
+        )
+        assert instance._backend_process is sandbox.exec.return_value
+        assert "entrypoint.py" in sandbox.exec.call_args.args[2]
+        assert instance.identity["modal_image_id"] == "im-EntrypointCleared123"
+        if imported_image_id:
+            image_lookup.assert_called_once_with(
+                imported_image_id, client=modal_client.return_value
+            )
+            registry_access.assert_not_called()
+            registry_import.assert_not_called()
+            assert (
+                instance.identity["imported_modal_image_id"]
+                == imported_image_id
+            )
+            assert (
+                instance.identity["image_selection"]
+                == "explicit_operational_pairing"
+            )
+        else:
+            image_lookup.assert_not_called()
+            registry_import.assert_called_once()
+            assert (
+                instance.identity["imported_modal_image_id"]
+                == "im-NewImport123"
+            )
+    assert (
+        json.loads((tmp_path / "native-service-identity.json").read_text())[
+            "service_url"
+        ]
+        == "https://random.w.modal.host"
+    )
+    sandbox.open.assert_not_called()
+    uploaded = {
+        call.args[1]: call.args[0]
+        for call in sandbox.filesystem.write_text.call_args_list
+    }
+    assert set(uploaded) == {
+        "/tmp/terminal-training/entrypoint.py",
+        "/tmp/terminal-training/backend_config.json",
+        "/tmp/terminal-training/diagnostics.py",
+        "/tmp/terminal-training/proxy.py",
+    }
+    assert uploaded["/tmp/terminal-training/proxy.py"] == PROXY_SOURCE
+    configuration = json.loads(
+        uploaded["/tmp/terminal-training/backend_config.json"]
+    )
+    assert (
+        configuration["generator.inference_engine.gpu_memory_utilization"]
+        == 0.5
+    )
+    source = Path(__file__).parent.parent / "training_server"
+    for name in ("entrypoint.py", "diagnostics.py"):
+        assert (
+            uploaded["/tmp/terminal-training/" + name]
+            == (source / name).read_text()
+        )
+    for name, expected_hash in instance.identity["source_sha256"].items():
+        assert (
+            hashlib.sha256(
+                uploaded["/tmp/terminal-training/" + name].encode()
+            ).hexdigest()
+            == expected_hash
+        )
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "random.w.modal.host",
+        "wtqcahqwhd4tu0.r5.modal.host",
+        "random.region.relay.modal.host",
+    ],
+)
+def test_owned_multilabel_tunnel_origin(host: str) -> None:
+    """Accept the complete SDK hostname across Modal relay DNS layouts.
+
+    Args:
+        host: Valid multi-label Modal tunnel hostname.
+    """
+    validate_training_url("https://" + host, host)
+    validate_training_url("https://" + host + ":443", host)
+
+
+@pytest.mark.parametrize(
+    "url, trusted_host",
+    [
+        ("https://other.w.modal.host", "random.w.modal.host"),
+        ("http://random.w.modal.host", "random.w.modal.host"),
+        ("https://random.w.modal.host:8001", "random.w.modal.host"),
+        ("https://key@random.w.modal.host", "random.w.modal.host"),
+        (
+            "https://random.w.modal.host.evil.test",
+            "random.w.modal.host.evil.test",
+        ),
+        ("https://random.w.notmodal.host", "random.w.notmodal.host"),
+        ("https://random..modal.host", "random..modal.host"),
+        ("https://random.-w.modal.host", "random.-w.modal.host"),
+        ("https://random.w-.modal.host", "random.w-.modal.host"),
+        ("https://random.w_.modal.host", "random.w_.modal.host"),
+        ("https://" + "a" * 64 + ".w.modal.host", "a" * 64 + ".w.modal.host"),
+    ],
+)
+def test_reject_untrusted_or_malformed_multilabel_origin(
+    url: str, trusted_host: str
+) -> None:
+    """Reject host substitution, non-TLS routes and invalid DNS labels.
+
+    Args:
+        url: Candidate training endpoint.
+        trusted_host: Host supplied by the service.
+    """
+    with pytest.raises(ValueError):
+        validate_training_url(url, trusted_host)
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, 137])
+def test_ready_rejects_exited_owned_backend(
+    tmp_path: Path, exit_code: int
+) -> None:
+    """Never accept another process's healthy endpoint after our backend exits.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+        exit_code: Exit status returned by the exact launched backend process.
+    """
+    import time
+
+    instance = service(tmp_path)
+    instance._sandbox = MagicMock()
+    instance._sandbox.poll.return_value = None
+    instance._backend_process = MagicMock()
+    instance._backend_process.poll.return_value = exit_code
+    instance._startup_deadline = time.monotonic() + 10
+    with patch("urllib.request.build_opener") as opener:
+        with pytest.raises(
+            RuntimeError, match="owned training backend exited"
+        ):
+            instance._wait_ready()
+    opener.return_value.open.assert_not_called()
+
+
+def test_ready_rechecks_backend_after_identity(tmp_path: Path) -> None:
+    """A backend exit during health verification invalidates otherwise valid identity.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+    """
+    import time
+    import urllib.error
+
+    instance = service(tmp_path)
+    instance._sandbox = MagicMock()
+    instance._sandbox.poll.return_value = None
+    instance._backend_process = MagicMock()
+    instance._backend_process.poll.side_effect = [None, 1]
+    instance._startup_deadline = time.monotonic() + 10
+    instance.base_url = "https://owned.w.modal.host"
+    identity = {
+        "model_name": instance.model["name"],
+        "model_revision": instance.model["revision"],
+        "backend_config": instance._backend_config,
+        "source_sha256": instance._source_hashes,
+    }
+    response = MagicMock()
+    response.__enter__.return_value.status = 200
+    opener = MagicMock()
+    opener.open.side_effect = [
+        response,
+        urllib.error.HTTPError(
+            instance.base_url, 401, "Unauthorized", Message(), None
+        ),
+    ]
+    with (
+        patch("urllib.request.build_opener", return_value=opener),
+        patch.object(instance, "_exec", return_value=json.dumps(identity)),
+    ):
+        with pytest.raises(
+            RuntimeError, match="owned training backend exited"
+        ):
+            instance._wait_ready()
+    assert instance._backend_process.poll.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "mismatch", ["workspace", "environment", "credentials"]
+)
+def test_service_identity_mismatch_prevents_allocation(
+    tmp_path: Path, mismatch: str
+) -> None:
+    """Reject configured identity mismatches before allocating the GPU or app.
+
+    Args:
+        tmp_path: Temporary lifecycle evidence directory.
+        mismatch: Identity check to fail.
+    """
+    from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+
+    instance = service(tmp_path)
+    instance.config = instance.config.model_copy(
+        update={"workspace": "external-team", "modal_environment": "research"}
+    )
+    component = MagicMock(spec=ModalSandbox)
+    component.config.modal_environment = (
+        "other" if mismatch == "environment" else "research"
+    )
+    component.config.token_id = (
+        None if mismatch == "credentials" else "test-id"
+    )
+    component.config.token_secret = "test-secret"
+    with (
+        patch("zenml.client.Client") as client,
+        patch("modal.Workspace.from_context") as workspace,
+        patch("modal.App.lookup") as app,
+        patch("modal.Sandbox.create") as allocate,
+        patch(
+            "zenml.integrations.modal.sandbox_utils.create_modal_client_from_credentials"
+        ),
+    ):
+        client.return_value.active_stack.sandbox = component
+        workspace.return_value.hydrate.return_value.name = "wrong-team"
+        with pytest.raises(ValueError):
+            instance._start()
+        app.assert_not_called()
+        allocate.assert_not_called()

--- a/examples/endless_terminals/tests/test_modal_submission.py
+++ b/examples/endless_terminals/tests/test_modal_submission.py
@@ -1,0 +1,120 @@
+"""Check explicit Modal placement before either submission allocates resources."""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name", ["run_modal_training", "run_modal_baseline"]
+)
+@pytest.mark.parametrize(
+    "mismatch", [None, "workspace", "environment", "credentials"]
+)
+@pytest.mark.parametrize("component_index", [0, 1])
+def test_submission_checks_both_component_identities(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    mismatch: str | None,
+    component_index: int,
+) -> None:
+    """Submit custom placement only when both authenticated components agree.
+
+    Args:
+        tmp_path: Temporary bundle and configuration directory.
+        monkeypatch: Scoped external boundary replacements.
+        module_name: Training or baseline submission entry point.
+        mismatch: Optional failing identity check.
+        component_index: Orchestrator or sandbox identity to reject.
+    """
+    module = importlib.import_module(module_name)
+    values = json.loads(
+        (Path(__file__).parents[1] / "modal-training.example.json").read_text()
+    )
+    values["service"].update(
+        workspace="external-team", modal_environment="research"
+    )
+    values["sandbox"].update(
+        modal_workspace="external-team", modal_environment="research"
+    )
+    if module_name == "run_modal_baseline":
+        task_id = values["training"]["task_ids"][0]
+        values = {
+            "controller_image": values["controller_image"],
+            "task_ids": [task_id],
+            "sandbox": values["sandbox"],
+            "service": values["service"],
+            "modal_agent_images": {
+                task_id: values["sandbox"]["modal_agent_image"]
+            },
+        }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(values))
+    (tmp_path / "task-manifest.json").write_text("{}")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [module_name, "--bundle", str(tmp_path), "--config", str(config_path)],
+    )
+    monkeypatch.setattr(module, "load_bundle_task", Mock())
+    orchestrator = Mock(spec=module.ModalOrchestrator)
+    sandbox = Mock(spec=module.ModalSandbox)
+    for component in (orchestrator, sandbox):
+        component.config = SimpleNamespace(
+            modal_environment="research",
+            token_id="test-id",
+            token_secret="test-secret",
+        )
+    rejected = (orchestrator, sandbox)[component_index]
+    if mismatch == "environment":
+        rejected.config.modal_environment = "other"
+    elif mismatch == "credentials":
+        rejected.config.token_id = None
+    monkeypatch.setattr(
+        module,
+        "Client",
+        Mock(
+            return_value=SimpleNamespace(
+                active_stack=SimpleNamespace(
+                    orchestrator=orchestrator, sandbox=sandbox
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(module, "create_modal_client_from_credentials", Mock())
+    workspaces = ["external-team", "external-team"]
+    if mismatch == "workspace":
+        workspaces[component_index] = "wrong-team"
+    sdk = Mock()
+    sdk.Workspace.from_context.side_effect = [
+        Mock(hydrate=Mock(return_value=SimpleNamespace(name=name)))
+        for name in workspaces
+    ]
+    monkeypatch.setattr(module, "modal", sdk)
+    publish = Mock(return_value=SimpleNamespace(id="artifact-id"))
+    monkeypatch.setattr(module, "save_artifact", publish)
+    pipeline = Mock()
+    pipeline_name = (
+        "endless_terminals_native_training"
+        if module_name == "run_modal_training"
+        else "endless_terminals_modal_baseline"
+    )
+    monkeypatch.setattr(module, pipeline_name, pipeline)
+    if mismatch:
+        with pytest.raises(RuntimeError):
+            module.main()
+        publish.assert_not_called()
+        pipeline.with_options.assert_not_called()
+    else:
+        module.main()
+        assert sdk.Workspace.from_context.call_count == 2
+        settings = pipeline.with_options.call_args.kwargs["settings"]
+        assert settings["orchestrator"].modal_environment == "research"
+        pipeline.with_options.return_value.assert_called_once()
+        publish.assert_called_once()

--- a/examples/endless_terminals/tests/test_modal_workspace.py
+++ b/examples/endless_terminals/tests/test_modal_workspace.py
@@ -1,0 +1,389 @@
+"""Exercise Modal persistence boundaries without creating cloud resources."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+from runtime.modal_workspace import ModalWorkspace
+from runtime.sandbox_workspace import SandboxRuntimeConfig
+
+from zenml.integrations.modal.flavors.modal_sandbox_flavor import (
+    ModalSandboxConfig,
+)
+from zenml.integrations.modal.sandboxes.modal_sandbox import ModalSandbox
+
+
+def workspace(
+    monkeypatch: pytest.MonkeyPatch, sdk: Mock | None = None
+) -> ModalWorkspace:
+    """Build a workspace with fake canonical and Modal clients.
+
+    Args:
+        monkeypatch: Test patch fixture.
+        sdk: Optional complete Modal SDK substitute.
+
+    Returns:
+        Isolated workspace fixture.
+    """
+    monkeypatch.setattr(
+        "runtime.modal_workspace.create_modal_client_from_credentials",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr("runtime.modal_workspace.modal", sdk or Mock())
+    sandbox = Mock(spec=ModalSandbox)
+    sandbox.config = ModalSandboxConfig(
+        modal_environment="dev", token_id="test-id", token_secret="test-secret"
+    )
+    sandbox.environment = {}
+    sandbox.secrets = []
+    return ModalWorkspace(
+        sandbox,
+        SandboxRuntimeConfig(
+            helper_image="helper@sha256:" + "a" * 64,
+            modal_agent_image="agent@sha256:" + "b" * 64,
+        ),
+    )
+
+
+def test_volume_creation_checks_hydrated_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wrong identity must fail before any paid or persistent allocation.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    target = workspace(monkeypatch)
+    context = Mock()
+    context.hydrate.return_value = SimpleNamespace(name="personal")
+    monkeypatch.setattr(
+        "runtime.modal_workspace.modal.Workspace.from_context",
+        Mock(return_value=context),
+    )
+    create = Mock()
+    monkeypatch.setattr(
+        "runtime.modal_workspace.modal.Volume.objects.create", create
+    )
+    with pytest.raises(RuntimeError, match="zenml-io"):
+        target.create_volume()
+    create.assert_not_called()
+    context.hydrate.return_value = SimpleNamespace(name="zenml-io")
+    target.create_volume()
+    create.assert_called_once_with(
+        target.name, environment_name="dev", client=None
+    )
+
+
+def test_settings_mount_only_home_and_block_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent cannot mount the image root or inject controller credentials.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    target = workspace(monkeypatch)
+    agent = target.settings("image", "/home/user")
+    assert agent.block_network and agent.sandbox_environment == {}
+    assert agent.gpu is None
+    assert agent.volumes["/home/user"].sub_path == "/home"
+    reader = target.settings("image", "/workspace", readonly=True)
+    assert reader.volumes["/workspace"].read_only
+    assert target.settings("image", None).volumes == {}
+
+
+def test_termination_commits_before_reader_and_deletion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reader cannot start and a Volume cannot disappear before the writer stops.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    target = workspace(monkeypatch)
+    session = Mock(id="sb-writer")
+    cast(Mock, target.sandbox.create_session).return_value = session
+    target.create_session("image", "/home/user")
+    with pytest.raises(RuntimeError, match="preceding"):
+        target.create_session("image", "/workspace", True)
+    remote = Mock()
+    remote.poll.return_value = None
+    monkeypatch.setattr(
+        "runtime.modal_workspace.modal.Sandbox.from_id",
+        Mock(return_value=remote),
+    )
+    delete = Mock()
+    monkeypatch.setattr(
+        "runtime.modal_workspace.modal.Volume.objects.delete", delete
+    )
+    target.volume_created = True
+    with pytest.raises(RuntimeError, match="cleanup incomplete"):
+        target.close()
+    delete.assert_not_called()
+    assert session.id in target.sessions
+    remote.poll.return_value = 137
+    target.close()
+    remote.terminate.assert_called_with(wait=True)
+    session.close.assert_called_once()
+    delete.assert_called_once_with(
+        target.name, environment_name="dev", client=None, allow_missing=True
+    )
+    assert target.provenance["cleanup_complete"]
+
+
+def test_component_environment_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Task containers cannot inherit any stack-injected credentials.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    target = workspace(monkeypatch)
+    target.sandbox.environment = {"TOKEN": "not-a-real-token"}
+    with pytest.raises(ValueError, match="inject"):
+        ModalWorkspace(target.sandbox, target.config)
+
+
+def test_uncertain_volume_creation_is_cleaned_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lost create response must not silently leave this episode's volume behind.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    sdk = Mock()
+    target = workspace(monkeypatch, sdk)
+    sdk.Workspace.from_context.return_value.hydrate.return_value.name = (
+        "zenml-io"
+    )
+    sdk.Volume.objects.create.side_effect = TimeoutError("response lost")
+    with pytest.raises(TimeoutError):
+        target.create_volume()
+    target.close()
+    sdk.Volume.objects.delete.assert_called_once_with(
+        target.name, environment_name="dev", client=None, allow_missing=True
+    )
+
+
+def test_uncertain_session_creation_preserves_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lost sandbox handle must never produce a successful cleanup report.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    sdk = Mock()
+    target = workspace(monkeypatch, sdk)
+    target.volume_created = True
+    cast(Mock, target.sandbox.create_session).side_effect = TimeoutError(
+        "response lost"
+    )
+    with pytest.raises(TimeoutError):
+        target.create_session("image", "/home/user")
+    with pytest.raises(RuntimeError, match="reconciliation"):
+        target.close()
+    sdk.Volume.objects.delete.assert_not_called()
+    assert target.provenance["session_creation_uncertain"] is True
+    assert target.provenance["cleanup_complete"] is False
+    with pytest.raises(RuntimeError, match="preceding"):
+        target.create_session("image", "/workspace", True)
+
+
+def test_trusted_seed_and_verifier_use_explicit_shell(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Shell control operators reach a shell on every canonical backend.
+
+    Args:
+        monkeypatch: Test patch fixture.
+        tmp_path: Temporary local filesystem used to replay the seed command.
+    """
+    import io
+    import subprocess
+    import tarfile
+
+    from runtime.sandbox_env import SandboxEnvironment
+
+    env = object.__new__(SandboxEnvironment)
+    env.workspace = Mock()
+    env.command_timeout = 1
+    env.episode_timeout = 1
+    env.shell = None
+    env.agent = None
+    session = Mock(id="sandbox")
+    session.exec.return_value.collect.return_value = SimpleNamespace(
+        exit_code=0, stdout="", stderr=""
+    )
+    monkeypatch.setattr(env, "_new", lambda *args, **kwargs: session)
+    monkeypatch.setattr(env, "_archive", lambda *args: b"initial")
+    monkeypatch.setattr("runtime.sandbox_env.SandboxShell", Mock())
+    env.__enter__()
+    seed_argv = session.exec.call_args.args[0]
+    assert seed_argv[:2] == ["sh", "-c"]
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "original.txt").write_text("seeded")
+    volume = tmp_path / "volume"
+    volume.mkdir()
+    script = (
+        seed_argv[2]
+        .replace("/workspace", str(volume))
+        .replace("/home/user", str(source))
+    )
+    subprocess.run([*seed_argv[:2], script], check=True)
+    assert (volume / "home" / "original.txt").read_text() == "seeded"
+
+    monkeypatch.setattr(env, "_upload", lambda *args: None)
+    monkeypatch.setattr(env, "_download", lambda *args: b"<testsuite/>")
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w"):
+        pass
+    test_path = tmp_path / "test_final_state.py"
+    test_path.write_text("def test_state(): assert True\n")
+    env.verify_snapshot(archive.getvalue(), test_path)
+    commands = [call.args[0] for call in session.exec.call_args_list]
+    assert all(command[:2] == ["sh", "-c"] for command in commands)
+    assert any(
+        "rm -rf /home/user && mkdir" in command[2] for command in commands
+    )
+    assert any(
+        "cd /opt/endless-grader && python3" in command[2]
+        for command in commands
+    )
+
+
+def test_agent_image_only_replaces_agent_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The derived image never replaces trusted seed, reader or verifier images.
+
+    Args:
+        monkeypatch: Test patch fixture.
+    """
+    target = workspace(monkeypatch)
+    original = "original@sha256:" + "c" * 64
+    assert (
+        target.settings(original, "/home/user").image
+        == target.config.modal_agent_image
+    )
+    for mount, readonly in [
+        ("/workspace", False),
+        ("/workspace", True),
+        (None, False),
+    ]:
+        assert target.settings(original, mount, readonly).image == original
+    cast(Mock, target.sandbox.create_session).return_value = Mock(
+        id="sb-agent"
+    )
+    target.create_session(original, "/home/user")
+    assert (
+        target.provenance["sandboxes"][0]["image"]
+        == target.config.modal_agent_image
+    )
+
+
+@pytest.mark.parametrize("image", [None, "agent:latest"])
+def test_modal_agent_image_must_be_configured_and_immutable(
+    monkeypatch: pytest.MonkeyPatch, image: str | None
+) -> None:
+    """Modal allocation requires an explicitly pinned mount-compatible image.
+
+    Args:
+        monkeypatch: Test patch fixture.
+        image: Missing or mutable image reference.
+    """
+    from dataclasses import replace
+
+    target = workspace(monkeypatch)
+    with pytest.raises(ValueError, match="modal_agent_image"):
+        ModalWorkspace(
+            target.sandbox, replace(target.config, modal_agent_image=image)
+        )
+
+
+def test_custom_workspace_and_environment_reach_all_allocations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use configured identity for volumes, sessions, cleanup, and provenance.
+
+    Args:
+        monkeypatch: Scoped external SDK replacement.
+    """
+    from dataclasses import replace
+
+    sdk = Mock()
+    original = workspace(monkeypatch, sdk)
+    cast(Mock, original.sandbox).config = original.sandbox.config.model_copy(
+        update={"modal_environment": "research"}
+    )
+    target = ModalWorkspace(
+        original.sandbox,
+        replace(
+            original.config,
+            modal_workspace="external-team",
+            modal_environment="research",
+        ),
+    )
+    sdk.Workspace.from_context.return_value.hydrate.return_value.name = (
+        "external-team"
+    )
+    target.create_volume()
+    sdk.Volume.objects.create.assert_called_once_with(
+        target.name, environment_name="research", client=None
+    )
+    assert target.settings("image", None).modal_environment == "research"
+    assert target.provenance["modal_workspace"] == "external-team"
+    assert target.provenance["modal_environment"] == "research"
+    target.close()
+    sdk.Volume.objects.delete.assert_called_once_with(
+        target.name,
+        environment_name="research",
+        client=None,
+        allow_missing=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "mismatch", ["workspace", "environment", "credentials"]
+)
+def test_custom_identity_mismatch_prevents_allocation(
+    monkeypatch: pytest.MonkeyPatch, mismatch: str
+) -> None:
+    """Reject wrong credentials or environment before persistent resources exist.
+
+    Args:
+        monkeypatch: Scoped external SDK replacement.
+        mismatch: Identity check to fail.
+    """
+    from dataclasses import replace
+
+    sdk = Mock()
+    original = workspace(monkeypatch, sdk)
+    cast(Mock, original.sandbox).config = original.sandbox.config.model_copy(
+        update={
+            "modal_environment": "research"
+            if mismatch != "environment"
+            else "other",
+            "token_id": None if mismatch == "credentials" else "test-id",
+        }
+    )
+    sdk.Workspace.from_context.return_value.hydrate.return_value.name = (
+        "wrong-team"
+    )
+    with pytest.raises((RuntimeError, ValueError)):
+        target = ModalWorkspace(
+            original.sandbox,
+            replace(
+                original.config,
+                modal_workspace="external-team",
+                modal_environment="research",
+            ),
+        )
+        target.create_volume()
+    sdk.Volume.objects.create.assert_not_called()
+    cast(Mock, original.sandbox.create_session).assert_not_called()

--- a/examples/endless_terminals/tests/test_native_client.py
+++ b/examples/endless_terminals/tests/test_native_client.py
@@ -1,0 +1,433 @@
+"""Exercise authentication and bounded adapter extraction with a local server."""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import threading
+from collections.abc import Iterator
+from contextlib import nullcontext
+from http.client import IncompleteRead
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import Mock
+from urllib.error import HTTPError, URLError
+
+import pytest
+from checkpoint_download import download_archive
+from training_client import validate_training_url
+
+
+def archive_bytes(name: str, kind: bytes = tarfile.REGTYPE) -> bytes:
+    """Build an archive using the backend's root-directory convention.
+
+    Args:
+        name: Archive member path.
+        kind: Member type.
+
+    Returns:
+        Serialized tar archive.
+    """
+    data = io.BytesIO()
+    with tarfile.open(fileobj=data, mode="w") as archive:
+        root = tarfile.TarInfo(".")
+        root.type = tarfile.DIRTYPE
+        archive.addfile(root)
+        info = tarfile.TarInfo(name)
+        info.type = kind
+        info.linkname = "/tmp/escape"
+        info.size = 2 if kind == tarfile.REGTYPE else 0
+        archive.addfile(info, io.BytesIO(b"{}"))
+    return data.getvalue()
+
+
+@pytest.fixture
+def use_pyqwest_transport() -> bool:
+    """Select HTTPX unless the SDK transport parity test overrides it.
+
+    Returns:
+        Whether the client should use its Pyqwest transport.
+    """
+    return False
+
+
+@pytest.fixture
+def archive_server(
+    use_pyqwest_transport: bool,
+) -> Iterator[tuple[str, list[tuple[str, str | None]]]]:
+    """Serve test archives only when the exact API key is present.
+
+    Args:
+        use_pyqwest_transport: SDK transport selected by the client configuration.
+
+    Yields:
+        Local origin and recorded paths and credentials.
+    """
+    requests: list[tuple[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            if self.path != "/api/v1/client/config":
+                self.send_error(404)
+                return
+            if self.headers.get("X-API-Key") != "tml-test-key":
+                self.send_error(401)
+                return
+            payload = json.dumps(
+                {"use_pyqwest_transport": use_pyqwest_transport}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:
+            requests.append((self.path, self.headers.get("X-API-Key")))
+            if self.headers.get("X-API-Key") != "tml-test-key":
+                self.send_error(401)
+                return
+            if (
+                self.path
+                == "/api/v1/training_runs/model_test/checkpoints/final/archive"
+            ):
+                self.send_response(302)
+                self.send_header(
+                    "Location", f"http://{self.headers['Host']}/archive"
+                )
+                self.end_headers()
+                return
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header("Location", "/archive")
+                self.end_headers()
+                return
+            payload = archive_bytes(
+                "../escape" if self.path == "/unsafe" else "./adapter.json",
+                tarfile.SYMTYPE
+                if self.path == "/symlink"
+                else tarfile.REGTYPE,
+            )
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def test_archive_requires_key_and_preserves_files(
+    archive_server: tuple[str, list[tuple[str, str | None]]], tmp_path: Path
+) -> None:
+    """Require authentication and retain only extracted adapter files.
+
+    Args:
+        archive_server: Authenticated local server fixture.
+        tmp_path: Empty download destination.
+    """
+    origin, requests = archive_server
+    with pytest.raises(HTTPError, match="401"):
+        download_archive(origin + "/archive", tmp_path, origin, "wrong")
+    download_archive(origin + "/archive", tmp_path, origin, "tml-test-key")
+    assert (tmp_path / "adapter.json").read_bytes() == b"{}"
+    assert list(tmp_path.iterdir()) == [tmp_path / "adapter.json"]
+    assert requests[-1] == ("/archive", "tml-test-key")
+
+
+@pytest.mark.parametrize("path", ["unsafe", "symlink"])
+def test_unsafe_archive_is_rejected(
+    archive_server: tuple[str, list[tuple[str, str | None]]],
+    tmp_path: Path,
+    path: str,
+) -> None:
+    """Reject traversal and links before writing any files.
+
+    Args:
+        archive_server: Authenticated local server fixture.
+        tmp_path: Empty download destination.
+        path: Endpoint supplying an unsafe archive.
+    """
+    origin, requests = archive_server
+    with pytest.raises(ValueError, match="Unsafe"):
+        download_archive(origin + "/" + path, tmp_path, origin, "tml-test-key")
+    assert not list(tmp_path.iterdir())
+    assert requests == [("/" + path, "tml-test-key")]
+
+
+def test_redirect_is_not_followed(
+    archive_server: tuple[str, list[tuple[str, str | None]]], tmp_path: Path
+) -> None:
+    """Never forward a credential through an archive redirect.
+
+    Args:
+        archive_server: Authenticated local server fixture.
+        tmp_path: Empty download destination.
+    """
+    origin, requests = archive_server
+    with pytest.raises(HTTPError, match="302"):
+        download_archive(
+            origin + "/redirect", tmp_path, origin, "tml-test-key"
+        )
+    assert requests == [("/redirect", "tml-test-key")]
+
+
+def test_other_origin_is_rejected_before_request(tmp_path: Path) -> None:
+    """Reject another origin before making a network request.
+
+    Args:
+        tmp_path: Empty download destination.
+    """
+    with pytest.raises(ValueError, match="origin"):
+        download_archive(
+            "http://example.com/weights",
+            tmp_path,
+            "http://127.0.0.1:80",
+            "tml-test-key",
+        )
+
+
+def test_exact_native_origin() -> None:
+    """Accept only the exact native service and proxy port."""
+    host = "endless-training-0123456789abcdef.test.svc.cluster.local"
+    validate_training_url(f"http://{host}:8001", host)
+    for url in [
+        f"http://{host}:8000",
+        "http://example.com:8001",
+        f"http://key@{host}:8001",
+    ]:
+        with pytest.raises(ValueError):
+            validate_training_url(url, host)
+
+
+@pytest.mark.parametrize(
+    "use_pyqwest_transport", [False, True], ids=["httpx", "pyqwest"]
+)
+@pytest.mark.parametrize(
+    "checkpoint",
+    ["tinker://model_test/final", "tinker://model_test/sampler_weights/final"],
+)
+def test_checkpoint_cli_uses_real_sdk_and_authenticated_archive_route(
+    archive_server: tuple[str, list[tuple[str, str | None]]],
+    tmp_path: Path,
+    checkpoint: str,
+) -> None:
+    """Resolve SkyRL checkpoint IDs through the installed SDK and export real files.
+
+    Args:
+        archive_server: Local authenticated API and archive endpoints.
+        tmp_path: Empty checkpoint destination.
+        checkpoint: Short SkyRL or canonical sampler checkpoint reference.
+    """
+    origin, requests = archive_server
+    output = tmp_path / "checkpoint"
+    output.mkdir()
+    helper = Path(__file__).parents[1] / "checkpoint_download.py"
+    result = subprocess.run(
+        [sys.executable, str(helper), checkpoint, str(output), origin],
+        env={**os.environ, "TINKER_API_KEY": "tml-test-key"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (output / "adapter.json").read_bytes() == b"{}"
+    assert list(output.iterdir()) == [output / "adapter.json"]
+    assert requests == [
+        (
+            "/api/v1/training_runs/model_test/checkpoints/final/archive",
+            "tml-test-key",
+        ),
+        ("/archive", "tml-test-key"),
+    ]
+    assert not (tmp_path / "checkpoint-download-error.json").exists()
+
+
+def test_malformed_checkpoint_cli_retains_structured_error(
+    archive_server: tuple[str, list[tuple[str, str | None]]], tmp_path: Path
+) -> None:
+    """Persist a parse failure without sending a malformed archive request.
+
+    Args:
+        archive_server: Local API fixture recording archive requests.
+        tmp_path: Parent directory for the checkpoint and error evidence.
+    """
+    origin, requests = archive_server
+    output = tmp_path / "checkpoint"
+    output.mkdir()
+    helper = Path(__file__).parents[1] / "checkpoint_download.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(helper),
+            "tinker://model_test/../final",
+            str(output),
+            origin,
+        ],
+        env={**os.environ, "TINKER_API_KEY": "tml-test-key"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode != 0
+    error = json.loads(
+        (tmp_path / "checkpoint-download-error.json").read_text()
+    )
+    assert error["type"] == "ValueError"
+    assert isinstance(error["message"], str) and error["message"]
+    assert "tml-test-key" not in json.dumps(error)
+    assert requests == []
+    assert not list(output.iterdir())
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        TimeoutError("read timed out"),
+        ConnectionResetError("reset"),
+        URLError(TimeoutError("connect timed out")),
+        IncompleteRead(b"partial"),
+    ],
+)
+def test_transient_download_restarts_without_partial_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    """Discard a partial transport response and publish only a complete archive.
+
+    Args:
+        tmp_path: Empty checkpoint destination.
+        monkeypatch: Scoped patch helper.
+        failure: Transient network failure after partial data.
+    """
+    partial = Mock()
+    partial.read.side_effect = [b"partial broken archive", failure]
+    opener = Mock()
+    opener.open.side_effect = [
+        nullcontext(partial),
+        io.BytesIO(archive_bytes("adapter.json")),
+    ]
+    monkeypatch.setattr(
+        "checkpoint_download.build_opener", lambda *args: opener
+    )
+    download_archive(
+        "http://localhost/archive", tmp_path, "http://localhost", "key"
+    )
+    assert opener.open.call_count == 2
+    assert all(
+        call.kwargs["timeout"] == 60 for call in opener.open.call_args_list
+    )
+    assert (tmp_path / "adapter.json").read_bytes() == b"{}"
+    assert list(tmp_path.iterdir()) == [tmp_path / "adapter.json"]
+
+
+def test_transient_download_stops_after_three_attempts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bound repeated transport failures and leave no output files.
+
+    Args:
+        tmp_path: Empty checkpoint destination.
+        monkeypatch: Scoped patch helper.
+    """
+    opener = Mock()
+    opener.open.side_effect = TimeoutError("read timed out")
+    monkeypatch.setattr(
+        "checkpoint_download.build_opener", lambda *args: opener
+    )
+    with pytest.raises(TimeoutError, match="read timed out"):
+        download_archive(
+            "http://localhost/archive", tmp_path, "http://localhost", "key"
+        )
+    assert opener.open.call_count == 3
+    assert not list(tmp_path.iterdir())
+
+
+def test_download_deadline_prevents_another_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Do not restart a failed download after its shared time budget expires.
+
+    Args:
+        tmp_path: Empty checkpoint destination.
+        monkeypatch: Scoped patch helper.
+    """
+    opener = Mock()
+    opener.open.side_effect = TimeoutError("read timed out")
+    monkeypatch.setattr(
+        "checkpoint_download.build_opener", lambda *args: opener
+    )
+    monkeypatch.setattr(
+        "checkpoint_download.time.monotonic", Mock(side_effect=[0, 0, 301])
+    )
+    with pytest.raises(TimeoutError, match="read timed out"):
+        download_archive(
+            "http://localhost/archive", tmp_path, "http://localhost", "key"
+        )
+    assert opener.open.call_count == 1
+    assert not list(tmp_path.iterdir())
+
+
+@pytest.mark.parametrize(
+    "payload", [b"not an archive", archive_bytes("../escape")]
+)
+def test_invalid_archive_is_never_retried(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, payload: bytes
+) -> None:
+    """Archive validation errors cannot become transport retries.
+
+    Args:
+        tmp_path: Empty checkpoint destination.
+        monkeypatch: Scoped patch helper.
+        payload: Invalid or unsafe archive content.
+    """
+    opener = Mock()
+    opener.open.return_value = io.BytesIO(payload)
+    monkeypatch.setattr(
+        "checkpoint_download.build_opener", lambda *args: opener
+    )
+    with pytest.raises((ValueError, tarfile.TarError)):
+        download_archive(
+            "http://localhost/archive", tmp_path, "http://localhost", "key"
+        )
+    assert opener.open.call_count == 1
+    assert not list(tmp_path.iterdir())
+
+
+def test_failed_extraction_leaves_destination_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An error while copying archive contents must not publish partial files.
+
+    Args:
+        tmp_path: Empty checkpoint destination.
+        monkeypatch: Scoped patch helper.
+    """
+    opener = Mock()
+    opener.open.return_value = io.BytesIO(archive_bytes("adapter.json"))
+    monkeypatch.setattr(
+        "checkpoint_download.build_opener", lambda *args: opener
+    )
+    monkeypatch.setattr(
+        "checkpoint_download.shutil.copyfileobj",
+        Mock(side_effect=OSError("disk full")),
+    )
+    with pytest.raises(OSError, match="disk full"):
+        download_archive(
+            "http://localhost/archive", tmp_path, "http://localhost", "key"
+        )
+    assert opener.open.call_count == 1
+    assert not list(tmp_path.iterdir())

--- a/examples/endless_terminals/tests/test_native_service.py
+++ b/examples/endless_terminals/tests/test_native_service.py
@@ -1,0 +1,458 @@
+"""Native GPU lifecycle guarantees without creating Kubernetes resources."""
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from kubernetes.client.rest import ApiException
+from native_service import (
+    NativeServiceConfig,
+    NativeTrainingService,
+    build_proxy_config,
+)
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> NativeTrainingService:
+    """Build a service with isolated fake API clients.
+
+    Args:
+        tmp_path: Temporary evidence parent directory.
+        monkeypatch: Scoped patch helper for stack selection.
+
+    Returns:
+        Configured service with mocked Kubernetes APIs.
+    """
+    sandbox = SimpleNamespace(
+        config=SimpleNamespace(kubernetes_namespace="tasks", incluster=True)
+    )
+    monkeypatch.setattr(
+        NativeTrainingService, "_select_sandbox", lambda self: sandbox
+    )
+    result = NativeTrainingService(
+        NativeServiceConfig(
+            training_image="registry/trainer@sha256:" + "a" * 64,
+            proxy_image="registry/proxy@sha256:" + "b" * 64,
+            cleanup_timeout=1,
+        ),
+        {"name": "test/model", "revision": "c" * 40},
+        "test-run",
+        tmp_path / "service",
+    )
+    result.namespace = "tasks"
+    result._controller_owner = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "name": "controller",
+        "uid": "controller-uid",
+    }
+    result._core = Mock()
+    result._batch = Mock()
+    result._client = Mock()
+    result._core.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    return result
+
+
+def resource(
+    session: NativeTrainingService, uid: str, token: str | None = None
+) -> SimpleNamespace:
+    """Create an API object carrying ownership metadata.
+
+    Args:
+        session: Service supplying default ownership labels.
+        uid: Resource UID returned by Kubernetes.
+        token: Alternate token for collision tests.
+
+    Returns:
+        Minimal Kubernetes-style object.
+    """
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            name=session.name,
+            uid=uid,
+            labels={"endless-owner": token or session.token},
+        ),
+        status=SimpleNamespace(conditions=[]),
+    )
+
+
+def test_constructor_does_not_create_output(
+    session: NativeTrainingService,
+) -> None:
+    """Training can create its output directory after constructing the session.
+
+    Args:
+        session: Isolated service.
+    """
+    assert not session.directory.exists()
+    assert session.service_host == f"{session.name}.tasks.svc.cluster.local"
+    assert session.base_url == f"http://{session.service_host}:8001"
+    assert session.serving_seconds_remaining == 0
+    assert session.cleanup_report["complete"] is False
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("proxy_image", "proxy:latest"),
+        ("training_image", "trainer:latest"),
+        ("startup_timeout", 1801),
+        ("serving_deadline", 5401),
+        ("cleanup_timeout", 301),
+        ("cleanup_timeout", 0),
+        ("api_key", "caller-supplied"),
+        ("inference_gpu_memory_utilization", 0),
+        ("inference_gpu_memory_utilization", 0.96),
+    ],
+)
+def test_rejects_unpinned_or_unbounded_configuration(
+    field: str, value: object
+) -> None:
+    """Images must be immutable and callers cannot bypass authentication.
+
+    Args:
+        field: Invalid configuration field.
+        value: Value that violates the configuration contract.
+    """
+    config: dict[str, object] = {
+        "training_image": "trainer@sha256:" + "a" * 64,
+        "proxy_image": "proxy@sha256:" + "b" * 64,
+    }
+    config[field] = value
+    with pytest.raises(ValidationError):
+        NativeServiceConfig.model_validate(config)
+
+
+def test_proxy_authenticates_all_routes_with_case_sensitive_key(
+    session: NativeTrainingService,
+) -> None:
+    """Auth covers health and download routes and keys do not enter upstream logs.
+
+    Args:
+        session: Isolated service with random credential.
+    """
+    config = build_proxy_config(session.api_key)
+    assert f"~^{session.api_key}$ 1;" in config
+    assert "if ($authenticated = 0) { return 401; }" in config
+    assert config.index("return 401") < config.index("location /")
+    assert "access_log off;" in config
+    assert "proxy_set_header Host $http_host;" in config
+    assert 'proxy_set_header X-API-Key "";' in config
+    assert "proxy_pass http://127.0.0.1:8000;" in config
+    with pytest.raises(ValueError):
+        build_proxy_config("untrusted-key; nginx injection")
+
+
+def test_manifest_is_owned_authenticated_and_gpu_bounded(
+    session: NativeTrainingService,
+) -> None:
+    """Tasks cannot mount the proxy secret or inherit the controller token.
+
+    Args:
+        session: Isolated service.
+    """
+    job, secret, service = session._manifests()
+    spec = job["spec"]["template"]["spec"]
+    assert job["metadata"]["ownerReferences"] == [session._controller_owner]
+    assert job["spec"]["backoffLimit"] == 0
+    assert (
+        job["spec"]["activeDeadlineSeconds"] == session.config.serving_deadline
+    )
+    assert spec["automountServiceAccountToken"] is False
+    assert spec["restartPolicy"] == "Never"
+    assert not spec["hostNetwork"] and not spec["hostPID"]
+    main, proxy = spec["containers"]
+    assert main["resources"]["limits"] == {
+        "memory": "28Gi",
+        "nvidia.com/gpu": "1",
+    }
+    assert main["resources"]["requests"]["memory"] == "26Gi"
+    assert main["securityContext"]["runAsUser"] == 1000
+    assert proxy["securityContext"]["readOnlyRootFilesystem"] is True
+    assert proxy["securityContext"]["runAsUser"] == 101
+    volumes = {volume["name"]: volume for volume in spec["volumes"]}
+    assert volumes["shm"]["emptyDir"]["sizeLimit"] == "8Gi"
+    assert {item["key"] for item in volumes["source"]["secret"]["items"]} == {
+        "entrypoint.py",
+        "backend_config.json",
+        "diagnostics.py",
+    }
+    assert volumes["proxy-config"]["secret"]["items"] == [
+        {"key": "nginx.conf", "path": "nginx.conf"}
+    ]
+    assert service["spec"]["type"] == "ClusterIP"
+    assert service["spec"]["ports"] == [
+        {"name": "authenticated-api", "port": 8001, "targetPort": 8001}
+    ]
+    assert session.api_key in secret["stringData"]["nginx.conf"]
+    assert session.api_key not in json.dumps(job)
+    assert session.api_key not in json.dumps(session.identity)
+    assert not session.directory.exists()
+
+
+@pytest.mark.parametrize("utilization", [0.35, 0.5])
+def test_inference_memory_setting_is_mounted_and_hashed(
+    session: NativeTrainingService, utilization: float
+) -> None:
+    """The server receives and verifies the run's inference memory budget.
+
+    Args:
+        session: Isolated service.
+        utilization: Fraction of GPU memory reserved for inference.
+    """
+    values = session.config.model_dump()
+    values["inference_gpu_memory_utilization"] = utilization
+    session.config = NativeServiceConfig.model_validate(values)
+    _, secret, _ = session._manifests()
+    content = secret["stringData"]["backend_config.json"]
+    backend = json.loads(content)
+    assert (
+        backend["generator.inference_engine.gpu_memory_utilization"]
+        == utilization
+    )
+    assert session._backend_config == backend
+    assert (
+        session.identity["source_sha256"]["backend_config.json"]
+        == hashlib.sha256(content.encode()).hexdigest()
+    )
+
+
+def test_ambiguous_create_is_reconciled_and_deleted_by_uid(
+    session: NativeTrainingService,
+) -> None:
+    """Lost create responses cannot leave an owned GPU Job behind.
+
+    Args:
+        session: Isolated service with fake API methods.
+    """
+    session._operation_deadline = float("inf")
+    session._batch.create_namespaced_job.side_effect = TimeoutError(
+        "response lost"
+    )
+    with pytest.raises(TimeoutError):
+        session._create("job", {})
+    assert session._attempted == {"job"}
+    session._batch.read_namespaced_job.side_effect = [
+        resource(session, "job-uid"),
+        ApiException(status=404),
+    ]
+    session._cleanup()
+    assert session.cleanup_report["complete"] is True
+    kwargs = session._batch.delete_namespaced_job.call_args.kwargs
+    assert kwargs["body"]["preconditions"] == {"uid": "job-uid"}
+    assert kwargs["body"]["propagationPolicy"] == "Foreground"
+    assert 0 < kwargs["_request_timeout"] <= 15
+
+
+def test_collision_is_never_deleted(session: NativeTrainingService) -> None:
+    """A same-name resource belonging to another run is preserved.
+
+    Args:
+        session: Isolated service.
+    """
+    session._attempted = {"job"}
+    session._batch.read_namespaced_job.return_value = resource(
+        session, "foreign", "foreign-token"
+    )
+    session._cleanup()
+    session._batch.delete_namespaced_job.assert_not_called()
+    assert session.cleanup_report["complete"] is False
+    assert "ownership token mismatch" in str(session.cleanup_report["errors"])
+
+
+def test_uid_replacement_is_never_deleted(
+    session: NativeTrainingService,
+) -> None:
+    """Even matching labels do not authorize deleting a replacement object.
+
+    Args:
+        session: Isolated service.
+    """
+    session._attempted = {"job"}
+    session._uids["job"] = "original"
+    session._batch.read_namespaced_job.return_value = resource(
+        session, "replacement"
+    )
+    session._cleanup()
+    session._batch.delete_namespaced_job.assert_not_called()
+    assert session.cleanup_report["complete"] is False
+
+
+def test_delete_failures_do_not_skip_other_resources(
+    session: NativeTrainingService,
+) -> None:
+    """Service, Job, and Secret cleanup proceeds independently.
+
+    Args:
+        session: Isolated service.
+    """
+    session._attempted = {"service", "job", "secret"}
+    for kind, api in (
+        ("service", session._core),
+        ("job", session._batch),
+        ("secret", session._core),
+    ):
+        getattr(api, f"read_namespaced_{kind}").side_effect = [
+            resource(session, kind + "-uid"),
+            ApiException(status=404),
+        ]
+    session._core.delete_namespaced_service.side_effect = RuntimeError(
+        "transport error"
+    )
+    session._cleanup()
+    session._batch.delete_namespaced_job.assert_called_once()
+    session._core.delete_namespaced_secret.assert_called_once()
+    assert session.cleanup_report["complete"] is False
+
+
+def test_startup_failure_captures_before_cleanup(
+    session: NativeTrainingService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed readiness preserves diagnostic evidence and still removes resources.
+
+    Args:
+        session: Isolated service.
+        monkeypatch: Scoped helper for replacing service methods.
+    """
+    order: list[str] = []
+    monkeypatch.setattr(session, "_connect", Mock())
+    monkeypatch.setattr(
+        session,
+        "_manifests",
+        Mock(return_value=({}, {"metadata": {}}, {"metadata": {}})),
+    )
+
+    def create(kind: str, body: dict[str, object]) -> None:
+        session._attempted.add(kind)
+        session._uids[kind] = kind + "-uid"
+
+    monkeypatch.setattr(session, "_create", Mock(side_effect=create))
+    monkeypatch.setattr(
+        session,
+        "_wait_ready",
+        Mock(side_effect=RuntimeError("main terminated")),
+    )
+    monkeypatch.setattr(
+        session, "_capture", Mock(side_effect=lambda: order.append("capture"))
+    )
+    monkeypatch.setattr(
+        session, "_cleanup", Mock(side_effect=lambda: order.append("cleanup"))
+    )
+    with pytest.raises(RuntimeError, match="main terminated"):
+        session.__enter__()
+    assert order == ["capture", "cleanup"]
+    assert (session.directory / "native-service-cleanup.json").exists()
+
+
+def test_diagnostic_failure_and_secrets_do_not_escape_evidence(
+    session: NativeTrainingService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Diagnostic errors remain separate and cannot leak the credential.
+
+    Args:
+        session: Isolated service with fake sensitive errors.
+        monkeypatch: Scoped helper for replacing service methods.
+    """
+    session.directory.mkdir()
+    session._attempted = {"job"}
+    monkeypatch.setattr(
+        session, "_capture", Mock(side_effect=RuntimeError(session.api_key))
+    )
+    session._batch.read_namespaced_job.side_effect = [
+        resource(session, "uid"),
+        ApiException(status=404),
+    ]
+    session._finish()
+    assert session.cleanup_report["complete"] is True
+    assert session.cleanup_report["diagnostic_errors"]
+    assert session.cleanup_report["errors"] == []
+    session._write("logs.txt", session.api_key)
+    for path in session.directory.iterdir():
+        assert session.api_key not in path.read_text()
+    assert session.api_key not in json.dumps(session.cleanup_report)
+
+
+def test_deadline_includes_startup_and_blocks_late_calls(
+    session: NativeTrainingService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Startup consumes the serving budget and no late API call is dispatched.
+
+    Args:
+        session: Isolated service.
+        monkeypatch: Scoped clock patch helper.
+    """
+    session._serving_deadline = 200
+    session._operation_deadline = 150
+    monkeypatch.setattr("native_service.time.monotonic", lambda: 120)
+    assert session.serving_seconds_remaining == 80
+    operation = Mock()
+    session._call(operation)
+    assert operation.call_args.kwargs["_request_timeout"] == 15
+    monkeypatch.setattr("native_service.time.monotonic", lambda: 201)
+    assert session.serving_seconds_remaining == 0
+    with pytest.raises(TimeoutError):
+        session._call(operation)
+    operation.assert_called_once()
+
+
+def test_terminated_main_fails_even_while_proxy_runs(
+    session: NativeTrainingService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A living sidecar cannot hide the training process exiting.
+
+    Args:
+        session: Isolated service.
+        monkeypatch: Scoped helper for replacing service methods.
+    """
+    session._operation_deadline = float("inf")
+    monkeypatch.setattr(
+        session, "_read", Mock(return_value=resource(session, "uid"))
+    )
+    pod = resource(session, "pod-uid")
+    pod.status.container_statuses = [
+        SimpleNamespace(
+            name="main",
+            state=SimpleNamespace(terminated=SimpleNamespace(exit_code=1)),
+        ),
+        SimpleNamespace(
+            name="auth-proxy", state=SimpleNamespace(terminated=None)
+        ),
+    ]
+    monkeypatch.setattr(session, "_pods", Mock(return_value=[pod]))
+    with pytest.raises(RuntimeError, match="main terminated"):
+        session._wait_ready()
+
+
+@pytest.mark.parametrize(
+    "changed", ["model_revision", "backend_config", "source_sha256"]
+)
+def test_identity_mismatch_is_rejected(
+    session: NativeTrainingService,
+    changed: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Health alone never validates different weights, settings, or source.
+
+    Args:
+        session: Isolated service.
+        changed: Identity field corrupted by the fake server.
+        monkeypatch: Scoped helper for replacing service methods.
+    """
+    identity = {
+        "model_name": session.model["name"],
+        "model_revision": session.model["revision"],
+        "backend_config": {},
+        "source_sha256": {},
+    }
+    identity[changed] = "wrong"
+    monkeypatch.setattr(
+        session, "_exec", Mock(return_value=json.dumps(identity))
+    )
+    with pytest.raises(RuntimeError, match="mismatch"):
+        session._verify_server()

--- a/examples/endless_terminals/tests/test_native_training.py
+++ b/examples/endless_terminals/tests/test_native_training.py
@@ -1,0 +1,247 @@
+"""Verify qualification blocks GPU allocation and compile the actual artifact graph."""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+from uuid import UUID
+
+import native_training as workflow
+import pytest
+from pydantic import ValidationError
+
+from zenml.models import ArtifactVersionResponse
+
+
+def pilot_config() -> workflow.NativeTrainingConfig:
+    """Load the documented bounded pilot configuration.
+
+    Returns:
+        Validated portable training configuration.
+    """
+    return workflow.NativeTrainingConfig.model_validate_json(
+        (
+            Path(__file__).parents[1] / "native-training.example.json"
+        ).read_text()
+    )
+
+
+def test_native_graph_links_qualification_and_training(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compile real steps while replacing only the external artifact lookup.
+
+    Args:
+        monkeypatch: Scoped external lookup replacement.
+    """
+    identifier = UUID("11111111-1111-4111-8111-111111111111")
+    artifact = ArtifactVersionResponse.model_construct(id=identifier)
+    monkeypatch.setattr(
+        workflow,
+        "Client",
+        lambda: SimpleNamespace(get_artifact_version=lambda _: artifact),
+    )
+    pipeline = workflow.endless_terminals_native_training.with_options()
+    pipeline.prepare(bundle_artifact_id=identifier, config=pilot_config())
+    invocations = pipeline.invocations
+    assert set(invocations) == {
+        "qualify_sandbox_initial",
+        "reference_fixture",
+        "noop_fixture",
+        "report_sandbox_results",
+        "train_native",
+        "report_training",
+    }
+    assert (
+        invocations["train_native"].external_artifacts["bundle"].id
+        == identifier
+    )
+    dependencies = invocations["train_native"].input_artifacts
+    assert set(dependencies) == {"initial", "reference", "noop"}
+    initial_artifact = dependencies["initial"]
+    assert not isinstance(initial_artifact, list)
+    assert initial_artifact.output_name == "sandbox_initial_qualification"
+    for name, output in {
+        "before": "before_evaluation",
+        "after_evaluation": "after_evaluation",
+        "training": "training_evidence",
+    }.items():
+        input_artifact = invocations["report_training"].input_artifacts[name]
+        assert not isinstance(input_artifact, list)
+        assert input_artifact.output_name == output
+
+
+@pytest.mark.parametrize(
+    "failure", ["initial", "reference", "noop", "cleanup"]
+)
+def test_failed_qualification_never_constructs_gpu_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    """Reject each failed prerequisite before a GPU service can be created.
+
+    Args:
+        tmp_path: Stand-in bundle path.
+        monkeypatch: Scoped task and allocation replacements.
+        failure: Qualification boundary to fail.
+    """
+    task = {"task_id": workflow.PILOT_TASK, "dataset_revision": "a" * 40}
+    initial: dict[str, Any] = {
+        "task": task,
+        "grading": {"audited_valid": True},
+        "cleanup_complete": True,
+    }
+    reference: dict[str, Any] = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {"raw_reward": 1, "audited_valid": True},
+    }
+    noop: dict[str, Any] = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {
+            "raw_reward": 0,
+            "audited_valid": False,
+            "test_counts": {"failure": 1},
+        },
+    }
+    if failure == "initial":
+        initial["grading"]["audited_valid"] = False
+    elif failure == "cleanup":
+        initial["cleanup_complete"] = False
+    else:
+        {"reference": reference, "noop": noop}[failure]["grading"][
+            "infrastructure_error"
+        ] = "failed"
+    monkeypatch.setattr(workflow, "load_bundle_task", lambda *_: task)
+    service = Mock()
+    publish = Mock()
+    monkeypatch.setattr(workflow, "NativeTrainingService", service)
+    monkeypatch.setattr(workflow, "save_artifact", publish)
+    with pytest.raises(RuntimeError, match="GPU service was not started"):
+        workflow.train_native.entrypoint(
+            tmp_path, initial, reference, noop, pilot_config()
+        )
+    service.assert_not_called()
+    publish.assert_called_once()
+
+
+def test_native_config_rejects_unqualified_task_selection() -> None:
+    """Keep every task selection on the one verified canonical pilot."""
+    config = pilot_config().model_dump(mode="json")
+    config["training"]["training_task_ids"] = ["another-task"]
+    with pytest.raises(ValidationError, match="canonical|native pilot"):
+        workflow.NativeTrainingConfig.model_validate(config)
+
+
+def test_successful_training_persists_initial_adapter_and_service_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retain starting weights and GPU diagnostics before the controller disappears.
+
+    Args:
+        tmp_path: Temporary controller output directory.
+        monkeypatch: Scoped replacements for external training and publishing.
+    """
+    task = {"task_id": workflow.PILOT_TASK, "dataset_revision": "a" * 40}
+    initial: dict[str, Any] = {
+        "task": task,
+        "grading": {"audited_valid": True},
+        "cleanup_complete": True,
+    }
+    reference: dict[str, Any] = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {"raw_reward": 1, "audited_valid": True},
+    }
+    noop: dict[str, Any] = {
+        "exit_reason": "done",
+        "cleanup_complete": True,
+        "grading": {
+            "raw_reward": 0,
+            "audited_valid": False,
+            "test_counts": {"failure": 1},
+        },
+    }
+    run_id = "native-test-run"
+    directory = tmp_path / run_id
+    diagnostics = directory / "service"
+    monkeypatch.setattr(workflow, "load_bundle_task", lambda *_: task)
+    monkeypatch.setattr(tempfile, "mkdtemp", lambda **_: str(tmp_path))
+    monkeypatch.setattr(
+        workflow,
+        "get_step_context",
+        lambda: SimpleNamespace(pipeline_run=SimpleNamespace(id=run_id)),
+    )
+    monkeypatch.setattr(workflow, "NativeTrainingService", Mock())
+    result: tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path] = (
+        {"before": True},
+        {"after": True},
+        {},
+        directory / "checkpoint",
+    )
+
+    def train(
+        *args: object, **kwargs: object
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path]:
+        diagnostics.mkdir(parents=True)
+        (diagnostics / "training-main.log").write_text("training completed")
+        initial_adapter = directory / "initial_checkpoint"
+        initial_adapter.mkdir()
+        (initial_adapter / "adapter.safetensors").write_bytes(
+            b"initial adapter"
+        )
+        return result
+
+    def publish(path: Path, name: str) -> None:
+        if name == "native_training_diagnostics":
+            assert path == diagnostics
+            assert (
+                path / "training-main.log"
+            ).read_text() == "training completed"
+        else:
+            assert name == "initial_adapter"
+            assert path == directory / "initial_checkpoint"
+            assert (
+                path / "adapter.safetensors"
+            ).read_bytes() == b"initial adapter"
+
+    publish_mock = Mock(side_effect=publish)
+    monkeypatch.setattr(workflow, "execute_training", train)
+    monkeypatch.setattr(workflow, "save_artifact", publish_mock)
+    assert (
+        workflow.train_native.entrypoint(
+            tmp_path, initial, reference, noop, pilot_config()
+        )
+        == result
+    )
+    assert {call.kwargs["name"] for call in publish_mock.call_args_list} == {
+        "native_training_diagnostics",
+        "initial_adapter",
+    }
+    assert publish_mock.call_count == 2
+
+
+@pytest.mark.parametrize("field", ["modal_workspace", "modal_environment"])
+def test_modal_service_and_task_identity_must_agree(field: str) -> None:
+    """Reject mismatches before qualification or service allocation.
+
+    Args:
+        field: Sandbox identity field to mismatch.
+    """
+    import json
+
+    values = json.loads(
+        (Path(__file__).parents[1] / "modal-training.example.json").read_text()
+    )
+    values["service"].update(
+        workspace="external-team", modal_environment="research"
+    )
+    values["sandbox"].update(
+        modal_workspace="external-team", modal_environment="research"
+    )
+    config = workflow.NativeTrainingConfig.model_validate(values)
+    assert config.sandbox.modal_workspace == "external-team"
+    values["sandbox"][field] = "other"
+    with pytest.raises(ValidationError, match="must match"):
+        workflow.NativeTrainingConfig.model_validate(values)

--- a/examples/endless_terminals/tests/test_pipeline.py
+++ b/examples/endless_terminals/tests/test_pipeline.py
@@ -1,0 +1,97 @@
+"""Verify lifecycle failures remain failed runs with inspectable evidence."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pipeline as workflow
+import pytest
+from config import EvaluationConfig
+
+
+def test_fixture_failure_persists_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An incorrect reference solution must not produce a green smoke run.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Scoped patches.
+    """
+    directory = tmp_path / "task" / "solution"
+    directory.mkdir(parents=True)
+    (directory / "solve.sh").write_text("false")
+    monkeypatch.setattr(
+        workflow,
+        "run_episode",
+        lambda *args, **kwargs: {
+            "task_id": "task",
+            "grading": {"raw_reward": 0, "audited_valid": False},
+            "cleanup_complete": True,
+            "exit_reason": "done",
+            "turns": [],
+        },
+    )
+    upload = Mock()
+    monkeypatch.setattr(workflow, "save_artifact", upload)
+    prepared = {
+        "dataset_revision": "pinned",
+        "tasks": [
+            {
+                "task_id": "task",
+                "task_file_sha256": {},
+                "local_image_id": "sha256:1",
+            }
+        ],
+    }
+    config = EvaluationConfig(
+        data_directory=str(tmp_path), output_directory=str(tmp_path / "runs")
+    )
+    with pytest.raises(RuntimeError, match="Reference fixture failed"):
+        workflow.execute_evaluation(prepared, config, "run")
+    result = json.loads((tmp_path / "runs/run/evaluation.json").read_text())
+    assert result["status"] == "failed"
+    assert len(result["episodes"]) == 1
+    assert upload.call_count == 2
+
+
+def test_cloud_startup_failure_retains_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retain cleanup evidence when the inference context fails to enter.
+
+    Args:
+        tmp_path: Test directory.
+        monkeypatch: Scoped patches.
+    """
+    cloud_file = tmp_path / "cloud.json"
+    cloud_file.write_text(json.dumps({"vllm_image": "pinned"}))
+    session = Mock()
+    session.cleanup_report = {"complete": True, "job_deleted": True}
+    session.__enter__ = Mock(side_effect=RuntimeError("startup failed"))
+    session.__exit__ = Mock(return_value=False)
+    monkeypatch.setattr(
+        workflow, "KubernetesInference", Mock(return_value=session)
+    )
+    monkeypatch.setattr(workflow, "save_artifact", Mock())
+    episode = Mock()
+    monkeypatch.setattr(workflow, "run_episode", episode)
+    config = EvaluationConfig(
+        mode="kubernetes",
+        cloud_config_path=str(cloud_file),
+        output_directory=str(tmp_path / "runs"),
+    )
+    with pytest.raises(RuntimeError, match="startup failed"):
+        workflow.execute_evaluation(
+            {"dataset_revision": "pinned", "tasks": []}, config, "run"
+        )
+    result = json.loads((tmp_path / "runs/run/evaluation.json").read_text())
+    assert result["cleanup"]["complete"] is True
+    assert result["status"] == "failed"
+    episode.assert_not_called()
+
+
+def test_custom_model_requires_revision() -> None:
+    """Do not attach the default Qwen revision to a different model."""
+    with pytest.raises(ValueError, match="explicit model_revision"):
+        EvaluationConfig(model_name="another/model")

--- a/examples/endless_terminals/tests/test_qualification_report.py
+++ b/examples/endless_terminals/tests/test_qualification_report.py
@@ -1,0 +1,108 @@
+"""Verify readable reports preserve raw evidence and honest qualification states."""
+
+import copy
+import html
+import json
+from typing import Any
+
+from sandbox_pipeline import report_sandbox_results
+
+
+def evidence() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Build three distinct qualification phases with expected binary outcomes.
+
+    Returns:
+        Initial readiness, solved fixture, and untouched fixture evidence.
+    """
+    grade: dict[str, Any] = {
+        "raw_reward": 1,
+        "audited_valid": True,
+        "test_counts": {"total": 3, "failure": 0, "error": 0, "skipped": 0},
+        "verifier_output": "3 passed",
+    }
+    initial: dict[str, Any] = {
+        "task": {"task_id": "task-one", "dataset_revision": "a" * 40},
+        "grading": copy.deepcopy(grade),
+        "cleanup_complete": True,
+    }
+    reference: dict[str, Any] = {
+        "grading": copy.deepcopy(grade),
+        "exit_reason": "done",
+        "cleanup_complete": True,
+    }
+    noop = copy.deepcopy(reference)
+    noop["grading"].update(raw_reward=0, audited_valid=False)
+    noop["grading"]["test_counts"]["failure"] = 2
+    noop["grading"]["verifier_output"] = "1 passed, 2 failed"
+    return initial, reference, noop
+
+
+def test_report_explains_expected_failure_and_keeps_full_evidence() -> None:
+    """Show reference and no-op differences without converting fixtures to scores."""
+    phases = evidence()
+    original = copy.deepcopy(phases)
+    results, report = report_sandbox_results.entrypoint(*phases)
+    assert phases == original
+    assert results == {
+        "status": "passed",
+        "scope": "CPU Kubernetes sandbox qualification; no model inference or training",
+        **dict(zip(("initial", "reference", "noop"), phases)),
+    }
+    assert "Sandbox qualification passed" in report
+    assert "Initial environment ready" in report
+    assert "3 passed · 0 failed" in report
+    assert "1 passed · 2 failed" in report
+    assert "An untouched-task failure is the expected result" in report
+    assert report.count('class="badge">As expected') == 2
+    assert html.escape(json.dumps(results, indent=2), quote=True) in report
+    assert "<details>" in report
+    assert "No model inference or training" in report
+    assert "<script" not in report
+    assert "<link" not in report
+
+
+def test_report_surfaces_runtime_failure_even_with_expected_reward() -> None:
+    """A nominal pass cannot conceal broken cleanup or infrastructure."""
+    initial, reference, noop = evidence()
+    reference["cleanup_complete"] = False
+    noop["grading"]["infrastructure_error"] = "Verifier unavailable"
+    results, report = report_sandbox_results.entrypoint(
+        initial, reference, noop
+    )
+    assert results["status"] == "failed"
+    assert "Qualification needs attention" in report
+    assert "Cleanup needs review" in report
+    assert "Reference: unconfirmed" in report
+    assert "Verifier unavailable" in report
+    assert 'class="badge">As expected' not in report
+
+
+def test_report_distinguishes_initial_failure_from_unrun_fixtures() -> None:
+    """Missing qualification does not appear as an expected untouched-task fail."""
+    initial, _, _ = evidence()
+    initial["grading"] = None
+    skipped = {
+        "skipped": "initial qualification failed",
+        "cleanup_complete": True,
+    }
+    results, report = report_sandbox_results.entrypoint(
+        initial, skipped, skipped
+    )
+    assert results["status"] == "failed"
+    assert "Initial environment not qualified" in report
+    assert report.count('<div class="value">Not run</div>') == 2
+    assert "Test counts unavailable" in report
+
+
+def test_report_escapes_task_logs_and_error_content() -> None:
+    """Untrusted task strings remain text in summaries and collapsed evidence."""
+    initial, reference, noop = evidence()
+    payload = '<script>alert("bad")</script><img src=x onerror=alert(1)>'
+    initial["task"]["task_id"] = payload
+    reference["grading"]["verifier_output"] = payload
+    noop["error"] = payload
+    _, report = report_sandbox_results.entrypoint(initial, reference, noop)
+    assert payload not in report
+    assert html.escape(payload, quote=True) in report
+    assert "<script" not in report
+    assert "<img" not in report

--- a/examples/endless_terminals/tests/test_reporting.py
+++ b/examples/endless_terminals/tests/test_reporting.py
@@ -1,0 +1,204 @@
+"""Behavior checks for deterministic evaluation reporting."""
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+from reporting import (
+    render_evaluation_report,
+    summarize_evaluation,
+)
+
+
+def evaluation() -> dict[str, Any]:
+    """Return a small recorded evaluation for reporting checks.
+
+    Returns:
+        Example evaluation with one passing task.
+    """
+    return {
+        "model": {"name": "small-model", "revision": "revision-1"},
+        "mode": "model",
+        "dataset_revision": "dataset-1",
+        "protocol": {"max_actions": 16},
+        "task_hashes": {"task-a": "hash-a"},
+        "status": "completed",
+        "cleanup": {"complete": True},
+        "episodes": [
+            {
+                "task_id": "task-a",
+                "exit_reason": "done",
+                "turns": [
+                    {
+                        "action": {"type": "invalid"},
+                        "usage": {"total_tokens": 10},
+                    },
+                    {
+                        "action": {"type": "command"},
+                        "usage": {"total_tokens": 20},
+                    },
+                    {"action": {"type": "done"}, "usage": {"total_tokens": 5}},
+                ],
+                "grading": {"raw_reward": 1, "audited_valid": True},
+                "elapsed_seconds": 2.5,
+                "cleanup_complete": True,
+                "transcript": [],
+            }
+        ],
+    }
+
+
+def test_counts_and_format_validity() -> None:
+    """Derive totals from recorded responses and audited outcomes."""
+    result = summarize_evaluation(evaluation())
+    assert result["passes"] == result["attempts"] == 1
+    assert result["responses"] == 3
+    assert result["format_errors"] == 1
+    assert result["valid_response_percent"] == pytest.approx(200 / 3)
+    assert result["total_tokens"] == 35
+    assert result["elapsed_seconds"] == 2.5
+
+
+def test_infrastructure_errors_are_not_task_failures() -> None:
+    """Do not classify an unavailable verifier as an ordinary wrong answer."""
+    data = evaluation()
+    base = data["episodes"][0]
+    failure = deepcopy(base)
+    failure["grading"] = {"raw_reward": 0, "audited_valid": False}
+    error = deepcopy(base)
+    error["grading"] = {"raw_reward": 0, "infrastructure_error": "Docker lost"}
+    incomplete = deepcopy(base)
+    incomplete["grading"] = None
+    data["episodes"] += [failure, error, incomplete]
+    result = summarize_evaluation(data)
+    assert result["attempts"] == 4
+    assert result["passes"] == result["failures"] == 1
+    assert result["infrastructure_errors"] == result["incomplete"] == 1
+
+
+def test_escaped_untrusted_content() -> None:
+    """Escape task labels, model names, transcript text, and verifier output."""
+    data = evaluation()
+    attack = '<script>alert("x")</script><img src=x onerror=alert(1)>'
+    data["model"]["name"] = attack
+    data["episodes"][0]["task_id"] = attack
+    data["episodes"][0]["grading"]["verifier_output"] = attack
+    data["episodes"][0]["transcript"] = [
+        {"role": "assistant", "content": attack}
+    ]
+    report = render_evaluation_report(data)
+    assert "<script>" not in report
+    assert "<img" not in report
+    assert "&lt;script&gt;" in report
+    assert report == render_evaluation_report(data)
+
+
+def test_zero_episodes_and_fixture_badge() -> None:
+    """An empty fixture run has no score or response validity denominator."""
+    data = evaluation()
+    data["episodes"] = []
+    data["mode"] = "fixture"
+    result = summarize_evaluation(data)
+    assert result["attempts"] == result["passes"] == 0
+    assert result["valid_response_percent"] is None
+    report = render_evaluation_report(data)
+    assert "FIXTURE CHECK: NOT A MODEL SCORE" in report
+    assert "N/A (no responses)" in report
+    assert "No episodes recorded" in report
+
+
+@pytest.mark.parametrize(
+    "key", ["dataset_revision", "protocol", "task_hashes", "mode"]
+)
+def test_comparison_rejects_mismatched_identity(key: str) -> None:
+    """Only identically configured evaluations may be paired.
+
+    Args:
+        key: Identity field changed in the baseline.
+    """
+    current = evaluation()
+    baseline = deepcopy(current)
+    baseline[key] = "different"
+    with pytest.raises(ValueError, match=key):
+        render_evaluation_report(current, baseline)
+
+
+def test_comparison_rejects_different_tasks() -> None:
+    """Equal attempt counts do not imply equal evaluation tasks."""
+    current = evaluation()
+    baseline = deepcopy(current)
+    baseline["episodes"][0]["task_id"] = "task-b"
+    with pytest.raises(ValueError, match="task sets"):
+        render_evaluation_report(current, baseline)
+
+
+def test_comparison_accepts_changed_model() -> None:
+    """Model identity may differ when the evaluation contract matches."""
+    current = evaluation()
+    baseline = deepcopy(current)
+    baseline["model"] = {
+        "name": "earlier-model",
+        "revision": "earlier-revision",
+    }
+    baseline["episodes"][0]["grading"] = {
+        "raw_reward": 0,
+        "audited_valid": False,
+    }
+    report = render_evaluation_report(current, baseline)
+    assert "0/1 baseline; 1/1 current" in report
+    assert "earlier-model" in report
+
+
+def test_unverified_endpoint_cannot_be_compared() -> None:
+    """A claimed endpoint revision is insufficient for checkpoint comparison."""
+    current = evaluation()
+    current["model"]["revision_verified"] = False
+    with pytest.raises(ValueError, match="unverified"):
+        render_evaluation_report(current, deepcopy(current))
+
+
+def test_verifier_setup_error_is_infrastructure_failure() -> None:
+    """Keep broken verifier setup separate from a failed task assertion."""
+    current = evaluation()
+    current["episodes"][0]["grading"] = {
+        "raw_reward": 0,
+        "audited_valid": False,
+        "test_counts": {"error": 1},
+    }
+    summary = summarize_evaluation(current)
+    assert summary["infrastructure_errors"] == 1
+    assert summary["failures"] == 0
+
+
+def test_comparison_pairs_repeated_attempts_by_index() -> None:
+    """Pair outcomes by attempt identity even when episode order differs."""
+    current = evaluation()
+    current["episodes"][0]["attempt_index"] = 1
+    second = deepcopy(current["episodes"][0])
+    second["attempt_index"] = 2
+    second["grading"] = {"raw_reward": 0, "audited_valid": False}
+    current["episodes"].append(second)
+    baseline = deepcopy(current)
+    baseline["episodes"].reverse()
+    report = render_evaluation_report(current, baseline)
+    assert "1/2 baseline; 1/2 current" in report
+    assert "task-a (attempt 1)</td><td>Passed</td><td>Passed</td>" in report
+    assert "task-a (attempt 2)</td><td>Failed</td><td>Failed</td>" in report
+
+
+@pytest.mark.parametrize("index", [1, 3])
+def test_comparison_rejects_duplicate_or_mismatched_attempts(
+    index: int,
+) -> None:
+    """Reject ambiguous duplicates and missing paired attempt identities.
+
+    Args:
+        index: Duplicate or mismatched attempt index.
+    """
+    current = evaluation()
+    current["episodes"][0]["attempt_index"] = 1
+    current["episodes"].append({**current["episodes"][0], "attempt_index": 2})
+    baseline = deepcopy(current)
+    baseline["episodes"][1]["attempt_index"] = index
+    with pytest.raises(ValueError, match="task sets"):
+        render_evaluation_report(current, baseline)

--- a/examples/endless_terminals/tests/test_sandbox_env.py
+++ b/examples/endless_terminals/tests/test_sandbox_env.py
@@ -1,0 +1,311 @@
+"""Check workspace isolation and trusted grading order without Kubernetes calls."""
+
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from kubernetes.client.rest import ApiException
+from runtime.sandbox_env import SandboxEnvironment
+from runtime.sandbox_workspace import SandboxRuntimeConfig, SandboxWorkspace
+
+from zenml.integrations.kubernetes.pod_settings import KubernetesPodSettings
+from zenml.integrations.kubernetes.sandboxes.kubernetes_sandbox import (
+    KubernetesSandbox,
+)
+
+
+def workspace() -> SandboxWorkspace:
+    """Build a workspace using fake Kubernetes API boundaries.
+
+    Returns:
+        Workspace with no allocated resources.
+    """
+    sandbox = Mock(
+        spec=KubernetesSandbox,
+        config=SimpleNamespace(
+            sandbox_environment={},
+            kubernetes_namespace="tasks",
+            pod_settings=KubernetesPodSettings(
+                node_selectors={"pool": "workloads"},
+                tolerations=[
+                    {
+                        "key": "pool",
+                        "value": "workloads",
+                        "effect": "NoSchedule",
+                        "operator": "Equal",
+                    }
+                ],
+            ),
+        ),
+        core_api=Mock(),
+    )
+    return SandboxWorkspace(
+        sandbox, SandboxRuntimeConfig(helper_image="helper@sha256:" + "a" * 64)
+    )
+
+
+def test_settings_isolate_network_and_preserve_cpu_placement() -> None:
+    """Only the trusted init container receives permission to disable interfaces."""
+    settings = workspace().settings("task@sha256:" + "b" * 64, "/home/user")
+    pod = settings.pod_settings
+    assert pod is not None
+    assert pod.node_selectors["pool"] == "workloads"
+    assert pod.volume_mounts[0]["subPath"] == "home"
+    assert settings.automount_service_account_token is False
+    assert (
+        "NET_ADMIN"
+        not in pod.container_security_context["capabilities"]["add"]
+    )
+    assert pod.additional_pod_spec_args["host_network"] is False
+    init = pod.additional_pod_spec_args["init_containers"][0]
+    assert init["securityContext"]["capabilities"]["add"] == ["NET_ADMIN"]
+    assert 'ip link set dev "$name" down' in init["command"][-1]
+    assert workspace().settings("image", None).pod_settings.volumes == []  # type: ignore[union-attr]
+
+
+def test_snapshot_reads_only_after_agent_termination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean read-only helper starts only after the agent deletion completes.
+
+    Args:
+        monkeypatch: Scoped environment method replacements.
+    """
+    env = object.__new__(SandboxEnvironment)
+    env.final = None
+    env.agent = Mock(id="agent")
+    env.shell = Mock()
+    env.workspace = Mock()
+    env.stopped = False
+    reader = Mock(id="reader")
+    events = []
+    env.workspace.destroy_session.side_effect = lambda session: events.append(
+        "delete-" + session.id
+    )
+
+    def create_reader(*args: object, **kwargs: object) -> Mock:
+        events.append("reader")
+        return reader
+
+    new_session = Mock(side_effect=create_reader)
+    monkeypatch.setattr(env, "_new", new_session)
+    monkeypatch.setattr(env, "_archive", Mock(return_value=b"archive"))
+    assert env.home_snapshot() == b"archive"
+    assert events == ["delete-agent", "reader", "delete-reader"]
+    new_session.assert_called_once_with("/workspace", readonly=True)
+    assert env.stopped
+
+
+def test_protected_hash_uses_trusted_archive_bytes() -> None:
+    """Source hashing does not invoke potentially modified binaries in the agent."""
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        member = tarfile.TarInfo("logs/input.log")
+        member.size = 4
+        tar.addfile(member, io.BytesIO(b"data"))
+    env = object.__new__(SandboxEnvironment)
+    env.stopped = False
+    env.initial = archive.getvalue()
+    assert (
+        env.source_hash("/home/user/logs/input.log")
+        == hashlib.sha256(b"data").hexdigest()
+    )
+    with pytest.raises(ValueError):
+        env.source_hash("/home/user/../etc/passwd")
+
+
+def test_timeout_cleanup_requires_pod_disappearance() -> None:
+    """Send a UID-preconditioned deletion and wait for a real NotFound response."""
+    item = workspace()
+    session = Mock(id="agent")
+    item.sessions[session.id] = (session, "pod", "uid")
+    item.sandbox.core_api.read_namespaced_pod.side_effect = [
+        SimpleNamespace(metadata=SimpleNamespace(uid="uid")),
+        ApiException(status=404),
+    ]
+    item.destroy_session(session)
+    assert (
+        item.sandbox.core_api.delete_namespaced_pod.call_args.kwargs[
+            "body"
+        ].preconditions.uid
+        == "uid"
+    )
+    assert not item.sessions
+    session.close.assert_called_once()
+
+
+def test_failed_start_orphan_is_removed_by_unique_workspace_label() -> None:
+    """Recover a created pod whose SDK session failed before returning its handle."""
+    item = workspace()
+    item.sandbox.core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                metadata=SimpleNamespace(name="orphan", uid="orphan-uid")
+            )
+        ]
+    )
+    item.sandbox.core_api.read_namespaced_pod.side_effect = ApiException(
+        status=404
+    )
+    item.close()
+    assert (
+        item.sandbox.core_api.delete_namespaced_pod.call_args.kwargs[
+            "body"
+        ].preconditions.uid
+        == "orphan-uid"
+    )
+    assert item.provenance["cleanup_complete"] is True
+
+
+def test_unsafe_archive_never_starts_verifier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject symlink transfers before provisioning a trusted verifier.
+
+    Args:
+        tmp_path: Temporary test-file directory.
+        monkeypatch: Scoped session constructor replacement.
+    """
+    data = io.BytesIO()
+    with tarfile.open(fileobj=data, mode="w") as tar:
+        member = tarfile.TarInfo("bad")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "/etc/passwd"
+        tar.addfile(member)
+    env = object.__new__(SandboxEnvironment)
+    new_session = Mock()
+    monkeypatch.setattr(env, "_new", new_session)
+    with pytest.raises(ValueError, match="Unsafe"):
+        env.verify_snapshot(data.getvalue(), tmp_path / "test.py")
+    new_session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "secret_volume",
+        "env_from",
+        "secret_env",
+        "literal_env",
+        "wrong_mount",
+        "init_mount",
+    ],
+)
+def test_admission_credentials_are_rejected(
+    mutation: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject injected credentials and mounts before exposing a sandbox session.
+
+    Args:
+        mutation: Admission mutation applied to an otherwise valid pod.
+        monkeypatch: Scoped sandbox session constructor replacement.
+    """
+    from kubernetes import client as k8s
+
+    item = workspace()
+    session = Mock(id="agent")
+    monkeypatch.setattr(
+        item.sandbox, "create_session", Mock(return_value=session)
+    )
+    container = k8s.V1Container(
+        name="main",
+        image="task",
+        env=[],
+        security_context=k8s.V1SecurityContext(
+            privileged=False,
+            allow_privilege_escalation=False,
+            capabilities=k8s.V1Capabilities(drop=["ALL"], add=["CHOWN"]),
+        ),
+        volume_mounts=[
+            k8s.V1VolumeMount(
+                name="workspace", mount_path="/home/user", sub_path="home"
+            )
+        ],
+    )
+    initializer = k8s.V1Container(
+        name="disable-network", image=item.config.helper_image
+    )
+    pod = k8s.V1Pod(
+        metadata=k8s.V1ObjectMeta(name="pod", uid="uid"),
+        spec=k8s.V1PodSpec(
+            containers=[container],
+            init_containers=[initializer],
+            automount_service_account_token=False,
+            volumes=[
+                k8s.V1Volume(
+                    name="workspace",
+                    persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=item.name
+                    ),
+                )
+            ],
+        ),
+        status=k8s.V1PodStatus(),
+    )
+    if mutation == "secret_volume":
+        pod.spec.volumes.append(
+            k8s.V1Volume(
+                name="credential",
+                secret=k8s.V1SecretVolumeSource(secret_name="secret"),
+            )
+        )
+    elif mutation == "env_from":
+        container.env_from = [
+            k8s.V1EnvFromSource(
+                secret_ref=k8s.V1SecretEnvSource(name="secret")
+            )
+        ]
+    elif mutation == "secret_env":
+        container.env = [
+            k8s.V1EnvVar(
+                name="KEY",
+                value_from=k8s.V1EnvVarSource(
+                    secret_key_ref=k8s.V1SecretKeySelector(
+                        name="secret", key="key"
+                    )
+                ),
+            )
+        ]
+    elif mutation == "literal_env":
+        container.env = [k8s.V1EnvVar(name="KEY", value="credential")]
+    elif mutation == "wrong_mount":
+        container.volume_mounts[0].mount_path = "/etc"
+    else:
+        initializer.volume_mounts = container.volume_mounts
+    item.sandbox.core_api.list_namespaced_pod.return_value = SimpleNamespace(
+        items=[pod]
+    )
+    with pytest.raises(RuntimeError, match="Admission"):
+        item.create_session("task", "/home/user")
+    assert session.id in item.sessions
+
+
+def test_cleanup_timeout_does_not_force_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the session tracked when graceful termination cannot be confirmed.
+
+    Args:
+        monkeypatch: Test-local clock replacement.
+    """
+    item = workspace()
+    session = Mock(id="agent")
+    item.sessions[session.id] = (session, "pod", "uid")
+    item.sandbox.core_api.read_namespaced_pod.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(uid="uid")
+    )
+    ticks = iter([0, 121])
+    monkeypatch.setattr(
+        "runtime.sandbox_workspace.time.monotonic", lambda: next(ticks)
+    )
+    with pytest.raises(TimeoutError, match="termination"):
+        item.destroy_session(session)
+    deletion = item.sandbox.core_api.delete_namespaced_pod
+    deletion.assert_called_once()
+    assert deletion.call_args.kwargs["body"].grace_period_seconds == 5
+    assert session.id in item.sessions
+    session.close.assert_not_called()

--- a/examples/endless_terminals/tests/test_sandbox_pipeline.py
+++ b/examples/endless_terminals/tests/test_sandbox_pipeline.py
@@ -1,0 +1,114 @@
+"""Compile the real pipeline boundary without uploading or querying artifacts."""
+
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+import sandbox_pipeline as workflow
+from pydantic import ValidationError
+
+from zenml.models import ArtifactVersionResponse
+
+
+def test_prepare_accepts_bundle_artifact_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compile real steps with a stored artifact response and JSON-safe inputs.
+
+    Args:
+        monkeypatch: Replace only the external artifact lookup.
+    """
+    identifier = UUID("11111111-1111-4111-8111-111111111111")
+    artifact = ArtifactVersionResponse.model_construct(id=identifier)
+    requested = []
+
+    def lookup(value: UUID) -> ArtifactVersionResponse:
+        """Return the test artifact response.
+
+        Args:
+            value: Requested artifact version ID.
+
+        Returns:
+            Existing artifact response fixture.
+        """
+        requested.append(value)
+        return artifact
+
+    monkeypatch.setattr(
+        workflow,
+        "Client",
+        lambda: SimpleNamespace(get_artifact_version=lookup),
+    )
+    pipeline = workflow.endless_terminals_sandbox.with_options()
+    pipeline.prepare(
+        bundle_artifact_id=identifier,
+        config=workflow.SandboxPipelineConfig(
+            helper_image="registry/helper@sha256:" + "a" * 64
+        ),
+    )
+    assert requested == [identifier]
+    invocations = pipeline.invocations
+    assert set(invocations) == {
+        "qualify_sandbox_initial",
+        "reference_fixture",
+        "noop_fixture",
+        "report_sandbox_results",
+    }
+    for name in (
+        "qualify_sandbox_initial",
+        "reference_fixture",
+        "noop_fixture",
+    ):
+        assert invocations[name].external_artifacts["bundle"].id == identifier
+    assert set(invocations["report_sandbox_results"].input_artifacts) == {
+        "initial",
+        "reference",
+        "noop",
+    }
+
+
+def test_config_rejects_mutable_image_and_multiple_tasks() -> None:
+    """Reject an unpinned helper and accidental expansion beyond one task."""
+    with pytest.raises(ValidationError):
+        workflow.SandboxPipelineConfig(helper_image="registry/helper:latest")
+    with pytest.raises(ValidationError):
+        workflow.SandboxPipelineConfig(
+            helper_image="registry/helper@sha256:" + "a" * 64,
+            task_ids=["task-one", "task-two"],
+        )
+
+
+def test_environment_receives_modal_agent_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The serialized pipeline option reaches the runtime without allocation.
+
+    Args:
+        monkeypatch: Replace the allocating runtime boundary.
+    """
+    from unittest.mock import Mock
+
+    from runtime import sandbox_env
+
+    factory = Mock()
+    monkeypatch.setattr(sandbox_env, "SandboxEnvironment", factory)
+    image = "registry/agent@sha256:" + "b" * 64
+    workflow.create_environment(
+        {"image_ref": "registry/task@sha256:" + "c" * 64},
+        workflow.SandboxPipelineConfig(
+            helper_image="registry/helper@sha256:" + "a" * 64,
+            modal_agent_image=image,
+            modal_workspace="external-team",
+            modal_environment="research",
+        ),
+    )
+    assert factory.call_args.kwargs["config"].modal_agent_image == image
+    assert (
+        factory.call_args.kwargs["config"].modal_workspace == "external-team"
+    )
+    assert factory.call_args.kwargs["config"].modal_environment == "research"
+    with pytest.raises(ValidationError):
+        workflow.SandboxPipelineConfig(
+            helper_image="registry/helper@sha256:" + "a" * 64,
+            modal_agent_image="registry/agent:latest",
+        )

--- a/examples/endless_terminals/tests/test_sandbox_shell.py
+++ b/examples/endless_terminals/tests/test_sandbox_shell.py
@@ -1,0 +1,220 @@
+"""FIFO shell deadlines and optional cached-image Docker integration."""
+
+import base64
+import os
+import subprocess
+import time
+from datetime import datetime
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from runtime.sandbox_shell import MAX_OUTPUT, SandboxShell
+
+
+def test_expired_episode_stops_without_remote_command() -> None:
+    """An expired controller deadline prevents another remote operation."""
+    session = Mock()
+    shell = SandboxShell(session, command_timeout=1, episode_timeout=1)
+    shell._process = Mock()
+    shell._deadline = time.monotonic() - 1
+    assert not shell.execute("echo late")[0]
+    assert shell.stopped
+    session.exec.assert_not_called()
+
+
+def test_upload_timeout_stops_terminal() -> None:
+    """A stalled public transfer cannot block the controller indefinitely."""
+    session = Mock()
+    session.upload_file.side_effect = lambda *_: time.sleep(0.2)
+    shell = SandboxShell(session, command_timeout=0.03, episode_timeout=1)
+    shell._process = Mock()
+    shell._deadline = time.monotonic() + 1
+    start = time.monotonic()
+    success, message = shell.execute("echo hello")
+    assert not success and "deadline" in message
+    assert time.monotonic() - start < 0.15
+    assert shell.stopped
+    session.exec.assert_not_called()
+
+
+def test_oversized_command_stops_without_transfer() -> None:
+    """Large commands fail before consuming remote resources."""
+    session = Mock()
+    shell = SandboxShell(session, command_timeout=1, episode_timeout=1)
+    shell._process = Mock()
+    shell._deadline = time.monotonic() + 1
+    assert not shell.execute("x" * (MAX_OUTPUT + 1))[0]
+    assert shell.stopped
+    session.upload_file.assert_not_called()
+
+
+def test_stream_overflow_is_bounded() -> None:
+    """The adapter rejects a stream chunk beyond its queue byte budget."""
+    shell = SandboxShell(Mock(), command_timeout=1, episode_timeout=1)
+    shell._process = Mock()
+    frame = base64.b64encode(b"x" * 4096).decode() + "\n"
+    shell._process.stdout.return_value = iter([frame] * 66)
+    shell._drain()
+    assert shell._failure.is_set()
+    assert shell._queued_bytes <= MAX_OUTPUT + 256
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ENDLESS_DOCKER_TEST_IMAGE"),
+    reason="Set ENDLESS_DOCKER_TEST_IMAGE to an existing local image",
+)
+def test_public_docker_session_preserves_state_and_stops_on_timeout() -> None:
+    """Exercise FIFO state and timeout behavior without image pulls."""
+    from zenml.enums import StackComponentType
+    from zenml.sandboxes.docker_sandbox import (
+        DockerSandbox,
+        DockerSandboxConfig,
+    )
+
+    sandbox = DockerSandbox(
+        name="fifo-test",
+        id=uuid4(),
+        flavor="docker",
+        type=StackComponentType.SANDBOX,
+        user=None,
+        created=datetime.now(),
+        updated=datetime.now(),
+        config=DockerSandboxConfig(
+            image=os.environ["ENDLESS_DOCKER_TEST_IMAGE"],
+            pull_policy="never",
+            workdir="/home/user",
+            cpu_limit=0.5,
+            memory_limit="256m",
+            run_args={"network_mode": "none"},
+        ),
+    )
+    session_id = None
+    try:
+        with sandbox.create_session(destroy_on_exit=True) as session:
+            session_id = session.id
+            shell = SandboxShell(
+                session, command_timeout=5, episode_timeout=30
+            )
+            try:
+                shell.start()
+                assert shell.execute(
+                    "mkdir /tmp/state; cd /tmp/state; export CHECK_VALUE=kept"
+                )[0]
+                ok, text = shell.execute(
+                    'printf "%s:%s" "$PWD" "$CHECK_VALUE"'
+                )
+                assert ok and text == "/tmp/state:kept"
+                assert not shell.execute("false")[0]
+                assert not shell.stopped
+                # No newline is emitted until after the byte limit is exceeded.
+                success, text = shell.execute(
+                    "python3 -c 'import sys; sys.stdout.write(\"x\" * 524288)'"
+                )
+                assert not success and shell.stopped
+                assert len(text.encode()) < MAX_OUTPUT + 512
+                shell.close()
+                shell = SandboxShell(
+                    session, command_timeout=5, episode_timeout=30
+                )
+                shell.start()
+                shell.command_timeout = 0.5
+                assert not shell.execute("sleep 10")[0]
+                assert shell.stopped
+                assert shell.execute("echo late") == (
+                    False,
+                    "Terminal is stopped",
+                )
+            finally:
+                shell.close()
+    finally:
+        if session_id:
+            remaining = subprocess.run(
+                [
+                    "docker",
+                    "ps",
+                    "-a",
+                    "--filter",
+                    "label=zenml-sandbox-session=" + session_id,
+                    "--format",
+                    "{{.ID}}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            assert not remaining.stdout.strip()
+
+
+def test_malformed_frame_stops_stream() -> None:
+    """Malformed transport framing never becomes agent output."""
+    shell = SandboxShell(Mock(), command_timeout=1, episode_timeout=1)
+    shell._process = Mock()
+    shell._process.stdout.return_value = iter(["invalid % framing\n"])
+    shell._drain()
+    assert shell._failure.is_set()
+    assert shell._output.empty()
+
+
+def test_control_commands_never_kill_the_shared_session() -> None:
+    """Successful setup, dispatch and close cannot trigger backend-wide kill."""
+    import queue
+    import re
+    import threading
+    from pathlib import Path
+    from typing import Iterator
+
+    frames: queue.Queue[str] = queue.Queue()
+    ended = threading.Event()
+    control = Mock()
+    control.wait.return_value = 0
+    control.kill.side_effect = AssertionError("Kill would destroy the session")
+    persistent = Mock()
+    persistent.kill.side_effect = AssertionError(
+        "Per-process kill unsupported"
+    )
+
+    def output() -> Iterator[str]:
+        """Deliver fake backend frames until the owner terminates the session.
+
+        Yields:
+            Base64 output frames.
+        """
+        while not ended.is_set():
+            try:
+                yield frames.get(timeout=0.05)
+            except queue.Empty:
+                pass
+
+    def upload(local: str, remote: str) -> None:
+        """Return a successful command marker from the fake persistent shell.
+
+        Args:
+            local: Controller script path.
+            remote: Remote script path.
+        """
+        match = re.search(r"ENDLESS_[a-f0-9]+", Path(local).read_text())
+        assert match is not None
+        frames.put(
+            base64.b64encode(
+                b"\x1e" + match[0].encode() + b":0\x1f\n"
+            ).decode()
+            + "\n"
+        )
+
+    persistent.stdout.side_effect = output
+    session = Mock()
+    session.exec.side_effect = lambda command: (
+        persistent if "exec 3<>" in command[-1] else control
+    )
+    session.upload_file.side_effect = upload
+    shell = SandboxShell(session, command_timeout=1, episode_timeout=5)
+    try:
+        shell.start()
+        assert shell.execute("printf ready")[0]
+        shell.close()
+        assert shell.stopped
+        control.kill.assert_not_called()
+        persistent.kill.assert_not_called()
+    finally:
+        ended.set()

--- a/examples/endless_terminals/tests/test_training.py
+++ b/examples/endless_terminals/tests/test_training.py
@@ -1,0 +1,686 @@
+"""Exercise paired training lifecycle without model or cloud requests."""
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+from unittest.mock import Mock
+
+import pytest
+import training
+from config import TrainingConfig
+from reporting import render_evaluation_report
+from runtime.contract import SYSTEM_MESSAGE
+
+
+@pytest.fixture
+def setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Prepare fake policy and cloud boundaries around the real training loop.
+
+    Args:
+        tmp_path: Temporary artifact directory.
+        monkeypatch: Scoped patch helper.
+
+    Returns:
+        Configuration, prepared tasks, and mocked external dependencies.
+    """
+    cloud = tmp_path / "cloud.json"
+    cloud.write_text(json.dumps({"training_image": "image@sha256:abc"}))
+    config = TrainingConfig(
+        cloud_config_path=str(cloud),
+        data_directory=str(tmp_path / "data"),
+        output_directory=str(tmp_path / "runs"),
+        training_task_ids=["task-a"],
+        groups=3,
+        group_size=2,
+        zero_signal_patience=2,
+    )
+    prepared = {
+        "dataset_revision": "dataset-1",
+        "tasks": [
+            {
+                "task_id": "task-a",
+                "task_file_sha256": {"instruction.md": "hash"},
+                "local_image_id": "image-id",
+            }
+        ],
+    }
+    session = Mock()
+    session.serving_seconds_remaining = 100000
+    session.base_url = "http://localhost:1234"
+    session.identity = {"job_name": "owned-test-job"}
+    session.cleanup_report = {"complete": False}
+    session.__enter__ = Mock(return_value=session)
+
+    def cleanup(*args: Any) -> None:
+        session.cleanup_report = {"complete": True}
+
+    session.__exit__ = Mock(side_effect=cleanup)
+    service_constructor = Mock(return_value=session)
+    monkeypatch.setattr(training, "KubernetesInference", service_constructor)
+    policy = Mock()
+    policy.optimizer_steps = 0
+    policy.snapshot.side_effect = lambda name, **kwargs: {
+        "identity": {"path": name},
+        "client": "fake-client",
+    }
+    policy.episode_model.side_effect = lambda snapshot: SimpleNamespace(
+        samples=[
+            {
+                "checkpoint": snapshot["identity"]["path"],
+                "prompt_ids": [1],
+                "completion_ids": [2],
+                "logprobs": [-0.5],
+            }
+        ]
+    )
+
+    def update(samples: list[Any], rewards: list[float]) -> dict[str, Any]:
+        changed = len(set(rewards)) > 1
+        policy.optimizer_steps += int(changed)
+        return {"updated": changed, "optimizer_steps": policy.optimizer_steps}
+
+    policy.update.side_effect = update
+
+    def download(name: str, directory: Path) -> Path:
+        directory.mkdir(parents=True)
+        manifest = directory / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {"kind": "sampler_adapter_not_resume_checkpoint", "name": name}
+            )
+        )
+        (directory / "adapter.safetensors").write_bytes(name.encode())
+        return manifest
+
+    policy.download_checkpoint.side_effect = download
+    policy_constructor = Mock(return_value=policy)
+    artifact_publisher = Mock()
+    monkeypatch.setattr(training, "TinkerPolicy", policy_constructor)
+    monkeypatch.setattr(training, "save_artifact", artifact_publisher)
+    rewards = [0, 0, 0, 0, 0, 0]
+
+    def episode(
+        task: dict[str, Any],
+        directory: Path,
+        model: Any,
+        output: Path,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        reward = rewards.pop(0) if "training" in output.parts else 0
+        return {
+            "task_id": task["task_id"],
+            "grading": {"raw_reward": reward, "audited_valid": bool(reward)},
+            "cleanup_complete": True,
+            "turns": [],
+            "elapsed_seconds": 1,
+            "exit_reason": "done",
+        }
+
+    episode_runner = Mock(side_effect=episode)
+    monkeypatch.setattr(training, "run_episode", episode_runner)
+    return SimpleNamespace(
+        service_constructor=service_constructor,
+        policy_constructor=policy_constructor,
+        artifact_publisher=artifact_publisher,
+        episode_runner=episode_runner,
+        config=config,
+        prepared=prepared,
+        session=session,
+        policy=policy,
+        rewards=rewards,
+        root=tmp_path,
+    )
+
+
+def test_zero_signal_stops_without_optimizer_updates(
+    setup: SimpleNamespace,
+) -> None:
+    """Repeated equal rewards stop at patience while retaining paired evaluations.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    before, after, evidence, _ = training.execute_training(
+        setup.prepared, setup.config, "zero"
+    )
+    assert evidence["optimizer_steps"] == 0
+    setup.policy.snapshot.assert_called_once_with("before", timeout=600)
+    assert evidence["stop_reason"] == "no_reward_variation"
+    assert len(evidence["groups"]) == 2
+    assert before["protocol"] == after["protocol"]
+    assert before["task_hashes"] == after["task_hashes"]
+    assert before["cleanup"]["complete"] is True
+    setup.session.__exit__.assert_called_once()
+    assert (
+        json.loads((setup.root / "runs/zero/training.json").read_text())[
+            "status"
+        ]
+        == "completed"
+    )
+
+
+def test_updates_use_new_snapshot(setup: SimpleNamespace) -> None:
+    """Later groups and the final evaluation use the updated sampling checkpoint.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    setup.rewards[:] = [0, 1, 0, 1, 0, 1]
+    before, after, evidence, _ = training.execute_training(
+        setup.prepared, setup.config, "updated"
+    )
+    assert evidence["optimizer_steps"] == 3
+    assert evidence["groups"][0]["samples"][0][0]["logprobs"] == [-0.5]
+    assert [group["checkpoint"]["path"] for group in evidence["groups"]] == [
+        "before",
+        "update-01",
+        "update-02",
+    ]
+    assert before["model"]["checkpoint"]["path"] == "before"
+    assert after["model"]["checkpoint"]["path"] == "update-03"
+    assert [call.args[0] for call in setup.policy.snapshot.call_args_list] == [
+        "before",
+        "update-01",
+        "update-02",
+        "update-03",
+    ]
+
+
+def test_update_failure_cleans_up_and_retains_partial_evidence(
+    setup: SimpleNamespace,
+) -> None:
+    """A failed optimizer operation does not bypass owned service cleanup.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    setup.rewards[:] = [0, 1]
+    setup.policy.update.side_effect = TimeoutError("uncertain update")
+    with pytest.raises(TimeoutError, match="uncertain"):
+        training.execute_training(setup.prepared, setup.config, "failed")
+    evidence = json.loads(
+        (setup.root / "runs/failed/training.json").read_text()
+    )
+    assert evidence["status"] == "failed"
+    assert evidence["error"] == {
+        "type": "TimeoutError",
+        "message": "uncertain update",
+    }
+    assert evidence["cleanup"]["complete"] is True
+    assert len(evidence["groups"][0]["episodes"]) == 2
+    setup.policy.update.assert_called_once()
+    setup.policy.download_checkpoint.assert_called_once_with(
+        "initial", setup.root / "runs/failed/initial_checkpoint"
+    )
+    assert evidence["initial_checkpoint"]["name"] == "initial"
+    setup.session.__exit__.assert_called_once()
+
+
+def test_service_budget_stops_before_new_training_group(
+    setup: SimpleNamespace,
+) -> None:
+    """Reserve the service lifetime before adding more training episodes.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    setup.session.serving_seconds_remaining = (
+        setup.config.episode_timeout + 310
+    )
+    _, _, evidence, _ = training.execute_training(
+        setup.prepared, setup.config, "budget"
+    )
+    assert evidence["stop_reason"] == "service_budget"
+    assert evidence["groups"] == []
+    setup.policy.update.assert_not_called()
+
+
+def test_native_pipeline_builds_separate_artifact_dependencies(
+    setup: SimpleNamespace,
+) -> None:
+    """Build the actual ZenML graph without allocating any cloud service.
+
+    Args:
+        setup: Mocked task and service boundaries.
+    """
+    workflow = training.endless_terminals_training
+    workflow.prepare(setup.config)
+    assert set(workflow.invocations) == {
+        "prepare_evaluation",
+        "train_and_evaluate",
+        "report_training",
+    }
+    assert set(training.train_and_evaluate.entrypoint_definition.outputs) == {
+        "before_evaluation",
+        "after_evaluation",
+        "training_evidence",
+        "trained_adapter",
+    }
+    inputs = workflow.invocations["report_training"].input_artifacts
+    for name, expected in {
+        "before": "before_evaluation",
+        "after_evaluation": "after_evaluation",
+        "training": "training_evidence",
+    }.items():
+        artifact = inputs[name]
+        assert not isinstance(artifact, list)
+        assert artifact.output_name == expected
+    setup.session.__enter__.assert_not_called()
+
+
+def test_injected_environment_used_for_before_groups_and_after(
+    setup: SimpleNamespace,
+) -> None:
+    """Use portable bundle paths and the sandbox factory for every model episode.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    setup.session.identity["training_image"] = (
+        "registry/training@sha256:" + "a" * 64
+    )
+    setup.prepared["tasks"][0]["image_ref"] = (
+        "registry/task@sha256:" + "b" * 64
+    )
+    bundle = setup.root / "materialized-bundle"
+    factory = Mock()
+    before, after, evidence, checkpoint = training.execute_training(
+        setup.prepared,
+        setup.config,
+        "injected",
+        session=setup.session,
+        environment_factory=factory,
+        data_directory=bundle,
+        output_directory=setup.root / "native-output",
+        client_api_key="run-secret",
+        trusted_service_host="service.namespace.svc",
+    )
+    setup.service_constructor.assert_not_called()
+    calls = setup.episode_runner.call_args_list
+    assert len(calls) == 6
+    assert all(call.args[1] == bundle / "task-a" for call in calls)
+    assert all(call.kwargs["environment_factory"] is factory for call in calls)
+    assert calls[0].args[3].name == "task-a"
+    assert calls[-1].args[3].parent.name == "after"
+    assert before["task_hashes"] == after["task_hashes"]
+    assert (
+        before["task_hashes"]["task-a"]["image"]
+        == setup.prepared["tasks"][0]["image_ref"]
+    )
+    assert evidence["optimizer_steps"] == 0
+    assert checkpoint.is_dir()
+    assert setup.policy_constructor.call_args.kwargs["api_key"] == "run-secret"
+    assert (
+        setup.policy_constructor.call_args.kwargs["trusted_service_host"]
+        == "service.namespace.svc"
+    )
+
+
+def test_injected_update_failure_publishes_diagnostics_after_cleanup(
+    setup: SimpleNamespace,
+) -> None:
+    """Preserve remote-step failure evidence after releasing the injected service.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    setup.session.identity["training_image"] = (
+        "registry/training@sha256:" + "a" * 64
+    )
+    setup.rewards[:] = [0, 1]
+    setup.policy.update.side_effect = TimeoutError("uncertain native update")
+    output = setup.root / "native-failure"
+    with pytest.raises(TimeoutError, match="uncertain native update"):
+        training.execute_training(
+            setup.prepared,
+            setup.config,
+            "failed-native",
+            session=setup.session,
+            output_directory=output,
+            data_directory=setup.root / "bundle",
+            environment_factory=Mock(),
+        )
+    setup.session.__exit__.assert_called_once()
+    evidence = json.loads((output / "training.json").read_text())
+    assert evidence["cleanup"]["complete"] is True
+    assert evidence["optimizer_steps"] == 0
+    assert [
+        call.kwargs["name"] for call in setup.artifact_publisher.call_args_list
+    ] == ["failed_training_evidence", "failed_training_diagnostics"]
+    assert setup.artifact_publisher.call_args.args[0] == output
+    assert evidence["initial_checkpoint"]["name"] == "initial"
+    assert (
+        output / "initial_checkpoint/adapter.safetensors"
+    ).read_bytes() == b"initial"
+    setup.policy.download_checkpoint.assert_called_once_with(
+        "initial", output / "initial_checkpoint"
+    )
+
+
+@pytest.mark.parametrize("variant", ["upstream", "concise_xml_v1"])
+def test_prompt_variant_reaches_every_episode(
+    setup: SimpleNamespace, variant: str
+) -> None:
+    """Use one explicit prompt across the before, training, and after episodes.
+
+    Args:
+        setup: Isolated training fixture.
+        variant: Selected training prompt.
+    """
+    config = TrainingConfig.model_validate(
+        {**setup.config.model_dump(), "prompt_variant": variant}
+    )
+    before, after, evidence, _ = training.execute_training(
+        setup.prepared, config, "prompt"
+    )
+    calls = setup.episode_runner.call_args_list
+    assert len(calls) == 6
+    messages = [call.kwargs["system_message"] for call in calls]
+    assert len(set(messages)) == 1
+    if variant == "upstream":
+        assert messages[0] == SYSTEM_MESSAGE
+    else:
+        from runtime.contract import CONCISE_XML_V1_SYSTEM_MESSAGE
+
+        assert messages[0] == CONCISE_XML_V1_SYSTEM_MESSAGE
+    digest = hashlib.sha256(messages[0].encode()).hexdigest()
+    for protocol in (
+        before["protocol"],
+        after["protocol"],
+        evidence["protocol"],
+    ):
+        assert protocol["prompt_variant"] == variant
+        assert protocol["system_prompt_sha256"] == digest
+    for key in ("prompt_variant", "system_prompt_sha256"):
+        mismatched = {
+            **after,
+            "protocol": {**after["protocol"], key: "different"},
+        }
+        with pytest.raises(ValueError, match="protocol"):
+            render_evaluation_report(mismatched, before)
+
+
+def test_prompt_variant_default_and_validation(setup: SimpleNamespace) -> None:
+    """Reject an unknown prompt variant before any training allocation.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    assert setup.config.prompt_variant == "upstream"
+    with pytest.raises(ValueError, match="prompt_variant"):
+        TrainingConfig.model_validate(
+            {**setup.config.model_dump(), "prompt_variant": "unknown"}
+        )
+    setup.service_constructor.assert_not_called()
+
+
+def test_initial_adapter_is_retained_before_any_training_episode(
+    setup: SimpleNamespace,
+) -> None:
+    """Export and persist the starting weights between before evaluation and updates.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    output = setup.root / "runs/initial-retention"
+    original_download: Callable[[str, Path], Path] = (
+        setup.policy.download_checkpoint.side_effect
+    )
+    original_episode: Callable[..., dict[str, Any]] = (
+        setup.episode_runner.side_effect
+    )
+
+    def download(name: str, directory: Path) -> Path:
+        if name == "initial":
+            assert setup.episode_runner.call_count == 1
+            setup.policy.update.assert_not_called()
+        return original_download(name, directory)
+
+    def episode(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        if "training" in args[3].parts:
+            persisted = json.loads((output / "training.json").read_text())
+            assert persisted["initial_checkpoint"]["name"] == "initial"
+            assert (
+                output / "initial_checkpoint/adapter.safetensors"
+            ).read_bytes() == b"initial"
+        return original_episode(*args, **kwargs)
+
+    setup.policy.download_checkpoint.side_effect = download
+    setup.episode_runner.side_effect = episode
+    _, _, evidence, final = training.execute_training(
+        setup.prepared, setup.config, "initial-retention"
+    )
+    assert [
+        call.args[0]
+        for call in setup.policy.download_checkpoint.call_args_list
+    ] == ["initial", "final"]
+    assert evidence["initial_checkpoint"]["name"] == "initial"
+    assert evidence["checkpoint"]["name"] == "final"
+    assert (final / "adapter.safetensors").read_bytes() == b"final"
+
+
+def test_final_export_failure_retains_completed_evaluation(
+    setup: SimpleNamespace,
+) -> None:
+    """Preserve both evaluations when downloading the final adapter fails.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    config = setup.config.model_copy(update={"evaluation_attempts": 3})
+    original_download: Callable[[str, Path], Path] = (
+        setup.policy.download_checkpoint.side_effect
+    )
+
+    def download(name: str, directory: Path) -> Path:
+        if name == "final":
+            raise TimeoutError("checkpoint transfer stalled")
+        return original_download(name, directory)
+
+    setup.policy.download_checkpoint.side_effect = download
+    with pytest.raises(TimeoutError, match="checkpoint transfer stalled"):
+        training.execute_training(setup.prepared, config, "export-failure")
+    output = setup.root / "runs/export-failure"
+    for phase in ("before", "after"):
+        evaluation = json.loads(
+            (output / phase / "evaluation.json").read_text()
+        )
+        assert evaluation["status"] == "completed"
+        assert len(evaluation["episodes"]) == 3
+        assert evaluation["cleanup"]["complete"] is True
+    evidence = json.loads((output / "training.json").read_text())
+    assert evidence["status"] == "failed"
+    assert evidence["error"]["type"] == "TimeoutError"
+
+
+def test_connection_resolved_only_after_service_start(
+    setup: SimpleNamespace,
+) -> None:
+    """Use the endpoint assigned during service startup.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+
+    def credentials() -> tuple[str, str]:
+        setup.session.__enter__.assert_called_once()
+        return "tml-native-test", "owned.modal.host"
+
+    training.execute_training(
+        setup.prepared,
+        setup.config,
+        "assigned-endpoint",
+        client_credentials_factory=credentials,
+    )
+    arguments = setup.policy_constructor.call_args.kwargs
+    assert arguments["api_key"] == "tml-native-test"
+    assert arguments["trusted_service_host"] == "owned.modal.host"
+
+
+@pytest.mark.parametrize("attempts", [0, 21])
+def test_evaluation_attempts_are_bounded(
+    setup: SimpleNamespace, attempts: int
+) -> None:
+    """Reject an unbounded evaluation before allocating the service.
+
+    Args:
+        setup: Isolated training fixture.
+        attempts: Invalid number of attempts per task.
+    """
+    assert setup.config.evaluation_attempts == 1
+    with pytest.raises(ValueError, match="evaluation_attempts"):
+        TrainingConfig.model_validate(
+            {**setup.config.model_dump(), "evaluation_attempts": attempts}
+        )
+    setup.service_constructor.assert_not_called()
+
+
+def test_repeated_evaluations_preserve_snapshots_and_each_attempt(
+    setup: SimpleNamespace,
+) -> None:
+    """Repeat every task with unique paths and retain evidence as attempts finish.
+
+    Args:
+        setup: Isolated training fixture.
+    """
+    config = TrainingConfig.model_validate(
+        {**setup.config.model_dump(), "evaluation_attempts": 3}
+    )
+    setup.prepared["tasks"].append(
+        {**setup.prepared["tasks"][0], "task_id": "task-b"}
+    )
+    setup.rewards[:] = [0, 1, 0, 1, 0, 1]
+    original_episode: Callable[..., dict[str, Any]] = (
+        setup.episode_runner.side_effect
+    )
+    completed = {"before": 0, "after": 0}
+
+    def episode(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        output: Path = args[3]
+        phase = output.parent.parent.name
+        if phase in completed:
+            if completed[phase]:
+                persisted = json.loads(
+                    (output.parent.parent / "evaluation.json").read_text()
+                )
+                assert len(persisted["episodes"]) == completed[phase]
+                assert persisted["status"] == "running"
+            completed[phase] += 1
+        return original_episode(*args, **kwargs)
+
+    setup.episode_runner.side_effect = episode
+    before, after, evidence, _ = training.execute_training(
+        setup.prepared, config, "repeated"
+    )
+    assert completed == {"before": 6, "after": 6}
+    assert evidence["optimizer_steps"] == 3
+    assert before["protocol"] == after["protocol"]
+    assert before["protocol"]["evaluation_attempts"] == 3
+    assert before["task_hashes"] == after["task_hashes"]
+    calls = setup.episode_runner.call_args_list
+    paths = [call.args[3] for call in calls]
+    assert len(paths) == len(set(paths)) == 18
+    for phase, evaluation, checkpoint in (
+        ("before", before, "before"),
+        ("after", after, "update-03"),
+    ):
+        assert [
+            (episode["task_id"], episode["attempt_index"])
+            for episode in evaluation["episodes"]
+        ] == [
+            (task, index)
+            for task in ("task-a", "task-b")
+            for index in range(1, 4)
+        ]
+        phase_calls = [
+            call for call in calls if call.args[3].parent.parent.name == phase
+        ]
+        assert all(
+            call.args[2].samples[0]["checkpoint"] == checkpoint
+            for call in phase_calls
+        )
+        assert [call.args[3].name for call in phase_calls] == [
+            "attempt-01",
+            "attempt-02",
+            "attempt-03",
+        ] * 2
+        assert evaluation["status"] == "completed"
+        assert evaluation["cleanup"]["complete"] is True
+
+
+@pytest.mark.parametrize("phase", ["before", "after"])
+def test_repeated_evaluation_failure_retains_completed_attempts(
+    setup: SimpleNamespace,
+    phase: str,
+) -> None:
+    """A later attempt failure leaves earlier results available and cleans up.
+
+    Args:
+        setup: Isolated training fixture.
+        phase: Evaluation phase that fails after its first attempt.
+    """
+    config = TrainingConfig.model_validate(
+        {**setup.config.model_dump(), "evaluation_attempts": 3}
+    )
+    original_episode: Callable[..., dict[str, Any]] = (
+        setup.episode_runner.side_effect
+    )
+
+    def episode(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        if (
+            args[3].name == "attempt-02"
+            and args[3].parent.parent.name == phase
+        ):
+            raise RuntimeError("attempt infrastructure failed")
+        return original_episode(*args, **kwargs)
+
+    setup.episode_runner.side_effect = episode
+    with pytest.raises(RuntimeError, match="attempt infrastructure failed"):
+        training.execute_training(setup.prepared, config, "repeated-failed")
+    persisted = json.loads(
+        (
+            setup.root / "runs/repeated-failed" / phase / "evaluation.json"
+        ).read_text()
+    )
+    assert len(persisted["episodes"]) == 1
+    assert persisted["episodes"][0]["attempt_index"] == 1
+    assert persisted["status"] == "failed"
+    assert persisted["cleanup"]["complete"] is True
+    assert persisted["error"]["message"] == "attempt infrastructure failed"
+    if phase == "before":
+        setup.policy.update.assert_not_called()
+    else:
+        before = json.loads(
+            (
+                setup.root / "runs/repeated-failed/before/evaluation.json"
+            ).read_text()
+        )
+        assert before["status"] == "completed"
+        assert len(before["episodes"]) == 3
+        assert before["cleanup"]["complete"] is True
+    setup.session.__exit__.assert_called_once()
+    assert setup.session.cleanup_report["complete"] is True
+
+
+def test_repeated_evaluation_reserve_covers_all_interaction_budgets(
+    setup: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reserve every after attempt plus measured overhead before starting a group.
+
+    Args:
+        setup: Isolated training fixture.
+        monkeypatch: Scoped patch helper.
+    """
+    config = TrainingConfig.model_validate(
+        {**setup.config.model_dump(), "evaluation_attempts": 10}
+    )
+    monkeypatch.setattr(time, "monotonic", Mock(side_effect=[0, 200]))
+    _, _, evidence, _ = training.execute_training(
+        setup.prepared, config, "repeated-reserve"
+    )
+    assert evidence["paired_evaluation_reserve_seconds"] == (
+        10 * config.episode_timeout + 200 + 660
+    )

--- a/examples/endless_terminals/tests/test_training_client.py
+++ b/examples/endless_terminals/tests/test_training_client.py
@@ -1,0 +1,447 @@
+"""Check training control and exact sampling evidence without remote requests."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from training_client import EpisodeModel, TinkerPolicy
+
+
+def policy() -> TinkerPolicy:
+    """Create a policy without initialization or remote operations.
+
+    Returns:
+        Policy with local mock dependencies.
+    """
+    instance = object.__new__(TinkerPolicy)
+    instance.failed = False
+    instance.optimizer_steps = 0
+    instance.max_tokens = 8
+    instance.max_context = 32
+    instance.temperature = 0.8
+    instance.learning_rate = 1e-4
+    instance.base_url = "http://127.0.0.1:8123"
+    instance.trusted_service_host = None
+    instance.api_key = "tml-local-skyrl"
+    instance.tokenizer = Mock()
+    instance.tokenizer.eos_token_id = 9
+    instance.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+    instance.tokenizer.decode.return_value = "<action>done</action>"
+    return instance
+
+
+def sample() -> list[list[dict[str, Any]]]:
+    """Build two samples from the same immutable checkpoint.
+
+    Returns:
+        One recorded turn per episode.
+    """
+    return [
+        [
+            {
+                "prompt_ids": [1],
+                "completion_ids": [2],
+                "logprobs": [-0.5],
+                "checkpoint": "snapshot-0",
+            }
+        ]
+        for _ in range(2)
+    ]
+
+
+def test_equal_reward_skips_optimizer() -> None:
+    """Avoid presenting zero-advantage groups as optimizer updates."""
+    instance = policy()
+    result = instance.update(sample(), [0.0, 0.0])
+    assert result == {
+        "updated": False,
+        "reason": "all_rewards_equal",
+        "optimizer_steps": 0,
+    }
+
+
+def test_cold_sampler_can_wait_longer_without_changing_later_defaults() -> (
+    None
+):
+    """Cold inference initialization gets an explicit, finite wait budget."""
+    instance = policy()
+    instance.model_name = "test/model"
+    instance.model_revision = "a" * 40
+    instance.client = Mock()
+    instance.client.save_weights_for_sampler.return_value.result.return_value = SimpleNamespace(
+        path="tinker://model/before"
+    )
+    instance.service = Mock(create_sampling_client_async=AsyncMock())
+    instance.snapshot("before", timeout=600)
+    instance.client.save_weights_for_sampler.return_value.result.assert_called_with(
+        timeout=600
+    )
+    instance.snapshot("later")
+    instance.client.save_weights_for_sampler.return_value.result.assert_called_with(
+        timeout=180
+    )
+
+
+@pytest.mark.parametrize("timeout", [0, 601, float("inf"), float("nan")])
+def test_snapshot_rejects_unbounded_waits(timeout: float) -> None:
+    """Invalid waits fail before a remote save is submitted.
+
+    Args:
+        timeout: Invalid sampler-save timeout.
+    """
+    with pytest.raises(ValueError, match="timeout"):
+        policy().snapshot("before", timeout=timeout)
+
+
+def test_mixed_checkpoints_are_rejected() -> None:
+    """Prevent accidentally mixing stale and current-policy trajectories."""
+    samples = sample()
+    samples[1][0]["checkpoint"] = "another"
+    with pytest.raises(ValueError, match="checkpoint"):
+        policy().update(samples, [0.0, 1.0])
+
+
+def test_uncertain_update_blocks_further_work() -> None:
+    """Never retry an uncertain optimizer update through a new SDK request."""
+    instance = policy()
+    instance.failed = True
+    with pytest.raises(RuntimeError, match="uncertain"):
+        instance.update(sample(), [0.0, 1.0])
+
+
+def test_sampling_keeps_exact_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Store sampled tokens directly instead of reconstructing decoded text.
+
+    Args:
+        monkeypatch: Scoped patch helper.
+    """
+    import sys
+
+    fake = SimpleNamespace(
+        ModelInput=SimpleNamespace(from_ints=lambda tokens: tokens),
+        SamplingParams=lambda **kwargs: kwargs,
+    )
+    monkeypatch.setitem(sys.modules, "tinker", fake)
+    client = Mock()
+    client.sample.return_value.result.return_value = SimpleNamespace(
+        sequences=[SimpleNamespace(tokens=[7, 8], logprobs=[-0.2, -0.3])]
+    )
+    model = EpisodeModel(
+        policy(), {"client": client, "identity": {"path": "snapshot-0"}}
+    )
+    text, usage = model.complete(
+        [{"role": "user", "content": "test"}], timeout=4
+    )
+    assert text == "<action>done</action>"
+    assert model.samples[0]["completion_ids"] == [7, 8]
+    assert model.samples[0]["logprobs"] == [-0.2, -0.3]
+    assert usage["total_tokens"] == 5
+    assert (
+        model.policy.tokenizer.apply_chat_template.call_args.kwargs[
+            "return_dict"
+        ]
+        is False
+    )
+    client.sample.return_value.result.assert_called_once_with(timeout=4)
+
+
+def test_context_overflow_never_calls_sampler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject overlong conversations instead of silently changing their context.
+
+    Args:
+        monkeypatch: Scoped patch helper.
+    """
+    import sys
+
+    monkeypatch.setitem(sys.modules, "tinker", SimpleNamespace())
+    instance = policy()
+    instance.max_context = 4
+    client = Mock()
+    with pytest.raises(ValueError, match="context"):
+        EpisodeModel(instance, {"client": client}).complete([], timeout=3)
+    client.sample.assert_not_called()
+
+
+def test_export_uses_explicit_service_and_hashes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep adapter exports attributable and separate from resumable state.
+
+    Args:
+        tmp_path: Temporary output directory.
+        monkeypatch: Scoped patch helper.
+    """
+    import json
+
+    instance = policy()
+    monkeypatch.setattr(
+        instance,
+        "snapshot",
+        lambda name: {
+            "identity": {
+                "path": "snapshot-final",
+                "kind": "sampler_adapter_not_resume_checkpoint",
+            }
+        },
+    )
+    calls = []
+
+    def download(args: list[str], **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+        Path(args[-2], "adapter.safetensors").write_bytes(b"adapter")
+
+    monkeypatch.setattr("training_client.subprocess.run", download)
+    manifest = instance.download_checkpoint("final", tmp_path / "adapter")
+    evidence = json.loads(manifest.read_text())
+    assert evidence["kind"] == "sampler_adapter_not_resume_checkpoint"
+    assert "adapter.safetensors" in evidence["files"]
+    assert calls[0][0][-1] == instance.base_url
+    assert calls[0][1]["timeout"] == 180
+    assert calls[0][1]["env"]["TINKER_API_KEY"] == "tml-local-skyrl"
+
+
+def test_official_cookbook_update_masks_nonappend_observations() -> None:
+    """Exercise real Cookbook grouping, token masks, and optimizer dispatch."""
+    from unittest.mock import AsyncMock
+
+    pytest.importorskip("tinker_cookbook.rl.train")
+    instance = policy()
+    data_seen: list[Any] = []
+
+    async def forward(data: list[Any], **kwargs: Any) -> Any:
+        data_seen.extend(data)
+        assert kwargs["loss_fn"] == "importance_sampling"
+        return SimpleNamespace(
+            result_async=AsyncMock(
+                return_value=SimpleNamespace(
+                    loss_fn_outputs=[
+                        {"logprobs": datum.loss_fn_inputs["logprobs"]}
+                        for datum in data
+                    ]
+                )
+            )
+        )
+
+    instance.client = SimpleNamespace(
+        forward_backward_async=AsyncMock(side_effect=forward),
+        optim_step_async=AsyncMock(
+            return_value=SimpleNamespace(
+                result_async=AsyncMock(
+                    return_value=SimpleNamespace(metrics={"grad_norm": 0.25})
+                )
+            )
+        ),
+    )
+    samples = [
+        [
+            {
+                "prompt_ids": [1, 2, 3],
+                "completion_ids": [4],
+                "logprobs": [-0.2],
+                "checkpoint": "step-0",
+            },
+            {
+                "prompt_ids": [8, 9],
+                "completion_ids": [10],
+                "logprobs": [-0.4],
+                "checkpoint": "step-0",
+            },
+        ],
+        [
+            {
+                "prompt_ids": [1],
+                "completion_ids": [2],
+                "logprobs": [-0.6],
+                "checkpoint": "step-0",
+            },
+        ],
+    ]
+    result = instance.update(samples, [0.0, 1.0])
+    assert result["updated"] is True
+    assert result["advantages"] == [-0.5, 0.5]
+    assert result["training_datums"] == 3
+    assert result["metrics"]["grad_norm"] == 0.25
+    instance.client.optim_step_async.assert_awaited_once()
+    assert all("mask" not in datum.loss_fn_inputs for datum in data_seen)
+    assert [
+        datum.loss_fn_inputs["advantages"].to_torch().tolist()
+        for datum in data_seen
+    ] == [
+        [0.0, 0.0, -0.5],
+        [0.0, -0.5],
+        [0.5],
+    ]
+
+
+def test_official_cookbook_failure_poisoning() -> None:
+    """Do not submit another optimizer request after uncertain update failure."""
+    from unittest.mock import AsyncMock
+
+    pytest.importorskip("tinker_cookbook.rl.train")
+    instance = policy()
+    instance.client = SimpleNamespace(
+        forward_backward_async=AsyncMock(
+            side_effect=TimeoutError("uncertain")
+        ),
+        optim_step_async=AsyncMock(),
+    )
+    with pytest.raises(TimeoutError):
+        instance.update(sample(), [0.0, 1.0])
+    assert instance.failed
+    with pytest.raises(RuntimeError, match="uncertain"):
+        instance.update(sample(), [0.0, 1.0])
+    instance.client.forward_backward_async.assert_awaited_once()
+    instance.client.optim_step_async.assert_not_awaited()
+
+
+def test_local_service_uses_explicit_placeholder_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not inherit a hosted-service key when connecting to local SkyRL.
+
+    Args:
+        monkeypatch: Scoped patch helper.
+    """
+    from unittest.mock import AsyncMock
+
+    tinker = pytest.importorskip("tinker")
+    transformers = pytest.importorskip("transformers")
+    service = Mock()
+    service.create_lora_training_client_async = AsyncMock(return_value=Mock())
+    constructor = Mock(return_value=service)
+    monkeypatch.setattr(tinker, "ServiceClient", constructor)
+    monkeypatch.setattr(transformers.AutoTokenizer, "from_pretrained", Mock())
+    monkeypatch.setattr("training_client.subprocess.run", Mock())
+    monkeypatch.setenv("TINKER_API_KEY", "synthetic-key-must-not-be-used")
+    TinkerPolicy("http://127.0.0.1:8123", "model", "a" * 40)
+    assert constructor.call_args.kwargs["api_key"] == "tml-local-skyrl"
+    with pytest.raises(ValueError, match="local port-forward"):
+        TinkerPolicy("https://remote.example", "model", "a" * 40)
+    assert constructor.call_count == 1
+
+
+def test_real_sdk_auth_and_session_against_loopback_server() -> None:
+    """Exercise SDK auth validation and HTTP session creation without cloud calls."""
+    import subprocess
+    import sys
+
+    pytest.importorskip("tinker")
+    script = """
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import tinker
+
+seen = []
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+    def respond(self):
+        seen.append(self.path)
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        if self.path.endswith("client/config"):
+            data = {"use_pyqwest_transport": False}
+        elif self.path.endswith("get_server_capabilities"):
+            data = {"supported_models": [{"model_name": "/models/base"}]}
+        elif self.path.endswith("create_session"):
+            data = {"session_id": "local-session", "type": "create_session"}
+        elif self.path.endswith("create_sampling_session"):
+            data = {"sampling_session_id": "local-sampling", "type": "create_sampling_session"}
+        elif self.path.endswith("session_heartbeat"):
+            data = {}
+        else:
+            self.send_error(404)
+            return
+        body = json.dumps(data).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    do_GET = respond
+    do_POST = respond
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+try:
+    service = tinker.ServiceClient(base_url=f"http://127.0.0.1:{server.server_port}", api_key="tml-local-skyrl", timeout=3)
+    capabilities = service.get_server_capabilities()
+    assert capabilities.supported_models[0].model_name == "/models/base"
+    sampler = service.create_sampling_client(base_model="/models/base")
+    assert sampler is not None
+    assert any(path.endswith("create_session") for path in seen), seen
+    assert any(path.endswith("create_sampling_session") for path in seen), seen
+finally:
+    server.shutdown()
+    server.server_close()
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        timeout=20,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("failure_kind", ["saved", "malformed", "timeout"])
+def test_native_export_reports_safe_actionable_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_kind: str
+) -> None:
+    """Expose the child failure or deadline while suppressing credentials.
+
+    Args:
+        tmp_path: Checkpoint and diagnostic destination.
+        monkeypatch: Scoped patch helper.
+        failure_kind: Structured, malformed, or timed-out child failure.
+    """
+    import json
+    import subprocess
+
+    instance = policy()
+    instance.trusted_service_host = "native-host"
+    monkeypatch.setattr(
+        instance, "snapshot", lambda name: {"identity": {"path": "final"}}
+    )
+    error_path = tmp_path / "checkpoint-download-error.json"
+    error_path.write_text('{"type":"OldError","message":"stale failure"}')
+
+    def fail(args: list[str], **kwargs: Any) -> None:
+        assert kwargs["timeout"] == 420
+        assert not error_path.exists()
+        if failure_kind == "timeout":
+            raise subprocess.TimeoutExpired(args, kwargs["timeout"])
+        if failure_kind == "saved":
+            error_path.write_text(
+                json.dumps(
+                    {
+                        "type": "TimeoutError",
+                        "message": f"read timed out {instance.api_key}",
+                    }
+                )
+            )
+        else:
+            error_path.write_text("broken JSON")
+        raise subprocess.CalledProcessError(1, args)
+
+    monkeypatch.setattr("training_client.subprocess.run", fail)
+    with pytest.raises(
+        RuntimeError, match="Checkpoint export failed"
+    ) as error:
+        instance.download_checkpoint("final", tmp_path / "adapter")
+    message = str(error.value)
+    assert instance.api_key not in message
+    assert "stale failure" not in message
+    assert not (tmp_path / "adapter" / "manifest.json").exists()
+    if failure_kind == "saved":
+        assert "TimeoutError: read timed out [REDACTED]" in message
+    elif failure_kind == "timeout":
+        assert "420s export deadline" in message
+    else:
+        assert "download process failed" in message

--- a/examples/endless_terminals/tests/test_training_diagnostics.py
+++ b/examples/endless_terminals/tests/test_training_diagnostics.py
@@ -1,0 +1,317 @@
+"""Check bounded diagnostic evidence without requiring Linux, Ray, or a GPU."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from training_server import diagnostics
+
+
+def redirect_paths(
+    monkeypatch: pytest.MonkeyPatch, roots: dict[str, Path]
+) -> None:
+    """Redirect diagnostic filesystem roots into controlled fixtures.
+
+    Args:
+        monkeypatch: Scoped replacement helper.
+        roots: Absolute runtime roots and their temporary replacements.
+    """
+    monkeypatch.setattr(
+        diagnostics, "Path", lambda value: roots.get(str(value), Path(value))
+    )
+
+
+def test_collection_keeps_mandatory_logs_when_worker_budget_is_full(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retain Raylet and GCS tails even with more recent workers than the cap.
+
+    Args:
+        tmp_path: Diagnostic filesystem fixture.
+        monkeypatch: Scoped filesystem and memory replacements.
+    """
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    checkpoints = tmp_path / "checkpoints"
+    checkpoints.mkdir()
+    redirect_paths(
+        monkeypatch,
+        {"/tmp/ray/session_latest/logs": logs, "/checkpoints": checkpoints},
+    )
+    monkeypatch.setattr(diagnostics, "memory_sample", lambda: {"cgroup": {}})
+    mandatory = [
+        "raylet.out",
+        "raylet.err",
+        "gcs_server.out",
+        "gcs_server.err",
+        "debug_state.txt",
+    ]
+    for name in mandatory:
+        path = logs / name
+        path.write_text("old-prefix\n" + "m" * 32768)
+        os.utime(path, (1, 1))
+    for index in range(25):
+        path = logs / f"worker-{index:02d}.out"
+        path.write_text("old-prefix\n" + "w" * 32768)
+        os.utime(path, (100 + index, 100 + index))
+    (logs / "irrelevant.log").write_text("not collected")
+    (logs / "worker-directory").mkdir()
+    for name in ("runtime-metrics.jsonl", "runtime-metrics.previous.jsonl"):
+        (checkpoints / name).write_text("old-prefix\n" + "t" * 131072)
+
+    result = diagnostics.collect()
+    collected = result["logs"]
+    assert result["memory"] == {"cgroup": {}}
+    assert set(collected) == {
+        *(str(logs / name) for name in mandatory),
+        *(str(logs / f"worker-{index:02d}.out") for index in range(5, 25)),
+        str(checkpoints / "runtime-metrics.jsonl"),
+        str(checkpoints / "runtime-metrics.previous.jsonl"),
+    }
+    assert all(
+        collected[str(logs / name)] == "m" * 32768 for name in mandatory
+    )
+    assert (
+        sum(len(value) for value in collected.values())
+        == 25 * 32768 + 2 * 131072
+    )
+
+
+def test_missing_ray_directory_still_returns_memory_and_explicit_missing_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing Ray files must not discard the memory evidence or required names.
+
+    Args:
+        tmp_path: Empty diagnostic filesystem.
+        monkeypatch: Scoped diagnostic dependencies.
+    """
+    logs = tmp_path / "absent-logs"
+    redirect_paths(
+        monkeypatch,
+        {"/tmp/ray/session_latest/logs": logs, "/checkpoints": tmp_path},
+    )
+    monkeypatch.setattr(
+        diagnostics, "memory_sample", lambda: {"timestamp": 123}
+    )
+    result = diagnostics.collect()
+    assert result["memory"] == {"timestamp": 123}
+    assert (
+        result["logs"][str(logs / "raylet.out")]
+        == "unavailable: FileNotFoundError"
+    )
+    assert (
+        result["logs"][str(logs / "gcs_server.err")]
+        == "unavailable: FileNotFoundError"
+    )
+    assert result["logs"]["worker_listing_error"] == "FileNotFoundError"
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {
+            "memory.current": "12345\n",
+            "memory.max": "max\n",
+            "memory.events": "low 0\noom 2\noom_kill 1\n",
+        },
+        {
+            "memory/memory.usage_in_bytes": "54321\n",
+            "memory/memory.failcnt": "2\n",
+            "memory/memory.oom_control": "oom_kill_disable 0\nunder_oom 0\noom_kill 1\n",
+        },
+    ],
+)
+def test_memory_sample_retains_v1_and_v2_cgroup_counters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, files: dict[str, str]
+) -> None:
+    """Preserve raw cgroup counters, including unlimited and OOM values.
+
+    Args:
+        tmp_path: Cgroup filesystem fixture.
+        monkeypatch: Scoped process and GPU replacements.
+        files: Either cgroup v1 or cgroup v2 kernel-file contents.
+    """
+    for name, value in files.items():
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value)
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable: 123 kB\n")
+    redirect_paths(
+        monkeypatch, {"/sys/fs/cgroup": tmp_path, "/proc/meminfo": meminfo}
+    )
+    monkeypatch.setattr(diagnostics, "process_memory", lambda: [])
+    monkeypatch.setattr(
+        shutil,
+        "disk_usage",
+        lambda _: SimpleNamespace(used=5, total=10),
+    )
+    gpu = SimpleNamespace(stdout="GPU-123, 100, 200\n", returncode=0)
+    calls: list[dict[str, Any]] = []
+
+    def query(command: list[str], **kwargs: Any) -> Any:
+        calls.append({"command": command, **kwargs})
+        return gpu
+
+    monkeypatch.setattr(subprocess, "run", query)
+    result = diagnostics.memory_sample()
+    assert result["cgroup"] == files
+    assert result["host_meminfo"] == "MemAvailable: 123 kB\n"
+    assert result["shared_memory"] == {"used": 5, "total": 10}
+    assert result["gpu_memory_mib"] == gpu.stdout
+    assert calls[0]["timeout"] == 3
+
+
+@pytest.mark.parametrize(
+    "error", [FileNotFoundError(), subprocess.TimeoutExpired("nvidia-smi", 3)]
+)
+def test_gpu_query_failure_preserves_other_memory_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    """Keep container evidence when the GPU CLI is absent or hangs.
+
+    Args:
+        tmp_path: Empty cgroup filesystem.
+        monkeypatch: Scoped host and GPU dependencies.
+        error: Failure raised by the GPU query.
+    """
+    redirect_paths(monkeypatch, {"/sys/fs/cgroup": tmp_path})
+    monkeypatch.setattr(
+        diagnostics, "process_memory", lambda: [{"pid": 42, "rss_kib": 100}]
+    )
+    monkeypatch.setattr(
+        shutil,
+        "disk_usage",
+        lambda _: SimpleNamespace(used=0, total=10),
+    )
+
+    def query(*args: Any, **kwargs: Any) -> None:
+        raise error
+
+    monkeypatch.setattr(subprocess, "run", query)
+    result = diagnostics.memory_sample()
+    assert result["gpu_query_error"] == type(error).__name__
+    assert result["processes"] == [{"pid": 42, "rss_kib": 100}]
+    assert result["shared_memory"] == {"used": 0, "total": 10}
+
+
+def test_process_memory_limits_largest_residents_and_omits_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ignore malformed or vanished processes and report only top resident sizes.
+
+    Args:
+        tmp_path: Fake proc filesystem.
+        monkeypatch: Scoped proc root replacement.
+    """
+    for pid in range(1, 21):
+        directory = tmp_path / str(pid)
+        directory.mkdir()
+        (directory / "status").write_text(
+            f"Name:\tworker-{pid}\nVmRSS:\t{pid * 100} kB\n"
+        )
+        (directory / "cmdline").write_text("secret-in-process-arguments")
+    (tmp_path / "21").mkdir()
+    (tmp_path / "22").mkdir()
+    (tmp_path / "22/status").write_text(
+        "Name: malformed\nVmRSS: not-an-integer kB\n"
+    )
+    (tmp_path / "self").mkdir()
+    redirect_paths(monkeypatch, {"/proc": tmp_path})
+    result = diagnostics.process_memory()
+    assert [item["pid"] for item in result] == list(range(20, 5, -1))
+    assert result[0] == {"pid": 20, "name": "worker-20", "rss_kib": 2000}
+    assert all(set(item) == {"pid", "name", "rss_kib"} for item in result)
+
+
+def test_read_tail_decodes_partial_utf8_without_failing(
+    tmp_path: Path,
+) -> None:
+    """A byte boundary inside a multibyte character must not break collection.
+
+    Args:
+        tmp_path: Diagnostic log fixture.
+    """
+    log = tmp_path / "log"
+    log.write_bytes(b"old data" + "é!".encode())
+    assert diagnostics.read_tail(log, 2) == "\ufffd!"
+
+
+@pytest.mark.parametrize("unavailable", ["proc", "shared_memory", "both"])
+def test_collect_preserves_ray_logs_when_memory_filesystems_are_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, unavailable: str
+) -> None:
+    """Report missing memory sources while retaining other usage and Ray evidence.
+
+    Args:
+        tmp_path: Runtime filesystem fixture.
+        monkeypatch: Scoped filesystem and GPU dependencies.
+        unavailable: Which memory filesystem should fail.
+    """
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "raylet.err").write_text("Raylet failure details\n")
+    (logs / "gcs_server.out").write_text("GCS connection details\n")
+    cgroup = tmp_path / "cgroup"
+    cgroup.mkdir()
+    (cgroup / "memory.events").write_text("oom 1\noom_kill 1\n")
+    proc = tmp_path / "proc"
+    if unavailable == "shared_memory":
+        (proc / "42").mkdir(parents=True)
+        (proc / "42/status").write_text("Name: worker\nVmRSS: 100 kB\n")
+        (proc / "meminfo").write_text("MemAvailable: 123 kB\n")
+    redirect_paths(
+        monkeypatch,
+        {
+            "/proc": proc,
+            "/proc/meminfo": proc / "meminfo",
+            "/sys/fs/cgroup": cgroup,
+            "/tmp/ray/session_latest/logs": logs,
+            "/checkpoints": tmp_path,
+        },
+    )
+
+    def disk_usage(path: str) -> SimpleNamespace:
+        if unavailable in {"shared_memory", "both"}:
+            raise PermissionError("shared memory is inaccessible")
+        return SimpleNamespace(used=5, total=10)
+
+    monkeypatch.setattr(shutil, "disk_usage", disk_usage)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="GPU-123, 10, 20\n", returncode=0
+        ),
+    )
+    result = diagnostics.collect()
+    assert (
+        result["logs"][str(logs / "raylet.err")] == "Raylet failure details\n"
+    )
+    assert (
+        result["logs"][str(logs / "gcs_server.out")]
+        == "GCS connection details\n"
+    )
+    memory = result["memory"]
+    assert memory["cgroup"]["memory.events"] == "oom 1\noom_kill 1\n"
+    assert memory["gpu_memory_mib"] == "GPU-123, 10, 20\n"
+    if unavailable in {"proc", "both"}:
+        assert memory["process_query_error"] == "FileNotFoundError"
+        assert memory["processes"] == []
+        assert memory["host_meminfo"] == "unavailable: FileNotFoundError"
+    else:
+        assert memory["processes"] == [
+            {"pid": 42, "name": "worker", "rss_kib": 100}
+        ]
+        assert "process_query_error" not in memory
+    if unavailable in {"shared_memory", "both"}:
+        assert memory["shared_memory_query_error"] == "PermissionError"
+        assert "shared_memory" not in memory
+    else:
+        assert memory["shared_memory"] == {"used": 5, "total": 10}
+        assert "shared_memory_query_error" not in memory

--- a/examples/endless_terminals/training.example.json
+++ b/examples/endless_terminals/training.example.json
@@ -1,0 +1,19 @@
+{
+  "cloud_config_path": "cloud.local.json",
+  "data_directory": "data",
+  "output_directory": "runs",
+  "episode_timeout": 90,
+  "max_actions": 16,
+  "max_tokens": 1024,
+  "max_context": 8192,
+  "training_task_ids": [
+    "task_000000_0228cd64",
+    "task_000000_010b99da"
+  ],
+  "groups": 16,
+  "group_size": 4,
+  "training_max_actions": 4,
+  "zero_signal_patience": 4,
+  "learning_rate": 0.0001,
+  "lora_rank": 8
+}

--- a/examples/endless_terminals/training.py
+++ b/examples/endless_terminals/training.py
@@ -1,0 +1,542 @@
+"""Run bounded, task-reward-only RL with matched before/after evaluations."""
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from types import TracebackType
+from typing import Annotated, Any, Callable, Protocol
+
+from cloud import KubernetesInference
+from config import TrainingConfig
+from dataset import sha256
+from pipeline import prepare_evaluation
+from reporting import render_evaluation_report, summarize_evaluation
+from runtime.contract import CONCISE_XML_V1_SYSTEM_MESSAGE, SYSTEM_MESSAGE
+from runtime.environment import TerminalEnvironment
+from runtime.runner import run_episode
+from training_client import TinkerPolicy
+
+from zenml import (
+    ArtifactConfig,
+    get_step_context,
+    log_metadata,
+    pipeline,
+    save_artifact,
+    step,
+)
+from zenml.enums import ArtifactType
+from zenml.types import HTMLString
+
+EnvironmentFactory = Callable[[str, float, float], TerminalEnvironment]
+
+
+class TrainingService(Protocol):
+    """Bound the service contract shared by local and in-cluster training."""
+
+    identity: dict[str, Any]
+    base_url: str
+    cleanup_report: dict[str, Any]
+
+    @property
+    def serving_seconds_remaining(self) -> float:
+        """Return the remaining hard service lifetime.
+
+        Returns:
+            Seconds remaining before the service deadline.
+        """
+        ...
+
+    def __enter__(self) -> "TrainingService":
+        """Start the service and wait for readiness.
+
+        Returns:
+            Ready training service.
+        """
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Release service resources after success or failure.
+
+        Args:
+            exc_type: Raised exception class, if any.
+            exc_value: Raised exception instance, if any.
+            traceback: Exception traceback, if any.
+
+        Returns:
+            Whether the exception should be suppressed.
+        """
+        ...
+
+
+def evaluate_policy(
+    policy: TinkerPolicy,
+    snapshot: dict[str, Any],
+    prepared: dict[str, Any],
+    config: TrainingConfig,
+    directory: Path,
+    session: TrainingService,
+    protocol: dict[str, Any],
+    *,
+    system_message: str = SYSTEM_MESSAGE,
+    data_directory: Path | None = None,
+    environment_factory: EnvironmentFactory | None = None,
+) -> dict[str, Any]:
+    """Evaluate one immutable snapshot under the shared comparison protocol.
+
+    Args:
+        policy: Connected training policy.
+        snapshot: Fixed sampling checkpoint.
+        prepared: CPU-qualified tasks.
+        config: Evaluation limits.
+        directory: New episode output directory.
+        session: Bounded GPU service.
+        protocol: Identical configuration for both evaluations.
+        system_message: Selected system prompt shared by all training phases.
+        data_directory: Materialized task bundle, or the legacy configured directory.
+        environment_factory: Constructor for isolated terminal environments.
+
+    Returns:
+        Evaluation evidence compatible with the existing report renderer.
+
+    Raises:
+        RuntimeError: The service budget or episode infrastructure fails.
+    """
+    result = {
+        "run_id": directory.name,
+        "mode": "model",
+        "model": {
+            "name": config.model_name,
+            "revision": config.model_revision,
+            "revision_verified": True,
+            "checkpoint": snapshot["identity"],
+        },
+        "dataset_revision": prepared["dataset_revision"],
+        "protocol": protocol,
+        "task_hashes": {
+            t["task_id"]: {
+                "files": t["task_file_sha256"],
+                "image": t.get("image_ref") or t["local_image_id"],
+            }
+            for t in prepared["tasks"]
+        },
+        "episodes": [],
+        "status": "running",
+        "cleanup": {"complete": False},
+    }
+    directory.mkdir(parents=True, exist_ok=False)
+    for task in prepared["tasks"]:
+        for attempt_index in range(1, config.evaluation_attempts + 1):
+            episode_directory = directory / task["task_id"]
+            if config.evaluation_attempts > 1:
+                episode_directory /= f"attempt-{attempt_index:02d}"
+            if (
+                session.serving_seconds_remaining
+                < config.episode_timeout + 300
+            ):
+                raise RuntimeError(
+                    "Insufficient service lifetime for evaluation"
+                )
+            episode = run_episode(
+                {**task, "dataset_revision": prepared["dataset_revision"]},
+                (data_directory or Path(config.data_directory))
+                / task["task_id"],
+                policy.episode_model(snapshot),
+                episode_directory,
+                identity=result["model"],
+                system_message=system_message,
+                max_actions=config.max_actions,
+                command_timeout=config.command_timeout,
+                episode_timeout=config.episode_timeout,
+                environment_factory=environment_factory,
+            )
+            episode["attempt_index"] = attempt_index
+            result["episodes"].append(episode)
+            (directory / "evaluation.json").write_text(
+                json.dumps(result, indent=2)
+            )
+            summary = summarize_evaluation(result)
+            if summary["infrastructure_errors"] or summary["incomplete"]:
+                raise RuntimeError(
+                    "Evaluation infrastructure failed; inspect episode evidence"
+                )
+    result["status"] = "completed"
+    return result
+
+
+def execute_training(
+    prepared: dict[str, Any],
+    config: TrainingConfig,
+    run_id: str,
+    *,
+    session: TrainingService | None = None,
+    environment_factory: EnvironmentFactory | None = None,
+    data_directory: Path | None = None,
+    output_directory: Path | None = None,
+    client_api_key: str = "tml-local-skyrl",
+    trusted_service_host: str | None = None,
+    client_credentials_factory: Callable[[], tuple[str, str]] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path]:
+    """Allocate one GPU service for evaluation, updates, and checkpoint export.
+
+    Args:
+        prepared: Qualified task evidence.
+        config: Explicit bounded training settings.
+        run_id: Native ZenML pipeline run ID.
+        session: Injected service, or a legacy Kubernetes inference session.
+        environment_factory: Constructor for isolated terminal environments.
+        data_directory: Materialized task bundle directory.
+        output_directory: Run output directory retained through materialization.
+        client_api_key: Authentication for the training service.
+        trusted_service_host: Exact cluster DNS name trusted for adapter downloads.
+        client_credentials_factory: Resolve authentication and the exact owned
+            host after the service starts, when its endpoint is assigned.
+
+    Returns:
+        Before evaluation, after evaluation, training evidence, and adapter directory.
+
+    Raises:
+        ValueError: Training tasks are absent from the qualified selection.
+        RuntimeError: Episodes, training, checkpoint export, or cleanup fail.
+    """  # noqa: DOC503
+    system_message = {
+        "upstream": SYSTEM_MESSAGE,
+        "concise_xml_v1": CONCISE_XML_V1_SYSTEM_MESSAGE,
+    }[config.prompt_variant]
+    tasks = {task["task_id"]: task for task in prepared["tasks"]}
+    if (
+        not config.training_task_ids
+        or not set(config.training_task_ids) <= tasks.keys()
+    ):
+        raise ValueError(
+            "All training tasks must be in the qualified evaluation selection"
+        )
+    output = output_directory or Path(config.output_directory) / run_id
+    output.mkdir(parents=True, exist_ok=False)
+    if session is None:
+        cloud = json.loads(Path(str(config.cloud_config_path)).read_text())
+        cloud["server_kind"] = "skyrl"
+        session = KubernetesInference(
+            cloud,
+            {"name": config.model_name, "revision": config.model_revision},
+            run_id,
+            output / "service",
+        )
+        training_image = cloud["training_image"]
+    else:
+        training_image = session.identity["training_image"]
+    evidence: dict[str, Any] = {
+        "run_id": run_id,
+        "scope": "Training-set demonstration; no held-out claim",
+        "reward": "1 for audited task pass, 0 for audited task failure; no auxiliary rewards",
+        "config": config.model_dump(mode="json"),
+        "service": session.identity,
+        "groups": [],
+        "optimizer_steps": 0,
+        "status": "failed",
+        "stop_reason": "not_started",
+    }
+    before: dict[str, Any] = {}
+    after: dict[str, Any] = {}
+    checkpoint = output / "checkpoint"
+    protocol = {
+        "backend": "skyrl_tinker",
+        "prompt_variant": config.prompt_variant,
+        "system_prompt_sha256": hashlib.sha256(
+            system_message.encode()
+        ).hexdigest(),
+        "evaluation_attempts": config.evaluation_attempts,
+        "max_actions": config.max_actions,
+        "max_tokens": config.max_tokens,
+        "temperature": config.temperature,
+        "max_context": config.max_context,
+        "episode_timeout": config.episode_timeout,
+        "command_timeout": config.command_timeout,
+        "training_image": training_image,
+        "source_sha256": {
+            str(p.relative_to(Path(__file__).parent)): sha256(p)
+            for p in sorted(Path(__file__).parent.rglob("*.py"))
+            if "tests" not in p.parts
+        },
+    }
+    evidence["protocol"] = protocol
+    try:
+        with session:
+            if client_credentials_factory is not None:
+                client_api_key, trusted_service_host = (
+                    client_credentials_factory()
+                )
+            policy = TinkerPolicy(
+                session.base_url,
+                config.model_name,
+                config.model_revision,
+                rank=config.lora_rank,
+                learning_rate=config.learning_rate,
+                max_tokens=config.max_tokens,
+                temperature=config.temperature,
+                max_context=config.max_context,
+                api_key=client_api_key,
+                trusted_service_host=trusted_service_host,
+            )
+            # The first sampler save also initializes the cold inference engine.
+            initial_sampler_timeout = min(
+                600.0, session.serving_seconds_remaining
+            )
+            evidence["initial_sampler_timeout_seconds"] = (
+                initial_sampler_timeout
+            )
+            snapshot = policy.snapshot(
+                "before", timeout=initial_sampler_timeout
+            )
+            evaluation_started = time.monotonic()
+            before = evaluate_policy(
+                policy,
+                snapshot,
+                prepared,
+                config,
+                output / "before",
+                session,
+                protocol,
+                system_message=system_message,
+                data_directory=data_directory,
+                environment_factory=environment_factory,
+            )
+            evaluation_seconds = time.monotonic() - evaluation_started
+            initial_manifest = policy.download_checkpoint(
+                "initial", output / "initial_checkpoint"
+            )
+            evidence["initial_checkpoint"] = json.loads(
+                initial_manifest.read_text()
+            )
+            (output / "training.json").write_text(
+                json.dumps(evidence, indent=2)
+            )
+            no_signal = 0
+            evidence["stop_reason"] = "group_limit"
+            for index in range(config.groups):
+                # Reserve time for the complete paired evaluation and adapter export.
+                reserve = (
+                    max(
+                        evaluation_seconds * 2,
+                        config.evaluation_attempts
+                        * len(tasks)
+                        * config.episode_timeout
+                        + evaluation_seconds,
+                        config.episode_timeout + 420,
+                    )
+                    + 660
+                )
+                evidence["paired_evaluation_reserve_seconds"] = reserve
+                evidence["reserve_basis"] = (
+                    "heuristic: maximum of twice observed evaluation time, all paired interaction budgets plus observed evaluation time, and single-episode margin; plus 660s sampler save, client creation, and export; infrastructure stalls may exhaust the hard service lifetime"
+                )
+                if (
+                    session.serving_seconds_remaining
+                    < reserve
+                    + config.group_size * (config.episode_timeout + 150)
+                    + 480
+                ):
+                    evidence["stop_reason"] = "service_budget"
+                    break
+                task_id = config.training_task_ids[
+                    index % len(config.training_task_ids)
+                ]
+                group: dict[str, Any] = {
+                    "index": index,
+                    "task_id": task_id,
+                    "checkpoint": snapshot["identity"],
+                    "episodes": [],
+                    "rewards": [],
+                }
+                samples = []
+                evidence["groups"].append(group)
+                for sample_index in range(config.group_size):
+                    model = policy.episode_model(snapshot)
+                    episode = run_episode(
+                        {
+                            **tasks[task_id],
+                            "dataset_revision": prepared["dataset_revision"],
+                        },
+                        (data_directory or Path(config.data_directory))
+                        / task_id,
+                        model,
+                        output
+                        / "training"
+                        / f"group-{index:02d}"
+                        / f"sample-{sample_index:02d}",
+                        identity=snapshot["identity"],
+                        system_message=system_message,
+                        max_actions=config.training_max_actions,
+                        command_timeout=config.command_timeout,
+                        episode_timeout=config.episode_timeout,
+                        environment_factory=environment_factory,
+                    )
+                    group["episodes"].append(episode)
+                    summary = summarize_evaluation({"episodes": [episode]})
+                    if (
+                        summary["infrastructure_errors"]
+                        or summary["incomplete"]
+                    ):
+                        raise RuntimeError(
+                            "Training episode infrastructure failed"
+                        )
+                    group["rewards"].append(float(summary["passes"]))
+                    samples.append(model.samples)
+                    (output / "training.json").write_text(
+                        json.dumps(evidence, indent=2)
+                    )
+                group["samples"] = samples
+                (output / "training.json").write_text(
+                    json.dumps(evidence, indent=2)
+                )
+                group["update"] = policy.update(samples, group["rewards"])
+                evidence["optimizer_steps"] = policy.optimizer_steps
+                no_signal = 0 if group["update"]["updated"] else no_signal + 1
+                if group["update"]["updated"]:
+                    snapshot = policy.snapshot(
+                        f"update-{policy.optimizer_steps:02d}"
+                    )
+                if no_signal >= config.zero_signal_patience:
+                    evidence["stop_reason"] = "no_reward_variation"
+                    break
+            after = evaluate_policy(
+                policy,
+                snapshot,
+                prepared,
+                config,
+                output / "after",
+                session,
+                protocol,
+                system_message=system_message,
+                data_directory=data_directory,
+                environment_factory=environment_factory,
+            )
+            checkpoint_manifest = policy.download_checkpoint(
+                "final", checkpoint
+            )
+            evidence["checkpoint"] = json.loads(
+                checkpoint_manifest.read_text()
+            )
+            evidence["status"] = "completed"
+    except BaseException as exc:
+        evidence["error"] = {"type": type(exc).__name__, "message": str(exc)}
+        raise
+    finally:
+        evidence["cleanup"] = session.cleanup_report
+        if not session.cleanup_report["complete"]:
+            evidence["status"] = "failed"
+        for name, evaluation in (("before", before), ("after", after)):
+            evaluation_path = output / name / "evaluation.json"
+            if not evaluation and evaluation_path.is_file():
+                evaluation = json.loads(evaluation_path.read_text())
+                evaluation["status"] = "failed"
+                if "error" in evidence:
+                    evaluation["error"] = evidence["error"]
+            if evaluation:
+                evaluation["cleanup"] = session.cleanup_report
+                evaluation_path.write_text(json.dumps(evaluation, indent=2))
+        (output / "training.json").write_text(json.dumps(evidence, indent=2))
+        if evidence["status"] != "completed":
+            try:
+                save_artifact(evidence, name="failed_training_evidence")
+                save_artifact(output, name="failed_training_diagnostics")
+            except Exception:
+                print(f"Partial training evidence retained at {output}")
+    if evidence["status"] != "completed":
+        raise RuntimeError("Training or cleanup did not complete")
+    return before, after, evidence, checkpoint
+
+
+@step(enable_cache=False)
+def train_and_evaluate(
+    prepared: dict[str, Any], config: TrainingConfig
+) -> tuple[
+    Annotated[dict[str, Any], "before_evaluation"],
+    Annotated[dict[str, Any], "after_evaluation"],
+    Annotated[dict[str, Any], "training_evidence"],
+    Annotated[
+        Path,
+        ArtifactConfig(
+            name="trained_adapter", artifact_type=ArtifactType.MODEL
+        ),
+    ],
+]:
+    """Train and export a sampler adapter within one owned GPU session.
+
+    Args:
+        prepared: CPU-qualified tasks.
+        config: Bounded training settings.
+
+    Returns:
+        Paired evaluations, training evidence, and durable sampler adapter.
+    """
+    before, after, evidence, checkpoint = execute_training(
+        prepared, config, str(get_step_context().pipeline_run.id)
+    )
+    log_metadata(
+        metadata={
+            "optimizer_steps": evidence["optimizer_steps"],
+            "stop_reason": evidence["stop_reason"],
+        }
+    )
+    return before, after, evidence, checkpoint
+
+
+@step(enable_cache=False)
+def report_training(
+    before: dict[str, Any],
+    after_evaluation: dict[str, Any],
+    training: dict[str, Any],
+) -> Annotated[HTMLString, "training_report"]:
+    """Publish paired task results with explicit training limitations.
+
+    Args:
+        before: Fresh evaluation before updates.
+        after_evaluation: Matched evaluation after updates.
+        training: Recorded update and cleanup evidence.
+
+    Returns:
+        Self-contained HTML report for the ZenML dashboard.
+    """
+    import html
+
+    report = str(render_evaluation_report(after_evaluation, before))
+    details = "<section><h2>Training-set pilot</h2><p>No held-out generalization claim. "
+    details += f"Optimizer steps: {training['optimizer_steps']}. Stop reason: {html.escape(training['stop_reason'])}. "
+    details += "Checkpoint contains sampling adapter weights, not resumable optimizer state.</p>"
+    summary = {
+        **training,
+        "groups": [
+            {
+                key: value
+                for key, value in group.items()
+                if key not in {"samples", "episodes"}
+            }
+            for group in training["groups"]
+        ],
+    }
+    details += (
+        "<p>Exact sampled tokens and full training episodes are retained in the "
+        "training_evidence artifact.</p>"
+        "<details><summary>Training rewards and updates</summary><pre>"
+        + html.escape(json.dumps(summary, indent=2))
+        + "</pre></details></section>"
+    )
+    return HTMLString(report.replace("</body>", details + "</body>"))
+
+
+@pipeline(enable_cache=False)
+def endless_terminals_training(config: TrainingConfig) -> None:
+    """Qualify, train, evaluate, export, and report through native artifacts.
+
+    Args:
+        config: Explicit task and compute settings.
+    """
+    prepared = prepare_evaluation(config)
+    before, after, training, checkpoint = train_and_evaluate(prepared, config)
+    report_training(before, after, training)

--- a/examples/endless_terminals/training_client.py
+++ b/examples/endless_terminals/training_client.py
@@ -1,0 +1,517 @@
+"""Use official Tinker Cookbook policy-gradient updates with local episodes.
+
+A timeout stops this controller from submitting further updates. It cannot undo
+an optimizer request already accepted by the server; reconcile its checkpoint
+and sequence state before starting another controller.
+"""
+
+import asyncio
+import hashlib
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Awaitable
+from urllib.parse import urlsplit
+
+
+def validate_training_url(
+    base_url: str, trusted_service_host: str | None = None
+) -> None:
+    """Restrict credentials to loopback or the exact owned service endpoint.
+
+    Args:
+        base_url: Training API origin.
+        trusted_service_host: Exact DNS name provided by the native service.
+
+    Raises:
+        ValueError: The URL is not an allowed training origin.
+    """
+    parsed = urlsplit(base_url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError(
+            "Training requires an HTTP(S) origin without credentials"
+        )
+    if trusted_service_host is None:
+        if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+            raise ValueError(
+                "Training service must use a local port-forward URL"
+            )
+        return
+    if (
+        re.fullmatch(
+            r"(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+modal\.host",
+            trusted_service_host,
+        )
+        and parsed.hostname == trusted_service_host
+        and parsed.scheme == "https"
+        and parsed.port in {None, 443}
+    ):
+        return
+    if (
+        not re.fullmatch(
+            r"endless-training-[0-9a-f]{16}\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?\.svc\.cluster\.local",
+            trusted_service_host,
+        )
+        or parsed.hostname != trusted_service_host
+        or parsed.port != 8001
+    ):
+        raise ValueError(
+            "Training URL does not match the owned internal service"
+        )
+
+
+async def _wait(awaitable: Awaitable[Any], timeout: float) -> Any:
+    """Await a remote operation within a controller deadline.
+
+    Args:
+        awaitable: SDK or Cookbook operation.
+        timeout: Maximum waiting time in seconds.
+
+    Returns:
+        Completed operation result.
+    """
+    return await asyncio.wait_for(awaitable, timeout=timeout)
+
+
+class EpisodeModel:
+    """Adapt Tinker sampling to the existing terminal runner contract."""
+
+    def __init__(
+        self, policy: "TinkerPolicy", snapshot: dict[str, Any]
+    ) -> None:
+        """Keep one sampling checkpoint and exact per-turn training records.
+
+        Args:
+            policy: Policy settings and tokenizer.
+            snapshot: Sampling client and immutable checkpoint identity.
+        """
+        self.policy = policy
+        self.snapshot = snapshot
+        self.samples: list[dict[str, Any]] = []
+
+    def complete(
+        self, messages: list[dict[str, str]], timeout: float
+    ) -> tuple[str, dict[str, int]]:
+        """Sample an action and retain token IDs before decoding for the parser.
+
+        Args:
+            messages: Existing terminal-runner conversation.
+            timeout: Remaining per-call deadline.
+
+        Returns:
+            Decoded action and token usage.
+
+        Raises:
+            ValueError: Context budget or sampling evidence is invalid.
+        """
+        import tinker
+
+        self.policy.ensure_available()
+        prompt_ids = self.policy.tokenizer.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=False,
+        )
+        if len(prompt_ids) + self.policy.max_tokens > self.policy.max_context:
+            raise ValueError(
+                "Training context budget exceeded; no silent truncation"
+            )
+        result = (
+            self.snapshot["client"]
+            .sample(
+                prompt=tinker.ModelInput.from_ints(prompt_ids),
+                num_samples=1,
+                sampling_params=tinker.SamplingParams(
+                    max_tokens=self.policy.max_tokens,
+                    temperature=self.policy.temperature,
+                    stop=[self.policy.tokenizer.eos_token_id],
+                ),
+            )
+            .result(timeout=timeout)
+        )
+        sequence = result.sequences[0]
+        tokens = list(sequence.tokens)
+        logprobs = sequence.logprobs
+        if not tokens or logprobs is None or len(tokens) != len(logprobs):
+            raise ValueError(
+                "Sampler must return one log probability per generated token"
+            )
+        if not all(math.isfinite(value) for value in logprobs):
+            raise ValueError("Sampler returned nonfinite log probabilities")
+        self.samples.append(
+            {
+                "prompt_ids": list(prompt_ids),
+                "completion_ids": tokens,
+                "logprobs": list(logprobs),
+                "checkpoint": self.snapshot["identity"]["path"],
+            }
+        )
+        usage = {
+            "prompt_tokens": len(prompt_ids),
+            "completion_tokens": len(tokens),
+            "total_tokens": len(prompt_ids) + len(tokens),
+        }
+        return self.policy.tokenizer.decode(
+            tokens, skip_special_tokens=True
+        ), usage
+
+
+class TinkerPolicy:
+    """Train LoRA through pinned Tinker/Cookbook APIs without custom RL loss."""
+
+    def __init__(
+        self,
+        base_url: str,
+        model_name: str,
+        model_revision: str,
+        server_model: str = "/models/base",
+        rank: int = 8,
+        learning_rate: float = 1e-4,
+        max_tokens: int = 512,
+        temperature: float = 0.8,
+        max_context: int = 8192,
+        api_key: str = "tml-local-skyrl",
+        trusted_service_host: str | None = None,
+    ) -> None:
+        """Connect to an explicitly configured private training service.
+
+        Args:
+            base_url: Loopback or authenticated internal SkyRL service URL.
+            model_name: Hugging Face tokenizer/model identity.
+            model_revision: Immutable tokenizer/model revision.
+            server_model: Pinned model location on the training server.
+            rank: LoRA rank.
+            learning_rate: Adam learning rate.
+            max_tokens: Generated tokens per terminal response.
+            temperature: Sampling temperature.
+            max_context: Total prompt plus completion token limit.
+            api_key: API credential, kept out of public training evidence.
+            trusted_service_host: Exact native service DNS name, if applicable.
+
+        Raises:
+            ValueError: Settings are invalid.
+        """
+        import tinker
+        from transformers import AutoTokenizer
+
+        if (
+            not base_url
+            or rank <= 0
+            or learning_rate <= 0
+            or not 0 < max_tokens < max_context
+        ):
+            raise ValueError("Invalid bounded training configuration")
+        if len(model_revision) != 40 or any(
+            c not in "0123456789abcdef" for c in model_revision
+        ):
+            raise ValueError("Use an immutable 40-character model revision")
+        validate_training_url(base_url, trusted_service_host)
+        if not api_key or (
+            trusted_service_host is not None
+            and not re.fullmatch(r"tml-native-[0-9a-f]{64}", api_key)
+        ):
+            raise ValueError("Native training requires its per-run API key")
+        self.base_url = base_url
+        self.api_key = api_key
+        self.trusted_service_host = trusted_service_host
+        self.model_name = model_name
+        self.model_revision = model_revision
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.max_context = max_context
+        self.learning_rate = learning_rate
+        self.optimizer_steps = 0
+        self.failed = False
+        self.service = tinker.ServiceClient(
+            base_url=base_url, api_key=api_key, timeout=60.0
+        )
+        self.client = asyncio.run(
+            _wait(
+                self.service.create_lora_training_client_async(
+                    base_model=server_model, rank=rank
+                ),
+                600,
+            )
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; from transformers import AutoTokenizer; "
+                "AutoTokenizer.from_pretrained(sys.argv[1], revision=sys.argv[2])",
+                model_name,
+                model_revision,
+            ],
+            timeout=180,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, revision=model_revision, local_files_only=True
+        )
+
+    def ensure_available(self) -> None:
+        """Prevent subsequent training after an uncertain remote update.
+
+        Raises:
+            RuntimeError: An earlier update failed or timed out.
+        """
+        if self.failed:
+            raise RuntimeError(
+                "Training state is uncertain; reconcile before resuming"
+            )
+
+    def snapshot(self, name: str, *, timeout: float = 180) -> dict[str, Any]:
+        """Save sampler weights and return their sampling client and identity.
+
+        Args:
+            name: Unique checkpoint name.
+            timeout: Maximum wait for saving sampler weights, in seconds.
+
+        Returns:
+            Sampling handle with serializable identity in its identity field.
+
+        Raises:
+            ValueError: The timeout is outside the bounded supported range.
+        """
+        if not 0 < timeout <= 600:
+            raise ValueError("Sampler snapshot timeout must be in (0, 600]")
+        self.ensure_available()
+        saved = self.client.save_weights_for_sampler(name).result(
+            timeout=timeout
+        )
+        sampler = asyncio.run(
+            _wait(
+                self.service.create_sampling_client_async(
+                    model_path=saved.path
+                ),
+                60,
+            )
+        )
+        return {
+            "client": sampler,
+            "identity": {
+                "path": saved.path,
+                "model_name": self.model_name,
+                "model_revision": self.model_revision,
+                "optimizer_steps": self.optimizer_steps,
+                "kind": "sampler_adapter_not_resume_checkpoint",
+            },
+        }
+
+    def episode_model(self, snapshot: dict[str, Any]) -> EpisodeModel:
+        """Build an independent episode recorder for the given checkpoint.
+
+        Args:
+            snapshot: Snapshot returned by this policy.
+
+        Returns:
+            Terminal-runner-compatible model with public samples.
+        """
+        return EpisodeModel(self, snapshot)
+
+    def update(
+        self, group_samples: list[list[dict[str, Any]]], rewards: list[float]
+    ) -> dict[str, Any]:
+        """Run one official group-relative policy-gradient optimizer update.
+
+        Args:
+            group_samples: Per-episode turns sampled from the same checkpoint/task.
+            rewards: Explicit controller-calculated reward for each episode.
+
+        Returns:
+            Update status, group advantages, and official optimizer metrics.
+
+        Raises:
+            ValueError: Group evidence is incomplete or mixes checkpoints.
+            BaseException: The remote update fails or exceeds its deadline.
+        """
+        self.ensure_available()
+        if (
+            len(group_samples) != len(rewards)
+            or len(rewards) < 2
+            or not all(group_samples)
+        ):
+            raise ValueError(
+                "Need at least two nonempty episodes and matching rewards"
+            )
+        if not all(math.isfinite(value) for value in rewards):
+            raise ValueError("Rewards must be finite")
+        checkpoints = {
+            sample["checkpoint"]
+            for episode in group_samples
+            for sample in episode
+        }
+        if len(checkpoints) != 1:
+            raise ValueError("An update must use one sampling checkpoint")
+        if len(set(rewards)) == 1:
+            return {
+                "updated": False,
+                "reason": "all_rewards_equal",
+                "optimizer_steps": self.optimizer_steps,
+            }
+        import tinker
+        from tinker_cookbook.completers import TokensWithLogprobs
+        from tinker_cookbook.rl.data_processing import (
+            assemble_training_data,
+            compute_advantages,
+        )
+        from tinker_cookbook.rl.train import train_step
+        from tinker_cookbook.rl.types import (
+            Trajectory,
+            TrajectoryGroup,
+            Transition,
+        )
+
+        trajectories = []
+        for samples in group_samples:
+            transitions = [
+                Transition(
+                    ob=tinker.ModelInput.from_ints(sample["prompt_ids"]),
+                    ac=TokensWithLogprobs(
+                        tokens=sample["completion_ids"],
+                        maybe_logprobs=sample["logprobs"],
+                    ),
+                    reward=0.0,
+                    episode_done=index == len(samples) - 1,
+                )
+                for index, sample in enumerate(samples)
+            ]
+            trajectories.append(
+                Trajectory(
+                    transitions=transitions,
+                    final_ob=tinker.ModelInput.from_ints([]),
+                )
+            )
+        groups = [
+            TrajectoryGroup(
+                trajectories_G=trajectories,
+                final_rewards_G=rewards,
+                metrics_G=[{} for _ in rewards],
+            )
+        ]
+        advantages = compute_advantages(groups)
+        data, _ = assemble_training_data(groups, advantages)
+        metrics: dict[str, Any] = {}
+        try:
+            asyncio.run(
+                _wait(
+                    train_step(
+                        data_D=data,
+                        training_client=self.client,
+                        learning_rate=self.learning_rate,
+                        num_substeps=1,
+                        loss_fn="importance_sampling",
+                        metrics=metrics,
+                    ),
+                    300,
+                )
+            )
+        except BaseException:
+            self.failed = True
+            raise
+        self.optimizer_steps += 1
+        return {
+            "updated": True,
+            "optimizer_steps": self.optimizer_steps,
+            "advantages": advantages[0].tolist(),
+            "metrics": metrics,
+            "training_datums": len(data),
+        }
+
+    def download_checkpoint(self, name: str, directory: Path) -> Path:
+        """Download sampler-only adapter files and write their provenance hashes.
+
+        Args:
+            name: New sampler checkpoint name.
+            directory: New local artifact directory.
+
+        Returns:
+            Manifest path identifying downloaded adapter files, not optimizer state.
+
+        Raises:
+            RuntimeError: The checkpoint export failed or contains no files.
+        """
+        self.ensure_available()
+        directory.mkdir(parents=True, exist_ok=False)
+        snapshot = self.snapshot(name)
+        command = (
+            [
+                sys.executable,
+                str(Path(__file__).with_name("checkpoint_download.py")),
+                snapshot["identity"]["path"],
+                str(directory.resolve()),
+                self.base_url,
+            ]
+            if self.trusted_service_host is not None
+            else [
+                sys.executable,
+                "-c",
+                "import sys; from tinker_cookbook import weights; "
+                "weights.download(tinker_path=sys.argv[1], output_dir=sys.argv[2], base_url=sys.argv[3])",
+                snapshot["identity"]["path"],
+                str(directory.resolve()),
+                self.base_url,
+            ]
+        )
+        error_path = directory.parent / "checkpoint-download-error.json"
+        error_path.unlink(missing_ok=True)
+        export_timeout = 420 if self.trusted_service_host is not None else 180
+        try:
+            subprocess.run(
+                command,
+                env={**os.environ, "TINKER_API_KEY": self.api_key},
+                timeout=export_timeout,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+        ) as error:
+            detail = (
+                f"exceeded the {export_timeout}s export deadline"
+                if isinstance(error, subprocess.TimeoutExpired)
+                else "download process failed"
+            )
+            try:
+                saved = json.loads(error_path.read_text())
+                if (
+                    isinstance(saved, dict)
+                    and isinstance(saved.get("type"), str)
+                    and isinstance(saved.get("message"), str)
+                ):
+                    detail = f"{saved['type']}: {saved['message']}"
+            except (OSError, ValueError):
+                pass
+            detail = detail.replace(self.api_key, "[REDACTED]")[:4096]
+            raise RuntimeError(f"Checkpoint export failed: {detail}") from None
+        hashes = {
+            str(path.relative_to(directory)): hashlib.sha256(
+                path.read_bytes()
+            ).hexdigest()
+            for path in sorted(directory.rglob("*"))
+            if path.is_file()
+        }
+        if not hashes:
+            raise RuntimeError("Checkpoint export returned no files")
+        manifest = directory / "manifest.json"
+        manifest.write_text(
+            json.dumps({**snapshot["identity"], "files": hashes}, indent=2)
+            + "\n"
+        )
+        return manifest

--- a/examples/endless_terminals/training_server/.dockerignore
+++ b/examples/endless_terminals/training_server/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Dockerfile
+!entrypoint.py
+!backend_config.json

--- a/examples/endless_terminals/training_server/Dockerfile
+++ b/examples/endless_terminals/training_server/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM novaskyai/skyrl-train-ray-2.57.0-py3.12-cu13.0@sha256:609b7df001fa41a657d1d6a3607cb78af9290208d2f3397e4c7ce7182ec1d622
+
+USER root
+ENV SKYRL_COMMIT=0b286bacba2bb51dfe50186b6b5d6b1e0b5f5518 \
+    UV_PROJECT_ENVIRONMENT=/opt/skyrl-venv \
+    PATH=/opt/skyrl-venv/bin:/home/ray/.local/bin:$PATH \
+    HF_HOME=/models/huggingface \
+    HF_HUB_DISABLE_TELEMETRY=1 \
+    DO_NOT_TRACK=1 \
+    WANDB_MODE=disabled \
+    SKYRL_RAY_NUM_CPUS=4
+
+RUN mkdir -p /opt/skyrl /opt/terminal-training /models /checkpoints \
+    && curl -fL --retry 0 "https://codeload.github.com/NovaSky-AI/SkyRL/tar.gz/${SKYRL_COMMIT}" -o /tmp/skyrl.tar.gz \
+    && echo "2ce7e93a5631f0f8d08adb14d9a237f1d73df421484e57f5ddbffea8d8e0a731  /tmp/skyrl.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/skyrl.tar.gz --strip-components=1 -C /opt/skyrl \
+    && rm /tmp/skyrl.tar.gz
+WORKDIR /opt/skyrl
+# Keep the upstream lock and its prebuilt Astral CUDA13/Torch2.11 wheels.
+# Fail rather than silently compile GPU extensions under AMD64 emulation.
+RUN uv sync --frozen --no-dev --extra fsdp --extra tinker \
+    --no-build-package flash-attn --no-build-package causal-conv1d \
+    && uv run --frozen --no-sync --extra fsdp --extra tinker -m skyrl.tinker.api --help > /dev/null \
+    && uv cache clean
+COPY entrypoint.py backend_config.json diagnostics.py /opt/terminal-training/
+RUN chown -R ray: /models /checkpoints
+USER ray
+EXPOSE 8000
+HEALTHCHECK --interval=15s --timeout=5s --start-period=15m --retries=4 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/healthz', timeout=3)"
+ENTRYPOINT ["python", "/opt/terminal-training/entrypoint.py"]

--- a/examples/endless_terminals/training_server/README.md
+++ b/examples/endless_terminals/training_server/README.md
@@ -1,0 +1,67 @@
+# SkyRL training server
+
+This image provides an HTTP training and sampling API on one GPU. In the native pipeline, a CPU ZenML step controls this service and terminal tasks run in separate CPU Kubernetes or Modal sandboxes. The legacy path instead uses a local controller and Docker task containers. The GPU pod needs no Docker daemon and makes no callback to the controller. It runs FSDP training and vLLM inference in alternating phases on the same GPU.
+
+## Build
+
+From the ZenML repository root, on a Linux AMD64 builder with ample disk space:
+
+```bash
+docker build --platform linux/amd64 \
+  -t endless-training-server:skyrl-0b286ba \
+  examples/endless_terminals/training_server
+```
+
+The build uses the Dockerfile, entrypoint, backend configuration and `diagnostics.py`. It downloads the pinned SkyRL source archive and verifies its SHA-256 before installing FSDP and Tinker extras with the upstream frozen lock. The source commit is `0b286bacba2bb51dfe50186b6b5d6b1e0b5f5518`. The official base image is pinned by digest in the Dockerfile. The lock resolves Tinker SDK `0.24.0`, PyTorch `2.11.0`, and vLLM `0.28.0`.
+
+FlashAttention and causal-conv1d use the prebuilt CUDA 13/PyTorch 2.11 wheels from the index specified by upstream. The build explicitly forbids compiling those packages. No model weights are downloaded during the image build. A build still needs substantial network and disk capacity: the base image alone contains 7.77 GiB of compressed layers. Allow approximately 60–80 GiB free for base layers, dependency downloads, unpacking, and image snapshots; that planning allowance is an estimate, not a measured completed build size.
+
+## Run in the GPU pod
+
+Use an NVIDIA driver from the r580 series or newer and one GPU. The default model is `Qwen/Qwen2.5-1.5B-Instruct`, pinned to revision `989aa7980e4cf806f80c7fef2b1adb7bc71aa306`. Override `SKYRL_MODEL_NAME` and `SKYRL_MODEL_REVISION` together for another checkpoint. The entrypoint rejects mutable revisions, downloads that exact snapshot, records `server-identity.json`, creates `/models/base` as a symlink to the snapshot, and passes that stable path to SkyRL. An existing directory at `/models/base` is rejected rather than overwritten. It does not use `trust_remote_code`.
+
+Mount writable storage at `/models` for the model cache and `/checkpoints` for API state and checkpoints. Provide a memory-backed `/dev/shm`, for example 8 GiB, and allow sufficient host RAM for offloaded policy state. The container runs as the base image's `ray` user; volume permissions must allow that user to write. The backend configuration uses one GPU, microbatches of one, gradient checkpointing, an 8192-token context bound, and 35% vLLM GPU utilization. The native Job provides 8 GiB shared memory, requests 26 GiB host memory and limits it to 28 GiB. Set `service.inference_gpu_memory_utilization` to override the inference allocation for a particular native run; its default remains 0.35. The mounted configuration and its hash record the effective value. Larger checkpoints also require sufficient GPU and host memory for the pinned backend’s FP32 training weights; BF16 inference fit does not establish training fit. Sampling has run on a 24 GiB L4 with this configuration; memory fit for a nonzero-gradient optimizer update remains unverified.
+
+The entrypoint starts the API with `uv run --frozen --no-sync --extra fsdp --extra tinker -m skyrl.tinker.api`. SkyRL inspects that parent command to start its background training engine with the same environment flags. Starting the API directly with `python -m skyrl.tinker.api` fails during API startup. `--no-sync` uses the environment installed during the image build without changing dependencies at runtime.
+
+The API listens on **127.0.0.1:8000**. The Kubernetes Job runs an nginx proxy in the same pod, exposes only proxy port 8001 through a ClusterIP Service, and requires a random per-run API key. Modal uses an authenticated proxy on port 8001 through its TLS tunnel. SkyRL remains on loopback. The legacy local-controller path uses `kubectl port-forward` instead. The backend readiness endpoint is:
+
+```text
+GET http://127.0.0.1:8000/api/v1/healthz
+```
+
+The native controller checks health through the authenticated proxy, then verifies model identity, backend configuration and source hashes through Kubernetes exec. It mounts the current entrypoint, backend configuration and diagnostics from an immutable Secret; those file hashes are recorded in `server-identity.json` and the run evidence. A Kubernetes exec readiness probe can also run the same Python command as the Dockerfile's health check. Docker health checks are not automatically applied by Kubernetes. First startup downloads about 3 GB of model weights and initializes the API; actual model allocation and inference initialization can occur on the first client requests. An HTTP health response alone does not prove a training step fits in GPU memory. Allow at least 15 minutes for the initial download and startup when caches are cold.
+
+The controller should use `tinker==0.24.0`, create one LoRA training client with rank 8, and complete generation before invoking an optimizer step. Use `base_model="/models/base"` when creating the client. `get_server_capabilities()` and `server-identity.json` expose that stable served identity. Load the controller's tokenizer separately using the same Hugging Face model name and revision, since the server's snapshot path is not a local controller path. Configure bounded SDK request timeouts and explicit retry behavior in the controller.
+
+## Export before deleting the pod
+
+SkyRL already exposes sampler checkpoint archives, so no separate file server is needed. Save sampler weights through the SDK and wait for completion:
+
+```python
+checkpoint = training_client.save_weights_for_sampler(name="final").result()
+print(checkpoint.path)
+```
+
+Pinned SkyRL returns a short `tinker://MODEL_ID/CHECKPOINT_ID` identity. The native [checkpoint downloader](../checkpoint_download.py) accepts that form and the canonical `tinker://MODEL_ID/sampler_weights/CHECKPOINT_ID` form, then calls the SDK's explicit `get_checkpoint_archive_url(model_id, checkpoint_id)` method. The SDK's generic Tinker-path helper rejects the short form. Download through the authenticated native proxy, or the same local port forward for legacy use:
+
+```text
+GET /api/v1/training_runs/MODEL_ID/checkpoints/CHECKPOINT_ID/download
+```
+
+The `/archive` variant returns a redirect to this download route. The native downloader checks that the returned URL belongs to the training origin, authenticates the download, rejects further redirects, and bounds archive size and extraction paths. The controller hashes the extracted files before deleting the Job; ZenML then materializes the local adapter directory into its artifact store. Do not treat the returned `tinker://` URI as durable storage: it identifies server-side state. The server writes sampler archives under `/checkpoints/MODEL_ID/sampler_weights/CHECKPOINT_ID.tar.gz`. Training-state saves are separate from sampler saves; the verified HTTP archive route serves sampler checkpoints only. Preserve a persistent `/checkpoints` volume if resumable optimizer state is required.
+
+The pinned FSDP sampler [routes requests by model ID to the currently loaded vLLM adapter](https://github.com/NovaSky-AI/SkyRL/blob/0b286bacba2bb51dfe50186b6b5d6b1e0b5f5518/skyrl/backends/skyrl_train_backend.py#L1082). Creating a new sampling client with an old sampler URI does not independently reload its saved files. Validate an export by loading its LoRA files into a fresh base model. Record any inference-backend change, such as using Transformers locally instead of SkyRL/vLLM, when interpreting evaluation results.
+
+## Verification and sources
+
+The pinned image has completed native Kubernetes sampling and adapter export on an L4, and nonzero-gradient Qwen2.5-7B LoRA updates on a Modal H200 with 256 GiB host memory. The September 8 DNS demonstration ran 10 initial evaluations, four groups of eight training episodes, and 10 final evaluations. Pass counts were 9/10 before and 10/10 after; two groups updated the optimizer, and two equal-reward groups skipped it. All 392 exported adapter tensors changed and artifact hashes matched. This verifies execution and export, not held-out generalization or a statistically established training gain.
+
+The paired evaluations use the currently loaded policy rather than reloading the downloaded files. A separate fresh Transformers/PEFT process has loaded an earlier exported adapter and completed local task evaluations; that validates export usability across a different inference backend. Native checkpoint downloads retry transient transfer failures and retain redacted failure diagnostics. Final evaluation precedes final export so a transfer failure does not discard the paired evaluation.
+
+- [SkyRL installation and official base images](https://docs.skyrl.ai/docs/getting-started/installation)
+- [Pinned dependency and wheel configuration](https://github.com/NovaSky-AI/SkyRL/blob/0b286bacba2bb51dfe50186b6b5d6b1e0b5f5518/pyproject.toml)
+- [Pinned Tinker API, including checkpoint download](https://github.com/NovaSky-AI/SkyRL/blob/0b286bacba2bb51dfe50186b6b5d6b1e0b5f5518/skyrl/tinker/api.py)
+- [Tinker backend configuration](https://docs.skyrl.ai/docs/tinker/configuration)
+
+The pinned exporter gathers the full state dictionary on CPU even for LoRA, so host memory is a separate constraint from GPU memory. The tested 7B configuration uses an H200 and 256 GiB host RAM; smaller hardware has not been validated for this workload. The initial sampler save permits up to 600 seconds within the remaining service deadline; later saves retain the 180-second default, and sampling-client creation has a separate 60-second timeout. Native export then has a 420-second subprocess deadline.

--- a/examples/endless_terminals/training_server/__init__.py
+++ b/examples/endless_terminals/training_server/__init__.py
@@ -1,0 +1,1 @@
+"""Pinned SkyRL service entrypoint and bounded runtime diagnostics."""

--- a/examples/endless_terminals/training_server/backend_config.json
+++ b/examples/endless_terminals/training_server/backend_config.json
@@ -1,0 +1,16 @@
+{
+  "trainer.placement.colocate_all": true,
+  "trainer.placement.policy_num_nodes": 1,
+  "trainer.placement.policy_num_gpus_per_node": 1,
+  "trainer.micro_forward_batch_size_per_gpu": 1,
+  "trainer.micro_train_batch_size_per_gpu": 1,
+  "trainer.gradient_checkpointing": true,
+  "trainer.logger": "console",
+  "generator.inference_engine.num_engines": 1,
+  "generator.inference_engine.tensor_parallel_size": 1,
+  "generator.inference_engine.run_engines_locally": true,
+  "generator.inference_engine.gpu_memory_utilization": 0.35,
+  "generator.inference_engine.max_num_seqs": 1,
+  "generator.inference_engine.engine_init_kwargs.max_model_len": 8192,
+  "generator.inference_engine.engine_init_kwargs.enforce_eager": true
+}

--- a/examples/endless_terminals/training_server/diagnostics.py
+++ b/examples/endless_terminals/training_server/diagnostics.py
@@ -1,0 +1,188 @@
+"""Retain bounded memory and Ray evidence around a GPU worker failure."""
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+def read_tail(path: Path, limit: int = 32768) -> str:
+    """Read the final bytes without loading a potentially large log.
+
+    Args:
+        path: Diagnostic file.
+        limit: Maximum bytes to read.
+
+    Returns:
+        Decoded tail or a concise read error.
+    """
+    try:
+        with path.open("rb") as source:
+            source.seek(max(0, path.stat().st_size - limit))
+            return source.read(limit).decode(errors="replace")
+    except OSError as exc:
+        return f"unavailable: {type(exc).__name__}"
+
+
+def process_memory() -> list[dict[str, Any]]:
+    """Report the largest resident processes without recording command arguments.
+
+    Returns:
+        Up to fifteen process identities and RSS values in KiB.
+
+    Raises:
+        OSError: The process filesystem cannot be listed.
+    """  # noqa: DOC502 - Path.iterdir propagates OSError.
+    processes: list[dict[str, Any]] = []
+    for path in Path("/proc").iterdir():
+        if not path.name.isdigit():
+            continue
+        try:
+            fields = dict(
+                line.split(":", 1)
+                for line in (path / "status").read_text().splitlines()
+                if ":" in line
+            )
+            processes.append(
+                {
+                    "pid": int(path.name),
+                    "name": fields.get("Name", "").strip(),
+                    "rss_kib": int(fields.get("VmRSS", "0 kB").split()[0]),
+                }
+            )
+        except (OSError, ValueError):
+            continue
+    return sorted(processes, key=lambda item: item["rss_kib"], reverse=True)[
+        :15
+    ]
+
+
+def memory_sample() -> dict[str, Any]:
+    """Collect host, container, shared-memory, GPU and process usage.
+
+    Returns:
+        JSON-safe measurements with explicit unavailable values.
+    """
+    result: dict[str, Any] = {
+        "timestamp": time.time(),
+        "host_meminfo": read_tail(Path("/proc/meminfo")),
+        "processes": [],
+        "cgroup": {},
+    }
+    try:
+        result["processes"] = process_memory()
+    except OSError as exc:
+        result["process_query_error"] = type(exc).__name__
+    for name in (
+        "memory.current",
+        "memory.peak",
+        "memory.max",
+        "memory.events",
+        "memory.stat",
+        "memory/memory.usage_in_bytes",
+        "memory/memory.max_usage_in_bytes",
+        "memory/memory.limit_in_bytes",
+        "memory/memory.failcnt",
+        "memory/memory.oom_control",
+    ):
+        path = Path("/sys/fs/cgroup") / name
+        if path.exists():
+            result["cgroup"][name] = read_tail(path)
+    try:
+        usage = shutil.disk_usage("/dev/shm")
+        result["shared_memory"] = {"used": usage.used, "total": usage.total}
+    except OSError as exc:
+        result["shared_memory_query_error"] = type(exc).__name__
+    try:
+        gpu = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=uuid,memory.used,memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+        result["gpu_memory_mib"] = gpu.stdout[:4096]
+        result["gpu_query_exit_code"] = gpu.returncode
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        result["gpu_query_error"] = type(exc).__name__
+    return result
+
+
+def collect() -> dict[str, Any]:
+    """Collect mandatory Ray logs independently of the worker-log budget.
+
+    Returns:
+        Current usage, recent telemetry, mandatory Ray logs, and worker tails.
+    """
+    root = Path("/tmp/ray/session_latest/logs")
+    mandatory = [
+        root / name
+        for name in (
+            "raylet.out",
+            "raylet.err",
+            "gcs_server.out",
+            "gcs_server.err",
+            "debug_state.txt",
+        )
+    ]
+    logs = {str(path): read_tail(path) for path in mandatory}
+    for name in ("runtime-metrics.jsonl", "runtime-metrics.previous.jsonl"):
+        path = Path("/checkpoints") / name
+        logs[str(path)] = read_tail(path, 131072)
+    try:
+        workers = [
+            path
+            for path in root.iterdir()
+            if path.is_file()
+            and path.name.startswith(
+                ("worker-", "python-core-worker-", "python-core-driver-")
+            )
+        ]
+        workers.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+        logs.update({str(path): read_tail(path) for path in workers[:20]})
+    except OSError as exc:
+        logs["worker_listing_error"] = type(exc).__name__
+    return {"memory": memory_sample(), "logs": logs}
+
+
+def monitor(path: Path) -> None:
+    """Write periodic samples for at most two hours with bounded disk usage.
+
+    Args:
+        path: JSONL output inside the transient checkpoint directory.
+    """
+    deadline = time.monotonic() + 7200
+    while time.monotonic() < deadline:
+        try:
+            sample = memory_sample()
+            if path.exists() and path.stat().st_size > 8 * 1024 * 1024:
+                path.replace(path.with_name("runtime-metrics.previous.jsonl"))
+            with path.open("a") as output:
+                output.write(json.dumps(sample) + "\n")
+        except (OSError, ValueError):
+            pass
+        time.sleep(5)
+
+
+def main() -> None:
+    """Collect one report or start the bounded background monitor."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    choice = parser.add_mutually_exclusive_group(required=True)
+    choice.add_argument("--collect", action="store_true")
+    choice.add_argument("--monitor", type=Path)
+    args = parser.parse_args()
+    if args.collect:
+        print(json.dumps(collect()))
+    else:
+        monitor(args.monitor)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/endless_terminals/training_server/entrypoint.py
+++ b/examples/endless_terminals/training_server/entrypoint.py
@@ -1,0 +1,113 @@
+"""Download immutable weights before starting the local training API."""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+CHECKPOINTS = Path("/checkpoints")
+MODEL_PATH = Path("/models/base")
+MODEL_REVISION = "989aa7980e4cf806f80c7fef2b1adb7bc71aa306"
+
+
+def main() -> None:
+    """Start SkyRL using a pinned model snapshot and persisted API state.
+
+    Raises:
+        ValueError: The revision is mutable or the stable model path is not a symlink.
+    """
+    model = os.environ.get("SKYRL_MODEL_NAME", "Qwen/Qwen2.5-1.5B-Instruct")
+    revision = os.environ.get("SKYRL_MODEL_REVISION", MODEL_REVISION)
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ValueError("SKYRL_MODEL_REVISION must be a 40-character commit")
+    checkpoints = CHECKPOINTS
+    checkpoints.mkdir(parents=True, exist_ok=True)
+    subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).with_name("diagnostics.py")),
+            "--monitor",
+            str(checkpoints / "runtime-metrics.jsonl"),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    snapshot = snapshot_download(
+        repo_id=model,
+        revision=revision,
+        allow_patterns=[
+            "*.json",
+            "*.safetensors",
+            "*.txt",
+            "*.model",
+            "*.jinja",
+        ],
+    )
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if MODEL_PATH.is_symlink():
+        MODEL_PATH.unlink()
+    elif MODEL_PATH.exists():
+        raise ValueError("/models/base already exists and is not a symlink")
+    MODEL_PATH.symlink_to(snapshot, target_is_directory=True)
+    config = json.loads(
+        Path(__file__).with_name("backend_config.json").read_text()
+    )
+    identity = {
+        "model_name": model,
+        "model_revision": revision,
+        "model_path": str(MODEL_PATH),
+        "snapshot_path": snapshot,
+        "skyrl_commit": os.environ["SKYRL_COMMIT"],
+        "backend_config": config,
+        "source_sha256": {
+            name: hashlib.sha256(
+                Path(__file__).with_name(name).read_bytes()
+            ).hexdigest()
+            for name in (
+                "entrypoint.py",
+                "backend_config.json",
+                "diagnostics.py",
+            )
+        },
+    }
+    (checkpoints / "server-identity.json").write_text(
+        json.dumps(identity, indent=2) + "\n"
+    )
+    print(json.dumps({"training_server_identity": identity}), flush=True)
+    # SkyRL reads its uv parent command to launch the background training engine.
+    args = [
+        "uv",
+        "run",
+        "--frozen",
+        "--no-sync",
+        "--extra",
+        "fsdp",
+        "--extra",
+        "tinker",
+        "-m",
+        "skyrl.tinker.api",
+        "--base-model",
+        str(MODEL_PATH),
+        "--backend",
+        "fsdp",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "8000",
+        "--checkpoints-base",
+        str(checkpoints),
+        "--database-url",
+        "sqlite:////checkpoints/tinker.db",
+        "--backend-config",
+        json.dumps(config),
+    ]
+    os.execvp("uv", args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zenml/integrations/modal/__init__.py
+++ b/src/zenml/integrations/modal/__init__.py
@@ -32,7 +32,7 @@ class ModalIntegration(Integration):
     """Definition of Modal integration for ZenML."""
 
     NAME = MODAL
-    REQUIREMENTS = ["modal>=1.4,<2"]
+    REQUIREMENTS = ["modal>=1.4.3,<2"]
 
     @classmethod
     def flavors(cls) -> List[Type[Flavor]]:

--- a/src/zenml/integrations/modal/flavors/modal_sandbox_flavor.py
+++ b/src/zenml/integrations/modal/flavors/modal_sandbox_flavor.py
@@ -13,9 +13,9 @@
 #  permissions and limitations under the License.
 """Modal sandbox flavor."""
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Dict, Optional, Type
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from zenml.integrations.modal import MODAL_SANDBOX_FLAVOR
 from zenml.integrations.modal.flavors.modal_base_flavor import (
@@ -33,8 +33,24 @@ if TYPE_CHECKING:
     from zenml.integrations.modal.sandboxes import ModalSandbox
 
 
+class ModalSandboxVolumeMount(BaseModel):
+    """An existing named Modal Volume and its per-container mount options."""
+
+    name: str = Field(min_length=1)
+    sub_path: Optional[str] = None
+    read_only: bool = False
+
+
 class ModalSandboxSettings(ContainerizedSandboxSettings, ModalSettingsMixin):
     """Per-step settings for the Modal sandbox."""
+
+    block_network: bool = Field(
+        default=False, description="Block all outbound sandbox network access."
+    )
+    volumes: Dict[str, ModalSandboxVolumeMount] = Field(
+        default_factory=dict,
+        description="Existing named Modal Volumes keyed by container mount path.",
+    )
 
     cpu: Optional[int] = Field(
         default=None,

--- a/src/zenml/integrations/modal/sandboxes/modal_sandbox.py
+++ b/src/zenml/integrations/modal/sandboxes/modal_sandbox.py
@@ -170,6 +170,7 @@ class ModalSandboxSession(SandboxSession):
         *,
         parent: "ModalSandbox",
         destroy_on_exit: bool = False,
+        block_network: bool = False,
     ) -> None:
         """Initialize the session wrapper.
 
@@ -178,7 +179,9 @@ class ModalSandboxSession(SandboxSession):
             parent: The owning Modal sandbox component.
             destroy_on_exit: Whether to destroy the sandbox session when the
                 session context manager exits.
+            block_network: Whether snapshots must retain blocked network access.
         """
+        self._block_network = block_network
         # Assign _sandbox before super().__init__ so the dashboard hook,
         # which is called during base __init__ via _publish_sandbox_metadata,
         # has the state it needs.
@@ -248,7 +251,11 @@ class ModalSandboxSession(SandboxSession):
             in-memory process state is captured.
         """
         image = self._sandbox.snapshot_filesystem()
-        return SandboxSnapshot(sandbox_id=self._parent.id, ref=image.object_id)
+        return SandboxSnapshot(
+            sandbox_id=self._parent.id,
+            ref=image.object_id,
+            metadata={"block_network": self._block_network},
+        )
 
     def _upload_file(self, local_path: str, remote_path: str) -> None:
         """Upload a local file into the Sandbox.
@@ -417,7 +424,7 @@ class ModalSandbox(BaseSandbox):
         environment_name = sandbox_utils.normalize_optional_config_value(
             settings.modal_environment
         )
-        return sandbox_utils.build_sandbox_create_kwargs(
+        kwargs = sandbox_utils.build_sandbox_create_kwargs(
             app=sandbox_utils.lookup_modal_app(
                 self.config.app_name,
                 modal_environment=environment_name,
@@ -431,6 +438,19 @@ class ModalSandbox(BaseSandbox):
             environment=environment,
             modal_client=modal_client,
         )
+        kwargs["block_network"] = settings.block_network
+        if settings.volumes:
+            kwargs["volumes"] = {
+                path: modal.Volume.from_name(
+                    mount.name,
+                    environment_name=environment_name,
+                    client=modal_client,
+                ).with_mount_options(
+                    sub_path=mount.sub_path, read_only=mount.read_only
+                )
+                for path, mount in settings.volumes.items()
+            }
+        return kwargs
 
     def create_session(
         self,
@@ -452,21 +472,33 @@ class ModalSandbox(BaseSandbox):
         image = sandbox_utils.get_modal_image_from_registry(
             settings.image,
             registry_credentials=self._registry_credentials(settings.image),
-        )
+        ).entrypoint([])
+        # Interactive sessions must outlive the image's default command, and
+        # an inherited entrypoint must not intercept the keepalive command.
         sandbox = modal.Sandbox.create(
+            "sleep",
+            "infinity",
             **self._build_create_kwargs(
                 settings,
                 image=image,
                 modal_client=modal_client,
                 environment=self._resolve_session_environment(settings),
-            )
+            ),
         )
         return ModalSandboxSession(
-            sandbox, parent=self, destroy_on_exit=destroy_on_exit
+            sandbox,
+            parent=self,
+            destroy_on_exit=destroy_on_exit,
+            block_network=settings.block_network,
         )
 
     def attach(self, session_id: str) -> SandboxSession:
         """Reconnect to a still-live Modal Sandbox by id.
+
+        The SDK cannot report the original network policy. Snapshots taken
+        through attached sessions use the component network policy on
+        restore. Configure ``block_network`` on the component when
+        snapshotting attached sessions that must remain network-isolated.
 
         Args:
             session_id: The Modal sandbox object id (e.g. ``sb_xxx``).
@@ -500,6 +532,10 @@ class ModalSandbox(BaseSandbox):
     def restore(self, snapshot: SandboxSnapshot) -> SandboxSession:
         """Boot a new Session from a stored filesystem snapshot.
 
+        Network access stays blocked if either the snapshot or the current
+        component settings require it. Other runtime settings use the
+        current component configuration.
+
         Args:
             snapshot: A ``SandboxSnapshot`` whose ``ref`` is a Modal Image
                 id captured via ``snapshot_filesystem()``.
@@ -513,23 +549,35 @@ class ModalSandbox(BaseSandbox):
         """
         self._validate_snapshot(snapshot)
         settings = cast(ModalSandboxSettings, self.resolve_settings(None))
+        settings = settings.model_copy(
+            update={
+                "block_network": settings.block_network
+                or snapshot.metadata.get("block_network") is True
+            }
+        )
         modal_client = self._get_modal_client()
         try:
-            image = modal.Image.from_id(snapshot.ref, client=modal_client)
+            image = modal.Image.from_id(
+                snapshot.ref, client=modal_client
+            ).entrypoint([])
             # Env vars are runtime config, not filesystem state, so the
             # snapshot image doesn't carry them — re-apply the resolved
             # session environment on restore.
             sandbox = modal.Sandbox.create(
+                "sleep",
+                "infinity",
                 **self._build_create_kwargs(
                     settings,
                     image=image,
                     modal_client=modal_client,
                     environment=self._resolve_session_environment(settings),
-                )
+                ),
             )
         except Exception as e:
             raise RuntimeError(
                 f"Failed to restore Modal sandbox from image "
                 f"'{snapshot.ref}' ({type(e).__name__}): {e}"
             ) from e
-        return ModalSandboxSession(sandbox, parent=self)
+        return ModalSandboxSession(
+            sandbox, parent=self, block_network=settings.block_network
+        )

--- a/tests/integration/integrations/modal/sandboxes/test_modal_sandbox.py
+++ b/tests/integration/integrations/modal/sandboxes/test_modal_sandbox.py
@@ -431,6 +431,13 @@ class TestModalSandbox:
             session = sandbox.restore(snap)
         modal_mock.Image.from_id.assert_called_once_with("im-old", client=None)
         modal_mock.Sandbox.create.assert_called_once()
+        assert modal_mock.Sandbox.create.call_args.args == (
+            "sleep",
+            "infinity",
+        )
+        modal_mock.Image.from_id.return_value.entrypoint.assert_called_once_with(
+            []
+        )
         assert session.id == "sb_new"
 
     def test_restore_uses_configured_modal_client(self) -> None:
@@ -505,6 +512,46 @@ class TestModalSandbox:
             settings = ModalSandboxSettings(image="my-registry/app:v1")
             _make_modal_sandbox().create_session(settings=settings)
         modal_mock.Image.from_registry.assert_called_with("my-registry/app:v1")
+
+    def test_create_session_overrides_image_startup_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Keep sessions alive despite short-lived image commands or entrypoints.
+
+        Args:
+            monkeypatch: Scoped replacement for the active stack lookup.
+        """
+        client = MagicMock()
+        client.active_stack.container_registry = None
+        monkeypatch.setattr(
+            "zenml.integrations.modal.sandboxes.modal_sandbox.Client",
+            lambda: client,
+        )
+        with _patch_modal() as modal_mock:
+            registry_image = MagicMock(name="registry_image")
+            session_image = MagicMock(name="session_image")
+            registry_image.entrypoint.return_value = session_image
+            modal_mock.Image.from_registry.return_value = registry_image
+            modal_mock.Sandbox.create.return_value = MagicMock(
+                object_id="sb_keepalive"
+            )
+
+            _make_modal_sandbox().create_session(
+                settings=ModalSandboxSettings(image="registry/task:v1")
+            )
+
+        registry_image.entrypoint.assert_called_once_with([])
+        modal_mock.Image.from_registry.assert_called_once_with(
+            "registry/task:v1"
+        )
+        assert modal_mock.Sandbox.create.call_args.args == (
+            "sleep",
+            "infinity",
+        )
+        assert (
+            modal_mock.Sandbox.create.call_args.kwargs["image"]
+            is session_image
+        )
 
     def test_cpu_and_memory_settings_reach_sandbox_create(self) -> None:
         with _patch_modal() as modal_mock:
@@ -714,3 +761,114 @@ class TestModalDashboardUrl:
         )
         session = _make_session(fake_sandbox)
         assert session._get_dashboard_url() == "https://modal.com/id/sb-x"
+
+
+def test_volume_mounts_use_component_client_and_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing volumes resolve with the same identity as the sandbox."""
+    from zenml.integrations.modal.flavors.modal_sandbox_flavor import (
+        ModalSandboxVolumeMount,
+    )
+
+    component = _make_modal_sandbox(
+        config=ModalSandboxConfig(
+            token_id="test-id", token_secret="test-secret"
+        )
+    )
+    zenml_client = MagicMock()
+    zenml_client.active_stack.container_registry = None
+    monkeypatch.setattr(
+        "zenml.integrations.modal.sandboxes.modal_sandbox.Client",
+        lambda: zenml_client,
+    )
+    explicit_client = MagicMock()
+    with _patch_modal() as fake:
+        fake.Client.from_credentials.return_value = explicit_client
+        settings = ModalSandboxSettings(
+            modal_environment="dev",
+            block_network=True,
+            volumes={
+                "/home/user": ModalSandboxVolumeMount(
+                    name="episode-volume", sub_path="/home", read_only=True
+                )
+            },
+        )
+        component.create_session(settings=settings)
+        kwargs = fake.Sandbox.create.call_args.kwargs
+        fake.Volume.from_name.assert_called_once_with(
+            "episode-volume", environment_name="dev", client=explicit_client
+        )
+        fake.Volume.from_name.return_value.with_mount_options.assert_called_once_with(
+            sub_path="/home", read_only=True
+        )
+        assert kwargs["block_network"] is True
+        assert "/home/user" in kwargs["volumes"]
+        assert "secrets" not in kwargs
+
+
+@pytest.mark.parametrize("read_only", [False, True])
+def test_volume_mount_options_supported_by_installed_sdk(
+    read_only: bool,
+) -> None:
+    """Exercise real SDK mount construction without credentials or cloud calls.
+
+    Args:
+        read_only: Whether sandbox writes to the mounted volume are allowed.
+    """
+    import modal
+
+    from zenml.integrations.modal.flavors.modal_sandbox_flavor import (
+        ModalSandboxVolumeMount,
+    )
+
+    mount = ModalSandboxVolumeMount(
+        name="sdk-contract-test", sub_path="/episodes", read_only=read_only
+    )
+    volume = modal.Volume.from_name(
+        mount.name, environment_name="test"
+    ).with_mount_options(sub_path=mount.sub_path, read_only=mount.read_only)
+    assert isinstance(volume, modal.Volume)
+
+
+@pytest.mark.parametrize(
+    ("original_blocked", "current_blocked"),
+    [(True, False), (False, True), (False, False)],
+)
+def test_snapshot_restore_preserves_network_restrictions(
+    monkeypatch: pytest.MonkeyPatch,
+    original_blocked: bool,
+    current_blocked: bool,
+) -> None:
+    """A restore retains either the original or current network restriction.
+
+    Args:
+        monkeypatch: Scoped replacement for the active stack lookup.
+        original_blocked: Per-call network restriction on the first session.
+        current_blocked: Network restriction configured for the restored session.
+    """
+    client = MagicMock()
+    client.active_stack.container_registry = None
+    monkeypatch.setattr(
+        "zenml.integrations.modal.sandboxes.modal_sandbox.Client",
+        lambda: client,
+    )
+    component = _make_modal_sandbox(
+        config=ModalSandboxConfig(block_network=current_blocked)
+    )
+    with _patch_modal() as fake:
+        fake.Sandbox.create.return_value = MagicMock(object_id="sb-original")
+        fake.Sandbox.create.return_value.snapshot_filesystem.return_value = (
+            MagicMock(object_id="im-snapshot")
+        )
+        session = component.create_session(
+            settings=ModalSandboxSettings(block_network=original_blocked)
+        )
+        snapshot = session.create_snapshot()
+        assert snapshot.metadata["block_network"] is original_blocked
+        restored = component.restore(snapshot)
+        expected = original_blocked or current_blocked
+        assert (
+            fake.Sandbox.create.call_args.kwargs["block_network"] is expected
+        )
+        assert restored.create_snapshot().metadata["block_network"] is expected


### PR DESCRIPTION
## Describe changes

Run terminal-agent evaluation and bounded reinforcement learning as ZenML pipelines, retaining task provenance, episode traces, before/after evaluations, and exported LoRA adapters. The example uses public Endless Terminals tasks, SkyRL for training, and isolated CPU task environments, with a documented Modal H200 path and Kubernetes and local Docker alternatives.

The native pipeline qualifies the task with initial-state, reference-solution, and no-op checks before allocating a GPU. One CPU step runs evaluation and training against a bounded GPU service, then publishes artifacts and an HTML comparison report. Keeping the service within that step makes its lifetime and cleanup explicit.

### Review points

- Start with `examples/endless_terminals/native_training.py` for the six-step pipeline and the example README for setup.
- The Modal sandbox gains existing-volume mounts and outbound-network blocking. Interactive sessions clear inherited image entrypoints and run a keepalive command. Snapshots made directly from these sessions retain network blocking on restore.
- Modal now requires `>=1.4.3,<2.0.0`; 1.4.3 introduced the volume mount options API. Existing installations on 1.4.0–1.4.2 must upgrade.
- Task grading runs in a fresh environment and receives only audited home-directory data. Exact sampled token IDs and log probabilities are retained for training; infrastructure failures remain separate from task failures.
- This is a bounded, serial training demonstration on a task used during development. It is not a reproduction of Mercor's APEX-Agents recipe or a benchmark generalization claim. Exported adapters contain sampling weights, not resumable optimizer state.

### Validation

- Live Modal H200 run: all six ZenML steps completed. Four groups of eight episodes produced rewards of 6/8, 6/8, 8/8, and 8/8, with two optimizer updates. Repeated evaluation passed 9/10 before and 10/10 after on the same DNS task.
- Downloaded initial/final adapters: all file hashes verified; all 392 adapter tensors were finite and changed. All 52 model episodes reported cleanup, and a final Modal inventory showed no remaining sandboxes or episode volumes.
- Kubernetes CPU qualification and L4 sampling/export were exercised earlier. The L4 runs had equal rewards and no optimizer updates.
- Example CPU regressions: 260 passed, 1 skipped, and 3 subtests passed. Modal sandbox regressions: 57 passed, including a real-SDK volume API contract check.
- Scoped repository formatting and example lint passed, including Ruff, pydoclint, and mypy. Changed Modal files passed Ruff, pydoclint, and focused mypy; broader core mypy encountered existing transitive dependency/type errors. Unchanged GitHub workflow/YAML checks were not rerun locally.
- Public workspace configuration and documentation changes were checked locally; the final publication cleanup has not been rerun on a new GPU allocation. Full integration CI should run because this changes the Modal integration.

### Group-relative rewards

Each training group contains several attempts at the same task. The trainer compares each attempt's binary reward with the group average, reinforcing relatively successful attempts. A group in which every attempt receives the same reward has no relative signal, so this example skips the optimizer update. This makes the reported update count necessary when interpreting a completed training run.

## Pre-requisites

Please ensure you have done the following:

- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io): setup and limitations documented in the example README.
  - [x] Dashboard: no dashboard changes required.
  - [x] Templates: no existing template changes required.
  - [x] [Projects](https://github.com/zenml-io/zenml-projects): no existing project changes required.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change): minimum supported Modal SDK increases from 1.4.0 to 1.4.3.
- [ ] Other (add details above)
