### PR TITLE
Fix dynamic pipeline DAG ordering

### DIFF
--- a/src/zenml/zen_stores/dag/utils.py
+++ b/src/zenml/zen_stores/dag/utils.py
@@ -15,7 +15,8 @@
 
 import json
 from collections import defaultdict
-from typing import Dict, List
+from graphlib import TopologicalSorter
+from typing import Dict, List, Tuple
 from uuid import UUID
 
 from sqlalchemy import select
@@ -24,7 +25,11 @@ from sqlmodel import Session, col
 from zenml.enums import ExecutionStatus, MetadataResourceTypes
 from zenml.metadata.metadata_types import MetadataType
 from zenml.models import RunMetadataEntry
-from zenml.zen_stores.dag.models import InputArtifactRow, OutputArtifactRow
+from zenml.zen_stores.dag.models import (
+    DAGStepView,
+    InputArtifactRow,
+    OutputArtifactRow,
+)
 from zenml.zen_stores.schemas import (
     ArtifactVersionSchema,
     RunMetadataResourceSchema,
@@ -34,6 +39,31 @@ from zenml.zen_stores.schemas import (
     StepRunSchema,
 )
 from zenml.zen_stores.schemas.utils import resolve_metadata_collection
+
+
+def sort_dag_steps(
+    steps: Dict[str, DAGStepView],
+) -> List[Tuple[str, DAGStepView]]:
+    """Sort DAG steps in dependency order.
+
+    Args:
+        steps: The DAG steps.
+
+    Returns:
+        The sorted DAG steps.
+    """
+    dependencies = {
+        name: [
+            upstream
+            for upstream in step.spec.upstream_steps
+            if upstream in steps
+        ]
+        for name, step in steps.items()
+    }
+    return [
+        (name, steps[name])
+        for name in TopologicalSorter(dependencies).static_order()
+    ]
 
 
 def load_input_artifact_rows(

--- a/src/zenml/zen_stores/sql_zen_store.py
+++ b/src/zenml/zen_stores/sql_zen_store.py
@@ -414,6 +414,7 @@ from zenml.zen_stores.dag.utils import (
     load_input_artifact_rows,
     load_output_artifact_rows,
     load_step_run_metadata,
+    sort_dag_steps,
 )
 from zenml.zen_stores.migrations.alembic import (
     Alembic,
@@ -6396,7 +6397,7 @@ class SqlZenStore(BaseZenStore):
                     substituted_output_name
                 ]
 
-            for step_name, step in steps.items():
+            for step_name, step in sort_dag_steps(steps):
                 upstream_steps = set(step.spec.upstream_steps)
 
                 step_id = None

--- a/tests/unit/zen_stores/test_dag_utils.py
+++ b/tests/unit/zen_stores/test_dag_utils.py
@@ -1,0 +1,39 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License")
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Unit tests for DAG generation utilities."""
+
+from typing import List
+
+from zenml.config.step_configurations import StepSpec
+from zenml.zen_stores.dag.models import DAGStepView
+from zenml.zen_stores.dag.utils import sort_dag_steps
+
+
+def _step_with_upstream_steps(upstream_steps: List[str]) -> DAGStepView:
+    """Create a DAG step view with upstream steps."""
+    return DAGStepView.model_construct(
+        spec=StepSpec.model_construct(upstream_steps=upstream_steps)
+    )
+
+
+def test_sort_dag_steps_uses_dependency_order() -> None:
+    """DAG steps are sorted independently of their input order."""
+    steps = {
+        "downstream": _step_with_upstream_steps(["upstream"]),
+        "upstream": _step_with_upstream_steps([]),
+    }
+
+    sorted_steps = sort_dag_steps(steps)
+
+    assert [name for name, _ in sorted_steps] == ["upstream", "downstream"]


### PR DESCRIPTION
This PR fixes dynamic pipeline run DAGs failing to load when step records are returned outside dependency order.