### PR TITLE
Prevent overflow in capped exponential backoff

### DIFF
--- a/src/zenml/utils/time_utils.py
+++ b/src/zenml/utils/time_utils.py
@@ -189,8 +189,9 @@ def exponential_backoff_delays(
         raise ValueError("`jitter` must be one of 'none', 'full', or 'equal'.")
 
     attempt = 0
+    capped_delay = min(initial_delay, max_delay)
     while attempts is None or attempt < attempts:
-        delay = min(initial_delay * (factor**attempt), max_delay)
+        delay = capped_delay
         if jitter == "full":
             delay = random.uniform(0, delay)
         elif jitter == "equal":
@@ -198,6 +199,8 @@ def exponential_backoff_delays(
             delay = half_delay + random.uniform(0, half_delay)
         yield delay
         attempt += 1
+        if capped_delay < max_delay:
+            capped_delay = min(capped_delay * factor, max_delay)
 
 
 def iso8601_to_utc_naive(value: str) -> datetime:

--- a/tests/unit/utils/test_time_utils.py
+++ b/tests/unit/utils/test_time_utils.py
@@ -1,8 +1,29 @@
+"""Tests for time utilities."""
+
 from datetime import datetime
 
 import pytest
 
-from zenml.utils.time_utils import iso8601_to_utc_naive
+from zenml.utils.time_utils import (
+    exponential_backoff_delays,
+    iso8601_to_utc_naive,
+)
+
+
+def test_exponential_backoff_remains_capped_for_many_attempts() -> None:
+    """Ensure capped backoff delays do not overflow after many attempts."""
+    delays = list(
+        exponential_backoff_delays(
+            attempts=2000,
+            initial_delay=1.0,
+            max_delay=20.0,
+            factor=2.0,
+            jitter="none",
+        )
+    )
+
+    assert delays[:6] == [1.0, 2.0, 4.0, 8.0, 16.0, 20.0]
+    assert delays[-1] == 20.0
 
 
 def test_iso8601_to_utc_naive_expected_behaviors() -> None:


### PR DESCRIPTION

## Description

Fixes an overflow in `exponential_backoff_delays` when a retry loop runs for a large number of attempts.

Previously, each delay was calculated with:

```python
min(initial_delay * factor**attempt, max_delay)
```

Even after the delay had reached `max_delay`, the exponentially growing value was still evaluated before being capped. For sufficiently long-running retry loops, this caused an `OverflowError: numerical result out of range`.

The implementation now grows the delay incrementally and stops multiplying once the maximum delay is reached. This preserves the existing delay and jitter behavior while allowing capped retry iterators to run indefinitely.

## Impact

The issue could affect every caller of `exponential_backoff_delays`, including:

- Resource-pool allocation polling while a step waits for requested resources.
- Server-side streaming broker reconnection during an extended broker or network outage. The stream reader uses an unbounded backoff iterator and resets it after a successful read, so a continuous outage could previously terminate the reader with an overflow.
- Initial streaming cursor resolution and terminal run-event publishing. These use bounded retry counts and were unlikely to reach the overflow, but share the corrected utility.
- Future or external callers that use the utility with an unbounded iterator or a large number of attempts.

This change does not alter configured timeout values, retry limits, maximum delays, or jitter semantics.

## Pre-requisites
Please ensure you have done the following:
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [ ] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [ ] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

