### PR TITLE
fix: enable backwards compatibility for db migration

### DIFF
--- a/helm/templates/server-db-job.yaml
+++ b/helm/templates/server-db-job.yaml
@@ -129,8 +129,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ $server.image.repository }}:{{ $server.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ $server.image.pullPolicy }}
-          args: ["-m", "zenml.zen_server.database_migration"]
-          command: ["python"]
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              if python -c 'import importlib.util; raise SystemExit(importlib.util.find_spec("zenml.zen_server.database_migration") is None)'; then
+                exec python -m zenml.zen_server.database_migration
+              else
+                exec zenml migrate-database
+              fi
           volumeMounts:
             - name: zenml-config
               mountPath: /zenml/.zenconfig


### PR DESCRIPTION
## Describe changes
Since we changed the DB Migration entrypoint, upgrading from older zenml versions causes the DB Migration to fail with the error: `/opt/venv/bin/python: No module named zenml.zen_server.database_migration`.  This PR fixes it.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

