### PR TITLE
Document `step_pod_service_account_name` for Kubernetes step pods

### DIFF
--- a/docs/book/component-guide/orchestrators/kubernetes.md
+++ b/docs/book/component-guide/orchestrators/kubernetes.md
@@ -155,7 +155,7 @@ The following configuration options can be set either through the orchestrator c
 - **`timeout`** (default: 0): How many seconds to wait for synchronous runs. `0` means to wait indefinitely.
 - **`stream_step_logs`** (default: True): If `True`, the orchestrator pod will stream the logs of the step pods.
 - **`service_account_name`**: The name of a Kubernetes service account to use for running the pipelines. If configured, it must point to an existing service account in the default or configured `namespace` that has associated RBAC roles granting permissions to create and manage pods in that namespace. This can also be configured as an individual pipeline setting in addition to the global orchestrator setting.
-- **`step_pod_service_account_name`**: Name of the service account to use for the step pods.
+- **`step_pod_service_account_name`**: Name of the service account to use for the step pods. If not set, the step pods fall back to `service_account_name`; if that is not set either, they run with the namespace's `default` service account. Note that `pod_settings` has no service account field, so `pod_settings={"service_account_name": ...}` is accepted but ignored.
 - **`privileged`** (default: False): If the container should be run in privileged mode.
 - **`pod_settings`**: Node selectors, labels, affinity, and tolerations, secrets, environment variables, image pull secrets, the scheduler name and additional arguments to apply to the Kubernetes Pods running the steps of your pipeline. These can be either specified using the Kubernetes model objects or as dictionaries.
 - **`orchestrator_pod_settings`**: Node selectors, labels, affinity, tolerations, secrets, environment variables and image pull secrets to apply to the Kubernetes Pod that is responsible for orchestrating the pipeline and starting the other Pods. These can be either specified using the Kubernetes model objects or as dictionaries.
@@ -230,6 +230,12 @@ If `pass_zenml_token_as_secret=True`, also grant:
 Step containers do not need Kubernetes API access for normal execution in this
 orchestrator flow. Unless your step code explicitly calls the Kubernetes API,
 you can keep this account with no additional Kubernetes RBAC grants.
+
+The step pods use `step_pod_service_account_name` if it is set, otherwise
+`service_account_name`, otherwise the namespace's `default` service account.
+Set it through the orchestrator settings, not through `pod_settings`:
+`KubernetesPodSettings` has no `service_account_name` field, and an unknown
+key passed to `pod_settings` is accepted without error and never applied.
 
 ```python
 from zenml.integrations.kubernetes.flavors.kubernetes_orchestrator_flavor import KubernetesOrchestratorSettings
@@ -402,6 +408,30 @@ def simple_ml_pipeline(parameter: int):
 ```
 
 This code will now run the `train_model` step on a GPU-enabled node in the `gpu-pool` node pool while the rest of the pipeline can run on ordinary nodes.
+
+To run a single step under its own Kubernetes service account (for example, one bound to a cloud identity with access to a specific bucket), set `step_pod_service_account_name` on that step. This is a top-level orchestrator setting, not part of `pod_settings`:
+
+```python
+@step(
+    settings={
+        "orchestrator": KubernetesOrchestratorSettings(
+            step_pod_service_account_name="train-model-sa",
+        )
+    }
+)
+def train_model(data: dict) -> None:
+    ...
+```
+
+The same override in a YAML config file:
+
+```yaml
+steps:
+  train_model:
+    settings:
+      orchestrator.kubernetes:
+        step_pod_service_account_name: train-model-sa
+```
 
 Check out the [SDK docs](https://sdkdocs.zenml.io/latest/integration_code_docs/integrations-kubernetes.html#zenml.integrations.kubernetes) for a full list of available attributes and [this docs page](https://docs.zenml.io/concepts/steps_and_pipelines/configuration) for more information on how to specify settings.
 


### PR DESCRIPTION
## Describe changes

Docs only. The Kubernetes orchestrator page lists `step_pod_service_account_name` in the settings table, but it never says how the step pod's service account is actually chosen, and the "Define settings on the step level" section promises "a different Kubernetes service account" while only showing a `pod_settings` example. The natural guess, `pod_settings={"service_account_name": ...}`, validates and does nothing: `KubernetesPodSettings` has no such field, and `BaseSettings` is configured with `extra="allow"`, so the unknown key is kept and never read.

What the code does (checked against `zenml` 0.96.4):

- `orchestrators/kubernetes_orchestrator_entrypoint.py` builds each step pod with `service_account_name=settings.step_pod_service_account_name or settings.service_account_name`.
- `manifest_utils.build_pod_manifest` sets `pod_spec.service_account_name` from that argument; `add_pod_settings` applies node selectors, affinity, tolerations, resources, volumes, env, security context, scheduler name and `additional_pod_spec_args`, but no service account.
- `flavors/kubernetes_orchestrator_flavor.py` describes the two fields as "Kubernetes service account for the orchestrator pod. If not specified, creates a new account with 'edit' permissions." and "Kubernetes service account for step execution pods. Uses the default service account if not specified."

This PR:

- expands the `step_pod_service_account_name` bullet with the fallback order (`step_pod_service_account_name` -> `service_account_name` -> namespace `default`) and a note that `pod_settings` has no service account field;
- adds the same fallback note under "Step pod service account" in the permissions section;
- adds a Python and a YAML example that give a single step its own service account.

Found while building the zenml-bench agent benchmark: every agent in a 12-trial baseline on the Kubernetes-settings task had to read the installed source under `site-packages` to discover this, because neither the docs nor the skill said it.

## Pre-requisites
Please ensure you have done the following:
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] I have based my new branch on `develop` and the open PR is targeting `develop`. If your branch wasn't based on develop read [Contribution guide on rebasing branch to develop](https://github.com/zenml-io/zenml/blob/main/CONTRIBUTING.md#-pull-requests-rebase-your-branch-on-develop).
- [x] **IMPORTANT**: I made sure that my changes are reflected properly in the following resources:
  - [x] [ZenML Docs](https://docs.zenml.io)
  - [ ] Dashboard: Needs to be communicated to the frontend team.
  - [ ] Templates: Might need adjustments (that are not reflected in the template tests) in case of non-breaking changes and deprecations.
  - [ ] [Projects](https://github.com/zenml-io/zenml-projects): Depending on the version dependencies, different projects might get affected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (add details above)
